### PR TITLE
fix(android): Robolectric for MOB.5 LiveGameLogicTest

### DIFF
--- a/clients/android/app/src/test/kotlin/com/lextures/android/core/lms/LiveQuizLogicTest.kt
+++ b/clients/android/app/src/test/kotlin/com/lextures/android/core/lms/LiveQuizLogicTest.kt
@@ -7,6 +7,8 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 class LiveQuizLogicTest {
     @Before
@@ -121,6 +123,7 @@ class LiveQuizLogicTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class LiveGameLogicTest {
     @Test
     fun answerPayloadShapes() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #503: Android CI failed on three `LiveGameLogicTest` cases because `org.json.JSONObject` is stubbed on the JVM unit-test classpath.

Run `LiveGameLogicTest` under Robolectric (same pattern as other Android LMS tests) so handshake/payload/parse coverage exercises a real JSON implementation.

## Test plan

- [ ] Android CI: `./gradlew lint test assembleDebug`
- [ ] Confirm `LiveGameLogicTest` (answerPayloadShapes, authHandshakeAndReconnectDelay, parseInboundMessages) pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d2efb3-1396-430c-983e-045d2e72c9d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d2efb3-1396-430c-983e-045d2e72c9d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

