### PR TITLE
fix(iac): force non-sensitive self-aws topology flags

### DIFF
--- a/iac/self-aws/locals.tf
+++ b/iac/self-aws/locals.tf
@@ -29,21 +29,21 @@ locals {
   web_subnet_ids = local.api_subnet_ids
 
   # SPA from the GHCR web image on Fargate (ALB path routing); otherwise S3 static deploy.
-  # web_image / server_image are sensitive (variable blocks + HCP). Emptiness is not secret
-  # and must be non-sensitive for count/for_each. Always declare the vars sensitive so
-  # nonsensitive() is valid; do not use try(nonsensitive(x), x) — Terraform treats the
-  # whole try as sensitive if any branch is sensitive.
-  web_image_set     = nonsensitive(var.web_image != "")
-  server_image_set  = nonsensitive(var.server_image != "")
-  use_web_container = var.enable_ecs && local.web_image_set
-  use_api_container = var.enable_ecs && local.server_image_set
+  #
+  # Topology flags (count/for_each/outputs) must be non-sensitive. Image refs and any
+  # HCP-marked vars (enable_ecs, etc.) can taint expressions. try(nonsensitive(x), x)
+  # does NOT work — try() marks the whole result sensitive if any branch is.
+  # nonsensitive(sensitive(expr)) always works: sensitive() forces the mark, then
+  # nonsensitive() strips it, whether or not expr was already sensitive. Emptiness and
+  # enable toggles are not secrets.
+  use_web_container = nonsensitive(sensitive(var.enable_ecs && var.web_image != ""))
+  use_api_container = nonsensitive(sensitive(var.enable_ecs && var.server_image != ""))
   # Keep the static bucket when enable_static_site so enabling web_image does not destroy it.
   create_web_bucket = var.enable_static_site
   # CloudFront default origin is S3 only when we are not using the web container.
   serve_spa_from_s3 = var.enable_static_site && !local.use_web_container
 
   # Non-sensitive set for ALB listener rules (for_each keys must not be sensitive).
-  # Condition uses non-sensitive booleans above so the ternary result stays non-sensitive.
   api_listener_path_patterns = toset(
     local.use_web_container && local.use_api_container ? local.api_path_patterns : []
   )

--- a/iac/self-aws/outputs.tf
+++ b/iac/self-aws/outputs.tf
@@ -59,7 +59,7 @@ output "ecs_api_service_name" {
 
 output "use_web_container" {
   description = "True when the SPA is served from the web container image on Fargate."
-  # Non-sensitive boolean (see locals.tf); deploy-web.sh reads this with terraform output -raw.
+  # Forced non-sensitive in locals.tf via nonsensitive(sensitive(...)); deploy-web.sh uses -raw.
   value = local.use_web_container
 }
 

--- a/iac/self-aws/variables.tf
+++ b/iac/self-aws/variables.tf
@@ -109,8 +109,7 @@ variable "server_image" {
   description = "Container image for the Go API (e.g. ghcr.io/org/lextures/server:latest). Leave empty to skip the ECS API service."
   type        = string
   default     = ""
-  # Marked sensitive so HCP/workspace "sensitive" flags are consistent; emptiness is
-  # stripped with nonsensitive() for count/for_each (see locals.tf).
+  # May also be marked sensitive in HCP. Emptiness for count/for_each is stripped in locals.tf.
   sensitive = true
 }
 
@@ -118,7 +117,7 @@ variable "web_image" {
   description = "Container image for the nginx SPA (e.g. ghcr.io/org/lextures/web:latest from publish-images). Leave empty to serve the SPA from S3 via deploy-web.sh instead."
   type        = string
   default     = ""
-  # Same as server_image: always sensitive so nonsensitive() on emptiness always works.
+  # Same as server_image.
   sensitive = true
 }
 


### PR DESCRIPTION
## Summary

- Root cause: `nonsensitive(var.web_image != "")` alone was not enough — combining with `var.enable_ecs` (or other HCP-sensitive toggles) re-marked `use_web_container` / `use_api_container` as sensitive, so ALB `for_each` and the root output still failed.
- Fix: derive both flags with `nonsensitive(sensitive(var.enable_ecs && var.*_image != ""))`. The `sensitive()` + `nonsensitive()` sandwich always strips the mark whether or not the inputs were already sensitive. Avoid `try(nonsensitive(x), x)`, which taints the whole result.

## Test plan

- [ ] `terraform plan` in HCP workspace `lextures-self-aws-production` with sensitive `server_image` / `web_image` (and optionally sensitive `enable_ecs`)
- [ ] Confirm no `Invalid for_each argument` on `aws_lb_listener_rule.api_paths`
- [ ] Confirm no `Output refers to sensitive values` on `use_web_container`
- [ ] Confirm `terraform output -raw use_web_container` prints `true`/`false`