### PR TITLE
fix(zapier): upgrade adm-zip to ≥0.6.0 for Dependabot alert

### DIFF
--- a/integrations/zapier/package-lock.json
+++ b/integrations/zapier/package-lock.json
@@ -3747,13 +3747,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -10434,7 +10434,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/integrations/zapier/package.json
+++ b/integrations/zapier/package.json
@@ -25,6 +25,7 @@
     "lodash": "^4.18.0",
     "got": "^11.8.5",
     "js-yaml": "^4.2.0",
-    "@tootallnate/once": "^2.0.1"
+    "@tootallnate/once": "^2.0.1",
+    "adm-zip": ">=0.6.0"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades the transitive `adm-zip` dependency in `integrations/zapier` from `0.5.16` to `0.6.0` to clear the Dependabot security alert.

`adm-zip` is pulled in by `zapier-platform-cli@19.0.0`. This change adds an npm `overrides` pin (`"adm-zip": ">=0.6.0"`) alongside the existing Zapier security overrides, and refreshes `package-lock.json` so the resolved version is `0.6.0`.

## Checklist

- [x] Tests added/updated as appropriate (existing Zapier unit tests + `zapier-platform validate` pass locally)
- [x] N/A — no plan moved into `docs/completed/`
- [x] N/A — dependency-only security fix, no feature flags

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5c7a183-47fe-427f-ab96-b8ebfb5f26ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5c7a183-47fe-427f-ab96-b8ebfb5f26ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

