### PR TITLE
fix(web): defer nginx API upstream DNS for ECS Fargate

### DIFF
--- a/clients/web/nginx.conf
+++ b/clients/web/nginx.conf
@@ -1,8 +1,17 @@
-# Single public port (80): static SPA, API + WebSocket via reverse proxy to the server container.
+# Static SPA + optional reverse proxy to the Go API.
+#
+# Docker Compose / small-VM: hostname "server" resolves on the compose network.
+# ECS Fargate: ALB path-routes /api /health /tus to the API task; this container
+# only needs to serve static assets. Upstream DNS is deferred to request time
+# (variable proxy_pass) so nginx can start when "server" is not in DNS.
+
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
 }
+
+# Docker embedded DNS first; VPC DNS for Fargate (used only at request time).
+resolver 127.0.0.11 169.254.169.253 valid=10s ipv6=off;
 
 server {
     listen 80;
@@ -14,8 +23,10 @@ server {
     index index.html;
 
     # REST + WebSocket (e.g. /api/v1/communication/ws) — same origin, port 80 only.
+    # Variable form defers DNS so startup succeeds without a "server" host.
     location /api/ {
-        proxy_pass http://server:8080;
+        set $api_upstream server:8080;
+        proxy_pass http://$api_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -28,12 +39,14 @@ server {
     }
 
     location = /health {
-        proxy_pass http://server:8080/health;
+        set $api_upstream server:8080;
+        proxy_pass http://$api_upstream/health;
         proxy_set_header Host $host;
     }
 
     location = /health/ready {
-        proxy_pass http://server:8080/health/ready;
+        set $api_upstream server:8080;
+        proxy_pass http://$api_upstream/health/ready;
         proxy_set_header Host $host;
     }
 


### PR DESCRIPTION
## Summary

- ECS Fargate web tasks pull the GHCR image successfully, then nginx exits with `host not found in upstream "server"`.
- On self-aws, the ALB path-routes `/api` / `/health` to the API task; the web container only needs to serve the SPA.
- Defer upstream DNS with variable `proxy_pass` + Docker/VPC resolvers so nginx starts without a `server` hostname. Docker Compose / small-VM deploys still proxy to `server:8080` when that host exists.

## Context

GHCR pull auth (`registry_username` / `registry_password` in HCP) is already working. This unblocks `lextures-production-web` after image pull.

## Test plan

- [ ] After merge, confirm **Publish container images** builds a new `web` image
- [ ] Confirm **Deploy Self AWS** rolls `lextures-production-web` to the new tag
- [ ] ECS web service reaches `runningCount: 1` (no `upstream "server"` in logs)
- [ ] SPA loads via CloudFront/ALB; `/api/*` still hits the API target group
- [ ] Local/compose (if used): API reverse-proxy via hostname `server` still works