### PR TITLE
fix(web): stop CDN-caching nginx 404s as immutable assets

### DIFF
--- a/clients/web/nginx.conf
+++ b/clients/web/nginx.conf
@@ -10,6 +10,15 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+# Long-cache only successful fingerprinted assets. `add_header ... always` on
+# /assets/ previously stamped 404 HTML with max-age=31536000,immutable, so
+# Cloudflare (and browsers) could poison a hashed .css/.js URL for a year
+# during ECS rolling deploys when one task still lacked the new file.
+map $status $assets_cache_control {
+    200     "public, max-age=31536000, immutable";
+    default "no-store";
+}
+
 # Docker embedded DNS first; VPC DNS for Fargate (used only at request time).
 resolver 127.0.0.11 169.254.169.253 valid=10s ipv6=off;
 
@@ -55,7 +64,7 @@ server {
     # CDNs do not cache index.html under a .js URL after a rolling deploy.
     location /assets/ {
         try_files $uri =404;
-        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        add_header Cache-Control $assets_cache_control always;
         access_log off;
     }
 

--- a/iac/self-aws/README.md
+++ b/iac/self-aws/README.md
@@ -132,6 +132,8 @@ public_web_origin = "https://beta.example.com"
    ```
 5. Point the site CNAME: `beta` → CloudFront domain (`terraform output cloudfront_domain_name`), also **DNS only**.
 
+Keep the apex/`self` record **DNS only** (grey cloud). Proxied Cloudflare in front of CloudFront double-caches responses; during an ECS roll a brief `/assets/*` 404 can be stored for a year when the origin sends long `Cache-Control`, which shows up as unstyled pages (CSS/JS URLs returning HTML). If that happens, purge Cloudflare for `/assets/*` (and hard-refresh the browser) after the web tasks are healthy.
+
 A full apply without the validation CNAMEs in place waits up to **45 minutes** for ACM issuance and then fails if DNS is still missing.
 
 **Existing cert:** set `web_acm_certificate_arn` to a real us-east-1 ACM ARN instead of leaving it empty.


### PR DESCRIPTION
## Summary
- Map `/assets/` `Cache-Control` so only HTTP 200 responses get long immutable caching; 404s (and other errors) use `no-store` so Cloudflare/browsers cannot poison hashed CSS/JS URLs during ECS rolling deploys.
- Document that `self.lextures.com` should stay Cloudflare **DNS only** (grey cloud) in front of CloudFront, and purge `/assets/*` if a poisoned response is already cached.

## Test plan
- [ ] Confirm a missing asset (`/assets/missing.css`) returns `404` with `Cache-Control: no-store` after the web image ships (not `immutable`).
- [ ] Confirm a real fingerprinted CSS/JS URL still returns `200` with `public, max-age=31536000, immutable`.
- [ ] Purge Cloudflare `/assets/*` (or everything) for `self.lextures.com`, hard-refresh `/login`, and verify styles load.
- [ ] Prefer grey-cloud DNS for `self` → CloudFront to avoid double-caching.


Made with [Cursor](https://cursor.com)