### PR TITLE
feat(ci): add deploy-self-aws workflow and fix sensitive for_each

### DIFF
--- a/.github/workflows/deploy-self-aws.yml
+++ b/.github/workflows/deploy-self-aws.yml
@@ -1,0 +1,134 @@
+# Deploy Self AWS: apply iac/self-aws Terraform after publish-images pushes container images.
+#
+# Runs terraform init → plan → apply -auto-approve in iac/self-aws, passing
+# server_image and web_image (immutable :<git-sha> tags) from the publish-images
+# workflow so ECS task definitions roll to the new images.
+#
+# Required repository secrets:
+#   TF_TOKEN, TF_CLOUD_ORGANIZATION — HCP Terraform
+# AWS credentials, registry pull secrets (if GHCR is private), and other deploy
+# settings live in the HCP workspace (lextures-self-aws-production) or tfvars.
+# Do not pass GITHUB_TOKEN as registry_password: it is short-lived and would be
+# stored in Secrets Manager for ECS pulls.
+#
+# Triggers:
+#   - Automatically after "Publish container images" succeeds on main
+#   - Manual workflow_dispatch
+
+name: Deploy Self AWS
+
+on:
+  workflow_run:
+    workflows:
+      - Publish container images
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-self-aws
+  cancel-in-progress: false
+
+env:
+  TF_IN_AUTOMATION: true
+  TF_INPUT: "false"
+  TF_TOKEN: ${{ secrets.TF_TOKEN }}
+  TF_TOKEN_app_terraform_io: ${{ secrets.TF_TOKEN }}
+  TF_CLOUD_ORGANIZATION: ${{ secrets.TF_CLOUD_ORGANIZATION }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    name: Deploy Self AWS
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Resolve deploy SHA
+        id: deploy
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.deploy.outputs.sha }}
+
+      - name: Set image tags
+        id: images
+        run: |
+          REPO_LOWER="$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
+          SHA="${{ steps.deploy.outputs.sha }}"
+          echo "server=ghcr.io/${REPO_LOWER}/server:${SHA}" >> "$GITHUB_OUTPUT"
+          echo "web=ghcr.io/${REPO_LOWER}/web:${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.0
+          terraform_wrapper: false
+
+      # Registry provider installs occasionally fail with 5xx (e.g. GitHub 502 during
+      # signature fetch). Retries help both local init and remote-run init on HCP Terraform.
+      - name: Terraform init
+        working-directory: iac/self-aws
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4; do
+            if terraform init -input=false; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 4 ]; then
+              exit 1
+            fi
+            echo "terraform init failed (attempt ${attempt}/4); retrying in 30s..."
+            sleep 30
+          done
+
+      - name: Terraform plan
+        working-directory: iac/self-aws
+        env:
+          TF_VAR_server_image: ${{ steps.images.outputs.server }}
+          TF_VAR_web_image: ${{ steps.images.outputs.web }}
+        run: terraform plan -input=false -out=tfplan
+
+      - name: Terraform apply
+        working-directory: iac/self-aws
+        run: terraform apply -auto-approve -input=false tfplan
+
+      - name: Deploy summary
+        if: always()
+        working-directory: iac/self-aws
+        run: |
+          {
+            echo "## Deploy Self AWS summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Commit | \`${{ steps.deploy.outputs.sha }}\` |"
+            echo "| Server image | \`${{ steps.images.outputs.server }}\` |"
+            echo "| Web image | \`${{ steps.images.outputs.web }}\` |"
+            cf="$(terraform output -raw cloudfront_domain_name 2>/dev/null || true)"
+            if [ -n "$cf" ] && [ "$cf" != "null" ]; then
+              echo "| CloudFront | \`https://${cf}\` |"
+            fi
+            alb="$(terraform output -raw alb_dns_name 2>/dev/null || true)"
+            if [ -n "$alb" ] && [ "$alb" != "null" ]; then
+              echo "| ALB DNS | \`${alb}\` |"
+            fi
+            cluster="$(terraform output -raw ecs_cluster_name 2>/dev/null || true)"
+            if [ -n "$cluster" ] && [ "$cluster" != "null" ]; then
+              echo "| ECS cluster | \`${cluster}\` |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,7 +1,8 @@
 # Publish small-tier / VM container images to GHCR on every merge to main.
 #
-# Deploy Demo and Deploy Self run after this workflow completes successfully and
-# pull the immutable :<git-sha> tags (see deploy-demo.yml and deploy-self.yml).
+# Deploy Self and Deploy Self AWS run after this workflow completes successfully
+# and pull the immutable :<git-sha> tags (see deploy-self.yml and
+# deploy-self-aws.yml).
 #
 # Images:
 #   ghcr.io/<org>/<repo>/server:latest  (+ :<git-sha>)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
   <a href="https://github.com/StudyDrift/lextures/actions/workflows/deploy-self.yml">
     <img src="https://github.com/StudyDrift/lextures/actions/workflows/deploy-self.yml/badge.svg" alt="Deploy Self GitHub Action status." />
   </a>
+  <a href="https://github.com/StudyDrift/lextures/actions/workflows/deploy-self-aws.yml">
+    <img src="https://github.com/StudyDrift/lextures/actions/workflows/deploy-self-aws.yml/badge.svg" alt="Deploy Self AWS GitHub Action status." />
+  </a>
 </p>
 <p align="center">
   <a href="https://self.lextures.com/">Start studying</a>

--- a/iac/self-aws/README.md
+++ b/iac/self-aws/README.md
@@ -50,7 +50,11 @@ ALB path patterns for the API: `/api/*`, `/health`, `/health/*`, `/tus/*`. The n
 
 ### Deploying new versions
 
-After `publish-images` pushes new GHCR tags (or you push manually):
+**CI (recommended):** [`.github/workflows/deploy-self-aws.yml`](../../.github/workflows/deploy-self-aws.yml) runs after [Publish container images](../../.github/workflows/publish-images.yml) succeeds on `main` (same trigger as Deploy Self). It applies this module with immutable `server_image` / `web_image` tags `ghcr.io/<org>/<repo>/{server,web}:<git-sha>`, which updates ECS task definitions and rolls the services. Manual runs: **Actions → Deploy Self AWS → Run workflow**.
+
+Repository secrets: `TF_TOKEN`, `TF_CLOUD_ORGANIZATION` (shared with Deploy Self). AWS credentials and optional GHCR pull credentials (`registry_username` / `registry_password`) belong in the HCP workspace `lextures-self-aws-production` — use a long-lived PAT for private packages, not `GITHUB_TOKEN` (it expires and would be stored in Secrets Manager).
+
+**Local / force redeploy** after images are already in the registry:
 
 ```bash
 # Roll the nginx SPA (force-new-deployment pulls the tag in web_image)
@@ -60,7 +64,7 @@ After `publish-images` pushes new GHCR tags (or you push manually):
 ./iac/self-aws/scripts/deploy-api.sh
 ```
 
-To pin a new immutable tag, change `server_image` / `web_image` in `terraform.tfvars` and `terraform apply` (creates new task definitions). With `:latest`, the force-deploy scripts above re-pull after a registry push.
+To pin a new immutable tag manually, change `server_image` / `web_image` in `terraform.tfvars` (or HCP vars) and `terraform apply` (creates new task definitions). With `:latest`, the force-deploy scripts above re-pull after a registry push.
 
 If `web_image` is empty, `deploy-web.sh` falls back to build + S3 sync + CloudFront invalidation.
 

--- a/iac/self-aws/locals.tf
+++ b/iac/self-aws/locals.tf
@@ -29,11 +29,12 @@ locals {
   web_subnet_ids = local.api_subnet_ids
 
   # SPA from the GHCR web image on Fargate (ALB path routing); otherwise S3 static deploy.
-  # Image refs may be marked sensitive in HCP Terraform workspace variables; emptiness is not
-  # secret and must be non-sensitive for count/for_each. try(nonsensitive(...)) works whether
-  # or not the var is actually sensitive (nonsensitive errors only when the value is not).
-  web_image_set     = try(nonsensitive(var.web_image), var.web_image) != ""
-  server_image_set  = try(nonsensitive(var.server_image), var.server_image) != ""
+  # web_image / server_image are sensitive (variable blocks + HCP). Emptiness is not secret
+  # and must be non-sensitive for count/for_each. Always declare the vars sensitive so
+  # nonsensitive() is valid; do not use try(nonsensitive(x), x) — Terraform treats the
+  # whole try as sensitive if any branch is sensitive.
+  web_image_set     = nonsensitive(var.web_image != "")
+  server_image_set  = nonsensitive(var.server_image != "")
   use_web_container = var.enable_ecs && local.web_image_set
   use_api_container = var.enable_ecs && local.server_image_set
   # Keep the static bucket when enable_static_site so enabling web_image does not destroy it.
@@ -42,10 +43,9 @@ locals {
   serve_spa_from_s3 = var.enable_static_site && !local.use_web_container
 
   # Non-sensitive set for ALB listener rules (for_each keys must not be sensitive).
-  api_listener_path_patterns = (
-    local.use_web_container && local.use_api_container
-    ? toset(local.api_path_patterns)
-    : toset([])
+  # Condition uses non-sensitive booleans above so the ternary result stays non-sensitive.
+  api_listener_path_patterns = toset(
+    local.use_web_container && local.use_api_container ? local.api_path_patterns : []
   )
 
   sqs_queues = {

--- a/iac/self-aws/outputs.tf
+++ b/iac/self-aws/outputs.tf
@@ -59,7 +59,7 @@ output "ecs_api_service_name" {
 
 output "use_web_container" {
   description = "True when the SPA is served from the web container image on Fargate."
-  # Boolean is derived via nonsensitive emptiness checks (see locals.tf).
+  # Non-sensitive boolean (see locals.tf); deploy-web.sh reads this with terraform output -raw.
   value = local.use_web_container
 }
 

--- a/iac/self-aws/variables.tf
+++ b/iac/self-aws/variables.tf
@@ -109,12 +109,17 @@ variable "server_image" {
   description = "Container image for the Go API (e.g. ghcr.io/org/lextures/server:latest). Leave empty to skip the ECS API service."
   type        = string
   default     = ""
+  # Marked sensitive so HCP/workspace "sensitive" flags are consistent; emptiness is
+  # stripped with nonsensitive() for count/for_each (see locals.tf).
+  sensitive = true
 }
 
 variable "web_image" {
   description = "Container image for the nginx SPA (e.g. ghcr.io/org/lextures/web:latest from publish-images). Leave empty to serve the SPA from S3 via deploy-web.sh instead."
   type        = string
   default     = ""
+  # Same as server_image: always sensitive so nonsensitive() on emptiness always works.
+  sensitive = true
 }
 
 variable "ecs_api_cpu" {


### PR DESCRIPTION
## Summary

- Fix Terraform sensitivity for `server_image` / `web_image` in `iac/self-aws` so ALB `for_each` and `use_web_container` work when HCP marks image vars sensitive (declare vars `sensitive = true`, use `nonsensitive(... != "")` instead of `try(nonsensitive(x), x)`).
- Add `.github/workflows/deploy-self-aws.yml`, triggered after **Publish container images** succeeds on `main` (and via `workflow_dispatch`), applying immutable `:<git-sha>` image tags to ECS.
- Document the pipeline in `iac/self-aws/README.md`, note it from `publish-images.yml`, and add a root README badge.

## Test plan

- [ ] Confirm `terraform validate` (or HCP plan) succeeds with sensitive image vars set
- [ ] Confirm ALB listener rule `for_each` no longer errors on `api_listener_path_patterns`
- [ ] Confirm `use_web_container` output is readable without `sensitive = true`
- [ ] Manually run **Deploy Self AWS** once HCP workspace has AWS + optional registry secrets
- [ ] After merge, verify the workflow fires when **Publish container images** succeeds on `main`