### PR TITLE
Fix intro course settings crash and backfill re-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache-dependency-path: clients/cli/go.sum
 
       - name: go mod download

--- a/clients/web/src/components/settings/__tests__/intro-course-panel.test.tsx
+++ b/clients/web/src/components/settings/__tests__/intro-course-panel.test.tsx
@@ -76,6 +76,18 @@ describe('IntroCoursePanel', () => {
     fetchIntroCourseAdminAnalytics.mockResolvedValue(mockAnalytics)
   })
 
+  it('renders when perModuleFunnel is null from API', async () => {
+    fetchIntroCourseAdminAnalytics.mockResolvedValue({
+      ...mockAnalytics,
+      perModuleFunnel: null,
+    })
+    renderPanel()
+    await waitFor(() => {
+      expect(screen.getByText('12')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /re-sync content/i })).toBeInTheDocument()
+  })
+
   it('loads status and analytics', async () => {
     renderPanel()
     await waitFor(() => {

--- a/clients/web/src/components/settings/intro-course-panel.tsx
+++ b/clients/web/src/components/settings/intro-course-panel.tsx
@@ -26,7 +26,8 @@ function percentLabel(rate: number): string {
 
 function FunnelTable({ analytics }: { analytics: IntroCourseAdminAnalytics }) {
   const { t } = useTranslation('introCourse')
-  if (analytics.perModuleFunnel.length === 0) {
+  const funnel = analytics.perModuleFunnel ?? []
+  if (funnel.length === 0) {
     return (
       <p className="text-sm text-slate-500 dark:text-neutral-400">
         {t('introCourse.admin.analytics.empty')}
@@ -51,7 +52,7 @@ function FunnelTable({ analytics }: { analytics: IntroCourseAdminAnalytics }) {
           </tr>
         </thead>
         <tbody>
-          {analytics.perModuleFunnel.map((row) => (
+          {funnel.map((row) => (
             <tr
               key={row.moduleSlug}
               className="border-b border-slate-100 dark:border-neutral-800"
@@ -190,7 +191,7 @@ export function IntroCoursePanel() {
   }
 
   const dropOffTitle =
-    analytics?.perModuleFunnel.find((m) => m.moduleSlug === analytics.dropOffModuleSlug)?.moduleTitle ??
+    analytics?.perModuleFunnel?.find((m) => m.moduleSlug === analytics.dropOffModuleSlug)?.moduleTitle ??
     analytics?.dropOffModuleSlug
 
   return (

--- a/server/internal/httpserver/intro_course_http.go
+++ b/server/internal/httpserver/intro_course_http.go
@@ -177,7 +177,7 @@ func (d Deps) handleAdminIntroCourseAnalytics() http.HandlerFunc {
 		}
 		if !found || courseID == uuid.Nil || !introcourseservice.Enabled(cfg) {
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(introcourseservice.Analytics{})
+			_ = json.NewEncoder(w).Encode(introcourseservice.EmptyAnalytics())
 			return
 		}
 		analytics, err := introcourseservice.LoadAnalytics(r.Context(), d.Pool, courseID)

--- a/server/internal/repos/introcourse/backfill.go
+++ b/server/internal/repos/introcourse/backfill.go
@@ -74,6 +74,18 @@ WHERE id = TRUE
 	return err
 }
 
+// ClearBackfillCompleted clears completed_at so a backfill pass can run again (e.g. remaining users after an early complete).
+func ClearBackfillCompleted(ctx context.Context, exec interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+}) error {
+	_, err := exec.Exec(ctx, `
+UPDATE settings.intro_course_backfill
+SET completed_at = NULL, updated_at = NOW()
+WHERE id = TRUE
+`)
+	return err
+}
+
 // CountBackfillRemaining returns eligible users not yet enrolled in the intro course.
 func CountBackfillRemaining(ctx context.Context, pool *pgxpool.Pool, introCourseID, defaultOrgID uuid.UUID, skipParents bool) (int64, error) {
 	parentClause := ""

--- a/server/internal/service/introcourse/completion.go
+++ b/server/internal/service/introcourse/completion.go
@@ -80,6 +80,11 @@ type Analytics struct {
 	AvgTimeToCompleteHours   *float64            `json:"avgTimeToCompleteHours,omitempty"`
 }
 
+// EmptyAnalytics returns a JSON-safe zero analytics payload (perModuleFunnel serializes as []).
+func EmptyAnalytics() Analytics {
+	return Analytics{PerModuleFunnel: []ModuleFunnelEntry{}}
+}
+
 type moduleQuiz struct {
 	ModuleSlug  string
 	ModuleTitle string
@@ -281,7 +286,7 @@ func RecheckCompletion(ctx context.Context, pool *pgxpool.Pool, cfg config.Confi
 
 // LoadAnalytics returns admin completion-rate and per-module funnel data.
 func LoadAnalytics(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (Analytics, error) {
-	var out Analytics
+	out := Analytics{PerModuleFunnel: []ModuleFunnelEntry{}}
 	if pool == nil || courseID == uuid.Nil {
 		return out, nil
 	}

--- a/server/internal/service/introcourse/enroll.go
+++ b/server/internal/service/introcourse/enroll.go
@@ -264,10 +264,6 @@ func (s *Service) RunBackfill(ctx context.Context, cfg config.Config) error {
 	if err != nil {
 		return err
 	}
-	if st.CompletedAt != nil {
-		slog.Debug("intro course backfill already completed")
-		return nil
-	}
 
 	courseID, ok, err := s.CourseID(ctx)
 	if err != nil {
@@ -281,6 +277,21 @@ func (s *Service) RunBackfill(ctx context.Context, cfg config.Config) error {
 		if err != nil || !ok {
 			return fmt.Errorf("intro course backfill: course unavailable: %w", err)
 		}
+	}
+
+	if st.CompletedAt != nil {
+		remaining, err := icrepo.CountBackfillRemaining(ctx, s.Pool, courseID, organization.SeedDefaultOrgID, SkipParentsOnEnroll)
+		if err != nil {
+			return err
+		}
+		if remaining == 0 {
+			slog.Debug("intro course backfill already completed")
+			return nil
+		}
+		if err := icrepo.ClearBackfillCompleted(ctx, s.Pool); err != nil {
+			return err
+		}
+		slog.Info("intro course backfill resuming", "remaining", remaining)
 	}
 
 	now := time.Now().UTC()
@@ -362,11 +373,19 @@ LIMIT $5
 		time.Sleep(50 * time.Millisecond)
 	}
 
+	remaining, err := icrepo.CountBackfillRemaining(ctx, s.Pool, courseID, organization.SeedDefaultOrgID, SkipParentsOnEnroll)
+	if err != nil {
+		return err
+	}
+	setBackfillProgress(1)
+	setBackfillRemaining(float64(remaining))
+	if remaining > 0 {
+		slog.Warn("intro course backfill pass finished with eligible users still not enrolled", "remaining", remaining)
+		return nil
+	}
 	if err := icrepo.MarkBackfillCompleted(ctx, s.Pool, time.Now().UTC()); err != nil {
 		return err
 	}
 	slog.Info("intro course backfill completed")
-	setBackfillProgress(1)
-	setBackfillRemaining(0)
 	return nil
 }

--- a/server/internal/service/introcourse/enroll_db_test.go
+++ b/server/internal/service/introcourse/enroll_db_test.go
@@ -189,9 +189,6 @@ WHERE id = TRUE`); err != nil {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.CompletedAt == nil {
-		t.Fatal("expected completed backfill")
-	}
 
 	for _, uid := range userIDs {
 		var role string
@@ -204,6 +201,14 @@ SELECT role FROM course.course_enrollments WHERE course_id = $1 AND user_id = $2
 		if role != "student" {
 			t.Fatalf("user %s role=%q", uid, role)
 		}
+	}
+
+	if st.Remaining == 0 {
+		if st.CompletedAt == nil {
+			t.Fatal("expected completed backfill when no eligible users remain")
+		}
+	} else if st.CompletedAt != nil {
+		t.Fatalf("expected incomplete backfill while %d eligible users remain", st.Remaining)
 	}
 
 	if err := svc.RunBackfill(ctx, cfg); err != nil {

--- a/server/internal/service/introcourse/jobs.go
+++ b/server/internal/service/introcourse/jobs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -11,6 +12,7 @@ import (
 	"github.com/lextures/lextures/server/internal/config"
 	icrepo "github.com/lextures/lextures/server/internal/repos/introcourse"
 	"github.com/lextures/lextures/server/internal/repos/jobqueue"
+	"github.com/lextures/lextures/server/internal/repos/organization"
 )
 
 const (
@@ -46,7 +48,25 @@ func EnqueueBackfillIfNeeded(ctx context.Context, pool *pgxpool.Pool, cfg config
 		return uuid.Nil, err
 	}
 	if st.CompletedAt != nil {
-		return uuid.Nil, nil
+		svc := New(pool)
+		courseID, ok, err := svc.CourseID(ctx)
+		if err != nil {
+			return uuid.Nil, err
+		}
+		if !ok || courseID == uuid.Nil {
+			return uuid.Nil, nil
+		}
+		remaining, err := icrepo.CountBackfillRemaining(ctx, pool, courseID, organization.SeedDefaultOrgID, SkipParentsOnEnroll)
+		if err != nil {
+			return uuid.Nil, err
+		}
+		if remaining == 0 {
+			return uuid.Nil, nil
+		}
+		if err := icrepo.ClearBackfillCompleted(ctx, pool); err != nil {
+			return uuid.Nil, err
+		}
+		slog.Info("intro course backfill re-queued", "remaining", remaining)
 	}
 	return jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
 		JobType:   JobTypeBackfill,


### PR DESCRIPTION
## Summary
- Fix `/settings/intro-course` crash when analytics returns `perModuleFunnel: null` (Go nil slice JSON) by null-guarding the admin panel and always serializing an empty funnel array from the API.
- Allow intro course backfill to resume when eligible users are still not enrolled, instead of treating a prior completed run as a permanent no-op.

## Test plan
- [x] `go test ./internal/service/introcourse/... -short`
- [x] `npm run test -- src/components/settings/__tests__/intro-course-panel.test.tsx`
- [ ] Deploy and open Settings → Intro course (page loads without error)
- [ ] Run backfill or trigger `intro_course_backfill` when users are still unenrolled; confirm enrollments are created and dashboard shows the welcome course card


Made with [Cursor](https://cursor.com)