### PR TITLE
feat(iac): manage CloudFront ACM certs in self-aws Terraform

### DIFF
--- a/iac/self-aws/README.md
+++ b/iac/self-aws/README.md
@@ -108,15 +108,33 @@ web_image      = "ghcr.io/YOUR_ORG/lextures/web:latest"
 # registry_username / registry_password if GHCR packages are private
 ```
 
-Custom domain (optional). Without these, CloudFront serves HTTPS on `*.cloudfront.net` automatically:
+Custom domain (optional). Without `web_domain_names`, CloudFront serves HTTPS on `*.cloudfront.net` automatically.
+
+**Terraform-managed cert (recommended):** set only the domain list — no certificate UUID needed.
 
 ```hcl
-# 1) Create/validate cert in ACM in us-east-1 (CloudFront requirement)
-# 2) Paste the real ARN (12-digit account ID + certificate UUID):
-web_domain_names        = ["app.example.com"]
-web_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-public_web_origin       = "https://app.example.com"
+web_domain_names  = ["beta.example.com"]
+public_web_origin = "https://beta.example.com"
+# web_acm_certificate_arn left empty → ACM cert created in us-east-1
 ```
+
+1. Set `web_domain_names` (and `public_web_origin`) in HCP or tfvars.
+2. Preferred first apply (creates the cert without waiting forever on DNS):
+   ```bash
+   cd iac/self-aws
+   terraform apply -target=aws_acm_certificate.web
+   terraform output acm_dns_validation_records
+   ```
+3. Create each record as a **CNAME** in Cloudflare (**DNS only** / grey cloud).
+4. Full apply (validates cert, attaches it to CloudFront):
+   ```bash
+   terraform apply
+   ```
+5. Point the site CNAME: `beta` → CloudFront domain (`terraform output cloudfront_domain_name`), also **DNS only**.
+
+A full apply without the validation CNAMEs in place waits up to **45 minutes** for ACM issuance and then fails if DNS is still missing.
+
+**Existing cert:** set `web_acm_certificate_arn` to a real us-east-1 ACM ARN instead of leaving it empty.
 
 ## Application configuration
 

--- a/iac/self-aws/acm.tf
+++ b/iac/self-aws/acm.tf
@@ -1,0 +1,67 @@
+# ACM certificate for CloudFront custom domains.
+#
+# CloudFront requires certificates in us-east-1 (provider alias), regardless of
+# var.aws_region. When web_domain_names is set and web_acm_certificate_arn is
+# empty, Terraform requests a DNS-validated cert and waits for issuance.
+#
+# Workflow when managing the cert here:
+#   1. Set web_domain_names = ["beta.example.com"] (leave web_acm_certificate_arn empty)
+#   2. terraform apply  (creates cert; may wait up to 45m for DNS validation)
+#   3. While waiting (or after a targeted apply of aws_acm_certificate.web):
+#        terraform output acm_dns_validation_records
+#      Add those CNAMEs in your DNS (Cloudflare: DNS only / grey cloud)
+#   4. After ISSUED, CloudFront picks up the cert on the same or next apply
+#
+# Or pass an existing us-east-1 ACM ARN via web_acm_certificate_arn to skip creation.
+
+locals {
+  web_acm_external = (
+    var.web_acm_certificate_arn != null
+    && var.web_acm_certificate_arn != ""
+  )
+  create_web_acm = length(var.web_domain_names) > 0 && !local.web_acm_external
+
+  # Effective ARN for CloudFront (null when using the default *.cloudfront.net cert).
+  web_acm_certificate_arn_effective = (
+    length(var.web_domain_names) == 0
+    ? null
+    : (
+      local.web_acm_external
+      ? var.web_acm_certificate_arn
+      : aws_acm_certificate_validation.web[0].certificate_arn
+    )
+  )
+}
+
+resource "aws_acm_certificate" "web" {
+  count = local.create_web_acm ? 1 : 0
+
+  provider = aws.us_east_1
+
+  domain_name               = var.web_domain_names[0]
+  subject_alternative_names = length(var.web_domain_names) > 1 ? slice(var.web_domain_names, 1, length(var.web_domain_names)) : []
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-web-cloudfront"
+  }
+}
+
+resource "aws_acm_certificate_validation" "web" {
+  count = local.create_web_acm ? 1 : 0
+
+  provider = aws.us_east_1
+
+  certificate_arn = aws_acm_certificate.web[0].arn
+  validation_record_fqdns = [
+    for dvo in aws_acm_certificate.web[0].domain_validation_options : dvo.resource_record_name
+  ]
+
+  timeouts {
+    create = "45m"
+  }
+}

--- a/iac/self-aws/outputs.tf
+++ b/iac/self-aws/outputs.tf
@@ -47,6 +47,27 @@ output "cloudfront_distribution_id" {
   value       = try(aws_cloudfront_distribution.web[0].id, null)
 }
 
+output "web_acm_certificate_arn" {
+  description = "ACM certificate ARN used by CloudFront for custom domains (managed or external)."
+  value       = local.web_acm_certificate_arn_effective
+}
+
+output "acm_dns_validation_records" {
+  description = <<-EOT
+    DNS records to create for ACM validation when Terraform manages the cert.
+    Add each as a CNAME in your DNS provider (Cloudflare: DNS only / grey cloud).
+    Empty when using an external web_acm_certificate_arn or no custom domains.
+  EOT
+  value = local.create_web_acm ? [
+    for dvo in aws_acm_certificate.web[0].domain_validation_options : {
+      domain  = dvo.domain_name
+      type    = dvo.resource_record_type
+      name    = dvo.resource_record_name
+      value   = dvo.resource_record_value
+    }
+  ] : []
+}
+
 output "ecs_web_service_name" {
   description = "ECS service name for the nginx SPA (null when web_image is empty)."
   value       = try(aws_ecs_service.web[0].name, null)

--- a/iac/self-aws/providers.tf
+++ b/iac/self-aws/providers.tf
@@ -5,3 +5,14 @@ provider "aws" {
     tags = local.common_tags
   }
 }
+
+# CloudFront custom-domain certs must live in us-east-1 even when the stack
+# region differs (ACM + CloudFront requirement).
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/iac/self-aws/static_site.tf
+++ b/iac/self-aws/static_site.tf
@@ -161,11 +161,14 @@ resource "aws_cloudfront_distribution" "web" {
   dynamic "viewer_certificate" {
     for_each = length(var.web_domain_names) > 0 ? [1] : []
     content {
-      acm_certificate_arn      = var.web_acm_certificate_arn
+      acm_certificate_arn      = local.web_acm_certificate_arn_effective
       ssl_support_method       = "sni-only"
       minimum_protocol_version = "TLSv1.2_2021"
     }
   }
+
+  # Wait for ACM issuance when Terraform manages the cert (CloudFront rejects PENDING_VALIDATION).
+  depends_on = [aws_acm_certificate_validation.web]
 
   tags = {
     Name = "${local.name_prefix}-web"

--- a/iac/self-aws/terraform.tfvars.example
+++ b/iac/self-aws/terraform.tfvars.example
@@ -14,9 +14,12 @@ aws_region   = "us-east-1"
 # web_bucket_force_destroy = true  # staging only
 # cloudfront_price_class   = "PriceClass_100"
 #
-# Custom domain (optional). Leave BOTH unset to use the free *.cloudfront.net cert.
-# Request/import a cert in ACM in us-east-1 first, then set the real ARN (12-digit account ID):
-# web_domain_names        = ["app.example.com"]
+# Custom domain (optional). Leave web_domain_names empty for free *.cloudfront.net cert.
+# Terraform will request a DNS-validated ACM cert in us-east-1 when domains are set
+# and web_acm_certificate_arn is empty — then `terraform output acm_dns_validation_records`.
+# web_domain_names  = ["beta.example.com"]
+# public_web_origin = "https://beta.example.com"
+# Optional: use an existing us-east-1 ACM cert instead of letting Terraform create one:
 # web_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
 # API + web on ECS Fargate (images from .github/workflows/publish-images.yml)

--- a/iac/self-aws/variables.tf
+++ b/iac/self-aws/variables.tf
@@ -216,17 +216,23 @@ variable "cloudfront_price_class" {
 }
 
 variable "web_domain_names" {
-  description = "Optional custom domain aliases for CloudFront (requires a real web_acm_certificate_arn in us-east-1). Leave empty to use the default *.cloudfront.net certificate."
+  description = <<-EOT
+    Optional custom domain aliases for CloudFront (e.g. ["beta.lextures.com"]).
+    Leave empty to use the default *.cloudfront.net certificate.
+    When set, either leave web_acm_certificate_arn empty (Terraform creates a
+    DNS-validated ACM cert in us-east-1) or pass an existing us-east-1 ACM ARN.
+  EOT
   type        = list(string)
   default     = []
 }
 
 variable "web_acm_certificate_arn" {
   description = <<-EOT
-    ACM certificate ARN in us-east-1 for CloudFront custom domains.
+    Optional existing ACM certificate ARN in us-east-1 for CloudFront custom domains.
     Must be a real ARN with a 12-digit account ID, e.g.:
       arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Leave null/empty when web_domain_names is empty (CloudFront default cert).
+    Leave null/empty to either use the default CloudFront cert (when web_domain_names
+    is empty) or let Terraform request and DNS-validate a cert for web_domain_names.
   EOT
   type        = string
   default     = null
@@ -245,13 +251,11 @@ check "web_custom_domain_cert" {
   assert {
     condition = (
       length(var.web_domain_names) == 0
-      || (
-        var.web_acm_certificate_arn != null
-        && var.web_acm_certificate_arn != ""
-        && can(regex("^arn:aws:acm:us-east-1:[0-9]{12}:certificate/[0-9a-fA-F-]+$", var.web_acm_certificate_arn))
-      )
+      || var.web_acm_certificate_arn == null
+      || var.web_acm_certificate_arn == ""
+      || can(regex("^arn:aws:acm:us-east-1:[0-9]{12}:certificate/[0-9a-fA-F-]+$", var.web_acm_certificate_arn))
     )
-    error_message = "When web_domain_names is set, web_acm_certificate_arn must be a real ACM certificate ARN in us-east-1 (not a placeholder)."
+    error_message = "web_acm_certificate_arn must be empty (Terraform-managed cert) or a real ACM ARN in us-east-1 when using custom domains."
   }
 }
 


### PR DESCRIPTION
## Summary

- Terraform can create the us-east-1 ACM certificate for CloudFront custom domains — **no pre-existing certificate UUID required**.
- Set `web_domain_names = [\"beta.lextures.com\"]` and leave `web_acm_certificate_arn` empty.
- New output `acm_dns_validation_records` for Cloudflare DNS-only CNAMEs.
- Optional override: still pass `web_acm_certificate_arn` if the cert already exists.
- `aws` provider alias `us_east_1` for CloudFront’s ACM region requirement.

## How to use (beta.lextures.com)

1. HCP workspace vars (or tfvars):
   - `web_domain_names` = `[\"beta.lextures.com\"]` (HCL)
   - `public_web_origin` = `https://beta.lextures.com`
   - leave `web_acm_certificate_arn` empty
2. `terraform apply -target=aws_acm_certificate.web`
3. `terraform output acm_dns_validation_records` → add CNAMEs in Cloudflare (**DNS only**)
4. `terraform apply` (validation + CloudFront alias/cert)
5. CNAME `beta` → `terraform output -raw cloudfront_domain_name` (**DNS only**, not proxied)

## Test plan

- [ ] Plan with empty domains: no ACM resources
- [ ] Plan with domains, empty ARN: creates `aws_acm_certificate.web` + validation
- [ ] Plan with external ARN: skips managed cert, uses provided ARN
- [ ] After DNS validation, CloudFront aliases include the custom domain