### PR TITLE
fix(www): resolve marketplace hero images against self.lextures.com

### DIFF
--- a/www/scripts/prerender-courses.mjs
+++ b/www/scripts/prerender-courses.mjs
@@ -32,6 +32,16 @@ const SKIP = process.env.SKIP_COURSE_PRERENDER === '1'
 const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/assets/lextures-mark.svg`
 const CONCURRENCY = 6
 
+/** Turn API-relative asset paths into absolute URLs on the self-learner origin. */
+function resolveApiAssetUrl(url, apiBase = API_BASE) {
+  if (!url) return null
+  const trimmed = String(url).trim()
+  if (!trimmed) return null
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed
+  if (trimmed.startsWith('/')) return `${apiBase}${trimmed}`
+  return trimmed
+}
+
 const STATIC_ROUTES = [
   { loc: '/', priority: '1.0' },
   { loc: '/pricing', priority: '0.8' },
@@ -256,7 +266,7 @@ async function main() {
         title: `${c.title} — Lextures`,
         description: truncateMeta(c.description || c.title),
         canonical: `${SITE_ORIGIN}/courses/${encodeURIComponent(slug)}`,
-        image: c.heroImageUrl || DEFAULT_OG_IMAGE,
+        image: resolveApiAssetUrl(c.heroImageUrl) || DEFAULT_OG_IMAGE,
         jsonLd: detail.jsonLd || null,
       })
       const dir = path.join(DIST, 'courses', slug)
@@ -283,6 +293,7 @@ export {
   injectHead,
   buildSitemap,
   buildRobots,
+  resolveApiAssetUrl,
 }
 
 const isMain =

--- a/www/scripts/prerender-courses.test.mjs
+++ b/www/scripts/prerender-courses.test.mjs
@@ -6,6 +6,7 @@ import {
   buildSitemap,
   escapeHtml,
   injectHead,
+  resolveApiAssetUrl,
   truncateMeta,
 } from './prerender-courses.mjs'
 
@@ -93,5 +94,17 @@ describe('buildRobots', () => {
     const txt = buildRobots()
     assert.match(txt, /Allow: \/courses/)
     assert.match(txt, /Sitemap: https:\/\/lextures.com\/sitemap.xml/)
+  })
+})
+
+describe('resolveApiAssetUrl', () => {
+  it('prefixes API-relative hero image paths with self.lextures.com', () => {
+    assert.equal(
+      resolveApiAssetUrl(
+        '/api/v1/courses/C-AIESS1/course-files/ff993800-114b-4316-ba70-27406837f8a5/content',
+        'https://self.lextures.com',
+      ),
+      'https://self.lextures.com/api/v1/courses/C-AIESS1/course-files/ff993800-114b-4316-ba70-27406837f8a5/content',
+    )
   })
 })

--- a/www/src/components/courses/course-card.tsx
+++ b/www/src/components/courses/course-card.tsx
@@ -1,3 +1,4 @@
+import { resolveApiAssetUrl } from '../../lib/api-base'
 import { formatMarketplacePrice, type PublicMarketplaceCourse } from '../../lib/marketplace-api'
 import { COURSES_COPY } from '../../lib/courses-copy'
 
@@ -77,6 +78,7 @@ export function CourseCard({ course }: CourseCardProps) {
   const href = `/courses/${encodeURIComponent(course.slug || course.courseCode)}`
   const price = formatMarketplacePrice(course.priceCents, course.priceCurrency, COURSES_COPY.free)
   const accessibleName = `${course.title}, ${price}`
+  const heroImageUrl = resolveApiAssetUrl(course.heroImageUrl)
 
   return (
     <li>
@@ -92,9 +94,9 @@ export function CourseCard({ course }: CourseCardProps) {
         aria-label={accessibleName}
       >
         <div className="aspect-[16/9] w-full overflow-hidden" style={{ backgroundColor: 'var(--paper)' }}>
-          {course.heroImageUrl ? (
+          {heroImageUrl ? (
             <img
-              src={course.heroImageUrl}
+              src={heroImageUrl}
               alt=""
               loading="lazy"
               className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"

--- a/www/src/lib/api-base.ts
+++ b/www/src/lib/api-base.ts
@@ -2,3 +2,13 @@ import { APP_ORIGIN } from './site-links'
 
 /** API origin for www pages that call the Lextures backend (defaults to the self-learner app). */
 export const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? APP_ORIGIN).replace(/\/$/, '')
+
+/** Turn API-relative asset paths into absolute URLs on the self-learner origin. */
+export function resolveApiAssetUrl(url: string | null | undefined): string | null {
+  if (!url) return null
+  const trimmed = url.trim()
+  if (!trimmed) return null
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed
+  if (trimmed.startsWith('/')) return `${API_BASE}${trimmed}`
+  return trimmed
+}

--- a/www/src/pages/course-detail-page.tsx
+++ b/www/src/pages/course-detail-page.tsx
@@ -7,6 +7,7 @@ import { EnrollPanel } from '../components/courses/enroll-panel'
 import { ReviewList } from '../components/courses/review-list'
 import { WhatsIncluded } from '../components/courses/whats-included'
 import { MarketingPageShell } from '../components/marketing-page-shell'
+import { resolveApiAssetUrl } from '../lib/api-base'
 import { COURSES_COPY } from '../lib/courses-copy'
 import { truncateMetaDescription } from '../lib/document-head'
 import {
@@ -43,7 +44,8 @@ export function CourseDetailPage({ slug }: CourseDetailPageProps) {
     ? truncateMetaDescription(course.description || COURSES_COPY.pageDescription)
     : COURSES_COPY.pageDescription
   const canonical = `${SITE_ORIGIN}/courses/${encodeURIComponent(slug)}`
-  const image = course?.heroImageUrl || undefined
+  const heroImageUrl = resolveApiAssetUrl(course?.heroImageUrl)
+  const image = heroImageUrl || undefined
 
   useDocumentHead({
     title,
@@ -206,9 +208,9 @@ export function CourseDetailPage({ slug }: CourseDetailPageProps) {
                 borderRadius: 'var(--radius-card)',
               }}
             >
-              {course.heroImageUrl ? (
+              {heroImageUrl ? (
                 <img
-                  src={course.heroImageUrl}
+                  src={heroImageUrl}
                   alt=""
                   className="h-full w-full object-cover"
                 />


### PR DESCRIPTION
## Summary

- Fixes 404s when the www site loads marketplace course hero images from path-only API URLs like `/api/v1/courses/.../course-files/.../content`.
- Adds `resolveApiAssetUrl()` to prefix those paths with `API_BASE` (`https://self.lextures.com` by default) instead of letting the browser resolve them against `lextures.com`.
- Applies the fix in course cards, course detail pages, and prerendered Open Graph image tags.

## Test plan

- [x] `npm run test` in `www/`
- [x] `npm run lint` in `www/`
- [x] `tsc -b` in `www/`
- [ ] Verify course hero images load on `lextures.com/courses` and `/courses/<slug>` after deploy