### PR TITLE
feat(admin): clickable People and Courses dashboard filters

### DIFF
--- a/clients/web/src/components/settings/courses-panel.tsx
+++ b/clients/web/src/components/settings/courses-panel.tsx
@@ -1,20 +1,31 @@
-import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { type FormEvent, useCallback, useEffect, useId, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
+  Archive,
   ArrowLeft,
+  BookOpen,
+  BookPlus,
+  ChevronDown,
   ExternalLink,
+  FileEdit,
   Loader2,
   Search,
   Settings,
+  Sparkles,
   Users,
+  X,
 } from 'lucide-react'
 import { formatDateTime } from '../../lib/format'
 import { toastMutationError } from '../../lib/lms-toast'
 import {
   ensurePlatformCourseAdminAccess,
+  fetchCoursesStats,
   fetchPlatformCourseReport,
   searchPlatformCourses,
+  type CoursesDashboardStats,
+  type CoursesListFilter,
   type PlatformCourseReport,
+  type PlatformCourseRow,
   type PlatformCourseSearchStatus,
   type PaginatedPlatformCourses,
 } from '../../lib/platform-courses-api'
@@ -29,6 +40,251 @@ const STATUS_OPTIONS: { value: PlatformCourseSearchStatus; label: string }[] = [
   { value: 'all', label: 'All statuses' },
 ]
 
+function formatCount(value: number): string {
+  return value.toLocaleString()
+}
+
+type StatsTone = 'indigo' | 'emerald' | 'sky' | 'slate' | 'rose'
+
+const TONE_STYLES: Record<
+  StatsTone,
+  {
+    card: string
+    cardSelected: string
+    iconWrap: string
+    icon: string
+    value: string
+  }
+> = {
+  indigo: {
+    card: 'border-indigo-100/80 bg-gradient-to-br from-indigo-50/90 via-white to-white dark:border-indigo-900/40 dark:from-indigo-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-indigo-400 ring-2 ring-indigo-500/30 dark:border-indigo-500 dark:ring-indigo-400/30',
+    iconWrap: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-950/80 dark:text-indigo-300',
+    icon: 'text-indigo-600 dark:text-indigo-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  emerald: {
+    card: 'border-emerald-100/80 bg-gradient-to-br from-emerald-50/90 via-white to-white dark:border-emerald-900/40 dark:from-emerald-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-emerald-400 ring-2 ring-emerald-500/30 dark:border-emerald-500 dark:ring-emerald-400/30',
+    iconWrap: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-950/80 dark:text-emerald-300',
+    icon: 'text-emerald-600 dark:text-emerald-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  sky: {
+    card: 'border-sky-100/80 bg-gradient-to-br from-sky-50/90 via-white to-white dark:border-sky-900/40 dark:from-sky-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-sky-400 ring-2 ring-sky-500/30 dark:border-sky-500 dark:ring-sky-400/30',
+    iconWrap: 'bg-sky-100 text-sky-600 dark:bg-sky-950/80 dark:text-sky-300',
+    icon: 'text-sky-600 dark:text-sky-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  slate: {
+    card: 'border-slate-200/90 bg-gradient-to-br from-slate-50/90 via-white to-white dark:border-neutral-700 dark:from-neutral-800/60 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-slate-400 ring-2 ring-slate-400/40 dark:border-neutral-500 dark:ring-neutral-400/30',
+    iconWrap: 'bg-slate-100 text-slate-600 dark:bg-neutral-800 dark:text-neutral-300',
+    icon: 'text-slate-600 dark:text-neutral-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  rose: {
+    card: 'border-rose-100/80 bg-gradient-to-br from-rose-50/90 via-white to-white dark:border-rose-900/40 dark:from-rose-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-rose-400 ring-2 ring-rose-500/30 dark:border-rose-500 dark:ring-rose-400/30',
+    iconWrap: 'bg-rose-100 text-rose-600 dark:bg-rose-950/80 dark:text-rose-300',
+    icon: 'text-rose-600 dark:text-rose-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+}
+
+const STAT_CARDS: {
+  filter: CoursesListFilter
+  statsKey: keyof CoursesDashboardStats
+  label: string
+  hint?: string
+  icon: typeof BookOpen
+  tone: StatsTone
+  tableTitle: string
+  tableDescription: string
+}[] = [
+  {
+    filter: 'created_7d',
+    statsKey: 'createdLast7Days',
+    label: 'New courses',
+    hint: 'Past 7 days',
+    icon: BookPlus,
+    tone: 'indigo',
+    tableTitle: 'New courses',
+    tableDescription: 'Courses created in the past 7 days.',
+  },
+  {
+    filter: 'active',
+    statsKey: 'activeCourses',
+    label: 'Active courses',
+    hint: 'Published and open',
+    icon: BookOpen,
+    tone: 'emerald',
+    tableTitle: 'Active courses',
+    tableDescription: 'Published courses that are not archived.',
+  },
+  {
+    filter: 'draft',
+    statsKey: 'draftCourses',
+    label: 'Draft courses',
+    hint: 'Not yet published',
+    icon: FileEdit,
+    tone: 'sky',
+    tableTitle: 'Draft courses',
+    tableDescription: 'Unpublished courses that are not archived.',
+  },
+  {
+    filter: 'total',
+    statsKey: 'totalCourses',
+    label: 'Total courses',
+    icon: BookOpen,
+    tone: 'slate',
+    tableTitle: 'All courses',
+    tableDescription: 'Every course on the platform.',
+  },
+  {
+    filter: 'archived',
+    statsKey: 'archivedCourses',
+    label: 'Archived',
+    hint: 'Hidden from catalogs',
+    icon: Archive,
+    tone: 'rose',
+    tableTitle: 'Archived courses',
+    tableDescription: 'Courses hidden from catalogs.',
+  },
+]
+
+function CoursesStatsCard({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  tone,
+  loading,
+  selected,
+  onSelect,
+}: {
+  label: string
+  value: number | null
+  hint?: string
+  icon: typeof BookOpen
+  tone: StatsTone
+  loading?: boolean
+  selected?: boolean
+  onSelect: () => void
+}) {
+  const styles = TONE_STYLES[tone]
+  const countLabel = value == null ? 'unknown count' : `${formatCount(value)} ${label}`
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      aria-label={`${selected ? 'Hide' : 'Show'} ${label}: ${countLabel}`}
+      className={`relative flex h-full w-full flex-col overflow-hidden rounded-2xl border px-4 py-4 text-left shadow-sm transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 ${styles.card} ${
+        selected ? styles.cardSelected : ''
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        {/* Fixed 2-line label band so values line up across cards */}
+        <p className="min-h-[2.5rem] min-w-0 flex-1 text-[11px] font-semibold uppercase leading-tight tracking-wider text-slate-500 dark:text-neutral-400">
+          {label}
+        </p>
+        <span
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${styles.iconWrap}`}
+          aria-hidden
+        >
+          <Icon className={`h-5 w-5 ${styles.icon}`} />
+        </span>
+      </div>
+      {loading ? (
+        <div
+          className="mt-1.5 h-9 w-16 animate-pulse rounded-md bg-slate-200/80 dark:bg-neutral-700"
+          aria-hidden
+        />
+      ) : (
+        <p
+          className={`mt-1.5 h-9 text-3xl font-semibold leading-none tracking-tight tabular-nums underline-offset-4 group-hover:underline ${styles.value}`}
+        >
+          {value == null ? '—' : formatCount(value)}
+        </p>
+      )}
+      {/* Fixed 2-line hint band (empty when no hint) keeps footers aligned */}
+      <p className="mt-1.5 min-h-[2rem] text-xs leading-snug text-slate-500 dark:text-neutral-500">
+        {hint ?? '\u00a0'}
+      </p>
+      <p className="mt-auto pt-2 inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 dark:text-neutral-400">
+        {selected ? 'Hide list' : 'View list'}
+        <ChevronDown
+          className={`h-3.5 w-3.5 transition-transform ${selected ? 'rotate-180' : ''}`}
+          aria-hidden
+        />
+      </p>
+    </button>
+  )
+}
+
+function CoursesDashboardCards({
+  stats,
+  loading,
+  error,
+  selectedFilter,
+  onSelectFilter,
+}: {
+  stats: CoursesDashboardStats | null
+  loading: boolean
+  error: string | null
+  selectedFilter: CoursesListFilter | null
+  onSelectFilter: (filter: CoursesListFilter) => void
+}) {
+  if (error) {
+    return (
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+      >
+        {error}
+      </p>
+    )
+  }
+
+  const value = (key: keyof CoursesDashboardStats): number | null =>
+    loading || !stats ? null : stats[key]
+
+  return (
+    <section aria-labelledby="courses-dashboard-heading" className="space-y-3">
+      <div className="flex items-end justify-between gap-3">
+        <h3 id="courses-dashboard-heading" className="sr-only">
+          Courses overview
+        </h3>
+        <p className="text-xs text-slate-500 dark:text-neutral-500">
+          Click a metric to inspect matching courses.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {STAT_CARDS.map((card) => (
+          <CoursesStatsCard
+            key={card.filter}
+            label={card.label}
+            hint={card.hint}
+            value={value(card.statsKey)}
+            icon={card.icon}
+            tone={card.tone}
+            loading={loading}
+            selected={selectedFilter === card.filter}
+            onSelect={() => onSelectFilter(card.filter)}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
 function statusLabel(status: string): string {
   switch (status) {
     case 'active':
@@ -40,6 +296,38 @@ function statusLabel(status: string): string {
     default:
       return status
   }
+}
+
+function CourseStatusBadge({ status }: { status: string }) {
+  if (status === 'active') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-inset ring-emerald-600/15 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-500/30">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+        Active
+      </span>
+    )
+  }
+  if (status === 'archived') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-rose-50 px-2.5 py-0.5 text-xs font-medium text-rose-700 ring-1 ring-inset ring-rose-600/15 dark:bg-rose-950/40 dark:text-rose-300 dark:ring-rose-500/30">
+        <span className="h-1.5 w-1.5 rounded-full bg-rose-500" aria-hidden />
+        Archived
+      </span>
+    )
+  }
+  if (status === 'draft') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-sky-50 px-2.5 py-0.5 text-xs font-medium text-sky-700 ring-1 ring-inset ring-sky-600/15 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-500/30">
+        <span className="h-1.5 w-1.5 rounded-full bg-sky-500" aria-hidden />
+        Draft
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700 ring-1 ring-inset ring-slate-500/15 dark:bg-neutral-800 dark:text-neutral-300 dark:ring-neutral-600/40">
+      {statusLabel(status)}
+    </span>
+  )
 }
 
 function CourseReportView({
@@ -97,7 +385,9 @@ function CourseReportView({
               </div>
               <div>
                 <dt className="text-slate-500 dark:text-neutral-500">Status</dt>
-                <dd className="text-slate-900 dark:text-neutral-100">{statusLabel(report.status)}</dd>
+                <dd className="mt-0.5">
+                  <CourseStatusBadge status={report.status} />
+                </dd>
               </div>
               <div>
                 <dt className="text-slate-500 dark:text-neutral-500">Instructor</dt>
@@ -152,10 +442,151 @@ function CourseReportView({
   )
 }
 
+function CoursesResultsTable({
+  data,
+  loading,
+  emptyTitle,
+  emptyHint,
+  loadingLabel,
+  onOpen,
+}: {
+  data: PaginatedPlatformCourses | null
+  loading: boolean
+  emptyTitle: string
+  emptyHint: string
+  loadingLabel: string
+  onOpen: (courseId: string) => void
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-left text-sm">
+        <thead className="bg-slate-50/80 text-slate-500 dark:bg-neutral-950/60 dark:text-neutral-400">
+          <tr>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Title
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Code
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Organization
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Instructor
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Status
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Enrollments
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
+          {loading ? (
+            <tr>
+              <td colSpan={6} className="px-5 py-12 text-center">
+                <Loader2 className="mx-auto h-5 w-5 animate-spin text-indigo-500" aria-hidden />
+                <p className="mt-2 text-sm text-slate-500">{loadingLabel}</p>
+              </td>
+            </tr>
+          ) : !data?.items.length ? (
+            <tr>
+              <td colSpan={6} className="px-5 py-12 text-center">
+                <BookOpen
+                  className="mx-auto h-8 w-8 text-slate-300 dark:text-neutral-600"
+                  aria-hidden
+                />
+                <p className="mt-2 text-sm font-medium text-slate-700 dark:text-neutral-300">
+                  {emptyTitle}
+                </p>
+                <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">{emptyHint}</p>
+              </td>
+            </tr>
+          ) : (
+            data.items.map((course: PlatformCourseRow) => (
+              <tr
+                key={course.id}
+                className="transition-colors hover:bg-slate-50/80 dark:hover:bg-neutral-800/40"
+              >
+                <td className="px-5 py-3">
+                  <button
+                    type="button"
+                    onClick={() => onOpen(course.id)}
+                    className="font-medium text-slate-900 hover:text-indigo-600 dark:text-neutral-100 dark:hover:text-indigo-400"
+                  >
+                    {course.title}
+                  </button>
+                </td>
+                <td className="px-5 py-3 font-mono text-xs text-slate-600 dark:text-neutral-400">
+                  {course.courseCode}
+                </td>
+                <td className="px-5 py-3 text-slate-700 dark:text-neutral-300">{course.orgName}</td>
+                <td className="px-5 py-3 text-slate-600 dark:text-neutral-400">
+                  {course.instructorName ?? '—'}
+                </td>
+                <td className="px-5 py-3">
+                  <CourseStatusBadge status={course.status} />
+                </td>
+                <td className="px-5 py-3 tabular-nums text-slate-700 dark:text-neutral-300">
+                  {formatCount(course.enrollmentCount)}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function PaginationNav({
+  label,
+  page,
+  totalPages,
+  onPrev,
+  onNext,
+}: {
+  label: string
+  page: number
+  totalPages: number
+  onPrev: () => void
+  onNext: () => void
+}) {
+  if (totalPages <= 1) return null
+  return (
+    <nav
+      aria-label={label}
+      className="flex items-center justify-between gap-3 border-t border-slate-100 px-5 py-3 dark:border-neutral-800"
+    >
+      <button
+        type="button"
+        disabled={page <= 1}
+        onClick={onPrev}
+        className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+      >
+        Previous
+      </button>
+      <span className="text-sm text-slate-600 dark:text-neutral-400">
+        Page {page} of {totalPages}
+      </span>
+      <button
+        type="button"
+        disabled={page >= totalPages}
+        onClick={onNext}
+        className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+      >
+        Next
+      </button>
+    </nav>
+  )
+}
+
 export function CoursesPanel() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const selectedCourseId = searchParams.get('courseId')
+  const filterPanelId = useId()
 
   const [q, setQ] = useState('')
   const [submittedQ, setSubmittedQ] = useState('')
@@ -167,9 +598,37 @@ export function CoursesPanel() {
   const [error, setError] = useState<string | null>(null)
   const [accessBusy, setAccessBusy] = useState(false)
 
+  const [selectedFilter, setSelectedFilter] = useState<CoursesListFilter | null>(null)
+  const [filterPage, setFilterPage] = useState(1)
+  const [filterPerPage, setFilterPerPage] = useState(25)
+  const [filterData, setFilterData] = useState<PaginatedPlatformCourses | null>(null)
+  const [filterLoading, setFilterLoading] = useState(false)
+  const [filterError, setFilterError] = useState<string | null>(null)
+
   const [report, setReport] = useState<PlatformCourseReport | null>(null)
   const [reportLoading, setReportLoading] = useState(false)
   const [reportError, setReportError] = useState<string | null>(null)
+
+  const [stats, setStats] = useState<CoursesDashboardStats | null>(null)
+  const [statsLoading, setStatsLoading] = useState(true)
+  const [statsError, setStatsError] = useState<string | null>(null)
+
+  const loadStats = useCallback(async () => {
+    setStatsLoading(true)
+    setStatsError(null)
+    try {
+      setStats(await fetchCoursesStats())
+    } catch (e) {
+      setStatsError(e instanceof Error ? e.message : 'Failed to load course stats.')
+      setStats(null)
+    } finally {
+      setStatsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadStats()
+  }, [loadStats])
 
   const loadSearch = useCallback(async () => {
     const query = submittedQ.trim()
@@ -192,6 +651,34 @@ export function CoursesPanel() {
   useEffect(() => {
     void loadSearch()
   }, [loadSearch])
+
+  const loadFilter = useCallback(async () => {
+    if (!selectedFilter) {
+      setFilterData(null)
+      setFilterError(null)
+      return
+    }
+    setFilterLoading(true)
+    setFilterError(null)
+    try {
+      setFilterData(
+        await searchPlatformCourses({
+          filter: selectedFilter,
+          page: filterPage,
+          perPage: filterPerPage,
+        }),
+      )
+    } catch (e) {
+      setFilterError(e instanceof Error ? e.message : 'Failed to load courses.')
+      setFilterData(null)
+    } finally {
+      setFilterLoading(false)
+    }
+  }, [selectedFilter, filterPage, filterPerPage])
+
+  useEffect(() => {
+    void loadFilter()
+  }, [loadFilter])
 
   const loadReport = useCallback(async (courseId: string) => {
     setReportLoading(true)
@@ -219,6 +706,17 @@ export function CoursesPanel() {
     e.preventDefault()
     setSubmittedQ(q.trim())
     setPage(1)
+  }
+
+  function toggleFilter(filter: CoursesListFilter) {
+    if (selectedFilter === filter) {
+      setSelectedFilter(null)
+      setFilterData(null)
+      setFilterError(null)
+      return
+    }
+    setSelectedFilter(filter)
+    setFilterPage(1)
   }
 
   function openCourse(courseId: string) {
@@ -259,153 +757,258 @@ export function CoursesPanel() {
     )
   }
 
+  const resultCount = data?.total ?? data?.items.length
+  const activeStat = STAT_CARDS.find((c) => c.filter === selectedFilter) ?? null
+  const filterCount = filterData?.total
+
   return (
     <div className="mt-6 space-y-6">
-      <p className="text-sm text-slate-600 dark:text-neutral-400">
-        Search courses by course code or title. Results are not shown until you search.
-      </p>
+      <CoursesDashboardCards
+        stats={stats}
+        loading={statsLoading}
+        error={statsError}
+        selectedFilter={selectedFilter}
+        onSelectFilter={toggleFilter}
+      />
 
-      <form onSubmit={onSearchSubmit} className="flex flex-wrap items-end gap-3">
-        <label className="flex min-w-[16rem] flex-1 flex-col text-sm">
-          <span className="mb-1 text-slate-600 dark:text-neutral-400">Search</span>
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden />
-            <input
-              type="search"
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-              placeholder="Course code or title"
-              className="w-full rounded-lg border border-slate-300 py-2 pl-9 pr-3 dark:border-neutral-700 dark:bg-neutral-900"
+      {selectedFilter && activeStat ? (
+        <section
+          id={filterPanelId}
+          aria-label={activeStat.tableTitle}
+          className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-100 px-5 py-4 dark:border-neutral-800">
+            <div>
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                {activeStat.tableTitle}
+              </h3>
+              <p className="mt-0.5 text-sm text-slate-500 dark:text-neutral-400">
+                {activeStat.tableDescription}
+                {filterCount != null && !filterLoading ? (
+                  <>
+                    {' '}
+                    <span className="font-medium text-slate-700 dark:text-neutral-300">
+                      {formatCount(filterCount)}
+                    </span>{' '}
+                    {filterCount === 1 ? 'course' : 'courses'}.
+                  </>
+                ) : null}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-neutral-400">
+                <span className="text-xs font-medium uppercase tracking-wide">Page size</span>
+                <select
+                  value={filterPerPage}
+                  onChange={(e) => {
+                    setFilterPerPage(Number(e.target.value))
+                    setFilterPage(1)
+                  }}
+                  className="rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                >
+                  {PAGE_SIZES.map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                onClick={() => toggleFilter(selectedFilter)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <X className="h-4 w-4" aria-hidden />
+                Close
+              </button>
+            </div>
+          </div>
+
+          {filterError ? (
+            <div className="border-b border-slate-100 px-5 py-3 dark:border-neutral-800">
+              <p
+                role="alert"
+                className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+              >
+                {filterError}
+              </p>
+            </div>
+          ) : null}
+
+          <CoursesResultsTable
+            data={filterData}
+            loading={filterLoading}
+            emptyTitle="No courses in this segment"
+            emptyHint="Try another metric or search by code or title."
+            loadingLabel="Loading courses…"
+            onOpen={openCourse}
+          />
+
+          {filterData ? (
+            <PaginationNav
+              label={`${activeStat.tableTitle} pagination`}
+              page={filterData.page}
+              totalPages={filterData.totalPages}
+              onPrev={() => setFilterPage((p) => p - 1)}
+              onNext={() => setFilterPage((p) => p + 1)}
+            />
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-5 py-4 dark:border-neutral-800">
+          <div>
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Find courses</h3>
+            <p className="mt-0.5 text-sm text-slate-500 dark:text-neutral-400">
+              Search by course code or title. Results appear after you search.
+            </p>
+          </div>
+        </div>
+
+        <form onSubmit={onSearchSubmit} className="flex flex-wrap items-end gap-3 px-5 py-4">
+          <label className="flex min-w-[16rem] flex-1 flex-col text-sm">
+            <span className="mb-1.5 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+              Search
+            </span>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
+                aria-hidden
+              />
+              <input
+                type="search"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Course code or title"
+                className="w-full rounded-xl border border-slate-200 bg-slate-50/50 py-2.5 pl-10 pr-3 text-sm text-slate-900 shadow-inner transition-colors placeholder:text-slate-400 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500/50 dark:focus:bg-neutral-950"
+              />
+            </div>
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="mb-1.5 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+              Status
+            </span>
+            <select
+              value={status}
+              onChange={(e) => {
+                setStatus(e.target.value as PlatformCourseSearchStatus)
+                setPage(1)
+              }}
+              className="rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="mb-1.5 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+              Page size
+            </span>
+            <select
+              value={perPage}
+              onChange={(e) => {
+                setPerPage(Number(e.target.value))
+                setPage(1)
+              }}
+              className="rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+            >
+              {PAGE_SIZES.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="submit"
+            disabled={!q.trim() || loading}
+            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+          >
+            {loading ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Search className="h-4 w-4" aria-hidden />
+            )}
+            {loading ? 'Searching…' : 'Search'}
+          </button>
+        </form>
+
+        {error ? (
+          <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800">
+            <p
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+            >
+              {error}
+            </p>
+          </div>
+        ) : null}
+
+        {!submittedQ.trim() ? (
+          <div className="border-t border-slate-100 px-5 py-12 dark:border-neutral-800">
+            <div className="mx-auto flex max-w-sm flex-col items-center text-center">
+              <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 ring-1 ring-indigo-100 dark:bg-indigo-950/50 dark:text-indigo-300 dark:ring-indigo-900/50">
+                <Sparkles className="h-6 w-6" aria-hidden />
+              </span>
+              <p className="mt-4 text-sm font-medium text-slate-900 dark:text-neutral-100">
+                Search to manage courses
+              </p>
+              <p className="mt-1.5 text-sm leading-relaxed text-slate-500 dark:text-neutral-400">
+                Enter a course code or title above, or click a metric card above.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="border-t border-slate-100 dark:border-neutral-800">
+            {data && !loading ? (
+              <div className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-2.5 dark:border-neutral-800">
+                <p className="text-xs text-slate-500 dark:text-neutral-400">
+                  {resultCount != null ? (
+                    <>
+                      <span className="font-medium text-slate-700 dark:text-neutral-300">
+                        {formatCount(resultCount)}
+                      </span>{' '}
+                      {resultCount === 1 ? 'result' : 'results'} for{' '}
+                      <span className="font-medium text-slate-700 dark:text-neutral-300">
+                        “{submittedQ}”
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      Results for{' '}
+                      <span className="font-medium text-slate-700 dark:text-neutral-300">
+                        “{submittedQ}”
+                      </span>
+                    </>
+                  )}
+                </p>
+              </div>
+            ) : null}
+            <CoursesResultsTable
+              data={data}
+              loading={loading}
+              emptyTitle="No courses matched your search"
+              emptyHint="Try a different code, title, or status filter."
+              loadingLabel="Searching…"
+              onOpen={openCourse}
             />
           </div>
-        </label>
-        <label className="flex flex-col text-sm">
-          <span className="mb-1 text-slate-600 dark:text-neutral-400">Status</span>
-          <select
-            value={status}
-            onChange={(e) => {
-              setStatus(e.target.value as PlatformCourseSearchStatus)
-              setPage(1)
-            }}
-            className="rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
-          >
-            {STATUS_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col text-sm">
-          <span className="mb-1 text-slate-600 dark:text-neutral-400">Page size</span>
-          <select
-            value={perPage}
-            onChange={(e) => {
-              setPerPage(Number(e.target.value))
-              setPage(1)
-            }}
-            className="rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
-          >
-            {PAGE_SIZES.map((n) => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </select>
-        </label>
-        <button
-          type="submit"
-          disabled={!q.trim() || loading}
-          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
-        >
-          {loading ? 'Searching…' : 'Search'}
-        </button>
-      </form>
+        )}
 
-      {error ? (
-        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
-          {error}
-        </p>
-      ) : null}
-
-      {!submittedQ.trim() ? (
-        <p className="rounded-xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-500 dark:border-neutral-700 dark:text-neutral-400">
-          Enter a course code or title above to find courses.
-        </p>
-      ) : (
-        <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
-          <table className="min-w-full text-left text-sm">
-            <thead className="bg-slate-50 text-slate-600 dark:bg-neutral-950 dark:text-neutral-400">
-              <tr>
-                <th scope="col" className="px-4 py-2 font-medium">Title</th>
-                <th scope="col" className="px-4 py-2 font-medium">Code</th>
-                <th scope="col" className="px-4 py-2 font-medium">Organization</th>
-                <th scope="col" className="px-4 py-2 font-medium">Instructor</th>
-                <th scope="col" className="px-4 py-2 font-medium">Status</th>
-                <th scope="col" className="px-4 py-2 font-medium">Enrollments</th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
-                    <Loader2 className="mx-auto h-5 w-5 animate-spin" aria-hidden />
-                  </td>
-                </tr>
-              ) : !data?.items.length ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
-                    No courses matched your search.
-                  </td>
-                </tr>
-              ) : (
-                data.items.map((course) => (
-                  <tr key={course.id} className="border-t border-slate-100 dark:border-neutral-800">
-                    <td className="px-4 py-2">
-                      <button
-                        type="button"
-                        onClick={() => openCourse(course.id)}
-                        className="font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-                      >
-                        {course.title}
-                      </button>
-                    </td>
-                    <td className="px-4 py-2 font-mono text-xs">{course.courseCode}</td>
-                    <td className="px-4 py-2">{course.orgName}</td>
-                    <td className="px-4 py-2">{course.instructorName ?? '—'}</td>
-                    <td className="px-4 py-2">{statusLabel(course.status)}</td>
-                    <td className="px-4 py-2 tabular-nums">{course.enrollmentCount}</td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {data && data.totalPages > 1 ? (
-        <nav aria-label="Courses search pagination" className="flex items-center gap-2">
-          <button
-            type="button"
-            disabled={page <= 1}
-            onClick={() => setPage((p) => p - 1)}
-            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-          >
-            Previous
-          </button>
-          <span className="text-sm text-slate-600 dark:text-neutral-400">
-            Page {data.page} of {data.totalPages}
-          </span>
-          <button
-            type="button"
-            disabled={page >= data.totalPages}
-            onClick={() => setPage((p) => p + 1)}
-            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-          >
-            Next
-          </button>
-        </nav>
-      ) : null}
+        {data ? (
+          <PaginationNav
+            label="Courses search pagination"
+            page={data.page}
+            totalPages={data.totalPages}
+            onPrev={() => setPage((p) => p - 1)}
+            onNext={() => setPage((p) => p + 1)}
+          />
+        ) : null}
+      </section>
     </div>
   )
 }

--- a/clients/web/src/components/settings/people-panel.tsx
+++ b/clients/web/src/components/settings/people-panel.tsx
@@ -1,18 +1,22 @@
-import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { type FormEvent, useCallback, useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 import { useConfirm } from '../use-confirm'
 import {
+  Activity,
   ArrowLeft,
+  ChevronDown,
   Loader2,
   MailPlus,
   Search,
+  Sparkles,
   Trash2,
   UserCheck,
   UserMinus,
   UserPlus,
   Users,
   UserX,
+  X,
 } from 'lucide-react'
 import { formatDateTime } from '../../lib/format'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
@@ -26,8 +30,11 @@ import {
   searchPeople,
   type PaginatedPeople,
   type PeopleDashboardStats,
+  type PeopleListFilter,
   type PersonReport,
+  type PersonRow,
 } from '../../lib/people-api'
+import { EnrollmentAvatar } from '../enrollment/enrollment-avatar'
 
 const PAGE_SIZES = [25, 50, 100]
 
@@ -35,32 +42,188 @@ function formatCount(value: number): string {
   return value.toLocaleString()
 }
 
+type StatsTone = 'indigo' | 'emerald' | 'sky' | 'slate' | 'rose'
+
+const TONE_STYLES: Record<
+  StatsTone,
+  {
+    card: string
+    cardSelected: string
+    iconWrap: string
+    icon: string
+    value: string
+  }
+> = {
+  indigo: {
+    card: 'border-indigo-100/80 bg-gradient-to-br from-indigo-50/90 via-white to-white dark:border-indigo-900/40 dark:from-indigo-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-indigo-400 ring-2 ring-indigo-500/30 dark:border-indigo-500 dark:ring-indigo-400/30',
+    iconWrap: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-950/80 dark:text-indigo-300',
+    icon: 'text-indigo-600 dark:text-indigo-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  emerald: {
+    card: 'border-emerald-100/80 bg-gradient-to-br from-emerald-50/90 via-white to-white dark:border-emerald-900/40 dark:from-emerald-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-emerald-400 ring-2 ring-emerald-500/30 dark:border-emerald-500 dark:ring-emerald-400/30',
+    iconWrap: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-950/80 dark:text-emerald-300',
+    icon: 'text-emerald-600 dark:text-emerald-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  sky: {
+    card: 'border-sky-100/80 bg-gradient-to-br from-sky-50/90 via-white to-white dark:border-sky-900/40 dark:from-sky-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-sky-400 ring-2 ring-sky-500/30 dark:border-sky-500 dark:ring-sky-400/30',
+    iconWrap: 'bg-sky-100 text-sky-600 dark:bg-sky-950/80 dark:text-sky-300',
+    icon: 'text-sky-600 dark:text-sky-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  slate: {
+    card: 'border-slate-200/90 bg-gradient-to-br from-slate-50/90 via-white to-white dark:border-neutral-700 dark:from-neutral-800/60 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-slate-400 ring-2 ring-slate-400/40 dark:border-neutral-500 dark:ring-neutral-400/30',
+    iconWrap: 'bg-slate-100 text-slate-600 dark:bg-neutral-800 dark:text-neutral-300',
+    icon: 'text-slate-600 dark:text-neutral-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+  rose: {
+    card: 'border-rose-100/80 bg-gradient-to-br from-rose-50/90 via-white to-white dark:border-rose-900/40 dark:from-rose-950/40 dark:via-neutral-900 dark:to-neutral-900',
+    cardSelected:
+      'border-rose-400 ring-2 ring-rose-500/30 dark:border-rose-500 dark:ring-rose-400/30',
+    iconWrap: 'bg-rose-100 text-rose-600 dark:bg-rose-950/80 dark:text-rose-300',
+    icon: 'text-rose-600 dark:text-rose-300',
+    value: 'text-slate-900 dark:text-neutral-50',
+  },
+}
+
+const STAT_CARDS: {
+  filter: PeopleListFilter
+  statsKey: keyof PeopleDashboardStats
+  label: string
+  hint?: string
+  icon: typeof Users
+  tone: StatsTone
+  tableTitle: string
+  tableDescription: string
+}[] = [
+  {
+    filter: 'signups_7d',
+    statsKey: 'signupsLast7Days',
+    label: 'New signups',
+    hint: 'Past 7 days',
+    icon: UserPlus,
+    tone: 'indigo',
+    tableTitle: 'New signups',
+    tableDescription: 'Accounts created in the past 7 days.',
+  },
+  {
+    filter: 'active',
+    statsKey: 'activeAccounts',
+    label: 'Active accounts',
+    hint: 'Can sign in',
+    icon: UserCheck,
+    tone: 'emerald',
+    tableTitle: 'Active accounts',
+    tableDescription: 'Users who can currently sign in.',
+  },
+  {
+    filter: 'recent_30d',
+    statsKey: 'recentlyActive30Days',
+    label: 'Active this month',
+    hint: 'Learning activity in 30 days',
+    icon: Activity,
+    tone: 'sky',
+    tableTitle: 'Active this month',
+    tableDescription: 'Users with learning activity in the past 30 days.',
+  },
+  {
+    filter: 'total',
+    statsKey: 'totalAccounts',
+    label: 'Total accounts',
+    icon: Users,
+    tone: 'slate',
+    tableTitle: 'All accounts',
+    tableDescription: 'Every non-system account on the platform.',
+  },
+  {
+    filter: 'suspended',
+    statsKey: 'suspendedAccounts',
+    label: 'Suspended',
+    hint: 'Blocked from signing in',
+    icon: UserX,
+    tone: 'rose',
+    tableTitle: 'Suspended accounts',
+    tableDescription: 'Users blocked from signing in.',
+  },
+]
+
 function PeopleStatsCard({
   label,
   value,
   hint,
   icon: Icon,
+  tone,
+  loading,
+  selected,
+  onSelect,
 }: {
   label: string
   value: number | null
   hint?: string
   icon: typeof Users
+  tone: StatsTone
+  loading?: boolean
+  selected?: boolean
+  onSelect: () => void
 }) {
+  const styles = TONE_STYLES[tone]
+  const countLabel = value == null ? 'unknown count' : `${formatCount(value)} ${label}`
   return (
-    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      aria-label={`${selected ? 'Hide' : 'Show'} ${label}: ${countLabel}`}
+      className={`relative flex h-full w-full flex-col overflow-hidden rounded-2xl border px-4 py-4 text-left shadow-sm transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 ${styles.card} ${
+        selected ? styles.cardSelected : ''
+      }`}
+    >
       <div className="flex items-start justify-between gap-3">
-        <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+        {/* Fixed 2-line label band so values line up across cards */}
+        <p className="min-h-[2.5rem] min-w-0 flex-1 text-[11px] font-semibold uppercase leading-tight tracking-wider text-slate-500 dark:text-neutral-400">
           {label}
         </p>
-        <Icon className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
+        <span
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${styles.iconWrap}`}
+          aria-hidden
+        >
+          <Icon className={`h-5 w-5 ${styles.icon}`} />
+        </span>
       </div>
-      <p className="mt-1 text-2xl font-semibold tabular-nums text-slate-900 dark:text-neutral-100">
-        {value == null ? '—' : formatCount(value)}
+      {loading ? (
+        <div
+          className="mt-1.5 h-9 w-16 animate-pulse rounded-md bg-slate-200/80 dark:bg-neutral-700"
+          aria-hidden
+        />
+      ) : (
+        <p
+          className={`mt-1.5 h-9 text-3xl font-semibold leading-none tracking-tight tabular-nums underline-offset-4 group-hover:underline ${styles.value}`}
+        >
+          {value == null ? '—' : formatCount(value)}
+        </p>
+      )}
+      {/* Fixed 2-line hint band (empty when no hint) keeps footers aligned */}
+      <p className="mt-1.5 min-h-[2rem] text-xs leading-snug text-slate-500 dark:text-neutral-500">
+        {hint ?? '\u00a0'}
       </p>
-      {hint ? (
-        <p className="mt-1 text-xs text-slate-500 dark:text-neutral-500">{hint}</p>
-      ) : null}
-    </div>
+      <p className="mt-auto pt-2 inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 dark:text-neutral-400">
+        {selected ? 'Hide list' : 'View list'}
+        <ChevronDown
+          className={`h-3.5 w-3.5 transition-transform ${selected ? 'rotate-180' : ''}`}
+          aria-hidden
+        />
+      </p>
+    </button>
   )
 }
 
@@ -68,14 +231,21 @@ function PeopleDashboardCards({
   stats,
   loading,
   error,
+  selectedFilter,
+  onSelectFilter,
 }: {
   stats: PeopleDashboardStats | null
   loading: boolean
   error: string | null
+  selectedFilter: PeopleListFilter | null
+  onSelectFilter: (filter: PeopleListFilter) => void
 }) {
   if (error) {
     return (
-      <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+      >
         {error}
       </p>
     )
@@ -86,46 +256,253 @@ function PeopleDashboardCards({
 
   return (
     <section aria-labelledby="people-dashboard-heading" className="space-y-3">
-      <h3 id="people-dashboard-heading" className="sr-only">
-        People overview
-      </h3>
+      <div className="flex items-end justify-between gap-3">
+        <h3 id="people-dashboard-heading" className="sr-only">
+          People overview
+        </h3>
+        <p className="text-xs text-slate-500 dark:text-neutral-500">
+          Click a metric to inspect matching accounts.
+        </p>
+      </div>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-        <PeopleStatsCard
-          label="New signups"
-          hint="Past 7 days"
-          value={value('signupsLast7Days')}
-          icon={UserPlus}
-        />
-        <PeopleStatsCard
-          label="Active accounts"
-          hint="Can sign in"
-          value={value('activeAccounts')}
-          icon={UserCheck}
-        />
-        <PeopleStatsCard
-          label="Active this month"
-          hint="Learning activity in 30 days"
-          value={value('recentlyActive30Days')}
-          icon={Users}
-        />
-        <PeopleStatsCard
-          label="Total accounts"
-          value={value('totalAccounts')}
-          icon={Users}
-        />
-        <PeopleStatsCard
-          label="Suspended"
-          hint="Blocked from signing in"
-          value={value('suspendedAccounts')}
-          icon={UserX}
-        />
+        {STAT_CARDS.map((card) => (
+          <PeopleStatsCard
+            key={card.filter}
+            label={card.label}
+            hint={card.hint}
+            value={value(card.statsKey)}
+            icon={card.icon}
+            tone={card.tone}
+            loading={loading}
+            selected={selectedFilter === card.filter}
+            onSelect={() => onSelectFilter(card.filter)}
+          />
+        ))}
       </div>
     </section>
   )
 }
 
+function StatusBadge({ active }: { active: boolean }) {
+  if (active) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-inset ring-emerald-600/15 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-500/30">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+        Active
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-rose-50 px-2.5 py-0.5 text-xs font-medium text-rose-700 ring-1 ring-inset ring-rose-600/15 dark:bg-rose-950/40 dark:text-rose-300 dark:ring-rose-500/30">
+      <span className="h-1.5 w-1.5 rounded-full bg-rose-500" aria-hidden />
+      Suspended
+    </span>
+  )
+}
+
 function statusLabel(active: boolean): string {
   return active ? 'Active' : 'Suspended'
+}
+
+function PeopleResultsTable({
+  data,
+  loading,
+  busyId,
+  emptyTitle,
+  emptyHint,
+  loadingLabel = 'Loading…',
+  onOpen,
+  onSuspend,
+  onReactivate,
+  onDelete,
+  showJoined = false,
+}: {
+  data: PaginatedPeople | null
+  loading: boolean
+  busyId: string | null
+  emptyTitle: string
+  emptyHint: string
+  loadingLabel?: string
+  onOpen: (userId: string) => void
+  onSuspend: (user: PersonRow) => void
+  onReactivate: (user: PersonRow) => void
+  onDelete: (user: PersonRow) => void
+  showJoined?: boolean
+}) {
+  const colSpan = showJoined ? 7 : 6
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-left text-sm">
+        <thead className="bg-slate-50/80 text-slate-500 dark:bg-neutral-950/60 dark:text-neutral-400">
+          <tr>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Name
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Email
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Organization
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Role
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Status
+            </th>
+            {showJoined ? (
+              <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                Joined
+              </th>
+            ) : null}
+            <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
+          {loading ? (
+            <tr>
+              <td colSpan={colSpan} className="px-5 py-12 text-center">
+                <Loader2 className="mx-auto h-5 w-5 animate-spin text-indigo-500" aria-hidden />
+                <p className="mt-2 text-sm text-slate-500">{loadingLabel}</p>
+              </td>
+            </tr>
+          ) : !data?.items.length ? (
+            <tr>
+              <td colSpan={colSpan} className="px-5 py-12 text-center">
+                <Users className="mx-auto h-8 w-8 text-slate-300 dark:text-neutral-600" aria-hidden />
+                <p className="mt-2 text-sm font-medium text-slate-700 dark:text-neutral-300">
+                  {emptyTitle}
+                </p>
+                <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">{emptyHint}</p>
+              </td>
+            </tr>
+          ) : (
+            data.items.map((user) => {
+              const displayName = personDisplayName(user)
+              return (
+                <tr
+                  key={user.id}
+                  className="transition-colors hover:bg-slate-50/80 dark:hover:bg-neutral-800/40"
+                >
+                  <td className="px-5 py-3">
+                    <button
+                      type="button"
+                      onClick={() => onOpen(user.id)}
+                      className="group flex items-center gap-3 text-left"
+                    >
+                      <EnrollmentAvatar
+                        userId={user.id}
+                        name={displayName}
+                        size="sm"
+                        showPreview={false}
+                      />
+                      <span className="font-medium text-slate-900 group-hover:text-indigo-600 dark:text-neutral-100 dark:group-hover:text-indigo-400">
+                        {displayName}
+                      </span>
+                    </button>
+                  </td>
+                  <td className="px-5 py-3 text-slate-600 dark:text-neutral-400">{user.email}</td>
+                  <td className="px-5 py-3 text-slate-700 dark:text-neutral-300">{user.orgName}</td>
+                  <td className="px-5 py-3">
+                    {user.role ? (
+                      <span className="inline-flex rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-neutral-800 dark:text-neutral-300">
+                        {user.role}
+                      </span>
+                    ) : (
+                      <span className="text-slate-400">—</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-3">
+                    <StatusBadge active={user.active} />
+                  </td>
+                  {showJoined ? (
+                    <td className="px-5 py-3 whitespace-nowrap text-slate-600 dark:text-neutral-400">
+                      {formatDateTime(user.createdAt)}
+                    </td>
+                  ) : null}
+                  <td className="px-5 py-3">
+                    <div className="flex flex-wrap gap-1.5">
+                      {user.active ? (
+                        <button
+                          type="button"
+                          disabled={busyId === user.id}
+                          onClick={() => onSuspend(user)}
+                          className="rounded-lg px-2 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-50 disabled:opacity-50 dark:text-amber-400 dark:hover:bg-amber-950/40"
+                        >
+                          Suspend
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          disabled={busyId === user.id}
+                          onClick={() => onReactivate(user)}
+                          className="rounded-lg px-2 py-1 text-xs font-medium text-emerald-700 transition-colors hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950/40"
+                        >
+                          Reactivate
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        disabled={busyId === user.id}
+                        onClick={() => onDelete(user)}
+                        className="rounded-lg px-2 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950/40"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function PaginationNav({
+  label,
+  page,
+  totalPages,
+  onPrev,
+  onNext,
+}: {
+  label: string
+  page: number
+  totalPages: number
+  onPrev: () => void
+  onNext: () => void
+}) {
+  if (totalPages <= 1) return null
+  return (
+    <nav
+      aria-label={label}
+      className="flex items-center justify-between gap-3 border-t border-slate-100 px-5 py-3 dark:border-neutral-800"
+    >
+      <button
+        type="button"
+        disabled={page <= 1}
+        onClick={onPrev}
+        className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+      >
+        Previous
+      </button>
+      <span className="text-sm text-slate-600 dark:text-neutral-400">
+        Page {page} of {totalPages}
+      </span>
+      <button
+        type="button"
+        disabled={page >= totalPages}
+        onClick={onNext}
+        className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+      >
+        Next
+      </button>
+    </nav>
+  )
 }
 
 function PersonReportView({
@@ -148,11 +525,19 @@ function PersonReportView({
   onDelete: () => void
 }) {
   if (loading) {
-    return <p className="mt-6 text-sm text-slate-500 dark:text-neutral-400">Loading report…</p>
+    return (
+      <div className="mt-6 flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-5 py-8 dark:border-neutral-800 dark:bg-neutral-900">
+        <Loader2 className="h-5 w-5 animate-spin text-indigo-500" aria-hidden />
+        <p className="text-sm text-slate-500 dark:text-neutral-400">Loading report…</p>
+      </div>
+    )
   }
   if (error) {
     return (
-      <p role="alert" className="mt-6 text-sm text-red-600 dark:text-red-400">
+      <p
+        role="alert"
+        className="mt-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+      >
         {error}
       </p>
     )
@@ -167,108 +552,138 @@ function PersonReportView({
       <button
         type="button"
         onClick={onBack}
-        className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+        className="inline-flex items-center gap-2 rounded-lg px-1 py-0.5 text-sm font-medium text-slate-600 transition-colors hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-100"
       >
         <ArrowLeft className="h-4 w-4" aria-hidden />
         Back to search
       </button>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-neutral-100">{name}</h3>
-            <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">{report.email}</p>
-            <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
-              <div>
-                <dt className="text-slate-500 dark:text-neutral-500">Organization</dt>
-                <dd className="text-slate-900 dark:text-neutral-100">{report.orgName}</dd>
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="border-b border-slate-100 bg-gradient-to-r from-slate-50/80 to-white px-5 py-5 dark:border-neutral-800 dark:from-neutral-950/50 dark:to-neutral-900">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex min-w-0 items-start gap-4">
+              <EnrollmentAvatar userId={report.id} name={name} size="md" showPreview={false} />
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="truncate text-lg font-semibold text-slate-900 dark:text-neutral-100">
+                    {name}
+                  </h3>
+                  <StatusBadge active={report.active} />
+                </div>
+                <p className="mt-0.5 truncate text-sm text-slate-600 dark:text-neutral-400">
+                  {report.email}
+                </p>
+                <p className="mt-1 text-xs text-slate-500 dark:text-neutral-500">
+                  {report.orgName}
+                  {report.role ? ` · ${report.role}` : ''}
+                </p>
               </div>
-              <div>
-                <dt className="text-slate-500 dark:text-neutral-500">Role</dt>
-                <dd className="text-slate-900 dark:text-neutral-100">{report.role || '—'}</dd>
-              </div>
-              <div>
-                <dt className="text-slate-500 dark:text-neutral-500">Status</dt>
-                <dd className="text-slate-900 dark:text-neutral-100">{statusLabel(report.active)}</dd>
-              </div>
-              <div>
-                <dt className="text-slate-500 dark:text-neutral-500">Joined</dt>
-                <dd className="text-slate-900 dark:text-neutral-100">{formatDateTime(report.createdAt)}</dd>
-              </div>
-              <div>
-                <dt className="text-slate-500 dark:text-neutral-500">Last activity</dt>
-                <dd className="text-slate-900 dark:text-neutral-100">
-                  {report.lastActivityAt ? formatDateTime(report.lastActivityAt) : '—'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-slate-500 dark:text-neutral-500">Enrollments</dt>
-                <dd className="text-slate-900 dark:text-neutral-100">{report.enrollmentCount}</dd>
-              </div>
-            </dl>
-          </div>
-          {!isErased ? (
-            <div className="flex flex-wrap gap-2">
-              {report.active ? (
-                <button
-                  type="button"
-                  disabled={busy}
-                  onClick={onSuspend}
-                  className="inline-flex items-center gap-2 rounded-lg border border-amber-300 px-3 py-2 text-sm font-medium text-amber-800 hover:bg-amber-50 disabled:opacity-50 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-950/40"
-                >
-                  <UserMinus className="h-4 w-4" aria-hidden />
-                  Suspend
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  disabled={busy}
-                  onClick={onReactivate}
-                  className="inline-flex items-center gap-2 rounded-lg border border-emerald-300 px-3 py-2 text-sm font-medium text-emerald-800 hover:bg-emerald-50 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-200 dark:hover:bg-emerald-950/40"
-                >
-                  <UserPlus className="h-4 w-4" aria-hidden />
-                  Reactivate
-                </button>
-              )}
-              <button
-                type="button"
-                disabled={busy}
-                onClick={onDelete}
-                className="inline-flex items-center gap-2 rounded-lg border border-red-300 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950/40"
-              >
-                <Trash2 className="h-4 w-4" aria-hidden />
-                Delete account
-              </button>
             </div>
-          ) : null}
+            {!isErased ? (
+              <div className="flex flex-wrap gap-2">
+                {report.active ? (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={onSuspend}
+                    className="inline-flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3.5 py-2 text-sm font-medium text-amber-900 transition-colors hover:bg-amber-100 disabled:opacity-50 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-200 dark:hover:bg-amber-950/70"
+                  >
+                    <UserMinus className="h-4 w-4" aria-hidden />
+                    Suspend
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={onReactivate}
+                    className="inline-flex items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-3.5 py-2 text-sm font-medium text-emerald-900 transition-colors hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-800/60 dark:bg-emerald-950/40 dark:text-emerald-200 dark:hover:bg-emerald-950/70"
+                  >
+                    <UserPlus className="h-4 w-4" aria-hidden />
+                    Reactivate
+                  </button>
+                )}
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={onDelete}
+                  className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-white px-3.5 py-2 text-sm font-medium text-red-700 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900/60 dark:bg-neutral-900 dark:text-red-300 dark:hover:bg-red-950/40"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden />
+                  Delete account
+                </button>
+              </div>
+            ) : null}
+          </div>
         </div>
+
+        <dl className="grid gap-px bg-slate-100 sm:grid-cols-2 lg:grid-cols-4 dark:bg-neutral-800">
+          {[
+            { label: 'Joined', value: formatDateTime(report.createdAt) },
+            {
+              label: 'Last activity',
+              value: report.lastActivityAt ? formatDateTime(report.lastActivityAt) : '—',
+            },
+            { label: 'Enrollments', value: String(report.enrollmentCount) },
+            { label: 'Status', value: statusLabel(report.active) },
+          ].map((item) => (
+            <div key={item.label} className="bg-white px-5 py-4 dark:bg-neutral-900">
+              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-500">
+                {item.label}
+              </dt>
+              <dd className="mt-1 text-sm font-medium text-slate-900 dark:text-neutral-100">
+                {item.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
       </div>
 
-      <section>
-        <h4 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Enrollments</h4>
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="border-b border-slate-100 px-5 py-3 dark:border-neutral-800">
+          <h4 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Enrollments</h4>
+        </div>
         {report.enrollments.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-500 dark:text-neutral-400">No enrollments.</p>
+          <p className="px-5 py-8 text-center text-sm text-slate-500 dark:text-neutral-400">
+            No enrollments.
+          </p>
         ) : (
-          <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
+          <div className="overflow-x-auto">
             <table className="min-w-full text-left text-sm">
-              <thead className="bg-slate-50 text-slate-600 dark:bg-neutral-950 dark:text-neutral-400">
+              <thead className="bg-slate-50/80 text-slate-500 dark:bg-neutral-950/60 dark:text-neutral-400">
                 <tr>
-                  <th scope="col" className="px-4 py-2 font-medium">Course</th>
-                  <th scope="col" className="px-4 py-2 font-medium">Role</th>
-                  <th scope="col" className="px-4 py-2 font-medium">State</th>
-                  <th scope="col" className="px-4 py-2 font-medium">Enrolled</th>
+                  <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                    Course
+                  </th>
+                  <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                    Role
+                  </th>
+                  <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                    State
+                  </th>
+                  <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                    Enrolled
+                  </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
                 {report.enrollments.map((e) => (
-                  <tr key={`${e.courseId}-${e.role}`} className="border-t border-slate-100 dark:border-neutral-800">
-                    <td className="px-4 py-2">
-                      <span className="font-medium text-slate-900 dark:text-neutral-100">{e.courseTitle}</span>
-                      <span className="ml-2 text-xs text-slate-500 dark:text-neutral-500">{e.courseCode}</span>
+                  <tr
+                    key={`${e.courseId}-${e.role}`}
+                    className="transition-colors hover:bg-slate-50/70 dark:hover:bg-neutral-800/40"
+                  >
+                    <td className="px-5 py-3">
+                      <span className="font-medium text-slate-900 dark:text-neutral-100">
+                        {e.courseTitle}
+                      </span>
+                      <span className="ml-2 font-mono text-xs text-slate-500 dark:text-neutral-500">
+                        {e.courseCode}
+                      </span>
                     </td>
-                    <td className="px-4 py-2">{e.role}</td>
-                    <td className="px-4 py-2">{e.state}</td>
-                    <td className="px-4 py-2">{formatDateTime(e.enrolledAt)}</td>
+                    <td className="px-5 py-3 text-slate-700 dark:text-neutral-300">{e.role}</td>
+                    <td className="px-5 py-3 text-slate-700 dark:text-neutral-300">{e.state}</td>
+                    <td className="px-5 py-3 whitespace-nowrap text-slate-600 dark:text-neutral-400">
+                      {formatDateTime(e.enrolledAt)}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -277,28 +692,47 @@ function PersonReportView({
         )}
       </section>
 
-      <section>
-        <h4 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Recent activity</h4>
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="border-b border-slate-100 px-5 py-3 dark:border-neutral-800">
+          <h4 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+            Recent activity
+          </h4>
+        </div>
         {report.recentActivity.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-500 dark:text-neutral-400">No recorded activity.</p>
+          <p className="px-5 py-8 text-center text-sm text-slate-500 dark:text-neutral-400">
+            No recorded activity.
+          </p>
         ) : (
-          <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
+          <div className="overflow-x-auto">
             <table className="min-w-full text-left text-sm">
-              <thead className="bg-slate-50 text-slate-600 dark:bg-neutral-950 dark:text-neutral-400">
+              <thead className="bg-slate-50/80 text-slate-500 dark:bg-neutral-950/60 dark:text-neutral-400">
                 <tr>
-                  <th scope="col" className="px-4 py-2 font-medium">When</th>
-                  <th scope="col" className="px-4 py-2 font-medium">Event</th>
-                  <th scope="col" className="px-4 py-2 font-medium">Course</th>
+                  <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                    When
+                  </th>
+                  <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                    Event
+                  </th>
+                  <th scope="col" className="px-5 py-2.5 text-xs font-semibold uppercase tracking-wide">
+                    Course
+                  </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
                 {report.recentActivity.map((a, i) => (
-                  <tr key={`${a.occurredAt}-${i}`} className="border-t border-slate-100 dark:border-neutral-800">
-                    <td className="px-4 py-2 whitespace-nowrap">{formatDateTime(a.occurredAt)}</td>
-                    <td className="px-4 py-2">{a.eventKind.replaceAll('_', ' ')}</td>
-                    <td className="px-4 py-2">
-                      {a.courseTitle}
-                      <span className="ml-2 text-xs text-slate-500">{a.courseCode}</span>
+                  <tr
+                    key={`${a.occurredAt}-${i}`}
+                    className="transition-colors hover:bg-slate-50/70 dark:hover:bg-neutral-800/40"
+                  >
+                    <td className="px-5 py-3 whitespace-nowrap text-slate-600 dark:text-neutral-400">
+                      {formatDateTime(a.occurredAt)}
+                    </td>
+                    <td className="px-5 py-3 capitalize text-slate-800 dark:text-neutral-200">
+                      {a.eventKind.replaceAll('_', ' ')}
+                    </td>
+                    <td className="px-5 py-3">
+                      <span className="text-slate-800 dark:text-neutral-200">{a.courseTitle}</span>
+                      <span className="ml-2 font-mono text-xs text-slate-500">{a.courseCode}</span>
                     </td>
                   </tr>
                 ))}
@@ -316,6 +750,7 @@ export function PeoplePanel() {
   const { confirm, ConfirmDialogHost } = useConfirm()
   const [searchParams, setSearchParams] = useSearchParams()
   const selectedUserId = searchParams.get('userId')
+  const filterPanelId = useId()
 
   const [q, setQ] = useState('')
   const [submittedQ, setSubmittedQ] = useState('')
@@ -325,6 +760,13 @@ export function PeoplePanel() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
+
+  const [selectedFilter, setSelectedFilter] = useState<PeopleListFilter | null>(null)
+  const [filterPage, setFilterPage] = useState(1)
+  const [filterPerPage, setFilterPerPage] = useState(25)
+  const [filterData, setFilterData] = useState<PaginatedPeople | null>(null)
+  const [filterLoading, setFilterLoading] = useState(false)
+  const [filterError, setFilterError] = useState<string | null>(null)
 
   const [report, setReport] = useState<PersonReport | null>(null)
   const [reportLoading, setReportLoading] = useState(false)
@@ -379,6 +821,34 @@ export function PeoplePanel() {
     void loadSearch()
   }, [loadSearch])
 
+  const loadFilter = useCallback(async () => {
+    if (!selectedFilter) {
+      setFilterData(null)
+      setFilterError(null)
+      return
+    }
+    setFilterLoading(true)
+    setFilterError(null)
+    try {
+      setFilterData(
+        await searchPeople({
+          filter: selectedFilter,
+          page: filterPage,
+          perPage: filterPerPage,
+        }),
+      )
+    } catch (e) {
+      setFilterError(e instanceof Error ? e.message : 'Failed to load accounts.')
+      setFilterData(null)
+    } finally {
+      setFilterLoading(false)
+    }
+  }, [selectedFilter, filterPage, filterPerPage])
+
+  useEffect(() => {
+    void loadFilter()
+  }, [loadFilter])
+
   const loadReport = useCallback(async (userId: string) => {
     setReportLoading(true)
     setReportError(null)
@@ -405,6 +875,17 @@ export function PeoplePanel() {
     e.preventDefault()
     setSubmittedQ(q.trim())
     setPage(1)
+  }
+
+  function toggleFilter(filter: PeopleListFilter) {
+    if (selectedFilter === filter) {
+      setSelectedFilter(null)
+      setFilterData(null)
+      setFilterError(null)
+      return
+    }
+    setSelectedFilter(filter)
+    setFilterPage(1)
   }
 
   function openPerson(userId: string) {
@@ -439,6 +920,7 @@ export function PeoplePanel() {
       setSubmittedQ(email)
       setPage(1)
       void loadStats()
+      void loadFilter()
     } catch (err) {
       toastMutationError(err instanceof Error ? err.message : 'Could not invite user.')
     } finally {
@@ -456,7 +938,7 @@ export function PeoplePanel() {
       await patchPerson(userId, { active })
       toastSaveOk(active ? 'Account reactivated.' : 'Account suspended.')
       if (selectedUserId === userId) await loadReport(userId)
-      await Promise.all([loadSearch(), loadStats()])
+      await Promise.all([loadSearch(), loadStats(), loadFilter()])
     } catch (e) {
       toastMutationError(e instanceof Error ? e.message : 'Update failed.')
     } finally {
@@ -471,7 +953,7 @@ export function PeoplePanel() {
       await deletePerson(userId)
       toastSaveOk('Account deleted.')
       closePerson()
-      await Promise.all([loadSearch(), loadStats()])
+      await Promise.all([loadSearch(), loadStats(), loadFilter()])
     } catch (e) {
       toastMutationError(e instanceof Error ? e.message : 'Delete failed.')
     } finally {
@@ -505,236 +987,342 @@ export function PeoplePanel() {
     )
   }
 
+  const resultCount = data?.total ?? data?.items.length
+  const activeStat = STAT_CARDS.find((c) => c.filter === selectedFilter) ?? null
+  const filterCount = filterData?.total
+
   return (
     <div className="mt-6 space-y-6">
-      <PeopleDashboardCards stats={stats} loading={statsLoading} error={statsError} />
+      <PeopleDashboardCards
+        stats={stats}
+        loading={statsLoading}
+        error={statsError}
+        selectedFilter={selectedFilter}
+        onSelectFilter={toggleFilter}
+      />
 
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <p className="text-sm text-slate-600 dark:text-neutral-400">
-          Search users by first name, last name, or email. Results are not shown until you search.
-        </p>
-        <button
-          type="button"
-          onClick={() => setInviteOpen(true)}
-          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
+      {selectedFilter && activeStat ? (
+        <section
+          id={filterPanelId}
+          aria-label={activeStat.tableTitle}
+          className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
         >
-          <MailPlus className="h-4 w-4" aria-hidden />
-          Invite user
-        </button>
-      </div>
+          <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-100 px-5 py-4 dark:border-neutral-800">
+            <div>
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                {activeStat.tableTitle}
+              </h3>
+              <p className="mt-0.5 text-sm text-slate-500 dark:text-neutral-400">
+                {activeStat.tableDescription}
+                {filterCount != null && !filterLoading ? (
+                  <>
+                    {' '}
+                    <span className="font-medium text-slate-700 dark:text-neutral-300">
+                      {formatCount(filterCount)}
+                    </span>{' '}
+                    {filterCount === 1 ? 'account' : 'accounts'}.
+                  </>
+                ) : null}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-neutral-400">
+                <span className="text-xs font-medium uppercase tracking-wide">Page size</span>
+                <select
+                  value={filterPerPage}
+                  onChange={(e) => {
+                    setFilterPerPage(Number(e.target.value))
+                    setFilterPage(1)
+                  }}
+                  className="rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                >
+                  {PAGE_SIZES.map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                onClick={() => toggleFilter(selectedFilter)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <X className="h-4 w-4" aria-hidden />
+                Close
+              </button>
+            </div>
+          </div>
 
-      <form onSubmit={onSearchSubmit} className="flex flex-wrap items-end gap-3">
-        <label className="flex min-w-[16rem] flex-1 flex-col text-sm">
-          <span className="mb-1 text-slate-600 dark:text-neutral-400">Search</span>
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden />
-            <input
-              type="search"
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-              placeholder="First name, last name, or email"
-              className="w-full rounded-lg border border-slate-300 py-2 pl-9 pr-3 dark:border-neutral-700 dark:bg-neutral-900"
+          {filterError ? (
+            <div className="border-b border-slate-100 px-5 py-3 dark:border-neutral-800">
+              <p
+                role="alert"
+                className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+              >
+                {filterError}
+              </p>
+            </div>
+          ) : null}
+
+          <PeopleResultsTable
+            data={filterData}
+            loading={filterLoading}
+            busyId={busyId}
+            emptyTitle="No accounts in this segment"
+            emptyHint="Try another metric or invite a user."
+            loadingLabel="Loading accounts…"
+            showJoined
+            onOpen={openPerson}
+            onSuspend={(user) => void mutatePerson(user.id, false, personDisplayName(user))}
+            onReactivate={(user) => void mutatePerson(user.id, true, '')}
+            onDelete={(user) => void removePerson(user.id, personDisplayName(user))}
+          />
+
+          {filterData ? (
+            <PaginationNav
+              label={`${activeStat.tableTitle} pagination`}
+              page={filterData.page}
+              totalPages={filterData.totalPages}
+              onPrev={() => setFilterPage((p) => p - 1)}
+              onNext={() => setFilterPage((p) => p + 1)}
+            />
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-5 py-4 dark:border-neutral-800">
+          <div>
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Find people</h3>
+            <p className="mt-0.5 text-sm text-slate-500 dark:text-neutral-400">
+              Search by first name, last name, or email. Results appear after you search.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setInviteOpen(true)}
+            className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm shadow-indigo-600/20 transition-colors hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:text-white"
+          >
+            <MailPlus className="h-4 w-4" aria-hidden />
+            Invite user
+          </button>
+        </div>
+
+        <form onSubmit={onSearchSubmit} className="flex flex-wrap items-end gap-3 px-5 py-4">
+          <label className="flex min-w-[16rem] flex-1 flex-col text-sm">
+            <span className="mb-1.5 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+              Search
+            </span>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
+                aria-hidden
+              />
+              <input
+                type="search"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="First name, last name, or email"
+                className="w-full rounded-xl border border-slate-200 bg-slate-50/50 py-2.5 pl-10 pr-3 text-sm text-slate-900 shadow-inner transition-colors placeholder:text-slate-400 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500/50 dark:focus:bg-neutral-950"
+              />
+            </div>
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="mb-1.5 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+              Page size
+            </span>
+            <select
+              value={perPage}
+              onChange={(e) => {
+                setPerPage(Number(e.target.value))
+                setPage(1)
+              }}
+              className="rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+            >
+              {PAGE_SIZES.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="submit"
+            disabled={!q.trim() || loading}
+            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+          >
+            {loading ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Search className="h-4 w-4" aria-hidden />
+            )}
+            {loading ? 'Searching…' : 'Search'}
+          </button>
+        </form>
+
+        {error ? (
+          <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800">
+            <p
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+            >
+              {error}
+            </p>
+          </div>
+        ) : null}
+
+        {!submittedQ.trim() ? (
+          <div className="border-t border-slate-100 px-5 py-12 dark:border-neutral-800">
+            <div className="mx-auto flex max-w-sm flex-col items-center text-center">
+              <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 ring-1 ring-indigo-100 dark:bg-indigo-950/50 dark:text-indigo-300 dark:ring-indigo-900/50">
+                <Sparkles className="h-6 w-6" aria-hidden />
+              </span>
+              <p className="mt-4 text-sm font-medium text-slate-900 dark:text-neutral-100">
+                Search to manage accounts
+              </p>
+              <p className="mt-1.5 text-sm leading-relaxed text-slate-500 dark:text-neutral-400">
+                Enter a name or email above, click a metric card above, or invite someone new.
+              </p>
+              <button
+                type="button"
+                onClick={() => setInviteOpen(true)}
+                className="mt-5 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <MailPlus className="h-4 w-4" aria-hidden />
+                Invite user
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="border-t border-slate-100 dark:border-neutral-800">
+            {data && !loading ? (
+              <div className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-2.5 dark:border-neutral-800">
+                <p className="text-xs text-slate-500 dark:text-neutral-400">
+                  {resultCount != null ? (
+                    <>
+                      <span className="font-medium text-slate-700 dark:text-neutral-300">
+                        {formatCount(resultCount)}
+                      </span>{' '}
+                      {resultCount === 1 ? 'result' : 'results'} for{' '}
+                      <span className="font-medium text-slate-700 dark:text-neutral-300">
+                        “{submittedQ}”
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      Results for{' '}
+                      <span className="font-medium text-slate-700 dark:text-neutral-300">
+                        “{submittedQ}”
+                      </span>
+                    </>
+                  )}
+                </p>
+              </div>
+            ) : null}
+            <PeopleResultsTable
+              data={data}
+              loading={loading}
+              busyId={busyId}
+              emptyTitle="No users matched your search"
+              emptyHint="Try a different name or email."
+              loadingLabel="Searching…"
+              onOpen={openPerson}
+              onSuspend={(user) => void mutatePerson(user.id, false, personDisplayName(user))}
+              onReactivate={(user) => void mutatePerson(user.id, true, '')}
+              onDelete={(user) => void removePerson(user.id, personDisplayName(user))}
             />
           </div>
-        </label>
-        <label className="flex flex-col text-sm">
-          <span className="mb-1 text-slate-600 dark:text-neutral-400">Page size</span>
-          <select
-            value={perPage}
-            onChange={(e) => {
-              setPerPage(Number(e.target.value))
-              setPage(1)
-            }}
-            className="rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
-          >
-            {PAGE_SIZES.map((n) => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </select>
-        </label>
-        <button
-          type="submit"
-          disabled={!q.trim() || loading}
-          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
-        >
-          {loading ? 'Searching…' : 'Search'}
-        </button>
-      </form>
+        )}
 
-      {error ? (
-        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
-          {error}
-        </p>
-      ) : null}
-
-      {!submittedQ.trim() ? (
-        <p className="rounded-xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-500 dark:border-neutral-700 dark:text-neutral-400">
-          Enter a name or email above to find users.
-        </p>
-      ) : (
-        <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
-          <table className="min-w-full text-left text-sm">
-            <thead className="bg-slate-50 text-slate-600 dark:bg-neutral-950 dark:text-neutral-400">
-              <tr>
-                <th scope="col" className="px-4 py-2 font-medium">Name</th>
-                <th scope="col" className="px-4 py-2 font-medium">Email</th>
-                <th scope="col" className="px-4 py-2 font-medium">Organization</th>
-                <th scope="col" className="px-4 py-2 font-medium">Role</th>
-                <th scope="col" className="px-4 py-2 font-medium">Status</th>
-                <th scope="col" className="px-4 py-2 font-medium">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
-                    <Loader2 className="mx-auto h-5 w-5 animate-spin" aria-hidden />
-                  </td>
-                </tr>
-              ) : !data?.items.length ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
-                    No users matched your search.
-                  </td>
-                </tr>
-              ) : (
-                data.items.map((user) => (
-                  <tr key={user.id} className="border-t border-slate-100 dark:border-neutral-800">
-                    <td className="px-4 py-2">
-                      <button
-                        type="button"
-                        onClick={() => openPerson(user.id)}
-                        className="font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-                      >
-                        {personDisplayName(user)}
-                      </button>
-                    </td>
-                    <td className="px-4 py-2">{user.email}</td>
-                    <td className="px-4 py-2">{user.orgName}</td>
-                    <td className="px-4 py-2">{user.role || '—'}</td>
-                    <td className="px-4 py-2">{statusLabel(user.active)}</td>
-                    <td className="px-4 py-2">
-                      <div className="flex flex-wrap gap-3">
-                        {user.active ? (
-                          <button
-                            type="button"
-                            disabled={busyId === user.id}
-                            onClick={() => void mutatePerson(user.id, false, personDisplayName(user))}
-                            className="text-sm text-amber-700 hover:underline disabled:opacity-50 dark:text-amber-400"
-                          >
-                            Suspend
-                          </button>
-                        ) : (
-                          <button
-                            type="button"
-                            disabled={busyId === user.id}
-                            onClick={() => void mutatePerson(user.id, true, '')}
-                            className="text-sm text-emerald-700 hover:underline disabled:opacity-50 dark:text-emerald-400"
-                          >
-                            Reactivate
-                          </button>
-                        )}
-                        <button
-                          type="button"
-                          disabled={busyId === user.id}
-                          onClick={() => void removePerson(user.id, personDisplayName(user))}
-                          className="text-sm text-red-600 hover:underline disabled:opacity-50 dark:text-red-400"
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {data && data.totalPages > 1 ? (
-        <nav aria-label="People search pagination" className="flex items-center gap-2">
-          <button
-            type="button"
-            disabled={page <= 1}
-            onClick={() => setPage((p) => p - 1)}
-            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-          >
-            Previous
-          </button>
-          <span className="text-sm text-slate-600 dark:text-neutral-400">
-            Page {data.page} of {data.totalPages}
-          </span>
-          <button
-            type="button"
-            disabled={page >= data.totalPages}
-            onClick={() => setPage((p) => p + 1)}
-            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-          >
-            Next
-          </button>
-        </nav>
-      ) : null}
+        {data ? (
+          <PaginationNav
+            label="People search pagination"
+            page={data.page}
+            totalPages={data.totalPages}
+            onPrev={() => setPage((p) => p - 1)}
+            onNext={() => setPage((p) => p + 1)}
+          />
+        ) : null}
+      </section>
 
       {inviteOpen ? (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4 backdrop-blur-[2px]"
           role="dialog"
           aria-modal="true"
           aria-labelledby="invite-user-title"
         >
           <form
             onSubmit={(e) => void onInvite(e)}
-            className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-xl dark:border-neutral-700 dark:bg-neutral-900"
+            className="w-full max-w-md overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl shadow-slate-900/15 dark:border-neutral-700 dark:bg-neutral-900"
           >
-            <h3 id="invite-user-title" className="text-base font-semibold text-slate-900 dark:text-neutral-100">
-              Invite user
-            </h3>
-            <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
-              Creates an account and emails a link to set their password.
-            </p>
-            <div className="mt-4 space-y-3">
+            <div className="border-b border-slate-100 bg-gradient-to-r from-indigo-50/80 to-white px-6 py-5 dark:border-neutral-800 dark:from-indigo-950/40 dark:to-neutral-900">
+              <div className="flex items-start gap-3">
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600 dark:bg-indigo-950 dark:text-indigo-300">
+                  <MailPlus className="h-5 w-5" aria-hidden />
+                </span>
+                <div>
+                  <h3
+                    id="invite-user-title"
+                    className="text-base font-semibold text-slate-900 dark:text-neutral-100"
+                  >
+                    Invite user
+                  </h3>
+                  <p className="mt-0.5 text-sm text-slate-500 dark:text-neutral-400">
+                    Creates an account and emails a link to set their password.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-3 px-6 py-5">
               <label className="block text-sm">
-                <span className="text-slate-600 dark:text-neutral-400">Email</span>
+                <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                  Email
+                </span>
                 <input
                   type="email"
                   required
                   value={inviteEmail}
                   onChange={(e) => setInviteEmail(e.target.value)}
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-950"
+                  className="mt-1.5 w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-700 dark:bg-neutral-950"
                 />
               </label>
-              <label className="block text-sm">
-                <span className="text-slate-600 dark:text-neutral-400">First name</span>
-                <input
-                  value={inviteFirst}
-                  onChange={(e) => setInviteFirst(e.target.value)}
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-950"
-                />
-              </label>
-              <label className="block text-sm">
-                <span className="text-slate-600 dark:text-neutral-400">Last name</span>
-                <input
-                  value={inviteLast}
-                  onChange={(e) => setInviteLast(e.target.value)}
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-950"
-                />
-              </label>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="block text-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                    First name
+                  </span>
+                  <input
+                    value={inviteFirst}
+                    onChange={(e) => setInviteFirst(e.target.value)}
+                    className="mt-1.5 w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+                <label className="block text-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                    Last name
+                  </span>
+                  <input
+                    value={inviteLast}
+                    onChange={(e) => setInviteLast(e.target.value)}
+                    className="mt-1.5 w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+              </div>
             </div>
-            <div className="mt-6 flex justify-end gap-2">
+            <div className="flex justify-end gap-2 border-t border-slate-100 bg-slate-50/50 px-6 py-4 dark:border-neutral-800 dark:bg-neutral-950/40">
               <button
                 type="button"
                 onClick={() => setInviteOpen(false)}
-                className="rounded-lg border border-slate-300 px-4 py-2 text-sm dark:border-neutral-700"
+                className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
               >
                 Cancel
               </button>
               <button
                 type="submit"
                 disabled={inviting}
-                className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm shadow-indigo-600/20 transition-colors hover:bg-indigo-700 disabled:opacity-50"
               >
                 {inviting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : null}
                 Send invite

--- a/clients/web/src/lib/people-api.ts
+++ b/clients/web/src/lib/people-api.ts
@@ -94,13 +94,24 @@ export async function fetchPeopleStats(): Promise<PeopleDashboardStats> {
   return parseJson(res)
 }
 
+/** Dashboard segment filters matching GET /api/v1/admin/people?filter=… */
+export type PeopleListFilter =
+  | 'signups_7d'
+  | 'active'
+  | 'recent_30d'
+  | 'total'
+  | 'suspended'
+
 export async function searchPeople(params: {
-  q: string
+  q?: string
+  filter?: PeopleListFilter
   page?: number
   perPage?: number
 }): Promise<PaginatedPeople> {
   const sp = new URLSearchParams()
-  sp.set('q', params.q.trim())
+  const q = params.q?.trim()
+  if (q) sp.set('q', q)
+  if (params.filter) sp.set('filter', params.filter)
   if (params.page) sp.set('page', String(params.page))
   if (params.perPage) sp.set('per_page', String(params.perPage))
   const res = await authorizedFetch(`/api/v1/admin/people?${sp}`)

--- a/clients/web/src/lib/platform-courses-api.ts
+++ b/clients/web/src/lib/platform-courses-api.ts
@@ -41,6 +41,14 @@ export type PlatformCourseReport = {
   updatedAt: string
 }
 
+export type CoursesDashboardStats = {
+  createdLast7Days: number
+  activeCourses: number
+  draftCourses: number
+  totalCourses: number
+  archivedCourses: number
+}
+
 async function parseJson<T>(res: Response): Promise<T> {
   const raw: unknown = await res.json().catch(() => ({}))
   if (!res.ok) {
@@ -55,15 +63,31 @@ async function parseJson<T>(res: Response): Promise<T> {
 
 export type PlatformCourseSearchStatus = 'open' | 'active' | 'draft' | 'archived' | 'all'
 
+/** Dashboard segment filters matching GET /api/v1/admin/courses?filter=… */
+export type CoursesListFilter =
+  | 'created_7d'
+  | 'active'
+  | 'draft'
+  | 'total'
+  | 'archived'
+
+export async function fetchCoursesStats(): Promise<CoursesDashboardStats> {
+  const res = await authorizedFetch('/api/v1/admin/courses/stats')
+  return parseJson(res)
+}
+
 export async function searchPlatformCourses(params: {
-  q: string
+  q?: string
   status?: PlatformCourseSearchStatus
+  filter?: CoursesListFilter
   page?: number
   perPage?: number
 }): Promise<PaginatedPlatformCourses> {
   const sp = new URLSearchParams()
-  sp.set('q', params.q.trim())
+  const q = params.q?.trim()
+  if (q) sp.set('q', q)
   if (params.status) sp.set('status', params.status)
+  if (params.filter) sp.set('filter', params.filter)
   if (params.page) sp.set('page', String(params.page))
   if (params.perPage) sp.set('per_page', String(params.perPage))
   const res = await authorizedFetch(`/api/v1/admin/courses?${sp}`)

--- a/clients/web/src/pages/lms/settings.tsx
+++ b/clients/web/src/pages/lms/settings.tsx
@@ -981,10 +981,16 @@ export default function Settings() {
 
         {activeView === 'people' && (
           <div>
-            <h2 className="text-base font-semibold text-slate-900 dark:text-neutral-100">People</h2>
-            <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
-              Search, invite, suspend, and manage user accounts across the platform.
-            </p>
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-neutral-100">
+                  People
+                </h2>
+                <p className="mt-1 max-w-2xl text-sm leading-relaxed text-slate-500 dark:text-neutral-400">
+                  Search, invite, suspend, and manage user accounts across the platform.
+                </p>
+              </div>
+            </div>
             <RequirePermission
               permission={PERM_RBAC_MANAGE}
               fallback={

--- a/server/internal/httpserver/platform_courses.go
+++ b/server/internal/httpserver/platform_courses.go
@@ -14,8 +14,28 @@ import (
 
 func (d Deps) registerPlatformCoursesRoutes(r chi.Router) {
 	r.Get("/api/v1/admin/courses", d.handleAdminCoursesSearch())
+	r.Get("/api/v1/admin/courses/stats", d.handleAdminCoursesStats())
 	r.Get("/api/v1/admin/courses/{courseId}/report", d.handleAdminCoursesReport())
 	r.Post("/api/v1/admin/courses/{courseId}/access", d.handleAdminCoursesAccess())
+}
+
+func (d Deps) handleAdminCoursesStats() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		stats, err := platformcourses.FetchDashboardStats(r.Context(), d.Pool)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course stats.")
+			return
+		}
+		writeJSON(w, http.StatusOK, stats)
+	}
 }
 
 func parsePlatformCoursesListParams(r *http.Request) platformcourses.ListParams {
@@ -26,6 +46,7 @@ func parsePlatformCoursesListParams(r *http.Request) platformcourses.ListParams 
 	p := platformcourses.ListParams{
 		Query:  strings.TrimSpace(r.URL.Query().Get("q")),
 		Status: status,
+		Filter: strings.TrimSpace(r.URL.Query().Get("filter")),
 	}
 	if v := strings.TrimSpace(r.URL.Query().Get("page")); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -56,6 +77,19 @@ func (d Deps) handleAdminCoursesSearch() http.HandlerFunc {
 			return
 		}
 		params := parsePlatformCoursesListParams(r)
+		if params.Filter != "" {
+			if platformcourses.NormalizeFilter(params.Filter) == "" {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid filter.")
+				return
+			}
+			result, err := platformcourses.ListByFilter(r.Context(), d.Pool, params)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list courses.")
+				return
+			}
+			writeJSON(w, http.StatusOK, result)
+			return
+		}
 		if params.Query == "" {
 			writeJSON(w, http.StatusOK, platformcourses.ListResult{Items: []platformcourses.CourseRow{}})
 			return

--- a/server/internal/httpserver/platform_courses_db_test.go
+++ b/server/internal/httpserver/platform_courses_db_test.go
@@ -1,0 +1,79 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	platformcourses "github.com/lextures/lextures/server/internal/repos/platformcourses"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+func TestAdminCoursesStats_OK_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	em := "coursestats-" + time.Now().Format("20060102150405") + "@e.com"
+	ph, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	row, err := user.InsertUser(ctx, pool, em, ph, nil)
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	uid, _ := uuid.Parse(row.ID)
+	if err := rbac.AssignUserRoleByName(ctx, pool, uid, "Global Admin"); err != nil {
+		t.Fatalf("ga: %v", err)
+	}
+	signer := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
+	tok, err := signer.Sign(ctx, row.ID, em, "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	expected, err := platformcourses.FetchDashboardStats(ctx, pool)
+	if err != nil {
+		t.Fatalf("repo stats: %v", err)
+	}
+
+	h := NewHandler(Deps{Pool: pool, JWTSigner: signer})
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/admin/courses/stats", nil)
+	r = r.WithContext(ctx)
+	r.Header.Set("Authorization", "Bearer "+tok)
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	var out platformcourses.DashboardStats
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != expected {
+		t.Fatalf("API stats %+v != repo stats %+v", out, expected)
+	}
+}

--- a/server/internal/httpserver/platform_courses_nodb_test.go
+++ b/server/internal/httpserver/platform_courses_nodb_test.go
@@ -28,4 +28,11 @@ func TestAdminCourses_UnauthenticatedReturns401(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("access status = %d, want 401", rr.Code)
 	}
+
+	rr = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "/api/v1/admin/courses/stats", nil)
+	d.handleAdminCoursesStats()(rr, r)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("stats status = %d, want 401", rr.Code)
+	}
 }

--- a/server/internal/httpserver/platform_people.go
+++ b/server/internal/httpserver/platform_people.go
@@ -39,7 +39,8 @@ func (d Deps) registerPlatformPeopleRoutes(r chi.Router) {
 
 func parsePlatformPeopleListParams(r *http.Request) platformpeople.ListParams {
 	p := platformpeople.ListParams{
-		Query: strings.TrimSpace(r.URL.Query().Get("q")),
+		Query:  strings.TrimSpace(r.URL.Query().Get("q")),
+		Filter: strings.TrimSpace(r.URL.Query().Get("filter")),
 	}
 	if v := strings.TrimSpace(r.URL.Query().Get("page")); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -89,11 +90,28 @@ func (d Deps) handleAdminPeopleSearch() http.HandlerFunc {
 			return
 		}
 		params := parsePlatformPeopleListParams(r)
+		var (
+			result platformpeople.ListResult
+			err    error
+		)
+		if params.Filter != "" {
+			if platformpeople.NormalizeFilter(params.Filter) == "" {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid filter.")
+				return
+			}
+			result, err = platformpeople.ListByFilter(r.Context(), d.Pool, params)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list users.")
+				return
+			}
+			writeJSON(w, http.StatusOK, result)
+			return
+		}
 		if params.Query == "" {
 			writeJSON(w, http.StatusOK, platformpeople.ListResult{Items: []platformpeople.PersonRow{}})
 			return
 		}
-		result, err := platformpeople.Search(r.Context(), d.Pool, params)
+		result, err = platformpeople.Search(r.Context(), d.Pool, params)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to search users.")
 			return

--- a/server/internal/repos/platformcourses/repo.go
+++ b/server/internal/repos/platformcourses/repo.go
@@ -13,6 +13,56 @@ import (
 	"github.com/lextures/lextures/server/internal/courseroles"
 )
 
+// rowQuerier is implemented by *pgxpool.Pool and pgx.Tx.
+type rowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// DashboardStats holds instance-wide course metrics for the admin Courses page.
+type DashboardStats struct {
+	CreatedLast7Days int64 `json:"createdLast7Days"`
+	ActiveCourses    int64 `json:"activeCourses"`
+	DraftCourses     int64 `json:"draftCourses"`
+	TotalCourses     int64 `json:"totalCourses"`
+	ArchivedCourses  int64 `json:"archivedCourses"`
+}
+
+// FetchDashboardStats returns aggregate course metrics for the admin dashboard.
+func FetchDashboardStats(ctx context.Context, pool *pgxpool.Pool) (DashboardStats, error) {
+	return fetchDashboardStats(ctx, pool)
+}
+
+func fetchDashboardStats(ctx context.Context, q rowQuerier) (DashboardStats, error) {
+	var stats DashboardStats
+	err := q.QueryRow(ctx, `
+SELECT
+    COUNT(*)::bigint AS total_courses,
+    COUNT(*) FILTER (
+        WHERE c.archived = false AND c.published = true
+    )::bigint AS active_courses,
+    COUNT(*) FILTER (
+        WHERE c.archived = false AND c.published = false
+    )::bigint AS draft_courses,
+    COUNT(*) FILTER (
+        WHERE c.archived = true
+    )::bigint AS archived_courses,
+    COUNT(*) FILTER (
+        WHERE c.created_at >= NOW() - INTERVAL '7 days'
+    )::bigint AS created_last_7_days
+FROM course.courses c
+`).Scan(
+		&stats.TotalCourses,
+		&stats.ActiveCourses,
+		&stats.DraftCourses,
+		&stats.ArchivedCourses,
+		&stats.CreatedLast7Days,
+	)
+	if err != nil {
+		return DashboardStats{}, err
+	}
+	return stats, nil
+}
+
 // CourseRow is a search result row.
 type CourseRow struct {
 	ID              string    `json:"id"`
@@ -29,12 +79,42 @@ type CourseRow struct {
 	UpdatedAt       time.Time `json:"updatedAt"`
 }
 
-// ListParams holds search pagination options.
+// Dashboard filter query values for listing courses behind a stats card.
+const (
+	FilterCreated7d = "created_7d"
+	FilterActive    = "active"
+	FilterDraft     = "draft"
+	FilterTotal     = "total"
+	FilterArchived  = "archived"
+)
+
+// ListParams holds search / filter pagination options.
 type ListParams struct {
-	Query   string
-	Status  string
+	Query  string
+	Status string
+	// Filter restricts results to a dashboard segment (see Filter* constants).
+	// Empty means free-text search only (Query required).
+	Filter  string
 	Page    int
 	PerPage int
+}
+
+// NormalizeFilter returns a known filter constant or empty string if unknown/blank.
+func NormalizeFilter(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case FilterCreated7d, "created_last_7_days", "new_courses":
+		return FilterCreated7d
+	case FilterActive, "active_courses":
+		return FilterActive
+	case FilterDraft, "draft_courses":
+		return FilterDraft
+	case FilterTotal, "total_courses":
+		return FilterTotal
+	case FilterArchived, "archived_courses":
+		return FilterArchived
+	default:
+		return ""
+	}
 }
 
 // ListResult is a paginated search response.
@@ -172,7 +252,83 @@ LIMIT $3 OFFSET $4
 		return ListResult{}, err
 	}
 	defer rows.Close()
+	return scanCourseList(rows, page, perPage)
+}
 
+// ListByFilter returns courses for a dashboard stats segment (optionally narrowed by free text).
+func ListByFilter(ctx context.Context, pool *pgxpool.Pool, p ListParams) (ListResult, error) {
+	filter := NormalizeFilter(p.Filter)
+	if filter == "" {
+		return ListResult{}, fmt.Errorf("platformcourses: invalid filter %q", p.Filter)
+	}
+	page, perPage := normalizePagination(p.Page, p.PerPage)
+	offset := (page - 1) * perPage
+	q := strings.TrimSpace(p.Query)
+
+	// Predicates match FetchDashboardStats segments.
+	where := `TRUE`
+	switch filter {
+	case FilterCreated7d:
+		where = `c.created_at >= NOW() - INTERVAL '7 days'`
+	case FilterActive:
+		where = `c.archived = false AND c.published = true`
+	case FilterDraft:
+		where = `c.archived = false AND c.published = false`
+	case FilterArchived:
+		where = `c.archived = true`
+	case FilterTotal:
+		// no extra predicate
+	}
+
+	args := []any{}
+	if q != "" {
+		like := "%" + strings.ToLower(q) + "%"
+		args = append(args, like)
+		where += fmt.Sprintf(`
+AND (
+    c.course_code ILIKE $%d
+    OR c.title ILIKE $%d
+)`, len(args), len(args))
+	}
+	args = append(args, perPage, offset)
+	limitPh := len(args) - 1
+	offsetPh := len(args)
+
+	sql := fmt.Sprintf(`
+SELECT
+    c.id::text,
+    c.course_code,
+    c.title,
+    c.archived,
+    c.published,
+    c.org_id::text,
+    o.name AS org_name,
+    COALESCE(NULLIF(TRIM(COALESCE(inst.display_name, '')), ''), inst.email) AS instructor_name,
+    c.term_id::text,
+    t.name AS term_name,
+    (SELECT COUNT(*)::bigint FROM course.course_enrollments ce
+     WHERE ce.course_id = c.id AND ce.active) AS enrollment_count,
+    c.created_at,
+    c.updated_at,
+    COUNT(*) OVER () AS total
+FROM course.courses c
+INNER JOIN tenant.organizations o ON o.id = c.org_id
+LEFT JOIN "user".users inst ON inst.id = c.created_by_user_id
+LEFT JOIN tenant.terms t ON t.id = c.term_id
+WHERE %s
+ORDER BY c.created_at DESC, c.title ASC
+LIMIT $%d OFFSET $%d
+`, where, limitPh, offsetPh)
+
+	rows, err := pool.Query(ctx, sql, args...)
+	if err != nil {
+		return ListResult{}, err
+	}
+	defer rows.Close()
+	return scanCourseList(rows, page, perPage)
+}
+
+func scanCourseList(rows pgx.Rows, page, perPage int) (ListResult, error) {
 	var items []CourseRow
 	var total int64
 	for rows.Next() {

--- a/server/internal/repos/platformcourses/repo_db_test.go
+++ b/server/internal/repos/platformcourses/repo_db_test.go
@@ -1,0 +1,85 @@
+package platformcourses
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+)
+
+func TestFetchDashboardStats_MatchesDirectCounts_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	// REPEATABLE READ snapshot so stats + verification counts stay consistent
+	// while parallel package tests insert/delete courses on the shared CI database.
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	stats, err := fetchDashboardStats(ctx, tx)
+	if err != nil {
+		t.Fatalf("FetchDashboardStats: %v", err)
+	}
+
+	var direct struct {
+		total, active, draft, archived, created7d int64
+	}
+	err = tx.QueryRow(ctx, `
+SELECT
+    COUNT(*)::bigint,
+    COUNT(*) FILTER (WHERE c.archived = false AND c.published = true)::bigint,
+    COUNT(*) FILTER (WHERE c.archived = false AND c.published = false)::bigint,
+    COUNT(*) FILTER (WHERE c.archived = true)::bigint,
+    COUNT(*) FILTER (WHERE c.created_at >= NOW() - INTERVAL '7 days')::bigint
+FROM course.courses c
+`).Scan(
+		&direct.total, &direct.active, &direct.draft, &direct.archived, &direct.created7d,
+	)
+	if err != nil {
+		t.Fatalf("direct course counts: %v", err)
+	}
+
+	if stats.TotalCourses != direct.total {
+		t.Fatalf("totalCourses = %d, want %d", stats.TotalCourses, direct.total)
+	}
+	if stats.ActiveCourses != direct.active {
+		t.Fatalf("activeCourses = %d, want %d", stats.ActiveCourses, direct.active)
+	}
+	if stats.DraftCourses != direct.draft {
+		t.Fatalf("draftCourses = %d, want %d", stats.DraftCourses, direct.draft)
+	}
+	if stats.ArchivedCourses != direct.archived {
+		t.Fatalf("archivedCourses = %d, want %d", stats.ArchivedCourses, direct.archived)
+	}
+	if stats.CreatedLast7Days != direct.created7d {
+		t.Fatalf("createdLast7Days = %d, want %d", stats.CreatedLast7Days, direct.created7d)
+	}
+
+	// Smoke the public pool entrypoint (non-snapshot); must not error.
+	if _, err := FetchDashboardStats(ctx, pool); err != nil {
+		t.Fatalf("FetchDashboardStats(pool): %v", err)
+	}
+}

--- a/server/internal/repos/platformpeople/filter_test.go
+++ b/server/internal/repos/platformpeople/filter_test.go
@@ -1,0 +1,29 @@
+package platformpeople
+
+import "testing"
+
+func TestNormalizeFilter(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"signups_7d", FilterSignups7d},
+		{"SIGNUPS_7D", FilterSignups7d},
+		{"signups_last_7_days", FilterSignups7d},
+		{"active", FilterActive},
+		{"active_accounts", FilterActive},
+		{"recent_30d", FilterRecent30d},
+		{"recently_active_30_days", FilterRecent30d},
+		{"total", FilterTotal},
+		{"total_accounts", FilterTotal},
+		{"suspended", FilterSuspended},
+		{"suspended_accounts", FilterSuspended},
+		{"nope", ""},
+		{"  active  ", FilterActive},
+	}
+	for _, tc := range cases {
+		if got := NormalizeFilter(tc.in); got != tc.want {
+			t.Errorf("NormalizeFilter(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/server/internal/repos/platformpeople/repo.go
+++ b/server/internal/repos/platformpeople/repo.go
@@ -33,11 +33,41 @@ type PersonRow struct {
 	CreatedAt   time.Time `json:"createdAt"`
 }
 
-// ListParams holds search pagination options.
+// Dashboard filter query values for listing users behind a stats card.
+const (
+	FilterSignups7d  = "signups_7d"
+	FilterActive     = "active"
+	FilterRecent30d  = "recent_30d"
+	FilterTotal      = "total"
+	FilterSuspended  = "suspended"
+)
+
+// ListParams holds search / filter pagination options.
 type ListParams struct {
 	Query   string
+	// Filter restricts results to a dashboard segment (see Filter* constants).
+	// Empty means free-text search only (Query required).
+	Filter  string
 	Page    int
 	PerPage int
+}
+
+// NormalizeFilter returns a known filter constant or empty string if unknown/blank.
+func NormalizeFilter(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case FilterSignups7d, "signups_last_7_days", "new_signups":
+		return FilterSignups7d
+	case FilterActive, "active_accounts":
+		return FilterActive
+	case FilterRecent30d, "recently_active_30_days", "active_this_month":
+		return FilterRecent30d
+	case FilterTotal, "total_accounts":
+		return FilterTotal
+	case FilterSuspended, "suspended_accounts":
+		return FilterSuspended
+	default:
+		return ""
+	}
 }
 
 // ListResult is a paginated search response.
@@ -188,7 +218,96 @@ LIMIT $3 OFFSET $4
 		return ListResult{}, err
 	}
 	defer rows.Close()
+	return scanPersonList(rows, page, perPage)
+}
 
+// ListByFilter returns users for a dashboard stats segment (optionally narrowed by free text).
+func ListByFilter(ctx context.Context, pool *pgxpool.Pool, p ListParams) (ListResult, error) {
+	filter := NormalizeFilter(p.Filter)
+	if filter == "" {
+		return ListResult{}, fmt.Errorf("platformpeople: invalid filter %q", p.Filter)
+	}
+	page, perPage := normalizePagination(p.Page, p.PerPage)
+	offset := (page - 1) * perPage
+	q := strings.TrimSpace(p.Query)
+
+	// Base human-account predicates match FetchDashboardStats.
+	where := `
+u.account_type <> 'system'
+AND u.email NOT ILIKE '%@erased.invalid'`
+	switch filter {
+	case FilterSignups7d:
+		where += `
+AND u.created_at >= NOW() - INTERVAL '7 days'`
+	case FilterActive:
+		where += `
+AND u.deactivated_at IS NULL AND NOT u.login_blocked`
+	case FilterSuspended:
+		where += `
+AND (u.deactivated_at IS NOT NULL OR u.login_blocked)`
+	case FilterRecent30d:
+		where += `
+AND EXISTS (
+    SELECT 1 FROM "user".user_audit ua
+    WHERE ua.user_id = u.id
+      AND ua.occurred_at >= NOW() - INTERVAL '30 days'
+)`
+	case FilterTotal:
+		// no extra predicate
+	}
+
+	args := []any{}
+	if q != "" {
+		like := "%" + strings.ToLower(q) + "%"
+		args = append(args, like)
+		where += fmt.Sprintf(`
+AND (
+    u.email ILIKE $%d
+    OR COALESCE(u.first_name, '') ILIKE $%d
+    OR COALESCE(u.last_name, '') ILIKE $%d
+    OR COALESCE(u.display_name, '') ILIKE $%d
+)`, len(args), len(args), len(args), len(args))
+	}
+	args = append(args, perPage, offset)
+	limitPh := len(args) - 1
+	offsetPh := len(args)
+
+	sql := fmt.Sprintf(`
+SELECT
+    u.id::text,
+    u.email,
+    u.first_name,
+    u.last_name,
+    u.display_name,
+    u.org_id::text,
+    o.name AS org_name,
+    COALESCE((
+        SELECT ar.name
+        FROM "user".user_app_roles uar
+        JOIN "user".app_roles ar ON ar.id = uar.role_id
+        WHERE uar.user_id = u.id
+        ORDER BY ar.name
+        LIMIT 1
+    ), '') AS role_name,
+    (u.deactivated_at IS NULL AND NOT u.login_blocked) AS active,
+    u.created_at,
+    COUNT(*) OVER () AS total
+FROM "user".users u
+INNER JOIN tenant.organizations o ON o.id = u.org_id
+WHERE %s
+ORDER BY u.created_at DESC, u.email ASC
+LIMIT $%d OFFSET $%d
+`, where, limitPh, offsetPh)
+
+	rows, err := pool.Query(ctx, sql, args...)
+	if err != nil {
+		return ListResult{}, err
+	}
+	defer rows.Close()
+	return scanPersonList(rows, page, perPage)
+}
+
+func scanPersonList(rows pgx.Rows, page, perPage int) (ListResult, error) {
 	var items []PersonRow
 	var total int64
 	for rows.Next() {


### PR DESCRIPTION
## Summary
- Add dashboard segment filters on admin People and Courses Settings panels so stats cards open the matching user/course list.
- Extend admin list APIs with a `filter` query param and add `GET /api/v1/admin/courses/stats` for courses metrics.
- Redesign the People and Courses admin UIs around clickable stats cards, URL-synced filter state, and optional free-text search within a segment.

## Test plan
- [x] `go test ./internal/repos/platformpeople/ ./internal/repos/platformcourses/ ./internal/httpserver/ -short`
- [x] DB-backed stats/filter tests for platform people/courses packages
- [x] `npm run typecheck` and `npm run lint` in `clients/web`
- [ ] Manually open Settings → People, click each stats card, confirm list/filter and search
- [ ] Manually open Settings → Courses, click each stats card, confirm list/filter and status search
- [ ] Confirm invalid `filter` query returns 400 from people/courses list endpoints