### PR TITLE
fix: public storefront hero images and stale hero redirects

### DIFF
--- a/clients/web/src/components/course-hero-image.tsx
+++ b/clients/web/src/components/course-hero-image.tsx
@@ -1,6 +1,8 @@
 import { type ComponentPropsWithoutRef, useEffect, useState } from 'react'
-import { authorizedFetch } from '../lib/api'
-import { needsAuthenticatedCourseImageSrc, resolveAuthorizedFetchPath } from '../lib/course-file-image'
+import {
+  fetchCourseFileImageBlob,
+  needsAuthenticatedCourseImageSrc,
+} from '../lib/course-file-image'
 import { courseHeroImageSrc, type CourseHeroImageSize } from '../lib/course-hero-image-url'
 
 type Props = ComponentPropsWithoutRef<'img'> & {
@@ -23,11 +25,7 @@ export function CourseHeroImage({ src, size = 'full', className, alt = '', ...pr
       setResolvedSrc(fetchSrc ?? undefined)
       return
     }
-    void authorizedFetch(resolveAuthorizedFetchPath(fetchSrc))
-      .then((r) => {
-        if (!r.ok) throw new Error(String(r.status))
-        return r.blob()
-      })
+    void fetchCourseFileImageBlob(fetchSrc)
       .then((blob) => {
         if (cancelled) return
         blobUrl = URL.createObjectURL(blob)

--- a/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
+++ b/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
@@ -3,10 +3,9 @@ import Image from '@tiptap/extension-image'
 import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { authorizedFetch } from '../../../lib/api'
 import {
+  fetchCourseFileImageBlob,
   needsAuthenticatedCourseImageSrc,
-  resolveAuthorizedFetchPath,
   stripImageDisplayFragment,
 } from '../../../lib/course-file-image'
 import { DECORATIVE_IMAGE_TITLE } from '../../../lib/image-alt-validation'
@@ -66,12 +65,7 @@ function CourseImageNodeView(props: NodeViewProps) {
       return
     }
     /* eslint-enable react-hooks/set-state-in-effect */
-    const path = resolveAuthorizedFetchPath(src)
-    void authorizedFetch(path)
-      .then((r) => {
-        if (!r.ok) throw new Error(String(r.status))
-        return r.blob()
-      })
+    void fetchCourseFileImageBlob(src)
       .then((blob) => {
         if (cancelled) return
         blobUrl = URL.createObjectURL(blob)

--- a/clients/web/src/components/syllabus/course-file-markdown-image.tsx
+++ b/clients/web/src/components/syllabus/course-file-markdown-image.tsx
@@ -1,9 +1,8 @@
 import type { CSSProperties } from 'react'
 import { useEffect, useState } from 'react'
-import { authorizedFetch } from '../../lib/api'
 import {
+  fetchCourseFileImageBlob,
   needsAuthenticatedCourseImageSrc,
-  resolveAuthorizedFetchPath,
   stripImageDisplayFragment,
 } from '../../lib/course-file-image'
 
@@ -33,12 +32,7 @@ export function CourseFileMarkdownImage({ src, alt, className, style }: CourseFi
       return
     }
     /* eslint-enable react-hooks/set-state-in-effect */
-    const path = resolveAuthorizedFetchPath(src)
-    void authorizedFetch(path)
-      .then((r) => {
-        if (!r.ok) throw new Error(String(r.status))
-        return r.blob()
-      })
+    void fetchCourseFileImageBlob(src)
       .then((blob) => {
         if (cancelled) return
         blobUrl = URL.createObjectURL(blob)

--- a/clients/web/src/lib/__tests__/course-file-image.test.ts
+++ b/clients/web/src/lib/__tests__/course-file-image.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   courseFileContentPathname,
+  fetchCourseFileImageBlob,
   needsAuthenticatedCourseImageSrc,
   resolveAuthorizedFetchPath,
 } from '../course-file-image'
+
+vi.mock('../api', () => ({
+  apiUrl: (path: string) => `http://api.test${path}`,
+  authorizedFetch: vi.fn(),
+}))
+
+import { authorizedFetch } from '../api'
 
 describe('courseFileContentPathname', () => {
   const courseFile =
@@ -38,5 +46,48 @@ describe('resolveAuthorizedFetchPath', () => {
     const src =
       '/api/v1/courses/C-WLCOME/course-files/6528692e-282a-4a23-94f7-d12c52082e59/content?w=640&h=320&q=85'
     expect(resolveAuthorizedFetchPath(src)).toBe(src)
+  })
+})
+
+describe('fetchCourseFileImageBlob', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(authorizedFetch).mockReset()
+  })
+
+  it('returns the public blob without auth when the storefront hero is readable', async () => {
+    const blob = new Blob(['hero'], { type: 'image/jpeg' })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) }),
+    )
+
+    const out = await fetchCourseFileImageBlob(
+      '/api/v1/courses/C-AIESS1/course-files/75782c7e-8410-4ac5-8f88-61a3290b938e/content',
+    )
+
+    expect(out).toBe(blob)
+    expect(authorizedFetch).not.toHaveBeenCalled()
+  })
+
+  it('falls back to authorizedFetch after a 401', async () => {
+    const blob = new Blob(['private'], { type: 'image/png' })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 401, blob: () => Promise.resolve(new Blob()) }),
+    )
+    vi.mocked(authorizedFetch).mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    } as Response)
+
+    const out = await fetchCourseFileImageBlob(
+      '/api/v1/courses/C-TEST/course-files/00000000-0000-4000-8000-000000000099/content',
+    )
+
+    expect(out).toBe(blob)
+    expect(authorizedFetch).toHaveBeenCalledWith(
+      '/api/v1/courses/C-TEST/course-files/00000000-0000-4000-8000-000000000099/content',
+    )
   })
 })

--- a/clients/web/src/lib/course-file-image.ts
+++ b/clients/web/src/lib/course-file-image.ts
@@ -1,3 +1,5 @@
+import { apiUrl, authorizedFetch } from './api'
+
 /** Parse `#w=…&h=…` display size appended to image URLs in Markdown (TipTap round-trip). */
 export function stripImageDisplayFragment(src: string): {
   base: string
@@ -50,4 +52,20 @@ export function resolveAuthorizedFetchPath(src: string): string {
   } catch {
     return base
   }
+}
+
+/**
+ * Load a course-file image blob. Storefront/catalog hero images are readable without
+ * a session; enrolled-only files fall back to `authorizedFetch` after a 401.
+ */
+export async function fetchCourseFileImageBlob(src: string): Promise<Blob> {
+  const path = resolveAuthorizedFetchPath(src)
+  const publicRes = await fetch(apiUrl(path))
+  if (publicRes.ok) return publicRes.blob()
+  if (publicRes.status !== 401) {
+    throw new Error(String(publicRes.status))
+  }
+  const authedRes = await authorizedFetch(path)
+  if (!authedRes.ok) throw new Error(String(authedRes.status))
+  return authedRes.blob()
 }

--- a/clients/web/src/pages/explore-catalog-page.tsx
+++ b/clients/web/src/pages/explore-catalog-page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { Search, Star } from 'lucide-react'
+import { CourseHeroImage } from '../components/course-hero-image'
 import {
   fetchPublicCatalogCategories,
   formatPrice,
@@ -39,10 +40,11 @@ function CourseCard({ course }: { course: PublicCatalogCourse }) {
   return (
     <article className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-[box-shadow,background-color,color,border-color] hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900">
       {course.heroImageUrl ? (
-        <img
+        <CourseHeroImage
           src={course.heroImageUrl}
+          size="catalog-card"
           alt=""
-          className="lex-content-img h-40 w-full object-cover"
+          className="h-40 w-full object-cover"
           loading="lazy"
         />
       ) : (

--- a/clients/web/src/pages/explore-course-page.tsx
+++ b/clients/web/src/pages/explore-course-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useState } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { ArrowLeft, Star } from 'lucide-react'
+import { CourseHeroImage } from '../components/course-hero-image'
 import { CourseReviewsSection } from '../components/reviews/course-reviews-section'
 import { fetchPublicCourseReviews, type ReviewsListResponse } from '../lib/course-reviews-api'
 import {
@@ -106,7 +107,7 @@ export default function ExploreCoursePage() {
           <article>
             <header className="overflow-hidden rounded-2xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
               {course.heroImageUrl ? (
-                <img src={course.heroImageUrl} alt="" className="lex-content-img h-56 w-full object-cover" />
+                <CourseHeroImage src={course.heroImageUrl} alt="" className="h-56 w-full object-cover" />
               ) : (
                 <div className="h-40 w-full bg-gradient-to-br from-indigo-100 to-sky-100 dark:from-indigo-950 dark:to-sky-950" />
               )}

--- a/clients/web/src/sw.ts
+++ b/clients/web/src/sw.ts
@@ -21,15 +21,17 @@ cleanupOutdatedCaches()
 // SPA navigation fallback: serve index.html for all navigation requests
 registerRoute(new NavigationRoute(createHandlerBoundToURL('/index.html')))
 
-// Cache-first for static assets (JS, CSS, fonts, images)
+// Cache-first for static assets (JS, CSS, fonts, images). Skip /api/ URLs so
+// authenticated course-file blobs are never served from a stale image cache.
 registerRoute(
-  ({ request }) =>
-    request.destination === 'script' ||
-    request.destination === 'style' ||
-    request.destination === 'font' ||
-    request.destination === 'image',
+  ({ request, url }) =>
+    !url.pathname.startsWith('/api/') &&
+    (request.destination === 'script' ||
+      request.destination === 'style' ||
+      request.destination === 'font' ||
+      request.destination === 'image'),
   new CacheFirst({
-    cacheName: 'static-assets-v1',
+    cacheName: 'static-assets-v2',
     plugins: [
       new ExpirationPlugin({ maxEntries: 150, maxAgeSeconds: 30 * 24 * 60 * 60 }),
     ],
@@ -44,7 +46,7 @@ registerRoute(
     !url.pathname.includes('/push') &&
     !url.pathname.includes('/vapid'),
   new NetworkFirst({
-    cacheName: 'api-cache-v1',
+    cacheName: 'api-cache-v2',
     networkTimeoutSeconds: 10,
     plugins: [
       new ExpirationPlugin({ maxEntries: 200, maxAgeSeconds: 10 * 60 }),

--- a/server/internal/httpserver/course_file_content.go
+++ b/server/internal/httpserver/course_file_content.go
@@ -48,6 +48,11 @@ func (d Deps) handleGetCourseFileContent() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load file.")
 			return
 		}
+		if row == nil {
+			if d.redirectStaleStorefrontHero(w, r, courseCode, fileID) {
+				return
+			}
+		}
 
 		// Public storefront/catalog hero images are readable without enrollment.
 		// Everything else requires course access first so unauthenticated callers
@@ -120,6 +125,28 @@ func (d Deps) handleGetCourseFileContent() http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(b)
 	}
+}
+
+// redirectStaleStorefrontHero sends clients to the current hero file when a storefront
+// course still references an old hero UUID (e.g. after reprovisioning).
+func (d Deps) redirectStaleStorefrontHero(w http.ResponseWriter, r *http.Request, courseCode string, requested uuid.UUID) bool {
+	if d.Pool == nil {
+		return false
+	}
+	readable, err := course.IsStorefrontHeroReadable(r.Context(), d.Pool, courseCode)
+	if err != nil || !readable {
+		return false
+	}
+	current, ok, err := course.GetStorefrontHeroFileID(r.Context(), d.Pool, courseCode)
+	if err != nil || !ok || current == requested {
+		return false
+	}
+	target := "/api/v1/courses/" + courseCode + "/course-files/" + current.String() + "/content"
+	if q := r.URL.RawQuery; q != "" {
+		target += "?" + q
+	}
+	http.Redirect(w, r, target, http.StatusFound)
+	return true
 }
 
 func (d Deps) isPublicStorefrontHero(r *http.Request, courseCode string, row *coursefiles.Row) bool {

--- a/server/internal/repos/course/marketplace.go
+++ b/server/internal/repos/course/marketplace.go
@@ -52,6 +52,48 @@ WHERE course_code = $1
 	return ok, err
 }
 
+// ParseHeroFileIDFromURL extracts the course-files UUID from a hero_image_url value.
+func ParseHeroFileIDFromURL(heroURL string) (uuid.UUID, bool) {
+	heroURL = strings.TrimSpace(heroURL)
+	const needle = "/course-files/"
+	i := strings.Index(heroURL, needle)
+	if i < 0 {
+		return uuid.UUID{}, false
+	}
+	rest := heroURL[i+len(needle):]
+	rest = strings.TrimSuffix(rest, "/content")
+	if j := strings.IndexByte(rest, '/'); j >= 0 {
+		rest = rest[:j]
+	}
+	if j := strings.IndexByte(rest, '?'); j >= 0 {
+		rest = rest[:j]
+	}
+	id, err := uuid.Parse(strings.TrimSpace(rest))
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	return id, true
+}
+
+// GetStorefrontHeroFileID returns the file UUID referenced by hero_image_url, if any.
+func GetStorefrontHeroFileID(ctx context.Context, pool *pgxpool.Pool, courseCode string) (uuid.UUID, bool, error) {
+	var heroURL *string
+	err := pool.QueryRow(ctx, `
+SELECT hero_image_url FROM course.courses WHERE course_code = $1
+`, courseCode).Scan(&heroURL)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.UUID{}, false, nil
+	}
+	if err != nil {
+		return uuid.UUID{}, false, err
+	}
+	if heroURL == nil {
+		return uuid.UUID{}, false, nil
+	}
+	id, ok := ParseHeroFileIDFromURL(*heroURL)
+	return id, ok, nil
+}
+
 // IsCourseHeroFile reports whether fileID is the course's configured hero_image_url target.
 func IsCourseHeroFile(ctx context.Context, pool *pgxpool.Pool, courseCode string, fileID uuid.UUID) (bool, error) {
 	var heroURL *string

--- a/server/internal/repos/course/marketplace_test.go
+++ b/server/internal/repos/course/marketplace_test.go
@@ -26,6 +26,21 @@ func TestIsFree(t *testing.T) {
 	}
 }
 
+func TestParseHeroFileIDFromURL(t *testing.T) {
+	id := "75782c7e-8410-4ac5-8f88-61a3290b938e"
+	got, ok := ParseHeroFileIDFromURL("/api/v1/courses/C-AIESS1/course-files/" + id + "/content")
+	if !ok {
+		t.Fatal("expected parse ok")
+	}
+	if got.String() != id {
+		t.Fatalf("got %s want %s", got, id)
+	}
+	_, ok = ParseHeroFileIDFromURL("/course-card-hero.png")
+	if ok {
+		t.Fatal("expected non-course-file URL to fail")
+	}
+}
+
 func TestCourseHeroContentPath(t *testing.T) {
 	id := "6bb960af-bc69-478e-8fca-7e8092976eca"
 	got := "/api/v1/courses/C-AIESS1/course-files/" + id + "/content"

--- a/www/src/app.tsx
+++ b/www/src/app.tsx
@@ -90,6 +90,12 @@ function resolveRoute(pathname: string, hash: string): string {
   return pathname !== '/' ? pathname : '/'
 }
 
+/** Slug from `/courses/:slug`, or `''` for `/courses/` with no slug. */
+function courseDetailSlug(route: string): string | null {
+  if (!route.startsWith('/courses/')) return null
+  return route.slice('/courses/'.length).replace(/\/+$/, '')
+}
+
 export default function App() {
   const hash = useHashRoute()
   const route = resolveRoute(window.location.pathname, hash)
@@ -101,7 +107,10 @@ export default function App() {
   if (route === '/self-learner') return <SelfLearnerPage />
   if (route === '/pricing') return <PricingPage />
   if (route === '/courses') return <CoursesPage />
-  if (route.startsWith('/courses/')) return <CourseDetailPage slug={route.slice('/courses/'.length)} />
+  const courseSlug = courseDetailSlug(route)
+  if (courseSlug !== null) {
+    return courseSlug ? <CourseDetailPage slug={courseSlug} /> : <CoursesPage />
+  }
   if (route === '/request-information') return <RequestInformationPage />
   if (route === '/blog') return <BlogIndex />
   if (route.startsWith('/blog/')) return <BlogPost slug={route.slice('/blog/'.length)} />

--- a/www/src/lib/marketplace-api.test.mjs
+++ b/www/src/lib/marketplace-api.test.mjs
@@ -32,6 +32,17 @@ function enrollHandoffUrl(slug) {
   return `https://self.lextures.com/explore/${encodeURIComponent(slug)}?ref=www-courses`
 }
 
+function requireMarketplaceSlug(slug) {
+  const trimmed = slug.trim()
+  if (!trimmed) {
+    const err = new Error('Course not found')
+    err.name = 'MarketplaceApiError'
+    err.status = 404
+    throw err
+  }
+  return trimmed
+}
+
 describe('marketplace-api helpers', () => {
   it('formats free and paid prices', () => {
     assert.equal(formatMarketplacePrice(0, 'usd'), 'Free')
@@ -58,5 +69,11 @@ describe('marketplace-api helpers', () => {
       enrollHandoffUrl('intro-python'),
       'https://self.lextures.com/explore/intro-python?ref=www-courses',
     )
+  })
+
+  it('rejects empty marketplace slug', () => {
+    assert.throws(() => requireMarketplaceSlug(''), /Course not found/)
+    assert.throws(() => requireMarketplaceSlug('   '), /Course not found/)
+    assert.equal(requireMarketplaceSlug(' intro-python '), 'intro-python')
   })
 })

--- a/www/src/lib/marketplace-api.ts
+++ b/www/src/lib/marketplace-api.ts
@@ -81,6 +81,14 @@ export class MarketplaceApiError extends Error {
   }
 }
 
+function requireMarketplaceSlug(slug: string): string {
+  const trimmed = slug.trim()
+  if (!trimmed) {
+    throw new MarketplaceApiError(404, 'Course not found')
+  }
+  return trimmed
+}
+
 export function buildMarketplaceParams(query: MarketplaceQuery = {}): string {
   const params = new URLSearchParams()
   if (query.q) params.set('q', query.q)
@@ -134,8 +142,9 @@ export async function fetchPublicMarketplaceCategories(): Promise<MarketplaceCat
 export async function fetchPublicMarketplaceCourse(
   slug: string,
 ): Promise<PublicMarketplaceCourseDetail> {
+  const normalized = requireMarketplaceSlug(slug)
   return fetchJSON<PublicMarketplaceCourseDetail>(
-    `/api/v1/public/marketplace/courses/${encodeURIComponent(slug)}`,
+    `/api/v1/public/marketplace/courses/${encodeURIComponent(normalized)}`,
   )
 }
 
@@ -143,12 +152,13 @@ export async function fetchPublicMarketplaceReviews(
   slug: string,
   opts: { cursor?: string; limit?: number } = {},
 ): Promise<CourseReviewsResponse> {
+  const normalized = requireMarketplaceSlug(slug)
   const params = new URLSearchParams()
   if (opts.cursor) params.set('cursor', opts.cursor)
   if (typeof opts.limit === 'number') params.set('limit', String(opts.limit))
   const qs = params.toString()
   const data = await fetchJSON<CourseReviewsResponse>(
-    `/api/v1/public/marketplace/courses/${encodeURIComponent(slug)}/reviews${qs ? `?${qs}` : ''}`,
+    `/api/v1/public/marketplace/courses/${encodeURIComponent(normalized)}/reviews${qs ? `?${qs}` : ''}`,
   )
   return {
     summary: data.summary,

--- a/www/src/pages/course-detail-page.tsx
+++ b/www/src/pages/course-detail-page.tsx
@@ -54,11 +54,19 @@ export function CourseDetailPage({ slug }: CourseDetailPageProps) {
   })
 
   useEffect(() => {
+    const normalizedSlug = slug.trim()
+    if (!normalizedSlug) {
+      setLoading(false)
+      setNotFound(true)
+      setError(null)
+      return
+    }
+
     setLoading(true)
     setError(null)
     setNotFound(false)
     let cancelled = false
-    fetchPublicMarketplaceCourse(slug)
+    fetchPublicMarketplaceCourse(normalizedSlug)
       .then(d => {
         if (cancelled) return
         setDetail(d)
@@ -75,7 +83,7 @@ export function CourseDetailPage({ slug }: CourseDetailPageProps) {
         setError(e instanceof Error ? e.message : COURSES_COPY.errorBody)
       })
 
-    fetchPublicMarketplaceReviews(slug, { limit: 20 })
+    fetchPublicMarketplaceReviews(normalizedSlug, { limit: 20 })
       .then(r => {
         if (cancelled) return
         setReviews(r.reviews)


### PR DESCRIPTION
## Summary

- Add `fetchCourseFileImageBlob` so storefront/catalog hero images load via unauthenticated fetch first, with `authorizedFetch` fallback on 401
- Use `CourseHeroImage` on explore catalog and course detail pages instead of raw `<img>` tags
- Exclude `/api/` URLs from the service worker static image cache (bump cache versions to v2)
- Server: redirect stale hero file UUIDs to the current `hero_image_url` when a storefront course is reprovisioned
- www: treat `/courses/` (no slug) as the courses index; reject empty marketplace slugs with 404

## Test plan

- [x] `go test ./internal/repos/course/... -short`
- [x] `npm run test` in `www/` (marketplace-api slug validation)
- [x] `course-file-image.test.ts` — public fetch and 401 fallback paths
- [ ] Manual: browse explore catalog/course pages logged out — hero images render
- [ ] Manual: reprovisioned storefront course with old hero UUID redirects to current hero