### PR TITLE
feat(iac): deploy GHCR web image on self-aws ECS Fargate

### DIFF
--- a/iac/self-aws/README.md
+++ b/iac/self-aws/README.md
@@ -9,9 +9,10 @@ This directory is **independent of Oracle Cloud** (`iac/self` + `iac/modules/ora
 ```mermaid
 flowchart TB
   Users --> CF[CloudFront]
-  CF -->|static SPA| S3Web[(S3 static site)]
-  CF -->|/api /health /tus| ALB[Application Load Balancer]
-  ALB --> API[ECS Fargate — Go API]
+  CF -->|default SPA| ALB[Application Load Balancer]
+  CF -->|/api /health /tus| ALB
+  ALB -->|default| Web[ECS Fargate — nginx web image]
+  ALB -->|/api /health /tus| API[ECS Fargate — Go API]
 
   subgraph private [Private subnets]
     RDS[(RDS PostgreSQL 16)]
@@ -27,62 +28,80 @@ flowchart TB
 
 | Concern | AWS service | Cost notes |
 |---------|-------------|------------|
-| **Web (SPA)** | **S3 + CloudFront** | Static Vite build; no Fargate for nginx |
-| **API** | **ECS Fargate** + ALB | API only; CloudFront proxies `/api/*` for same-origin |
+| **Web (SPA)** | **ECS Fargate** (`web_image`) + ALB, or **S3** when `web_image` is empty | Prefer the GHCR web image from `publish-images` |
+| **API** | **ECS Fargate** + ALB | CloudFront proxies `/api/*` (and ALB path-routes when web is on Fargate) |
+| CDN | **CloudFront** | HTTPS + optional custom domain; default origin is ALB when `web_image` is set |
 | Database | **RDS PostgreSQL 16** (`db.t4g.micro` default) | Free-tier eligible size; single-AZ |
 | Cache | **ElastiCache Redis 7** (`cache.t3.micro` default) | Free-tier eligible size; single node; TLS + auth |
 | Queues | **SQS** (4 queues + DLQs) | Always Free: 1M requests/month |
 | Files | **S3** (course files) | SSE-S3; IAM task role |
-| Secrets | **Secrets Manager** | `DATABASE_URL`, `REDIS_URL`, JWT, SQS URLs, storage |
+| Secrets | **Secrets Manager** | `DATABASE_URL`, `REDIS_URL`, JWT, SQS URLs, storage; optional registry pull auth |
 
-Default networking places Fargate API tasks in **public subnets with public IPs** so a NAT gateway is not required (~$32/mo savings). RDS and Redis stay private. Set `enable_nat_gateway = true` for private-subnet tasks.
+Default networking places Fargate tasks in **public subnets with public IPs** so a NAT gateway is not required (~$32/mo savings). RDS and Redis stay private. Set `enable_nat_gateway = true` for private-subnet tasks.
 
-### Static web vs API
+### Web image vs static S3
 
-- Build the SPA with **empty `VITE_API_URL`** so the browser uses same-origin (`window.location.origin`).
-- CloudFront serves `index.html` / assets from S3 and forwards `/api/*`, `/health`, `/health/*`, `/tus/*` to the ALB.
-- SPA client-side routes work via CloudFront custom error responses (403/404 → `/index.html`).
+- **Preferred:** set `web_image` (e.g. `ghcr.io/<org>/<repo>/web:latest` from `.github/workflows/publish-images.yml`). Terraform runs nginx on Fargate; ALB path-routes API vs SPA. CloudFront’s default origin is the ALB.
+- **Legacy / offline build:** leave `web_image` empty and run `scripts/deploy-web.sh` to build Vite and sync `clients/web/dist` to S3. CloudFront serves S3 and only proxies API paths to the ALB.
 
-Deploy the web app after `terraform apply`:
+Build the SPA (image or static) with **empty `VITE_API_URL`** so the browser uses same-origin (`window.location.origin`). The published web image already does this.
+
+ALB path patterns for the API: `/api/*`, `/health`, `/health/*`, `/tus/*`. The nginx image’s built-in reverse proxy to Docker hostname `server` is **not** used on Fargate; the ALB owns that routing.
+
+### Deploying new versions
+
+After `publish-images` pushes new GHCR tags (or you push manually):
 
 ```bash
+# Roll the nginx SPA (force-new-deployment pulls the tag in web_image)
 ./iac/self-aws/scripts/deploy-web.sh
+
+# Roll the Go API
+./iac/self-aws/scripts/deploy-api.sh
 ```
+
+To pin a new immutable tag, change `server_image` / `web_image` in `terraform.tfvars` and `terraform apply` (creates new task definitions). With `:latest`, the force-deploy scripts above re-pull after a registry push.
+
+If `web_image` is empty, `deploy-web.sh` falls back to build + S3 sync + CloudFront invalidation.
 
 ## Prerequisites
 
 - Terraform >= 1.5
 - AWS credentials with permission to create VPC, RDS, ElastiCache, SQS, S3, CloudFront, ECS, ALB, IAM, Secrets Manager, CloudWatch Logs
-- Container image for the **API only** (when `enable_ecs = true`)
-- Node.js + npm to build `clients/web` for static deploy
+- Container images for the **API** and (recommended) **web** when `enable_ecs = true`
+- For **private** GHCR packages: `registry_username` + `registry_password` (PAT with `read:packages`)
+- Node.js + npm only if using the static S3 path (`web_image` empty)
 
 ## Quick start
 
 ```bash
 cd iac/self-aws
 cp terraform.tfvars.example terraform.tfvars
-# Edit region, server_image, optional public_web_origin / custom domain
+# Edit region, server_image, web_image, optional public_web_origin / custom domain
 
 terraform init
 terraform plan
 terraform apply
 
-# Build + upload SPA
-../self-aws/scripts/deploy-web.sh   # or: ./scripts/deploy-web.sh from this dir
+# Roll tasks after images are in the registry (or after changing :latest contents)
+./scripts/deploy-web.sh
+./scripts/deploy-api.sh
 ```
 
 Data plane only (no ALB/ECS/CloudFront API proxy yet):
 
 ```hcl
 enable_ecs         = false
-enable_static_site = true   # can still host a built SPA
+enable_static_site = true   # can still host a built SPA on S3
 ```
 
-Then enable the API:
+Then enable the app:
 
 ```hcl
 enable_ecs     = true
 server_image   = "ghcr.io/YOUR_ORG/lextures/server:latest"
+web_image      = "ghcr.io/YOUR_ORG/lextures/web:latest"
+# registry_username / registry_password if GHCR packages are private
 ```
 
 Custom domain (optional). Without these, CloudFront serves HTTPS on `*.cloudfront.net` automatically:
@@ -126,18 +145,19 @@ Local / Oracle dev remains unchanged (`RABBITMQ_URL`, local Vite, etc.).
 | RDS `db.t4g.micro` single-AZ 20 GB | ~$12–15 (often $0 in free tier year 1) |
 | ElastiCache `cache.t3.micro` | ~$12 (often $0 in free tier year 1) |
 | SQS | ~$0 at modest volume |
-| S3 (web + course files) | storage + requests (often <$2 early) |
+| S3 (optional web bucket + course files) | storage + requests (often <$2 early) |
 | CloudFront | free tier 1 TB / 10M requests (year 1), then usage |
 | ALB | ~$16+ |
 | Fargate API 0.5 vCPU / 1 GB × 1 | ~$15–25 |
+| Fargate web 0.25 vCPU / 0.5 GB × 1 | ~$8–12 |
 | NAT (optional) | ~$32 |
-| **Typical lean total (no NAT, static web)** | **~$55–70** (lower during free tier) |
+| **Typical lean total (no NAT, web + API on Fargate)** | **~$65–85** (lower during free tier) |
 
 ## Migration notes (Oracle → AWS)
 
 1. Apply this stack (data plane first is fine).
 2. Dump OCI Postgres → restore into RDS.
-3. Sync course files into the course-files S3 bucket; deploy the SPA with `scripts/deploy-web.sh`.
+3. Sync course files into the course-files S3 bucket; set `web_image` / `server_image` and apply (or use static `deploy-web.sh` if not using the web image).
 4. Point DNS at CloudFront (`cloudfront_domain_name` or custom alias); set `public_web_origin` if needed.
 5. Leave the Oracle stack running until cutover validation is complete — **no resources here modify OCI**.
 
@@ -147,6 +167,9 @@ Local / Oracle dev remains unchanged (`RABBITMQ_URL`, local Vite, etc.).
 terraform output cloudfront_domain_name
 terraform output web_bucket
 terraform output alb_dns_name
+terraform output ecs_cluster_name
+terraform output ecs_web_service_name
+terraform output ecs_api_service_name
 terraform output -raw database_url   # sensitive
 terraform output sqs_queue_urls
 terraform output course_files_bucket

--- a/iac/self-aws/alb.tf
+++ b/iac/self-aws/alb.tf
@@ -15,7 +15,7 @@ resource "aws_lb" "main" {
 }
 
 resource "aws_lb_target_group" "api" {
-  count = var.enable_ecs ? 1 : 0
+  count = local.use_api_container ? 1 : 0
 
   name        = "${local.name_prefix}-api"
   port        = 8080
@@ -38,16 +38,64 @@ resource "aws_lb_target_group" "api" {
   }
 }
 
-# API-only ALB. The SPA is served from S3/CloudFront; CloudFront forwards /api/* here.
+resource "aws_lb_target_group" "web" {
+  count = local.use_web_container ? 1 : 0
+
+  name        = "${local.name_prefix}-web"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = module.vpc.vpc_id
+  target_type = "ip"
+
+  # nginx serves index.html for SPA routes; do not use /health (image proxies that to Docker hostname "server").
+  health_check {
+    enabled             = true
+    path                = "/"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-web"
+  }
+}
+
+# Default: web container when present, otherwise API-only.
 resource "aws_lb_listener" "http" {
-  count = var.enable_ecs ? 1 : 0
+  count = local.use_web_container || local.use_api_container ? 1 : 0
 
   load_balancer_arn = aws_lb.main[0].arn
   port              = 80
   protocol          = "HTTP"
 
   default_action {
+    type = "forward"
+    target_group_arn = (
+      local.use_web_container
+      ? aws_lb_target_group.web[0].arn
+      : aws_lb_target_group.api[0].arn
+    )
+  }
+}
+
+# When the SPA is on Fargate, route API/health/tus to the Go service; everything else stays on web.
+resource "aws_lb_listener_rule" "api_paths" {
+  for_each = local.use_web_container && local.use_api_container ? toset(local.api_path_patterns) : toset([])
+
+  listener_arn = aws_lb_listener.http[0].arn
+  priority     = 10 + index(local.api_path_patterns, each.value)
+
+  action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.api[0].arn
+  }
+
+  condition {
+    path_pattern {
+      values = [each.value]
+    }
   }
 }

--- a/iac/self-aws/ecs.tf
+++ b/iac/self-aws/ecs.tf
@@ -5,6 +5,13 @@ resource "aws_cloudwatch_log_group" "api" {
   retention_in_days = var.environment == "production" ? 30 : 7
 }
 
+resource "aws_cloudwatch_log_group" "web" {
+  count = local.use_web_container ? 1 : 0
+
+  name              = "/ecs/${local.name_prefix}/web"
+  retention_in_days = var.environment == "production" ? 30 : 7
+}
+
 resource "aws_ecs_cluster" "main" {
   count = var.enable_ecs ? 1 : 0
 
@@ -21,7 +28,7 @@ resource "aws_ecs_cluster" "main" {
 }
 
 locals {
-  # Prefer explicit origin, then CloudFront (static SPA), then ALB (API-only).
+  # Prefer explicit origin, then CloudFront (static SPA or CDN front door), then ALB.
   public_origin = var.public_web_origin != "" ? var.public_web_origin : (
     length(aws_cloudfront_distribution.web) > 0 ? "https://${aws_cloudfront_distribution.web[0].domain_name}" : (
       length(aws_lb.main) > 0 ? "http://${aws_lb.main[0].dns_name}" : "http://localhost"
@@ -43,10 +50,15 @@ locals {
     "STORAGE_REGION",
     "AWS_REGION",
   ]
+
+  # Optional private-registry pull credentials (GHCR, etc.).
+  repository_credentials = local.registry_credentials_arn != "" ? {
+    credentialsParameter = local.registry_credentials_arn
+  } : null
 }
 
 resource "aws_ecs_task_definition" "api" {
-  count = var.enable_ecs && var.server_image != "" ? 1 : 0
+  count = local.use_api_container ? 1 : 0
 
   family                   = "${local.name_prefix}-api"
   requires_compatibilities = ["FARGATE"]
@@ -56,60 +68,122 @@ resource "aws_ecs_task_definition" "api" {
   execution_role_arn       = aws_iam_role.ecs_execution.arn
   task_role_arn            = aws_iam_role.ecs_task.arn
 
-  container_definitions = jsonencode([{
-    name      = "api"
-    image     = var.server_image
-    essential = true
+  container_definitions = jsonencode([
+    merge(
+      {
+        name      = "api"
+        image     = var.server_image
+        essential = true
 
-    portMappings = [{
-      containerPort = 8080
-      protocol      = "tcp"
-    }]
+        portMappings = [{
+          containerPort = 8080
+          protocol      = "tcp"
+        }]
 
-    environment = [
-      { name = "APP_ENV", value = var.environment == "production" ? "production" : "staging" },
-      { name = "PORT", value = "8080" },
-      { name = "RUN_MIGRATIONS", value = "true" },
-      { name = "PUBLIC_WEB_ORIGIN", value = local.public_origin },
-      { name = "BACKGROUND_JOBS_ENABLED", value = "1" },
-      { name = "SCHEDULER_ENABLED", value = "1" },
-      # IAM task role — leave keys empty so minio-go / AWS SDK use the instance role.
-      { name = "STORAGE_ACCESS_KEY_ID", value = "" },
-      { name = "STORAGE_SECRET_ACCESS_KEY", value = "" },
-    ]
+        environment = [
+          { name = "APP_ENV", value = var.environment == "production" ? "production" : "staging" },
+          { name = "PORT", value = "8080" },
+          { name = "RUN_MIGRATIONS", value = "true" },
+          { name = "PUBLIC_WEB_ORIGIN", value = local.public_origin },
+          { name = "BACKGROUND_JOBS_ENABLED", value = "1" },
+          { name = "SCHEDULER_ENABLED", value = "1" },
+          # IAM task role — leave keys empty so minio-go / AWS SDK use the instance role.
+          { name = "STORAGE_ACCESS_KEY_ID", value = "" },
+          { name = "STORAGE_SECRET_ACCESS_KEY", value = "" },
+        ]
 
-    secrets = [
-      for key in local.app_secret_keys : {
-        name      = key
-        valueFrom = "${aws_secretsmanager_secret.app.arn}:${key}::"
-      }
-    ]
+        secrets = [
+          for key in local.app_secret_keys : {
+            name      = key
+            valueFrom = "${aws_secretsmanager_secret.app.arn}:${key}::"
+          }
+        ]
 
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        awslogs-group         = aws_cloudwatch_log_group.api[0].name
-        awslogs-region        = data.aws_region.current.name
-        awslogs-stream-prefix = "api"
-      }
-    }
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.api[0].name
+            awslogs-region        = data.aws_region.current.name
+            awslogs-stream-prefix = "api"
+          }
+        }
 
-    healthCheck = {
-      command     = ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/health >/dev/null || exit 1"]
-      interval    = 30
-      timeout     = 5
-      retries     = 3
-      startPeriod = 60
-    }
-  }])
+        healthCheck = {
+          command     = ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/health >/dev/null || exit 1"]
+          interval    = 30
+          timeout     = 5
+          retries     = 3
+          startPeriod = 60
+        }
+      },
+      local.repository_credentials != null ? { repositoryCredentials = local.repository_credentials } : {},
+    )
+  ])
 
   tags = {
     Name = "${local.name_prefix}-api"
   }
 }
 
+resource "aws_ecs_task_definition" "web" {
+  count = local.use_web_container ? 1 : 0
+
+  family                   = "${local.name_prefix}-web"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.ecs_web_cpu
+  memory                   = var.ecs_web_memory
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  # No app IAM needed; nginx only serves static assets.
+  task_role_arn = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    merge(
+      {
+        name      = "web"
+        image     = var.web_image
+        essential = true
+
+        portMappings = [{
+          containerPort = 80
+          protocol      = "tcp"
+        }]
+
+        # TLS_CERT_CN only matters for the image's optional self-signed 443 listener;
+        # ALB targets port 80. Still set for parity with the small-tier VM deploy.
+        environment = [
+          { name = "TLS_CERT_CN", value = replace(replace(local.public_origin, "https://", ""), "http://", "") },
+        ]
+
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.web[0].name
+            awslogs-region        = data.aws_region.current.name
+            awslogs-stream-prefix = "web"
+          }
+        }
+
+        # SPA root; the image's /health proxies to Docker hostname "server" (not used on Fargate).
+        healthCheck = {
+          command     = ["CMD-SHELL", "curl -fsS http://127.0.0.1/ >/dev/null || exit 1"]
+          interval    = 30
+          timeout     = 5
+          retries     = 3
+          startPeriod = 30
+        }
+      },
+      local.repository_credentials != null ? { repositoryCredentials = local.repository_credentials } : {},
+    )
+  ])
+
+  tags = {
+    Name = "${local.name_prefix}-web"
+  }
+}
+
 resource "aws_ecs_service" "api" {
-  count = var.enable_ecs && var.server_image != "" ? 1 : 0
+  count = local.use_api_container ? 1 : 0
 
   name            = "${local.name_prefix}-api"
   cluster         = aws_ecs_cluster.main[0].id
@@ -129,7 +203,10 @@ resource "aws_ecs_service" "api" {
     container_port   = 8080
   }
 
-  depends_on = [aws_lb_listener.http]
+  depends_on = [
+    aws_lb_listener.http,
+    aws_lb_listener_rule.api_paths,
+  ]
 
   lifecycle {
     ignore_changes = [desired_count]
@@ -137,5 +214,37 @@ resource "aws_ecs_service" "api" {
 
   tags = {
     Name = "${local.name_prefix}-api"
+  }
+}
+
+resource "aws_ecs_service" "web" {
+  count = local.use_web_container ? 1 : 0
+
+  name            = "${local.name_prefix}-web"
+  cluster         = aws_ecs_cluster.main[0].id
+  task_definition = aws_ecs_task_definition.web[0].arn
+  desired_count   = var.ecs_web_desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = local.web_subnet_ids
+    security_groups  = [aws_security_group.ecs_web.id]
+    assign_public_ip = !var.enable_nat_gateway
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.web[0].arn
+    container_name   = "web"
+    container_port   = 80
+  }
+
+  depends_on = [aws_lb_listener.http]
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-web"
   }
 }

--- a/iac/self-aws/iam.tf
+++ b/iac/self-aws/iam.tf
@@ -24,9 +24,12 @@ resource "aws_iam_role_policy" "ecs_execution_secrets" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = ["secretsmanager:GetSecretValue"]
-      Resource = [aws_secretsmanager_secret.app.arn]
+      Effect = "Allow"
+      Action = ["secretsmanager:GetSecretValue"]
+      Resource = compact([
+        aws_secretsmanager_secret.app.arn,
+        local.registry_credentials_arn,
+      ])
     }]
   })
 }

--- a/iac/self-aws/locals.tf
+++ b/iac/self-aws/locals.tf
@@ -26,6 +26,15 @@ locals {
   # Public Fargate avoids a ~$32/mo NAT gateway; tasks get public IPs and
   # reach private RDS/Redis inside the VPC. Flip enable_nat_gateway for private tasks.
   api_subnet_ids = var.enable_nat_gateway ? module.vpc.private_subnets : module.vpc.public_subnets
+  web_subnet_ids = local.api_subnet_ids
+
+  # SPA from the GHCR web image on Fargate (ALB path routing); otherwise S3 static deploy.
+  use_web_container = var.enable_ecs && var.web_image != ""
+  use_api_container = var.enable_ecs && var.server_image != ""
+  # Keep the static bucket when enable_static_site so enabling web_image does not destroy it.
+  create_web_bucket = var.enable_static_site
+  # CloudFront default origin is S3 only when we are not using the web container.
+  serve_spa_from_s3 = var.enable_static_site && !local.use_web_container
 
   sqs_queues = {
     canvas_import          = "canvas-course-import"
@@ -33,4 +42,12 @@ locals {
     sms_notification       = "notifications-sms"
     grading_agent          = "grading-agent-run"
   }
+
+  # Path patterns routed to the Go API on the ALB (and CloudFront when S3 is the SPA origin).
+  api_path_patterns = [
+    "/api/*",
+    "/health",
+    "/health/*",
+    "/tus/*",
+  ]
 }

--- a/iac/self-aws/outputs.tf
+++ b/iac/self-aws/outputs.tf
@@ -33,18 +33,33 @@ output "course_files_bucket" {
 }
 
 output "web_bucket" {
-  description = "S3 bucket for the static web SPA (sync clients/web/dist here)."
+  description = "S3 web bucket (created when enable_static_site). Used as the SPA origin only when web_image is empty; otherwise the SPA is the ECS web service."
   value       = try(aws_s3_bucket.web[0].id, null)
 }
 
 output "cloudfront_domain_name" {
-  description = "CloudFront domain for the static SPA (and API proxy when ECS is enabled)."
+  description = "CloudFront domain for the SPA (S3 or ECS web) and API proxy when ECS is enabled."
   value       = try(aws_cloudfront_distribution.web[0].domain_name, null)
 }
 
 output "cloudfront_distribution_id" {
-  description = "CloudFront distribution ID (for cache invalidation after deploys)."
+  description = "CloudFront distribution ID (for cache invalidation after static deploys)."
   value       = try(aws_cloudfront_distribution.web[0].id, null)
+}
+
+output "ecs_web_service_name" {
+  description = "ECS service name for the nginx SPA (null when web_image is empty)."
+  value       = try(aws_ecs_service.web[0].name, null)
+}
+
+output "ecs_api_service_name" {
+  description = "ECS service name for the Go API (null when server_image is empty)."
+  value       = try(aws_ecs_service.api[0].name, null)
+}
+
+output "use_web_container" {
+  description = "True when the SPA is served from the web container image on Fargate."
+  value       = local.use_web_container
 }
 
 output "sqs_queue_urls" {
@@ -60,7 +75,7 @@ output "app_secret_arn" {
 }
 
 output "alb_dns_name" {
-  description = "API ALB DNS name (internal origin for CloudFront /api/*)."
+  description = "ALB DNS name (CloudFront origin for API paths and, when web_image is set, the SPA)."
   value       = try(aws_lb.main[0].dns_name, null)
 }
 

--- a/iac/self-aws/scripts/deploy-api.sh
+++ b/iac/self-aws/scripts/deploy-api.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Force a new ECS deployment of the Go API service (after pushing a new server image tag).
+#
+# Usage:
+#   ./iac/self-aws/scripts/deploy-api.sh
+#
+# Env overrides:
+#   CLUSTER     — ECS cluster (default: terraform output ecs_cluster_name)
+#   API_SERVICE — ECS API service name (default: terraform output ecs_api_service_name)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+TF_DIR="$ROOT/iac/self-aws"
+cd "$TF_DIR"
+
+tf_out() {
+  local key="$1"
+  terraform output -raw "$key" 2>/dev/null || true
+}
+
+CLUSTER="${CLUSTER:-$(tf_out ecs_cluster_name)}"
+API_SERVICE="${API_SERVICE:-$(tf_out ecs_api_service_name)}"
+
+if [[ -z "${CLUSTER}" || "${CLUSTER}" == "null" || -z "${API_SERVICE}" || "${API_SERVICE}" == "null" ]]; then
+  echo "error: ecs_cluster_name / ecs_api_service_name missing. Set server_image and apply Terraform first." >&2
+  exit 1
+fi
+
+echo "==> Forcing new ECS deployment: cluster=${CLUSTER} service=${API_SERVICE}"
+aws ecs update-service \
+  --cluster "${CLUSTER}" \
+  --service "${API_SERVICE}" \
+  --force-new-deployment \
+  --no-cli-pager \
+  >/dev/null
+
+echo "Done. ECS is rolling the API tasks."

--- a/iac/self-aws/scripts/deploy-web.sh
+++ b/iac/self-aws/scripts/deploy-web.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# Build the Vite SPA and sync it to the self-aws static site bucket, then
-# invalidate CloudFront so clients pick up the new index.html.
+# Deploy the web SPA for self-aws.
+#
+# Modes (auto-detected from terraform outputs):
+#   1) web_image set  → force a new ECS deployment of the nginx web service
+#      (pulls the current image tag, e.g. :latest after publish-images).
+#   2) web_image empty → build the Vite SPA, sync to the static S3 bucket,
+#      and invalidate CloudFront.
 #
 # Usage (from repo root or this directory):
 #   ./iac/self-aws/scripts/deploy-web.sh
 #
 # Env overrides:
-#   WEB_BUCKET     — S3 bucket (default: terraform output web_bucket)
-#   DISTRIBUTION_ID — CloudFront ID (default: terraform output cloudfront_distribution_id)
-#   VITE_API_URL   — leave empty for same-origin via CloudFront (recommended)
+#   WEB_BUCKET      — S3 bucket (static mode; default: terraform output web_bucket)
+#   DISTRIBUTION_ID — CloudFront ID (static mode)
+#   CLUSTER         — ECS cluster (container mode)
+#   WEB_SERVICE     — ECS web service name (container mode)
+#   VITE_API_URL    — leave empty for same-origin via CloudFront (recommended)
 
 set -euo pipefail
 
@@ -18,11 +25,43 @@ WEB_DIR="$ROOT/clients/web"
 
 cd "$TF_DIR"
 
-WEB_BUCKET="${WEB_BUCKET:-$(terraform output -raw web_bucket 2>/dev/null || true)}"
-DISTRIBUTION_ID="${DISTRIBUTION_ID:-$(terraform output -raw cloudfront_distribution_id 2>/dev/null || true)}"
+tf_out() {
+  local key="$1"
+  terraform output -raw "$key" 2>/dev/null || true
+}
+
+USE_WEB_CONTAINER="$(tf_out use_web_container)"
+CLUSTER="${CLUSTER:-$(tf_out ecs_cluster_name)}"
+WEB_SERVICE="${WEB_SERVICE:-$(tf_out ecs_web_service_name)}"
+
+if [[ "${USE_WEB_CONTAINER}" == "true" ]]; then
+  if [[ -z "${CLUSTER}" || "${CLUSTER}" == "null" || -z "${WEB_SERVICE}" || "${WEB_SERVICE}" == "null" ]]; then
+    echo "error: web container mode but ecs_cluster_name / ecs_web_service_name outputs are missing." >&2
+    echo "  Set web_image and apply Terraform first." >&2
+    exit 1
+  fi
+
+  echo "==> Forcing new ECS deployment: cluster=${CLUSTER} service=${WEB_SERVICE}"
+  echo "    (ensure the image tag in web_image was pushed, e.g. after publish-images)"
+  aws ecs update-service \
+    --cluster "${CLUSTER}" \
+    --service "${WEB_SERVICE}" \
+    --force-new-deployment \
+    --no-cli-pager \
+    >/dev/null
+
+  echo "Done. ECS is rolling the web tasks. Public URL:"
+  echo "  https://$(tf_out cloudfront_domain_name 2>/dev/null || echo '<cloudfront-or-alb>')"
+  exit 0
+fi
+
+# --- Static S3 + CloudFront mode ---
+WEB_BUCKET="${WEB_BUCKET:-$(tf_out web_bucket)}"
+DISTRIBUTION_ID="${DISTRIBUTION_ID:-$(tf_out cloudfront_distribution_id)}"
 
 if [[ -z "${WEB_BUCKET}" || "${WEB_BUCKET}" == "null" ]]; then
-  echo "error: WEB_BUCKET is unset and terraform output web_bucket failed. Apply self-aws first." >&2
+  echo "error: WEB_BUCKET is unset and terraform output web_bucket failed." >&2
+  echo "  Either set web_image for ECS mode, or enable_static_site and apply first." >&2
   exit 1
 fi
 

--- a/iac/self-aws/secrets.tf
+++ b/iac/self-aws/secrets.tf
@@ -50,3 +50,29 @@ resource "aws_secretsmanager_secret_version" "app" {
     AWS_REGION                     = data.aws_region.current.name
   })
 }
+
+# Private registry auth for ECS image pulls (e.g. GHCR). JSON shape required by ECS.
+resource "aws_secretsmanager_secret" "registry" {
+  count = var.registry_username != "" && var.registry_password != "" ? 1 : 0
+
+  name                    = "${local.name_prefix}/registry"
+  recovery_window_in_days = var.environment == "production" ? 30 : 0
+
+  tags = {
+    Name = "${local.name_prefix}-registry"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "registry" {
+  count = length(aws_secretsmanager_secret.registry)
+
+  secret_id = aws_secretsmanager_secret.registry[0].id
+  secret_string = jsonencode({
+    username = var.registry_username
+    password = var.registry_password
+  })
+}
+
+locals {
+  registry_credentials_arn = try(aws_secretsmanager_secret.registry[0].arn, "")
+}

--- a/iac/self-aws/security_groups.tf
+++ b/iac/self-aws/security_groups.tf
@@ -64,6 +64,35 @@ resource "aws_security_group" "ecs_api" {
   }
 }
 
+resource "aws_security_group" "ecs_web" {
+  name_prefix = "${local.name_prefix}-ecs-web-"
+  description = "ECS Fargate web (nginx SPA) tasks"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description     = "HTTP from ALB"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-web"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_security_group" "rds" {
   name_prefix = "${local.name_prefix}-rds-"
   description = "PostgreSQL from ECS API tasks"

--- a/iac/self-aws/static_site.tf
+++ b/iac/self-aws/static_site.tf
@@ -1,6 +1,6 @@
-# Static Vite SPA on S3 + CloudFront.
-# Default origin: S3 (private via OAC). API paths are forwarded to the ALB so the
-# browser can use same-origin requests (empty VITE_API_URL).
+# CloudFront front door for the SPA.
+# - web_image empty: S3 origin (static deploy via scripts/deploy-web.sh) + ALB for API paths
+# - web_image set:   ALB origin for everything (ALB path-routes API vs nginx SPA)
 
 locals {
   web_bucket_name = coalesce(
@@ -12,17 +12,11 @@ locals {
   cf_cache_optimized   = "658327ea-f89d-4fab-a63d-7e88639e58f6"
   cf_cache_disabled    = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
   cf_origin_all_viewer = "216adef6-5c7f-47e4-b989-5492eafa07d3" # headers/query/cookies → ALB
-
-  api_path_patterns = [
-    "/api/*",
-    "/health",
-    "/health/*",
-    "/tus/*",
-  ]
 }
 
 resource "aws_s3_bucket" "web" {
-  count = var.enable_static_site ? 1 : 0
+  # Retained whenever enable_static_site is true (even if CloudFront serves the web container).
+  count = local.create_web_bucket ? 1 : 0
 
   bucket        = local.web_bucket_name
   force_destroy = var.web_bucket_force_destroy
@@ -33,7 +27,7 @@ resource "aws_s3_bucket" "web" {
 }
 
 resource "aws_s3_bucket_public_access_block" "web" {
-  count = var.enable_static_site ? 1 : 0
+  count = local.create_web_bucket ? 1 : 0
 
   bucket = aws_s3_bucket.web[0].id
 
@@ -44,7 +38,7 @@ resource "aws_s3_bucket_public_access_block" "web" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "web" {
-  count = var.enable_static_site ? 1 : 0
+  count = local.create_web_bucket ? 1 : 0
 
   bucket = aws_s3_bucket.web[0].id
 
@@ -57,7 +51,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "web" {
 }
 
 resource "aws_s3_bucket_versioning" "web" {
-  count = var.enable_static_site ? 1 : 0
+  count = local.create_web_bucket ? 1 : 0
 
   bucket = aws_s3_bucket.web[0].id
 
@@ -67,7 +61,7 @@ resource "aws_s3_bucket_versioning" "web" {
 }
 
 resource "aws_cloudfront_origin_access_control" "web" {
-  count = var.enable_static_site ? 1 : 0
+  count = local.create_web_bucket ? 1 : 0
 
   name                              = "${local.name_prefix}-web-oac"
   description                       = "OAC for static web bucket"
@@ -81,23 +75,26 @@ resource "aws_cloudfront_distribution" "web" {
 
   enabled             = true
   is_ipv6_enabled     = true
-  comment             = "${local.name_prefix} static web"
-  default_root_object = "index.html"
+  comment             = "${local.name_prefix} web"
+  default_root_object = local.use_web_container ? "" : "index.html"
   price_class         = var.cloudfront_price_class
   aliases             = var.web_domain_names
   wait_for_deployment = false
 
-  origin {
-    domain_name              = aws_s3_bucket.web[0].bucket_regional_domain_name
-    origin_id                = "s3-web"
-    origin_access_control_id = aws_cloudfront_origin_access_control.web[0].id
+  dynamic "origin" {
+    for_each = local.create_web_bucket ? [1] : []
+    content {
+      domain_name              = aws_s3_bucket.web[0].bucket_regional_domain_name
+      origin_id                = "s3-web"
+      origin_access_control_id = aws_cloudfront_origin_access_control.web[0].id
+    }
   }
 
   dynamic "origin" {
     for_each = var.enable_ecs ? [1] : []
     content {
       domain_name = aws_lb.main[0].dns_name
-      origin_id   = "alb-api"
+      origin_id   = "alb"
 
       custom_origin_config {
         http_port              = 80
@@ -108,24 +105,27 @@ resource "aws_cloudfront_distribution" "web" {
     }
   }
 
-  # SPA assets (hashed filenames under assets/ get long cache from build tooling + CF).
+  # SPA default: S3 when static-only; ALB (nginx web service) when web_image is set.
   default_cache_behavior {
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    allowed_methods        = local.use_web_container ? ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"] : ["GET", "HEAD", "OPTIONS"]
     cached_methods         = ["GET", "HEAD"]
-    target_origin_id       = "s3-web"
+    target_origin_id       = local.use_web_container ? "alb" : "s3-web"
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
-    cache_policy_id        = local.cf_cache_optimized
+    # Prefer origin Cache-Control when fronting nginx; disable cache for API-style methods on ALB SPA.
+    cache_policy_id          = local.use_web_container ? local.cf_cache_disabled : local.cf_cache_optimized
+    origin_request_policy_id = local.use_web_container ? local.cf_origin_all_viewer : null
   }
 
-  # Proxy API + health + tus to Fargate via ALB (no cache; forward auth cookies/headers).
+  # When SPA is on S3, proxy API + health + tus to Fargate via ALB (no cache).
+  # When SPA is on Fargate, ALB already path-routes these — still pin no-cache + full viewer forward.
   dynamic "ordered_cache_behavior" {
     for_each = var.enable_ecs ? local.api_path_patterns : []
     content {
       path_pattern             = ordered_cache_behavior.value
       allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
       cached_methods           = ["GET", "HEAD"]
-      target_origin_id         = "alb-api"
+      target_origin_id         = "alb"
       viewer_protocol_policy   = "redirect-to-https"
       compress                 = true
       cache_policy_id          = local.cf_cache_disabled
@@ -133,19 +133,16 @@ resource "aws_cloudfront_distribution" "web" {
     }
   }
 
-  # Client-side routing: missing keys → index.html
-  custom_error_response {
-    error_code            = 403
-    response_code         = 200
-    response_page_path    = "/index.html"
-    error_caching_min_ttl = 0
-  }
-
-  custom_error_response {
-    error_code            = 404
-    response_code         = 200
-    response_page_path    = "/index.html"
-    error_caching_min_ttl = 0
+  # Client-side routing for S3 origin: missing keys → index.html.
+  # nginx try_files already rewrites SPA routes when the origin is the web container.
+  dynamic "custom_error_response" {
+    for_each = local.serve_spa_from_s3 ? [403, 404] : []
+    content {
+      error_code            = custom_error_response.value
+      response_code         = 200
+      response_page_path    = "/index.html"
+      error_caching_min_ttl = 0
+    }
   }
 
   restrictions {
@@ -176,7 +173,7 @@ resource "aws_cloudfront_distribution" "web" {
 }
 
 resource "aws_s3_bucket_policy" "web" {
-  count = var.enable_static_site ? 1 : 0
+  count = local.create_web_bucket ? 1 : 0
 
   bucket = aws_s3_bucket.web[0].id
 

--- a/iac/self-aws/terraform.tfvars.example
+++ b/iac/self-aws/terraform.tfvars.example
@@ -19,9 +19,13 @@ aws_region   = "us-east-1"
 # web_domain_names        = ["app.example.com"]
 # web_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
-# API only on ECS Fargate (no web container)
-# enable_ecs = true
+# API + web on ECS Fargate (images from .github/workflows/publish-images.yml)
+# enable_ecs   = true
 # server_image = "ghcr.io/YOUR_ORG/lextures/server:latest"
+# web_image    = "ghcr.io/YOUR_ORG/lextures/web:latest"
+# Private GHCR: set both (PAT with read:packages). Leave empty if packages are public.
+# registry_username = ""
+# registry_password = ""
 
 # public_web_origin = "https://app.example.com"  # optional override; default = CloudFront URL
 # jwt_secret        = ""  # empty = auto-generate into Secrets Manager

--- a/iac/self-aws/variables.tf
+++ b/iac/self-aws/variables.tf
@@ -111,6 +111,12 @@ variable "server_image" {
   default     = ""
 }
 
+variable "web_image" {
+  description = "Container image for the nginx SPA (e.g. ghcr.io/org/lextures/web:latest from publish-images). Leave empty to serve the SPA from S3 via deploy-web.sh instead."
+  type        = string
+  default     = ""
+}
+
 variable "ecs_api_cpu" {
   description = "Fargate CPU units for the API task (256 = 0.25 vCPU)."
   type        = number
@@ -128,16 +134,63 @@ variable "ecs_api_desired_count" {
   default = 1
 }
 
+variable "ecs_web_cpu" {
+  description = "Fargate CPU units for the web (nginx) task (256 = 0.25 vCPU)."
+  type        = number
+  default     = 256
+}
+
+variable "ecs_web_memory" {
+  description = "Fargate memory (MiB) for the web task."
+  type        = number
+  default     = 512
+}
+
+variable "ecs_web_desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "registry_username" {
+  description = "Container registry username for private image pulls (e.g. GitHub username for GHCR). Leave empty when images are public."
+  type        = string
+  default     = ""
+}
+
+variable "registry_password" {
+  description = "Container registry password or PAT (GHCR: read:packages). Leave empty when images are public."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "enable_ecs" {
-  description = "Provision ALB + ECS Fargate for the API only. Set false to create only data plane (RDS, Redis, SQS, S3)."
+  description = "Provision ALB + ECS Fargate for the API (and web when web_image is set). Set false to create only data plane (RDS, Redis, SQS, S3)."
   type        = bool
   default     = true
 }
 
 variable "enable_static_site" {
-  description = "Provision S3 + CloudFront for the Vite static web app."
+  description = "Provision CloudFront (and an S3 origin for static SPA deploys when web_image is empty)."
   type        = bool
   default     = true
+}
+
+check "web_image_requires_ecs" {
+  assert {
+    condition     = var.web_image == "" || var.enable_ecs
+    error_message = "web_image requires enable_ecs = true (SPA is served by ECS Fargate behind the ALB)."
+  }
+}
+
+check "registry_credentials_pair" {
+  assert {
+    condition = (
+      (var.registry_username == "" && var.registry_password == "")
+      || (var.registry_username != "" && var.registry_password != "")
+    )
+    error_message = "registry_username and registry_password must both be set or both empty."
+  }
 }
 
 variable "web_bucket_name" {


### PR DESCRIPTION
## Summary
- Run the `publish-images` nginx SPA (`web_image`) as an ECS Fargate service in `iac/self-aws`, with ALB path routing for `/api/*`, `/health`, `/health/*`, and `/tus/*` to the Go API.
- When `web_image` is set, CloudFront’s default origin is the ALB (S3 static deploy remains available when `web_image` is empty).
- Add optional GHCR registry credentials for private package pulls, plus `deploy-web.sh` / `deploy-api.sh` force-new-deployment rollouts after image pushes.

## Test plan
- [ ] `cd iac/self-aws && terraform validate` (or `terraform plan`) with `server_image` + `web_image` set
- [ ] `terraform apply` creates web target group, ECS web service, and ALB listener rules
- [ ] CloudFront serves SPA via ALB; `/api/v1/...` reaches the API service
- [ ] `./scripts/deploy-web.sh` and `./scripts/deploy-api.sh` force new ECS deployments after pushing image tags
- [ ] With `web_image` empty, static S3 + CloudFront path still works via `deploy-web.sh` build/sync
- [ ] Private GHCR: set `registry_username` / `registry_password` and confirm tasks pull successfully