### PR TITLE
style(iac): terraform fmt self-aws ACM validation output

### DIFF
--- a/iac/self-aws/outputs.tf
+++ b/iac/self-aws/outputs.tf
@@ -60,10 +60,10 @@ output "acm_dns_validation_records" {
   EOT
   value = local.create_web_acm ? [
     for dvo in aws_acm_certificate.web[0].domain_validation_options : {
-      domain  = dvo.domain_name
-      type    = dvo.resource_record_type
-      name    = dvo.resource_record_name
-      value   = dvo.resource_record_value
+      domain = dvo.domain_name
+      type   = dvo.resource_record_type
+      name   = dvo.resource_record_name
+      value  = dvo.resource_record_value
     }
   ] : []
 }


### PR DESCRIPTION
## Summary

- `terraform fmt` alignment for `acm_dns_validation_records` in `iac/self-aws/outputs.tf`.
- Fixes CI **IaC (Terraform fmt + validate)** left red on #477 after merge.

## Test plan

- [ ] `make iac-check` / `terraform fmt -check -recursive iac/` passes