### PR TITLE
fix(iac): allow sensitive image vars for self-aws for_each

### DIFF
--- a/iac/self-aws/alb.tf
+++ b/iac/self-aws/alb.tf
@@ -83,7 +83,7 @@ resource "aws_lb_listener" "http" {
 
 # When the SPA is on Fargate, route API/health/tus to the Go service; everything else stays on web.
 resource "aws_lb_listener_rule" "api_paths" {
-  for_each = local.use_web_container && local.use_api_container ? toset(local.api_path_patterns) : toset([])
+  for_each = local.api_listener_path_patterns
 
   listener_arn = aws_lb_listener.http[0].arn
   priority     = 10 + index(local.api_path_patterns, each.value)

--- a/iac/self-aws/locals.tf
+++ b/iac/self-aws/locals.tf
@@ -29,12 +29,24 @@ locals {
   web_subnet_ids = local.api_subnet_ids
 
   # SPA from the GHCR web image on Fargate (ALB path routing); otherwise S3 static deploy.
-  use_web_container = var.enable_ecs && var.web_image != ""
-  use_api_container = var.enable_ecs && var.server_image != ""
+  # Image refs may be marked sensitive in HCP Terraform workspace variables; emptiness is not
+  # secret and must be non-sensitive for count/for_each. try(nonsensitive(...)) works whether
+  # or not the var is actually sensitive (nonsensitive errors only when the value is not).
+  web_image_set     = try(nonsensitive(var.web_image), var.web_image) != ""
+  server_image_set  = try(nonsensitive(var.server_image), var.server_image) != ""
+  use_web_container = var.enable_ecs && local.web_image_set
+  use_api_container = var.enable_ecs && local.server_image_set
   # Keep the static bucket when enable_static_site so enabling web_image does not destroy it.
   create_web_bucket = var.enable_static_site
   # CloudFront default origin is S3 only when we are not using the web container.
   serve_spa_from_s3 = var.enable_static_site && !local.use_web_container
+
+  # Non-sensitive set for ALB listener rules (for_each keys must not be sensitive).
+  api_listener_path_patterns = (
+    local.use_web_container && local.use_api_container
+    ? toset(local.api_path_patterns)
+    : toset([])
+  )
 
   sqs_queues = {
     canvas_import          = "canvas-course-import"

--- a/iac/self-aws/outputs.tf
+++ b/iac/self-aws/outputs.tf
@@ -59,7 +59,8 @@ output "ecs_api_service_name" {
 
 output "use_web_container" {
   description = "True when the SPA is served from the web container image on Fargate."
-  value       = local.use_web_container
+  # Boolean is derived via nonsensitive emptiness checks (see locals.tf).
+  value = local.use_web_container
 }
 
 output "sqs_queue_urls" {


### PR DESCRIPTION
## Summary
- HCP Terraform can mark `server_image` / `web_image` as sensitive workspace variables, which tainted `local.use_*_container` and blocked `for_each` on ALB listener rules plus the `use_web_container` output.
- Derive non-sensitive “image is set” flags via `try(nonsensitive(...), ...)` and use those for counts, `for_each`, and outputs.

## Test plan
- [ ] Re-run plan/apply on `lextures-self-aws-production` — no “Invalid for_each argument” / “Output refers to sensitive values”
- [ ] Confirm ALB listener rules for `/api/*`, `/health`, `/health/*`, `/tus/*` are planned when both images are set
- [ ] `terraform validate` locally still passes