### PR TITLE
feat(iac): wire bootstrap_admin_email into self-aws API tasks

### DIFF
--- a/iac/self-aws/README.md
+++ b/iac/self-aws/README.md
@@ -52,7 +52,7 @@ ALB path patterns for the API: `/api/*`, `/health`, `/health/*`, `/tus/*`. The n
 
 **CI (recommended):** [`.github/workflows/deploy-self-aws.yml`](../../.github/workflows/deploy-self-aws.yml) runs after [Publish container images](../../.github/workflows/publish-images.yml) succeeds on `main` (same trigger as Deploy Self). It applies this module with immutable `server_image` / `web_image` tags `ghcr.io/<org>/<repo>/{server,web}:<git-sha>`, which updates ECS task definitions and rolls the services. Manual runs: **Actions → Deploy Self AWS → Run workflow**.
 
-Repository secrets: `TF_TOKEN`, `TF_CLOUD_ORGANIZATION` (shared with Deploy Self). AWS credentials and optional GHCR pull credentials (`registry_username` / `registry_password`) belong in the HCP workspace `lextures-self-aws-production` — use a long-lived PAT for private packages, not `GITHUB_TOKEN` (it expires and would be stored in Secrets Manager).
+Repository secrets: `TF_TOKEN`, `TF_CLOUD_ORGANIZATION` (shared with Deploy Self). AWS credentials, optional GHCR pull credentials (`registry_username` / `registry_password`), and optional `bootstrap_admin_email` belong in the HCP workspace `lextures-self-aws-production` — use a long-lived PAT for private packages, not `GITHUB_TOKEN` (it expires and would be stored in Secrets Manager).
 
 **Local / force redeploy** after images are already in the registry:
 
@@ -133,6 +133,8 @@ Secrets Manager secret `${project}-${environment}/app` is a JSON object. ECS inj
 | `STORAGE_BUCKET` / `STORAGE_REGION` | Course files |
 
 `PUBLIC_WEB_ORIGIN` on the API task defaults to the CloudFront HTTPS URL (or `public_web_origin` when set).
+
+`BOOTSTRAP_ADMIN_EMAIL` comes from Terraform variable `bootstrap_admin_email` (HCP workspace or `terraform.tfvars`). When non-empty, the **first** password signup whose email matches (trimmed, lowercased) gets Global Admin if no human users exist yet. Leave empty and use `go run ./cmd/bootstrap-admin -email=…` against RDS to promote an account after the fact.
 
 Local / Oracle dev remains unchanged (`RABBITMQ_URL`, local Vite, etc.).
 

--- a/iac/self-aws/ecs.tf
+++ b/iac/self-aws/ecs.tf
@@ -87,6 +87,8 @@ resource "aws_ecs_task_definition" "api" {
           { name = "PUBLIC_WEB_ORIGIN", value = local.public_origin },
           { name = "BACKGROUND_JOBS_ENABLED", value = "1" },
           { name = "SCHEDULER_ENABLED", value = "1" },
+          # First matching password signup gets Global Admin when the human user table is empty.
+          { name = "BOOTSTRAP_ADMIN_EMAIL", value = var.bootstrap_admin_email },
           # IAM task role — leave keys empty so minio-go / AWS SDK use the instance role.
           { name = "STORAGE_ACCESS_KEY_ID", value = "" },
           { name = "STORAGE_SECRET_ACCESS_KEY", value = "" },

--- a/iac/self-aws/terraform.tfvars.example
+++ b/iac/self-aws/terraform.tfvars.example
@@ -29,5 +29,7 @@ aws_region   = "us-east-1"
 
 # public_web_origin = "https://app.example.com"  # optional override; default = CloudFront URL
 # jwt_secret        = ""  # empty = auto-generate into Secrets Manager
+# First password signup with this email gets Global Admin (only when no human users yet):
+# bootstrap_admin_email = "you@example.com"
 
 # course_files_bucket_force_destroy = true  # staging only

--- a/iac/self-aws/variables.tf
+++ b/iac/self-aws/variables.tf
@@ -105,6 +105,12 @@ variable "public_web_origin" {
   default     = ""
 }
 
+variable "bootstrap_admin_email" {
+  description = "If set, the first password signup whose email matches (case-insensitive) receives Global Admin when no human users exist yet. Empty disables bootstrap-on-signup (use server/cmd/bootstrap-admin instead)."
+  type        = string
+  default     = ""
+}
+
 variable "server_image" {
   description = "Container image for the Go API (e.g. ghcr.io/org/lextures/server:latest). Leave empty to skip the ECS API service."
   type        = string


### PR DESCRIPTION
## Summary

- Add Terraform variable `bootstrap_admin_email` (default empty).
- Inject `BOOTSTRAP_ADMIN_EMAIL` into the self-aws ECS API task environment.
- Document HCP / tfvars usage and the post-signup `bootstrap-admin` CLI fallback.

## How to use after merge

1. In HCP Terraform workspace **`lextures-self-aws-production`**, add Terraform variable:
   - **Key:** `bootstrap_admin_email`
   - **Value:** your email (e.g. `you@example.com`)
2. Apply (or re-run **Deploy Self AWS**).
3. Sign up with that **exact** email while no human users exist yet.

If an account already exists, promote with:
`go run ./cmd/bootstrap-admin -email=you@example.com` (needs `DATABASE_URL`).

## Test plan

- [ ] `terraform plan` in `iac/self-aws` shows API task env `BOOTSTRAP_ADMIN_EMAIL` when the var is set
- [ ] After apply, describe the API task definition and confirm the env var
- [ ] Empty var still applies cleanly (empty string on the container)