### PR TITLE
feat(motion): AN.7 delight and progress moments

### DIFF
--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/design/LexturesMotion.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/design/LexturesMotion.kt
@@ -494,6 +494,49 @@ fun indicatorOffsetPx(index: Int, optionWidths: List<Float>, gapPx: Float = 0f):
     return offset
 }
 
+// MARK: AN.7 — Delight & progress moments
+
+/** Max particles in a burst (FR-5 / FR-9). */
+const val DELIGHT_PARTICLE_CAP = 24
+
+/** WCAG 2.3.1 flash budget. */
+const val DELIGHT_MAX_FLASH_HZ = 3
+
+fun shouldAnimateProgress(reduceMotion: Boolean, enabled: Boolean): Boolean =
+    enabled && !reduceMotion
+
+fun shouldCelebrate(
+    reduceMotion: Boolean,
+    enabled: Boolean,
+    seriousContext: Boolean = false,
+    gamificationEnabled: Boolean = true,
+): Boolean = enabled && !reduceMotion && !seriousContext && gamificationEnabled
+
+fun shouldShowStaticDelight(
+    reduceMotion: Boolean,
+    enabled: Boolean,
+    seriousContext: Boolean = false,
+    gamificationEnabled: Boolean = true,
+): Boolean {
+    if (!enabled || !gamificationEnabled) return false
+    return reduceMotion || seriousContext
+}
+
+fun interpolateProgress(from: Float, to: Float, t: Float): Float {
+    val clamped = t.coerceIn(0f, 1f)
+    val eased = 1f - (1f - clamped).let { it * it * it }
+    return from + (to - from) * eased
+}
+
+fun particleCapForViewport(widthPx: Float, lowEnd: Boolean = false): Int {
+    if (lowEnd) return minOf(12, DELIGHT_PARTICLE_CAP)
+    if (widthPx < 480f) return minOf(16, DELIGHT_PARTICLE_CAP)
+    return DELIGHT_PARTICLE_CAP
+}
+
+fun progressDurationMs(reduceMotion: Boolean, enabled: Boolean): Int =
+    if (shouldAnimateProgress(reduceMotion, enabled)) LexturesMotion.DeliberateMs else 0
+
 /**
  * AN.6 — press scale for tappable controls (FR-1).
  * Reduced motion → opacity dip; kill-switch → identity.

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsFeatureModels.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsFeatureModels.kt
@@ -458,6 +458,7 @@ data class PlatformFeatures(
     val ffMotionLists: Boolean? = null,
     val ffMotionOverlays: Boolean? = null,
     val ffMotionControls: Boolean? = null,
+    val ffMotionDelight: Boolean? = null,
     val oerLibraryEnabled: Boolean? = null,
     val xapiEmissionEnabled: Boolean? = null,
     val customFieldsEnabled: Boolean? = null,

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/navigation/MobileDestinations.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/navigation/MobileDestinations.kt
@@ -201,6 +201,7 @@ data class MobilePlatformFeatures(
     val ffMotionOverlays: Boolean = true,
     /** AN.6 kill-switch; default on when unset. */
     val ffMotionControls: Boolean = true,
+    val ffMotionDelight: Boolean = true,
     val oerLibraryEnabled: Boolean = false,
     val xapiEmissionEnabled: Boolean = false,
     val customFieldsEnabled: Boolean = false,
@@ -304,6 +305,7 @@ data class MobilePlatformFeatures(
             ffMotionLists = features?.ffMotionLists != false,
             ffMotionOverlays = features?.ffMotionOverlays != false,
             ffMotionControls = features?.ffMotionControls != false,
+            ffMotionDelight = features?.ffMotionDelight != false,
             oerLibraryEnabled = features?.oerLibraryEnabled == true,
             xapiEmissionEnabled = features?.xapiEmissionEnabled == true,
             customFieldsEnabled = features?.customFieldsEnabled == true,

--- a/clients/android/app/src/test/kotlin/com/lextures/android/core/design/LexturesMotionTest.kt
+++ b/clients/android/app/src/test/kotlin/com/lextures/android/core/design/LexturesMotionTest.kt
@@ -91,4 +91,21 @@ class LexturesMotionTest {
         assertFalse(Haptics.shouldFire(enabled = false))
         assertFalse(Haptics.shouldFire(enabled = true, systemHapticsOff = true))
     }
+
+    /** AN.7: progress interpolate, celebrate gates, particle cap. */
+    @Test
+    fun delightMotionHelpers() {
+        assertEquals(24, DELIGHT_PARTICLE_CAP)
+        assertEquals(3, DELIGHT_MAX_FLASH_HZ)
+        assertTrue(shouldAnimateProgress(reduceMotion = false, enabled = true))
+        assertFalse(shouldAnimateProgress(reduceMotion = true, enabled = true))
+        assertFalse(shouldCelebrate(reduceMotion = true, enabled = true))
+        assertFalse(shouldCelebrate(reduceMotion = false, enabled = true, seriousContext = true))
+        assertFalse(shouldCelebrate(reduceMotion = false, enabled = true, gamificationEnabled = false))
+        assertTrue(shouldShowStaticDelight(reduceMotion = true, enabled = true))
+        assertEquals(0f, interpolateProgress(0f, 100f, 0f), 0.0001f)
+        assertEquals(100f, interpolateProgress(0f, 100f, 1f), 0.0001f)
+        assertTrue(particleCapForViewport(320f) <= 16)
+        assertEquals(0, progressDurationMs(reduceMotion = true, enabled = true))
+    }
 }

--- a/clients/ios/Lextures/Core/Design/LexturesMotion.swift
+++ b/clients/ios/Lextures/Core/Design/LexturesMotion.swift
@@ -420,6 +420,55 @@ enum LXControlMotion {
     }
 }
 
+// MARK: AN.7 — Delight & progress moments
+
+enum LXDelightMotion {
+    static let particleCap = 24
+    static let burstDuration = LexturesMotion.deliberate
+    static let maxFlashHz = 3
+
+    static func shouldAnimateProgress(reduceMotion: Bool, enabled: Bool) -> Bool {
+        enabled && !reduceMotion
+    }
+
+    static func shouldCelebrate(
+        reduceMotion: Bool,
+        enabled: Bool,
+        seriousContext: Bool = false,
+        gamificationEnabled: Bool = true
+    ) -> Bool {
+        guard enabled, !reduceMotion, !seriousContext, gamificationEnabled else { return false }
+        return true
+    }
+
+    static func shouldShowStaticDelight(
+        reduceMotion: Bool,
+        enabled: Bool,
+        seriousContext: Bool = false,
+        gamificationEnabled: Bool = true
+    ) -> Bool {
+        guard enabled else { return false }
+        if !gamificationEnabled { return false }
+        return reduceMotion || seriousContext
+    }
+
+    static func interpolateProgress(from: Double, to: Double, t: Double) -> Double {
+        let clamped = min(1, max(0, t))
+        let eased = 1 - pow(1 - clamped, 3)
+        return from + (to - from) * eased
+    }
+
+    static func particleCap(forWidth width: CGFloat, lowEnd: Bool = false) -> Int {
+        if lowEnd { return min(12, particleCap) }
+        if width < 480 { return min(16, particleCap) }
+        return particleCap
+    }
+
+    static func progressDuration(reduceMotion: Bool, enabled: Bool) -> TimeInterval {
+        shouldAnimateProgress(reduceMotion: reduceMotion, enabled: enabled) ? burstDuration : 0
+    }
+}
+
 private struct LXPressableModifier: ViewModifier {
     @Environment(\.lxReduceMotion) private var reduceMotion
     let isPressed: Bool

--- a/clients/ios/Lextures/Core/Design/LexturesMotion.swift
+++ b/clients/ios/Lextures/Core/Design/LexturesMotion.swift
@@ -452,10 +452,10 @@ enum LXDelightMotion {
         return reduceMotion || seriousContext
     }
 
-    static func interpolateProgress(from: Double, to: Double, t: Double) -> Double {
-        let clamped = min(1, max(0, t))
+    static func interpolateProgress(from startValue: Double, to endValue: Double, progress: Double) -> Double {
+        let clamped = min(1, max(0, progress))
         let eased = 1 - pow(1 - clamped, 3)
-        return from + (to - from) * eased
+        return startValue + (endValue - startValue) * eased
     }
 
     static func particleCap(forWidth width: CGFloat, lowEnd: Bool = false) -> Int {

--- a/clients/ios/Lextures/Core/LMS/LMSFeatureModelsPlatform.swift
+++ b/clients/ios/Lextures/Core/LMS/LMSFeatureModelsPlatform.swift
@@ -27,6 +27,7 @@ struct PlatformFeatures: Decodable {
     var ffMotionLists: Bool?
     var ffMotionOverlays: Bool?
     var ffMotionControls: Bool?
+    var ffMotionDelight: Bool?
     var oerLibraryEnabled: Bool?
     var xapiEmissionEnabled: Bool?
     var customFieldsEnabled: Bool?

--- a/clients/ios/Lextures/Core/Routing/MobileDestinations.swift
+++ b/clients/ios/Lextures/Core/Routing/MobileDestinations.swift
@@ -383,6 +383,7 @@ struct MobilePlatformFeatures: Equatable {
     /// AN.5 kill-switch; default on when unset.
     var ffMotionOverlays = true
     var ffMotionControls = true
+    var ffMotionDelight = true
     var oerLibraryEnabled = false
     var xapiEmissionEnabled = false
     var customFieldsEnabled = false
@@ -469,6 +470,7 @@ struct MobilePlatformFeatures: Equatable {
             ffMotionLists: features?.ffMotionLists != false,
             ffMotionOverlays: features?.ffMotionOverlays != false,
             ffMotionControls: features?.ffMotionControls != false,
+            ffMotionDelight: features?.ffMotionDelight != false,
             oerLibraryEnabled: features?.oerLibraryEnabled == true,
             xapiEmissionEnabled: features?.xapiEmissionEnabled == true,
             customFieldsEnabled: features?.customFieldsEnabled == true,

--- a/clients/ios/LexturesTests/LexturesMotionTests.swift
+++ b/clients/ios/LexturesTests/LexturesMotionTests.swift
@@ -106,8 +106,8 @@ final class LexturesMotionTests: XCTestCase {
         XCTAssertFalse(LXDelightMotion.shouldCelebrate(reduceMotion: false, enabled: true, seriousContext: true))
         XCTAssertFalse(LXDelightMotion.shouldCelebrate(reduceMotion: false, enabled: true, gamificationEnabled: false))
         XCTAssertTrue(LXDelightMotion.shouldShowStaticDelight(reduceMotion: true, enabled: true))
-        XCTAssertEqual(LXDelightMotion.interpolateProgress(from: 0, to: 100, t: 0), 0, accuracy: 0.0001)
-        XCTAssertEqual(LXDelightMotion.interpolateProgress(from: 0, to: 100, t: 1), 100, accuracy: 0.0001)
+        XCTAssertEqual(LXDelightMotion.interpolateProgress(from: 0, to: 100, progress: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(LXDelightMotion.interpolateProgress(from: 0, to: 100, progress: 1), 100, accuracy: 0.0001)
         XCTAssertLessThanOrEqual(LXDelightMotion.particleCap(forWidth: 320), 16)
         XCTAssertEqual(LXDelightMotion.progressDuration(reduceMotion: true, enabled: true), 0, accuracy: 0.0001)
     }

--- a/clients/ios/LexturesTests/LexturesMotionTests.swift
+++ b/clients/ios/LexturesTests/LexturesMotionTests.swift
@@ -95,4 +95,20 @@ final class LexturesMotionTests: XCTestCase {
         XCTAssertEqual(Haptics.systemName(for: .success), "notificationSuccess")
         XCTAssertEqual(Haptics.systemName(for: .error), "notificationError")
     }
+
+    /// AN.7: progress interpolate, celebrate gates, particle cap.
+    func testDelightMotionHelpers() {
+        XCTAssertEqual(LXDelightMotion.particleCap, 24)
+        XCTAssertEqual(LXDelightMotion.maxFlashHz, 3)
+        XCTAssertTrue(LXDelightMotion.shouldAnimateProgress(reduceMotion: false, enabled: true))
+        XCTAssertFalse(LXDelightMotion.shouldAnimateProgress(reduceMotion: true, enabled: true))
+        XCTAssertFalse(LXDelightMotion.shouldCelebrate(reduceMotion: true, enabled: true))
+        XCTAssertFalse(LXDelightMotion.shouldCelebrate(reduceMotion: false, enabled: true, seriousContext: true))
+        XCTAssertFalse(LXDelightMotion.shouldCelebrate(reduceMotion: false, enabled: true, gamificationEnabled: false))
+        XCTAssertTrue(LXDelightMotion.shouldShowStaticDelight(reduceMotion: true, enabled: true))
+        XCTAssertEqual(LXDelightMotion.interpolateProgress(from: 0, to: 100, t: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(LXDelightMotion.interpolateProgress(from: 0, to: 100, t: 1), 100, accuracy: 0.0001)
+        XCTAssertLessThanOrEqual(LXDelightMotion.particleCap(forWidth: 320), 16)
+        XCTAssertEqual(LXDelightMotion.progressDuration(reduceMotion: true, enabled: true), 0, accuracy: 0.0001)
+    }
 }

--- a/clients/web/src/components/gamification/gamification-dashboard-card.tsx
+++ b/clients/web/src/components/gamification/gamification-dashboard-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Award, Flame, Sparkles, X } from 'lucide-react'
 import {
@@ -8,6 +8,9 @@ import {
   type GamificationProfile,
 } from '../../lib/gamification-api'
 import { usePlatformFeatures } from '../../context/platform-features-context'
+import { AnimatedProgress } from '../ui/animated-progress'
+import { DelightMoment } from '../ui/delight-moment'
+import { useCountUp } from '../../lib/use-count-up'
 
 export function GamificationDashboardCard() {
   const { ffGamification, loading: featuresLoading } = usePlatformFeatures()
@@ -15,6 +18,9 @@ export function GamificationDashboardCard() {
   const [error, setError] = useState<string | null>(null)
   const [dismissedEnded, setDismissedEnded] = useState(false)
   const [freezing, setFreezing] = useState(false)
+  const [badgeDelight, setBadgeDelight] = useState(false)
+  const seenBadgesRef = useRef<Set<string>>(new Set())
+  const xpCount = useCountUp(profile?.xpTotal ?? 0)
 
   useEffect(() => {
     if (featuresLoading || !ffGamification) return
@@ -22,6 +28,21 @@ export function GamificationDashboardCard() {
     void fetchGamificationProfile()
       .then((p) => {
         if (!cancelled) {
+          if (seenBadgesRef.current.size === 0) {
+            // Seed seen set on first load without celebrating historical badges.
+            for (const b of p.recentBadges) {
+              seenBadgesRef.current.add(`${b.badgeType}-${b.awardedAt}`)
+            }
+          } else {
+            const newest = p.recentBadges[0]
+            if (newest) {
+              const key = `${newest.badgeType}-${newest.awardedAt}`
+              if (!seenBadgesRef.current.has(key)) {
+                seenBadgesRef.current.add(key)
+                setBadgeDelight(true)
+              }
+            }
+          }
           setProfile(p)
           setError(null)
         }
@@ -107,7 +128,7 @@ export function GamificationDashboardCard() {
             )}
             <p className="mt-2 text-xs text-slate-600 dark:text-neutral-400">
               Level <span className="lex-num">{profile.level}</span> ·{' '}
-              <span className="lex-num">{profile.xpTotal.toLocaleString()}</span> XP
+              <span className="lex-num">{xpCount.formatted}</span> XP
             </p>
           </div>
           <Link
@@ -119,19 +140,12 @@ export function GamificationDashboardCard() {
         </div>
 
         <div className="mt-4">
-          <div
-            className="h-2 overflow-hidden rounded-full bg-orange-200/80 dark:bg-orange-900/50"
-            role="progressbar"
-            aria-valuenow={profile.levelProgressPct}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label={`XP progress toward level ${profile.level + 1}`}
-          >
-            <div
-              className="h-full rounded-full bg-orange-600 motion-safe:transition-[width] motion-safe:duration-300 dark:bg-orange-500"
-              style={{ width: `${profile.levelProgressPct}%` }}
-            />
-          </div>
+          <AnimatedProgress
+            value={profile.levelProgressPct}
+            label={`XP progress toward level ${profile.level + 1}`}
+            className="h-2 overflow-hidden rounded-full bg-orange-200/80 dark:bg-orange-900/50 lx-delight-progress"
+            fillClassName="h-full rounded-full bg-orange-600 dark:bg-orange-500"
+          />
           <p className="mt-2 text-xs text-slate-700 dark:text-neutral-300">
             <span className="lex-num">{profile.xpToNextLevel.toLocaleString()}</span> XP to level{' '}
             <span className="lex-num">{profile.level + 1}</span>
@@ -144,13 +158,20 @@ export function GamificationDashboardCard() {
               Recent badges
             </p>
             <ul className="mt-2 flex gap-2 overflow-x-auto pb-1">
-              {profile.recentBadges.map((b) => (
-                <li
-                  key={`${b.badgeType}-${b.awardedAt}`}
-                  className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-orange-200 bg-white px-3 py-1 text-xs font-medium text-orange-900 dark:border-orange-800 dark:bg-neutral-900 dark:text-orange-100"
-                >
-                  <Award className="h-3.5 w-3.5" aria-hidden />
-                  <span>{badgeLabel(b.badgeType)}</span>
+              {profile.recentBadges.map((b, idx) => (
+                <li key={`${b.badgeType}-${b.awardedAt}`}>
+                  <DelightMoment
+                    active={badgeDelight && idx === 0}
+                    kind="badge"
+                    announcement={`Badge earned: ${badgeLabel(b.badgeType)}`}
+                    gamificationEnabled={ffGamification}
+                    onComplete={() => setBadgeDelight(false)}
+                  >
+                    <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-orange-200 bg-white px-3 py-1 text-xs font-medium text-orange-900 dark:border-orange-800 dark:bg-neutral-900 dark:text-orange-100">
+                      <Award className="h-3.5 w-3.5" aria-hidden />
+                      <span>{badgeLabel(b.badgeType)}</span>
+                    </span>
+                  </DelightMoment>
                 </li>
               ))}
             </ul>

--- a/clients/web/src/components/intro-course/intro-completion-celebration.tsx
+++ b/clients/web/src/components/intro-course/intro-completion-celebration.tsx
@@ -11,23 +11,18 @@ import {
 } from '../../lib/intro-course-api'
 import type { IssuedCredentialSummary } from '../../lib/credentials-api'
 import { recordIntroCourseCelebrationView } from '../../lib/intro-course-observability'
-
-function prefersReducedMotion(): boolean {
-  if (typeof window === 'undefined') return false
-  return (
-    document.documentElement.classList.contains('reduced-motion') ||
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  )
-}
+import { DelightMoment } from '../ui/delight-moment'
+import { usePrefersReducedMotion } from '../../lib/motion'
 
 export function IntroCompletionCelebration() {
   const { t } = useTranslation('introCourse')
   const { ffCompletionCredentials, ffHighContrastReducedMotion } = usePlatformFeatures()
   const { progress, loading, refresh } = useIntroCourseProgress()
   const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const reduceMotionPref = usePrefersReducedMotion()
 
   const visible = !loading && shouldShowIntroCelebration(progress)
-  const reducedMotion = ffHighContrastReducedMotion || prefersReducedMotion()
+  const reducedMotion = ffHighContrastReducedMotion || reduceMotionPref
 
   useEffect(() => {
     if (visible) {
@@ -65,51 +60,49 @@ export function IntroCompletionCelebration() {
       aria-label={t('introCourse.celebration.ariaLabel')}
       className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70 p-4"
     >
-      {!reducedMotion ? (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 overflow-hidden motion-safe:animate-pulse"
-        >
-          <div className="absolute left-1/4 top-1/4 h-2 w-2 rounded-full bg-amber-300 opacity-80" />
-          <div className="absolute right-1/3 top-1/3 h-2 w-2 rounded-full bg-sky-300 opacity-80" />
-          <div className="absolute bottom-1/4 left-1/3 h-2 w-2 rounded-full bg-emerald-300 opacity-80" />
-        </div>
-      ) : null}
-      <div className="relative w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-xl dark:bg-neutral-900">
-        <PartyPopper className="mx-auto h-12 w-12 text-emerald-500" aria-hidden />
-        <h2 className="mt-4 text-xl font-bold text-slate-900 dark:text-white">
-          {t('introCourse.celebration.title')}
-        </h2>
-        <p className="mt-2 text-sm text-slate-600 dark:text-neutral-300">
-          {credential
-            ? t('introCourse.celebration.bodyWithCredential')
-            : t('introCourse.celebration.body')}
-        </p>
-        {credential ? (
-          <div className="mt-6 text-left">
-            <div className="mb-3 flex items-center gap-2 text-sm font-medium text-slate-800 dark:text-neutral-100">
-              <Award className="h-4 w-4 text-emerald-600" aria-hidden />
-              <span>{t('introCourse.celebration.badgeLabel')}</span>
+      <DelightMoment
+        active
+        kind="completion"
+        announcement={t('introCourse.celebration.title')}
+        showBurst={!reducedMotion}
+        className="relative w-full max-w-md"
+      >
+        <div className="relative w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-xl dark:bg-neutral-900">
+          <PartyPopper className="mx-auto h-12 w-12 text-emerald-500" aria-hidden />
+          <h2 className="mt-4 text-xl font-bold text-slate-900 dark:text-white">
+            {t('introCourse.celebration.title')}
+          </h2>
+          <p className="mt-2 text-sm text-slate-600 dark:text-neutral-300">
+            {credential
+              ? t('introCourse.celebration.bodyWithCredential')
+              : t('introCourse.celebration.body')}
+          </p>
+          {credential ? (
+            <div className="mt-6 text-left">
+              <div className="mb-3 flex items-center gap-2 text-sm font-medium text-slate-800 dark:text-neutral-100">
+                <Award className="h-4 w-4 text-emerald-600" aria-hidden />
+                <span>{t('introCourse.celebration.badgeLabel')}</span>
+              </div>
+              <CredentialShareActions credential={credential} layout="stack" />
             </div>
-            <CredentialShareActions credential={credential} layout="stack" />
-          </div>
-        ) : (
-          <Link
-            to="/me/credentials"
-            className="mt-4 inline-flex text-sm font-medium text-sky-700 hover:underline dark:text-sky-300"
+          ) : (
+            <Link
+              to="/me/credentials"
+              className="mt-4 inline-flex text-sm font-medium text-sky-700 hover:underline dark:text-sky-300"
+            >
+              {t('introCourse.celebration.credentialsLink')}
+            </Link>
+          )}
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={handleClose}
+            className="mt-6 w-full rounded-lg px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 dark:text-neutral-300 dark:hover:bg-neutral-800"
           >
-            {t('introCourse.celebration.credentialsLink')}
-          </Link>
-        )}
-        <button
-          ref={closeButtonRef}
-          type="button"
-          onClick={handleClose}
-          className="mt-6 w-full rounded-lg px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 dark:text-neutral-300 dark:hover:bg-neutral-800"
-        >
-          {t('introCourse.celebration.close')}
-        </button>
-      </div>
+            {t('introCourse.celebration.close')}
+          </button>
+        </div>
+      </DelightMoment>
     </div>
   )
 }

--- a/clients/web/src/components/intro-course/intro-course-progress-bar.tsx
+++ b/clients/web/src/components/intro-course/intro-course-progress-bar.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { AnimatedProgress } from '../ui/animated-progress'
 
 export function IntroCourseProgressBar({
   percent,
@@ -30,19 +31,11 @@ export function IntroCourseProgressBar({
         </span>
         <span className="tabular-nums">{clamped}%</span>
       </p>
-      <div
-        role="progressbar"
-        aria-valuenow={clamped}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-label={ariaLabel}
-        className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-neutral-700"
-      >
-        <div
-          className="h-full rounded-full bg-sky-500 motion-safe:transition-[width] motion-safe:duration-300"
-          style={{ width: `${clamped}%` }}
-        />
-      </div>
+      <AnimatedProgress
+        value={clamped}
+        label={ariaLabel}
+        fillClassName="h-full rounded-full bg-sky-500"
+      />
     </div>
   )
 }

--- a/clients/web/src/components/live-quiz/leaderboard.tsx
+++ b/clients/web/src/components/live-quiz/leaderboard.tsx
@@ -1,10 +1,20 @@
 import { useTranslation } from 'react-i18next'
+import { AnimatedList } from '../ui/animated-list'
+import { useCountUp } from '../../lib/use-count-up'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import { usePrefersReducedMotion } from '../../lib/motion'
+import { motion } from '../../lib/motion'
 
 export type LeaderboardRow = {
   rank: number
   playerId: string
   nickname: string
   totalScore: number
+}
+
+function ScoreCell({ score, animate }: { score: number; animate: boolean }) {
+  const { formatted } = useCountUp(score, { enabled: animate })
+  return <span className="tabular-nums lx-delight-count-up">{formatted}</span>
 }
 
 export function LiveQuizLeaderboard({
@@ -21,9 +31,10 @@ export function LiveQuizLeaderboard({
   youRank?: number
 }) {
   const { t } = useTranslation('common')
-  const reduceMotion =
-    typeof window !== 'undefined' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  const { ffMotionDelight, ffMotionLists } = usePlatformFeatures()
+  const reduceMotion = usePrefersReducedMotion()
+  const delightOn = ffMotionDelight !== false && !reduceMotion
+  const listsOn = ffMotionLists !== false
 
   if (privacy === 'hidden') {
     return (
@@ -48,27 +59,24 @@ export function LiveQuizLeaderboard({
         role="region"
         aria-label={t('liveQuiz.leaderboard.podiumAria')}
       >
-        <ol
-          className={
-            reduceMotion
-              ? 'flex flex-wrap items-end justify-center gap-4'
-              : 'flex flex-wrap items-end justify-center gap-4 motion-safe:animate-in motion-safe:fade-in'
-          }
-        >
+        <ol className="flex flex-wrap items-end justify-center gap-4">
           {top3.map((row, i) => {
             const heights = ['h-28', 'h-36', 'h-24']
-            const order = [1, 0, 2]
-            const place = order.indexOf(i) >= 0 ? i : i
+            const place = i
+            const delay = delightOn ? motion.staggerDelay(i) : 0
             return (
               <li
                 key={row.playerId || `p-${i}`}
-                className={`flex w-28 flex-col items-center justify-end rounded-t-lg bg-muted/60 px-2 py-3 ${heights[place] ?? 'h-24'}`}
+                className={`flex w-28 flex-col items-center justify-end rounded-t-lg bg-muted/60 px-2 py-3 ${heights[place] ?? 'h-24'} ${delightOn ? 'lx-delight-badge-in' : ''}`}
+                style={delightOn ? { animationDelay: `${delay}ms` } : undefined}
               >
                 <span className="text-xs uppercase tracking-wide text-muted-foreground">
                   {t('liveQuiz.leaderboard.place', { rank: row.rank })}
                 </span>
                 <span className="mt-1 text-center text-sm font-semibold">{labelFor(row, i)}</span>
-                <span className="mt-1 tabular-nums text-lg font-bold">{row.totalScore}</span>
+                <span className="mt-1 text-lg font-bold">
+                  <ScoreCell score={row.totalScore} animate={delightOn} />
+                </span>
               </li>
             )
           })}
@@ -92,27 +100,34 @@ export function LiveQuizLeaderboard({
           {t('liveQuiz.leaderboard.yourRank', { rank: youRank })}
         </p>
       ) : null}
-      <ol className="space-y-1" aria-label={t('liveQuiz.leaderboard.listAria')}>
-        {rows.map((row, i) => {
+      <AnimatedList
+        as="ol"
+        items={rows}
+        getKey={(row) => row.playerId || `row-${row.rank}`}
+        enabled={listsOn && delightOn}
+        aria-label={t('liveQuiz.leaderboard.listAria')}
+        className="space-y-1"
+      >
+        {(row, meta) => {
           const mine = highlightPlayerId && row.playerId === highlightPlayerId
           return (
-            <li
-              key={row.playerId || `row-${i}`}
+            <div
               className={
-                mine
+                (mine
                   ? 'flex items-baseline justify-between rounded-md bg-primary/10 px-2 py-1.5 font-medium'
-                  : 'flex items-baseline justify-between px-2 py-1'
+                  : 'flex items-baseline justify-between px-2 py-1') +
+                (meta.className ? ` ${meta.className}` : '')
               }
             >
               <span>
                 <span className="me-2 tabular-nums text-muted-foreground">#{row.rank}</span>
-                {labelFor(row, i)}
+                {labelFor(row, meta.index)}
               </span>
-              <span className="tabular-nums">{row.totalScore}</span>
-            </li>
+              <ScoreCell score={row.totalScore} animate={delightOn} />
+            </div>
           )
-        })}
-      </ol>
+        }}
+      </AnimatedList>
     </div>
   )
 }

--- a/clients/web/src/components/live-quiz/play/__tests__/result-card.test.tsx
+++ b/clients/web/src/components/live-quiz/play/__tests__/result-card.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
+import { PlatformFeaturesProvider } from '../../../../context/platform-features-context'
 import { ResultCard } from '../result-card'
 import type { AnswerAck } from '../../../../lib/live-quiz-realtime'
 
@@ -19,6 +21,10 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+function wrap(ui: ReactNode) {
+  return render(<PlatformFeaturesProvider>{ui}</PlatformFeaturesProvider>)
+}
+
 describe('ResultCard', () => {
   it('renders explainable points breakdown', () => {
     const ack: AnswerAck = {
@@ -37,9 +43,22 @@ describe('ResultCard', () => {
         total: 1740,
       },
     }
-    render(<ResultCard ack={ack} />)
+    wrap(<ResultCard ack={ack} />)
     expect(screen.getByText('Correct!')).toBeTruthy()
     expect(screen.getByText('+1740')).toBeTruthy()
     expect(screen.getByText('+1000 base +640 speed +100 streak = 1740')).toBeTruthy()
+    expect(screen.getByTestId('quiz-answer-feedback')).toHaveAttribute('data-feedback', 'correct')
+  })
+
+  it('applies incorrect feedback without blocking (FR-3 / AC-2)', () => {
+    const ack: AnswerAck = {
+      type: 'answer_ack',
+      ok: true,
+      isCorrect: false,
+      points: 0,
+      pointsBreakdown: { base: 0, speedBonus: 0, streakBonus: 0, styleMultiplier: 1, powerUpFactor: 1, total: 0 },
+    }
+    wrap(<ResultCard ack={ack} />)
+    expect(screen.getByTestId('quiz-answer-feedback')).toHaveAttribute('data-feedback', 'incorrect')
   })
 })

--- a/clients/web/src/components/live-quiz/play/result-card.tsx
+++ b/clients/web/src/components/live-quiz/play/result-card.tsx
@@ -1,41 +1,78 @@
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { AnswerAck } from '../../../lib/live-quiz-realtime'
+import { quizAnswerFeedbackClass } from '../../../lib/delight-motion'
+import { usePrefersReducedMotion } from '../../../lib/motion'
+import { usePlatformFeatures } from '../../../context/platform-features-context'
+import { useHaptics } from '../../../lib/control-motion'
+import { DelightMoment } from '../../ui/delight-moment'
 
 export function ResultCard({
   ack,
   explanation,
   showCorrect,
+  seriousContext,
 }: {
   ack: AnswerAck | null
   explanation?: string | null
   showCorrect?: boolean
+  /** Exam / proctored / reduced-distraction — suppress flourish (FR-8). */
+  seriousContext?: boolean
 }) {
   const { t } = useTranslation('common')
-  if (!ack?.ok && !ack?.alreadyAnswered && !ack?.duplicate) {
-    if (ack?.late) {
-      return (
-        <div className="rounded-xl bg-amber-50 p-4 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100" role="status" aria-live="assertive">
-          {t('liveQuiz.answer.late')}
-        </div>
-      )
-    }
-    return null
+  const { ffMotionDelight } = usePlatformFeatures()
+  const reduceMotion = usePrefersReducedMotion()
+  const { trigger } = useHaptics()
+
+  const lateOnly = Boolean(ack?.late && !ack?.ok && !ack?.alreadyAnswered && !ack?.duplicate)
+  const visible = Boolean(ack && (ack.ok || ack.alreadyAnswered || ack.duplicate))
+  const correct = Boolean(ack?.isCorrect)
+  const points = ack?.points ?? 0
+  const bd = ack?.pointsBreakdown
+  const isPollLike = Boolean(
+    ack && ack.isCorrect === false && points === 0 && !ack.duplicate && bd == null,
+  )
+
+  useEffect(() => {
+    if (!visible || isPollLike || lateOnly) return
+    // Non-blocking haptic (FR-3 / FR-7) — never delays advance.
+    trigger(correct ? 'success' : 'error')
+  }, [visible, isPollLike, lateOnly, correct, trigger])
+
+  if (lateOnly) {
+    return (
+      <div
+        className="rounded-xl bg-amber-50 p-4 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100"
+        role="status"
+        aria-live="assertive"
+      >
+        {t('liveQuiz.answer.late')}
+      </div>
+    )
   }
 
-  const correct = !!ack.isCorrect
-  const points = ack.points ?? 0
-  const bd = ack.pointsBreakdown
-  const isPollLike = ack.isCorrect === false && points === 0 && !ack.duplicate && !bd?.base
+  if (!visible || !ack) return null
 
-  return (
+  const feedbackClass = isPollLike
+    ? ''
+    : quizAnswerFeedbackClass(correct ? 'correct' : 'incorrect', {
+        enabled: ffMotionDelight !== false,
+        reduceMotion,
+        seriousContext,
+      })
+
+  const card = (
     <div
       className={
-        correct
+        (correct
           ? 'rounded-xl bg-emerald-50 p-4 text-emerald-950 dark:bg-emerald-950/40 dark:text-emerald-50'
-          : 'rounded-xl bg-slate-100 p-4 text-slate-900 dark:bg-neutral-800 dark:text-neutral-50'
+          : 'rounded-xl bg-slate-100 p-4 text-slate-900 dark:bg-neutral-800 dark:text-neutral-50') +
+        (feedbackClass ? ` ${feedbackClass}` : '')
       }
       role="status"
       aria-live="assertive"
+      data-testid="quiz-answer-feedback"
+      data-feedback={isPollLike ? 'received' : correct ? 'correct' : 'incorrect'}
     >
       <p className="text-lg font-semibold">
         {isPollLike
@@ -71,5 +108,20 @@ export function ResultCard({
         <p className="mt-3 text-sm opacity-90">{explanation}</p>
       ) : null}
     </div>
+  )
+
+  if (isPollLike || !correct) return card
+
+  return (
+    <DelightMoment
+      active
+      kind="correct"
+      // Card already has assertive status text; keep burst without duplicating copy.
+      announcement=""
+      seriousContext={seriousContext}
+      showBurst={!seriousContext}
+    >
+      {card}
+    </DelightMoment>
   )
 }

--- a/clients/web/src/components/self-paced/self-paced-progress.test.tsx
+++ b/clients/web/src/components/self-paced/self-paced-progress.test.tsx
@@ -1,10 +1,16 @@
 import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
+import { PlatformFeaturesProvider } from '../../context/platform-features-context'
 import { SelfPacedProgressBar } from './self-paced-progress'
+
+function wrap(ui: ReactNode) {
+  return render(<PlatformFeaturesProvider>{ui}</PlatformFeaturesProvider>)
+}
 
 describe('SelfPacedProgressBar', () => {
   it('exposes an accessible progressbar with the percentage', () => {
-    render(<SelfPacedProgressBar percent={30} />)
+    wrap(<SelfPacedProgressBar percent={30} />)
     const bar = screen.getByRole('progressbar')
     expect(bar).toHaveAttribute('aria-valuenow', '30')
     expect(bar).toHaveAttribute('aria-valuemin', '0')
@@ -13,7 +19,7 @@ describe('SelfPacedProgressBar', () => {
   })
 
   it('clamps out-of-range values', () => {
-    render(<SelfPacedProgressBar percent={150} />)
+    wrap(<SelfPacedProgressBar percent={150} />)
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100')
   })
 })

--- a/clients/web/src/components/self-paced/self-paced-progress.tsx
+++ b/clients/web/src/components/self-paced/self-paced-progress.tsx
@@ -10,6 +10,8 @@ import {
   formatProgressLabel,
   type SelfPacedProgress,
 } from '../../lib/self-paced-api'
+import { AnimatedProgress } from '../ui/animated-progress'
+import { DelightMoment } from '../ui/delight-moment'
 
 /** Accessible WCAG 2.1 AA progress bar with a visible text percentage. */
 export function SelfPacedProgressBar({
@@ -23,19 +25,12 @@ export function SelfPacedProgressBar({
   const text = formatProgressLabel(clamped)
   return (
     <div className="flex items-center gap-3">
-      <div
-        role="progressbar"
-        aria-valuenow={clamped}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-label={label ?? text}
-        className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700"
-      >
-        <div
-          className="h-full rounded-full bg-emerald-500 motion-safe:transition-[width] motion-safe:duration-300"
-          style={{ width: `${clamped}%` }}
-        />
-      </div>
+      <AnimatedProgress
+        value={clamped}
+        label={label ?? text}
+        className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700 lx-delight-progress"
+        fillClassName="h-full rounded-full bg-emerald-500"
+      />
       <span className="shrink-0 text-xs font-semibold tabular-nums text-slate-700 dark:text-slate-200">
         {text}
       </span>
@@ -58,6 +53,12 @@ export function CompletionCelebration({
       aria-label="Course complete"
       className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70 p-4"
     >
+      <DelightMoment
+        active
+        kind="completion"
+        announcement="Course complete"
+        className="w-full max-w-md"
+      >
       <div className="w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-xl dark:bg-slate-800">
         <PartyPopper className="mx-auto h-12 w-12 text-emerald-500" aria-hidden />
         <h2 className="mt-4 text-xl font-bold text-slate-900 dark:text-white">
@@ -81,6 +82,7 @@ export function CompletionCelebration({
           </button>
         </div>
       </div>
+      </DelightMoment>
     </div>
   )
 }

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -747,7 +747,7 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
     key: 'ffMotionNavigation',
     label: 'Motion / animation',
     description:
-      'Kill-switch for splash handoff, route/section transitions, load choreography, list insert/remove/reorder, overlay enter/exit, and control micro-interactions. Turn off to disable all platform motion instantly (AN.2–AN.6).',
+      'Kill-switch for splash handoff, route/section transitions, load choreography, list insert/remove/reorder, overlay enter/exit, control micro-interactions, and delight/progress moments. Turn off to disable all platform motion instantly (AN.2–AN.7).',
     pack: 'accessibility',
   },
   {

--- a/clients/web/src/components/settings/platform-feature-exemptions.ts
+++ b/clients/web/src/components/settings/platform-feature-exemptions.ts
@@ -24,6 +24,7 @@ export const PLATFORM_FEATURE_EXEMPT_KEYS = [
   'ffMotionLists',
   'ffMotionOverlays',
   'ffMotionControls',
+  'ffMotionDelight',
   // COLLAPSE: accommodations audit log always follows accommodationsEngineEnabled.
   'ffAccommodationsEngine',
   // COLLAPSE: mobile create-course V1/V2 merged into ffMobileCreateCourse.

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -172,6 +172,7 @@ function emptyForm(): PlatformSettingsPayload {
     ffMotionLists: true,
     ffMotionOverlays: true,
     ffMotionControls: true,
+    ffMotionDelight: true,
     ffMobileCreateCourse: false,
     ffMobileCourseCreateV2: false,
     ffMobileCanvasImport: false,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -111,6 +111,7 @@ export type PlatformSettingsPayload = {
   ffMotionLists: boolean
   ffMotionOverlays: boolean
   ffMotionControls: boolean
+  ffMotionDelight: boolean
   ffMobileCreateCourse: boolean
   ffMobileCourseCreateV2: boolean
   ffMobileCanvasImport: boolean

--- a/clients/web/src/components/ui/__tests__/animated-progress.test.tsx
+++ b/clients/web/src/components/ui/__tests__/animated-progress.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+import { PlatformFeaturesProvider } from '../../../context/platform-features-context'
+import { AnimatedProgress } from '../animated-progress'
+
+function wrap(ui: ReactNode) {
+  return render(<PlatformFeaturesProvider>{ui}</PlatformFeaturesProvider>)
+}
+
+describe('AN.7 AnimatedProgress', () => {
+  it('exposes accessible progressbar and fill (AC-1)', () => {
+    wrap(<AnimatedProgress value={40} label="Module progress" />)
+    const bar = screen.getByRole('progressbar', { name: 'Module progress' })
+    expect(bar).toHaveAttribute('aria-valuenow', '40')
+    expect(screen.getByTestId('animated-progress-fill')).toBeTruthy()
+  })
+
+  it('renders ring variant', () => {
+    wrap(<AnimatedProgress value={75} variant="ring" label="Mastery" />)
+    expect(screen.getByRole('progressbar', { name: 'Mastery' })).toBeTruthy()
+  })
+})

--- a/clients/web/src/components/ui/animated-progress.tsx
+++ b/clients/web/src/components/ui/animated-progress.tsx
@@ -1,0 +1,158 @@
+/**
+ * AN.7 — `<AnimatedProgress>` bar/ring that fills from prior→new value.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  delightMotionClass,
+  interpolateProgress,
+  progressDurationMs,
+  shouldAnimateProgress,
+} from '../../lib/delight-motion'
+import { usePrefersReducedMotion } from '../../lib/motion'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+
+export type AnimatedProgressProps = {
+  value: number
+  max?: number
+  /** `bar` (default) or circular `ring`. */
+  variant?: 'bar' | 'ring'
+  label?: string
+  className?: string
+  trackClassName?: string
+  fillClassName?: string
+  /** Feature kill-switch override; defaults to `ffMotionDelight`. */
+  enabled?: boolean
+  /** Exam / serious context — snap without flourish. */
+  seriousContext?: boolean
+  sizePx?: number
+  strokeWidth?: number
+}
+
+export function AnimatedProgress({
+  value,
+  max = 100,
+  variant = 'bar',
+  label,
+  className,
+  trackClassName,
+  fillClassName,
+  enabled,
+  seriousContext,
+  sizePx = 64,
+  strokeWidth = 6,
+}: AnimatedProgressProps) {
+  const { ffMotionDelight } = usePlatformFeatures()
+  const reduceMotion = usePrefersReducedMotion()
+  const motionOn = enabled ?? ffMotionDelight !== false
+  const opts = { enabled: motionOn, reduceMotion, seriousContext }
+
+  const targetPct = max <= 0 ? 0 : Math.min(100, Math.max(0, (value / max) * 100))
+  const [displayPct, setDisplayPct] = useState(targetPct)
+  const fromRef = useRef(targetPct)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!shouldAnimateProgress(opts)) {
+      fromRef.current = targetPct
+      setDisplayPct(targetPct)
+      return
+    }
+    const from = fromRef.current
+    const to = targetPct
+    if (from === to) return
+    const duration = progressDurationMs(opts)
+    const start = performance.now()
+
+    const tick = (now: number) => {
+      const t = duration <= 0 ? 1 : Math.min(1, (now - start) / duration)
+      const next = interpolateProgress(from, to, t)
+      setDisplayPct(next)
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick)
+      } else {
+        fromRef.current = to
+      }
+    }
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+      fromRef.current = to
+    }
+  }, [targetPct, motionOn, reduceMotion, seriousContext])
+
+  const ariaNow = Math.round(targetPct)
+
+  if (variant === 'ring') {
+    const r = (sizePx - strokeWidth) / 2
+    const c = 2 * Math.PI * r
+    const offset = c * (1 - displayPct / 100)
+    return (
+      <div
+        className={className}
+        role="progressbar"
+        aria-valuenow={ariaNow}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label}
+      >
+        <svg
+          width={sizePx}
+          height={sizePx}
+          viewBox={`0 0 ${sizePx} ${sizePx}`}
+          className={delightMotionClass.progressRing}
+          aria-hidden
+        >
+          <circle
+            cx={sizePx / 2}
+            cy={sizePx / 2}
+            r={r}
+            fill="none"
+            strokeWidth={strokeWidth}
+            className={trackClassName ?? 'stroke-slate-200 dark:stroke-neutral-700'}
+          />
+          <circle
+            cx={sizePx / 2}
+            cy={sizePx / 2}
+            r={r}
+            fill="none"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={c}
+            strokeDashoffset={offset}
+            transform={`rotate(-90 ${sizePx / 2} ${sizePx / 2})`}
+            className={fillClassName ?? 'stroke-sky-500 transition-[stroke-dashoffset]'}
+            style={
+              shouldAnimateProgress(opts)
+                ? { transitionDuration: `${progressDurationMs(opts)}ms` }
+                : { transitionDuration: '0ms' }
+            }
+          />
+        </svg>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={ariaNow}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={label}
+      className={
+        className ??
+        `h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-neutral-700 ${delightMotionClass.progressBar}`
+      }
+    >
+      <div
+        className={
+          fillClassName ??
+          'h-full rounded-full bg-sky-500'
+        }
+        style={{ width: `${displayPct}%` }}
+        data-testid="animated-progress-fill"
+      />
+    </div>
+  )
+}

--- a/clients/web/src/components/ui/delight-moment.tsx
+++ b/clients/web/src/components/ui/delight-moment.tsx
@@ -1,0 +1,146 @@
+/**
+ * AN.7 — shared `<DelightMoment>` achievement primitive with capped burst.
+ *
+ * Non-blocking, dismissible, reduced-motion / exam aware. Particles tear down
+ * fully after `DELIGHT_BURST_MS` (AC-6 / FR-9).
+ */
+
+import { useEffect, useId, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import {
+  buildBurstParticles,
+  DELIGHT_BURST_MS,
+  delightMotionClass,
+  particleCapForViewport,
+  shouldCelebrate,
+  shouldShowStaticDelight,
+  type DelightKind,
+} from '../../lib/delight-motion'
+import { usePrefersReducedMotion } from '../../lib/motion'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import { useHaptics } from '../../lib/control-motion'
+
+export type DelightMomentProps = {
+  /** When true, play (or show static) the moment. */
+  active: boolean
+  kind?: DelightKind
+  /** Live-region announcement (required for a11y — not motion alone). */
+  announcement: string
+  children?: ReactNode
+  className?: string
+  enabled?: boolean
+  seriousContext?: boolean
+  gamificationEnabled?: boolean
+  /** Optional: center burst on this element; defaults to wrapper. */
+  onComplete?: () => void
+  showBurst?: boolean
+}
+
+export function DelightMoment({
+  active,
+  kind = 'generic',
+  announcement,
+  children,
+  className,
+  enabled,
+  seriousContext,
+  gamificationEnabled,
+  onComplete,
+  showBurst = true,
+}: DelightMomentProps) {
+  const { ffMotionDelight, ffGamification } = usePlatformFeatures()
+  const reduceMotion = usePrefersReducedMotion()
+  const { trigger } = useHaptics()
+  const motionOn = enabled ?? ffMotionDelight !== false
+  const gamify = gamificationEnabled ?? ffGamification !== false
+  const opts = {
+    enabled: motionOn,
+    reduceMotion,
+    seriousContext,
+    gamificationEnabled: gamify,
+  }
+
+  const celebrate = active && shouldCelebrate(opts)
+  const staticOnly = active && shouldShowStaticDelight(opts)
+  const [particles, setParticles] = useState<
+    Array<{ dx: number; dy: number; hue: number; delayMs: number }>
+  >([])
+  const teardownRef = useRef<number | null>(null)
+  const liveId = useId()
+
+  useEffect(() => {
+    if (!active) {
+      setParticles([])
+      return
+    }
+    if (kind === 'correct' || kind === 'level-up' || kind === 'badge' || kind === 'completion') {
+      trigger('success')
+    } else if (kind === 'xp' || kind === 'streak') {
+      trigger('selection')
+    }
+
+    if (!celebrate || !showBurst) {
+      const t = window.setTimeout(() => onComplete?.(), reduceMotion ? 0 : DELIGHT_BURST_MS)
+      return () => window.clearTimeout(t)
+    }
+
+    const width = typeof window !== 'undefined' ? window.innerWidth : 1024
+    const cap = particleCapForViewport(width)
+    setParticles(buildBurstParticles({ count: cap }))
+    teardownRef.current = window.setTimeout(() => {
+      setParticles([])
+      onComplete?.()
+    }, DELIGHT_BURST_MS)
+
+    return () => {
+      if (teardownRef.current != null) window.clearTimeout(teardownRef.current)
+      setParticles([])
+    }
+  }, [active, celebrate, showBurst, kind, onComplete, reduceMotion, trigger])
+
+  if (!active && !children) return null
+
+  return (
+    <div
+      className={`relative ${className ?? ''} ${celebrate ? delightMotionClass.badgeIn : ''}`}
+      data-delight-kind={kind}
+      data-delight-active={active ? 'true' : 'false'}
+      data-testid="delight-moment"
+    >
+      <span id={liveId} className="sr-only" role="status" aria-live="polite">
+        {active ? announcement : ''}
+      </span>
+      {children}
+      {staticOnly ? (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -end-1 -top-1 text-emerald-500"
+          data-testid="delight-static-indicator"
+        >
+          ✓
+        </span>
+      ) : null}
+      {celebrate && particles.length > 0 ? (
+        <div
+          aria-hidden
+          className={`pointer-events-none absolute inset-0 overflow-visible ${delightMotionClass.burst}`}
+          data-testid="delight-burst"
+        >
+          {particles.map((p, i) => (
+            <span
+              key={i}
+              className="lx-delight-particle"
+              style={
+                {
+                  '--dx': `${p.dx}px`,
+                  '--dy': `${p.dy}px`,
+                  '--hue': String(p.hue),
+                  animationDelay: `${p.delayMs}ms`,
+                } as CSSProperties
+              }
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -61,6 +61,7 @@ export type PlatformFeatures = {
   ffMotionLists: boolean
   ffMotionOverlays: boolean
   ffMotionControls: boolean
+  ffMotionDelight: boolean
   ffMobileCreateCourse: boolean
   ffMobileCourseCreateV2: boolean
   ffMobileCanvasImport: boolean
@@ -204,6 +205,7 @@ const defaultFeatures: PlatformFeatures = {
   ffMotionLists: true,
   ffMotionOverlays: true,
   ffMotionControls: true,
+  ffMotionDelight: true,
   ffMobileCreateCourse: false,
   ffMobileCourseCreateV2: false,
   ffMobileCanvasImport: false,
@@ -345,6 +347,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
     ffMotionLists: true,
     ffMotionOverlays: true,
     ffMotionControls: true,
+    ffMotionDelight: true,
     ffMobileCreateCourse: false,
     ffMobileCourseCreateV2: false,
     ffMobileCanvasImport: false,
@@ -493,6 +496,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffMotionLists: data.ffMotionLists !== false,
           ffMotionOverlays: data.ffMotionOverlays !== false,
           ffMotionControls: data.ffMotionControls !== false,
+          ffMotionDelight: data.ffMotionDelight !== false,
           ffMobileCreateCourse: data.ffMobileCreateCourse === true,
           ffMobileCourseCreateV2: data.ffMobileCourseCreateV2 === true,
           ffMobileCanvasImport: data.ffMobileCanvasImport === true,
@@ -598,6 +602,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffMotionLists: next.ffMotionLists !== false,
           ffMotionOverlays: next.ffMotionOverlays !== false,
           ffMotionControls: next.ffMotionControls !== false,
+          ffMotionDelight: next.ffMotionDelight !== false,
           ffMobileCreateCourse: next.ffMobileCreateCourse === true,
           ffMobileCourseCreateV2: next.ffMobileCourseCreateV2 === true,
           ffMobileCanvasImport: next.ffMobileCanvasImport === true,
@@ -711,6 +716,15 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
       delete root.dataset.motionControls
     }
   }, [features.ffMotionControls])
+
+  // AN.7 — expose delight-motion kill-switch to CSS (progress/burst/quiz feedback).
+  useEffect(() => {
+    const root = document.documentElement
+    root.dataset.motionDelight = features.ffMotionDelight !== false ? 'on' : 'off'
+    return () => {
+      delete root.dataset.motionDelight
+    }
+  }, [features.ffMotionDelight])
 
   const value = useMemo(
     () => ({

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -1678,6 +1678,130 @@ html[data-motion-controls='off'] .lx-control-spinner {
   }
 }
 
+/*
+ * AN.7 — Delight & progress moments (progress fills, quiz feedback, capped bursts).
+ * Gated by html[data-motion-delight] (set from ffMotionDelight) + reduced-motion.
+ */
+@keyframes lx-delight-correct-pop {
+  0% {
+    transform: scale(0.96);
+    opacity: 0.85;
+  }
+  60% {
+    transform: scale(1.03);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes lx-delight-incorrect-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}
+
+@keyframes lx-delight-badge-in {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes lx-delight-particle {
+  0% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--dx, 0), var(--dy, -40px)) scale(0.4);
+  }
+}
+
+.lx-delight-progress > [data-testid='animated-progress-fill'],
+.lx-delight-progress > div {
+  transition-property: width;
+  transition-duration: var(--dur-deliberate);
+  transition-timing-function: var(--ease-standard);
+}
+html.reduced-motion .lx-delight-progress > [data-testid='animated-progress-fill'],
+html.reduced-motion .lx-delight-progress > div,
+html[data-motion-delight='off'] .lx-delight-progress > [data-testid='animated-progress-fill'],
+html[data-motion-delight='off'] .lx-delight-progress > div {
+  transition-duration: 0ms;
+}
+
+.lx-delight-correct-pop {
+  animation: lx-delight-correct-pop var(--dur-base) var(--ease-bubble) 1;
+}
+.lx-delight-incorrect-shake {
+  animation: lx-delight-incorrect-shake var(--dur-base) var(--ease-standard) 1;
+}
+.lx-delight-correct-static,
+.lx-delight-incorrect-static {
+  /* Color/icon only — no motion (FR-6 / AC-5). */
+  transition: none;
+}
+.lx-delight-badge-in {
+  animation: lx-delight-badge-in var(--dur-deliberate) var(--ease-bubble) both;
+}
+html.reduced-motion .lx-delight-badge-in,
+html[data-motion-delight='off'] .lx-delight-badge-in {
+  animation: none;
+}
+html.reduced-motion .lx-delight-correct-pop,
+html.reduced-motion .lx-delight-incorrect-shake,
+html[data-motion-delight='off'] .lx-delight-correct-pop,
+html[data-motion-delight='off'] .lx-delight-incorrect-shake {
+  animation: none;
+}
+
+.lx-delight-burst {
+  z-index: 1;
+}
+.lx-delight-particle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  margin: -3px;
+  border-radius: 9999px;
+  background: hsl(var(--hue, 140) 70% 55%);
+  animation: lx-delight-particle var(--dur-deliberate) var(--ease-exit, var(--ease-standard)) forwards;
+  will-change: transform, opacity;
+  pointer-events: none;
+}
+html.reduced-motion .lx-delight-particle,
+html[data-motion-delight='off'] .lx-delight-particle {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:not(.reduced-motion) .lx-delight-correct-pop,
+  html:not(.reduced-motion) .lx-delight-incorrect-shake,
+  html:not(.reduced-motion) .lx-delight-badge-in {
+    animation: none;
+  }
+  html:not(.reduced-motion) .lx-delight-particle {
+    display: none;
+  }
+}
+
 /* Study Flashcard 3D flip effect styles */
 .perspective-1000 {
   perspective: 1000px;

--- a/clients/web/src/lib/__tests__/delight-motion.test.ts
+++ b/clients/web/src/lib/__tests__/delight-motion.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { durations } from '../motion'
+import {
+  buildBurstParticles,
+  countUpValue,
+  DelightQueue,
+  DELIGHT_BURST_MS,
+  DELIGHT_MAX_FLASH_HZ,
+  DELIGHT_PARTICLE_CAP,
+  formatCountUp,
+  interpolateProgress,
+  particleCapForViewport,
+  progressDurationMs,
+  quizAnswerFeedbackClass,
+  shouldAnimateProgress,
+  shouldCelebrate,
+  shouldShowStaticDelight,
+  delightMotionClass,
+} from '../delight-motion'
+
+describe('AN.7 delight motion helpers', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('reduced-motion')
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => true,
+      })),
+    )
+  })
+
+  afterEach(() => {
+    document.documentElement.classList.remove('reduced-motion')
+    vi.unstubAllGlobals()
+  })
+
+  it('progress interpolates old→new and snaps under reduced motion (FR-1 / AC-1)', () => {
+    expect(interpolateProgress(0, 100, 0)).toBe(0)
+    expect(interpolateProgress(0, 100, 1)).toBe(100)
+    expect(interpolateProgress(10, 50, 0.5)).toBeGreaterThan(10)
+    expect(interpolateProgress(10, 50, 0.5)).toBeLessThan(50)
+    expect(shouldAnimateProgress({ enabled: true, reduceMotion: false })).toBe(true)
+    expect(shouldAnimateProgress({ enabled: true, reduceMotion: true })).toBe(false)
+    expect(shouldAnimateProgress({ enabled: false })).toBe(false)
+    expect(progressDurationMs({ enabled: true, reduceMotion: false })).toBe(durations.deliberate)
+    expect(progressDurationMs({ enabled: true, reduceMotion: true })).toBe(0)
+  })
+
+  it('count-up respects locale formatting (i18n NFR)', () => {
+    expect(countUpValue(0, 1000, 1)).toBe(1000)
+    expect(countUpValue(0, 10, 0)).toBe(0)
+    expect(formatCountUp(1234, 'en-US')).toMatch(/1,234/)
+  })
+
+  it('celebrations suppress under reduced motion, exam, gamification-off (FR-6 / FR-8 / AC-5)', () => {
+    expect(shouldCelebrate({ enabled: true, reduceMotion: false })).toBe(true)
+    expect(shouldCelebrate({ enabled: true, reduceMotion: true })).toBe(false)
+    expect(shouldCelebrate({ enabled: true, seriousContext: true })).toBe(false)
+    expect(shouldCelebrate({ enabled: true, gamificationEnabled: false })).toBe(false)
+    expect(shouldCelebrate({ enabled: false })).toBe(false)
+    expect(shouldShowStaticDelight({ enabled: true, reduceMotion: true })).toBe(true)
+    expect(shouldShowStaticDelight({ enabled: true, seriousContext: true })).toBe(true)
+    expect(shouldShowStaticDelight({ enabled: true, gamificationEnabled: false })).toBe(false)
+  })
+
+  it('quiz feedback uses pop/shake vs static under reduced motion (FR-3 / AC-2)', () => {
+    expect(quizAnswerFeedbackClass('correct', { enabled: true, reduceMotion: false })).toBe(
+      delightMotionClass.correctPop,
+    )
+    expect(quizAnswerFeedbackClass('incorrect', { enabled: true, reduceMotion: false })).toBe(
+      delightMotionClass.incorrectShake,
+    )
+    expect(quizAnswerFeedbackClass('correct', { enabled: true, reduceMotion: true })).toBe(
+      delightMotionClass.correctStatic,
+    )
+    expect(quizAnswerFeedbackClass('incorrect', { enabled: true, seriousContext: true })).toBe(
+      delightMotionClass.incorrectStatic,
+    )
+    expect(quizAnswerFeedbackClass(null, { enabled: true })).toBe('')
+  })
+
+  it('particle burst is capped and delay respects flash budget (FR-5 / FR-7 / FR-9)', () => {
+    expect(DELIGHT_PARTICLE_CAP).toBe(24)
+    expect(DELIGHT_BURST_MS).toBe(durations.deliberate)
+    expect(DELIGHT_MAX_FLASH_HZ).toBe(3)
+    const particles = buildBurstParticles({ count: 100, seed: 42 })
+    expect(particles.length).toBe(DELIGHT_PARTICLE_CAP)
+    const maxDelay = Math.max(...particles.map((p) => p.delayMs))
+    expect(maxDelay).toBeLessThanOrEqual(1000 / DELIGHT_MAX_FLASH_HZ)
+    expect(particleCapForViewport(320)).toBeLessThanOrEqual(16)
+    expect(particleCapForViewport(1024, true)).toBeLessThanOrEqual(12)
+  })
+
+  it('delight queue coalesces rapid same-kind events and clears fully (AC-6)', () => {
+    const q = new DelightQueue()
+    q.enqueue({ id: '1', kind: 'xp', label: '+5 XP' }, 1000)
+    q.enqueue({ id: '2', kind: 'xp', label: '+10 XP' }, 1050)
+    expect(q.size).toBe(1)
+    expect(q.advance()?.label).toBe('+10 XP')
+    expect(q.current?.label).toBe('+10 XP')
+    // Finish active before enqueuing more (single-at-a-time).
+    q.advance()
+    expect(q.current).toBeNull()
+    q.enqueue({ id: '3', kind: 'badge', label: 'Badge' }, 2000)
+    q.enqueue({ id: '4', kind: 'streak', label: 'Streak' }, 3000)
+    expect(q.size).toBe(2)
+    q.clear()
+    expect(q.size).toBe(0)
+    expect(q.current).toBeNull()
+  })
+})

--- a/clients/web/src/lib/delight-motion.ts
+++ b/clients/web/src/lib/delight-motion.ts
@@ -1,0 +1,230 @@
+/**
+ * AN.7 — Delight & progress moments.
+ *
+ * Pure helpers for animated progress, count-up, achievement queue/coalesce,
+ * capped confetti bursts, and quiz answer feedback. Feature code imports from
+ * here — never hand-roll particle/progress motion.
+ */
+
+import { durations, prefersReducedMotion } from './motion'
+
+/** Max particles in a burst (FR-5 / FR-9). Lower on constrained viewports via capForViewport. */
+export const DELIGHT_PARTICLE_CAP = 24
+
+/** Burst auto-teardown (ms); ≤ deliberate (FR-9). */
+export const DELIGHT_BURST_MS = durations.deliberate
+
+/** WCAG 2.3.1 — never flash more than 3×/sec (FR-7). */
+export const DELIGHT_MAX_FLASH_HZ = 3
+
+/** Consecutive achievements coalesce within this window (AC-6). */
+export const DELIGHT_COALESCE_MS = durations.fast
+
+export type DelightKind = 'badge' | 'xp' | 'streak' | 'level-up' | 'completion' | 'correct' | 'generic'
+
+export type DelightMotionOptions = {
+  /** Feature kill-switch (`ff_motion_delight`). Default true. */
+  enabled?: boolean
+  reduceMotion?: boolean
+  /** Exam / proctored / reduced-distraction / serious context (FR-8). */
+  seriousContext?: boolean
+  /** Org/platform gamification disabled (FR-8). */
+  gamificationEnabled?: boolean
+}
+
+export type DelightEvent = {
+  id: string
+  kind: DelightKind
+  label: string
+  /** Optional intensity 0–1; HE/SL tend toward lower. */
+  intensity?: number
+}
+
+function resolveReduce(opts?: DelightMotionOptions): boolean {
+  return opts?.reduceMotion ?? prefersReducedMotion()
+}
+
+function resolveEnabled(opts?: DelightMotionOptions): boolean {
+  return opts?.enabled !== false
+}
+
+/**
+ * Whether progress bars/rings should interpolate old→new (FR-1 / AC-1).
+ * Reduced motion / kill-switch → set instantly.
+ */
+export function shouldAnimateProgress(opts?: DelightMotionOptions): boolean {
+  if (!resolveEnabled(opts)) return false
+  if (resolveReduce(opts)) return false
+  return true
+}
+
+/** Duration for progress fill / count-up (≤ deliberate). */
+export function progressDurationMs(opts?: DelightMotionOptions): number {
+  if (!shouldAnimateProgress(opts)) return 0
+  return durations.deliberate
+}
+
+/**
+ * Interpolate progress from `from` → `to` at t∈[0,1] (ease-out).
+ * Clamped to [0, 100] for percent meters; callers may use any numeric range.
+ */
+export function interpolateProgress(from: number, to: number, t: number): number {
+  const clampedT = Math.min(1, Math.max(0, t))
+  // Cubic ease-out (no overshoot on meters).
+  const eased = 1 - (1 - clampedT) ** 3
+  return from + (to - from) * eased
+}
+
+/**
+ * Count-up display value at t∈[0,1], rounded for display.
+ * Locale formatting is applied by `formatCountUp`.
+ */
+export function countUpValue(from: number, to: number, t: number): number {
+  return Math.round(interpolateProgress(from, to, t))
+}
+
+/** Locale-aware number formatting for count-up (i18n NFR). */
+export function formatCountUp(value: number, locale?: string): string {
+  try {
+    return new Intl.NumberFormat(locale).format(value)
+  } catch {
+    return String(value)
+  }
+}
+
+/**
+ * Whether a full celebration (particles/flourish) may run (FR-5 / FR-6 / FR-8 / AC-5).
+ * Kill-switch, reduced-motion, serious/exam, or gamification-off → false.
+ */
+export function shouldCelebrate(opts?: DelightMotionOptions): boolean {
+  if (!resolveEnabled(opts)) return false
+  if (resolveReduce(opts)) return false
+  if (opts?.seriousContext) return false
+  if (opts?.gamificationEnabled === false) return false
+  return true
+}
+
+/**
+ * Whether a calm static indicator should show instead of motion (AC-5).
+ * True when celebrations are suppressed but the achievement still surfaces.
+ */
+export function shouldShowStaticDelight(opts?: DelightMotionOptions): boolean {
+  if (!resolveEnabled(opts)) return false
+  if (opts?.seriousContext) return true
+  if (opts?.gamificationEnabled === false) return false
+  return resolveReduce(opts)
+}
+
+/**
+ * Quiz correct/incorrect feedback class path (FR-3 / AC-2).
+ * Correct → bubble pop; incorrect → single shake; reduced → accent/pulse only.
+ */
+export function quizAnswerFeedbackClass(
+  result: 'correct' | 'incorrect' | null,
+  opts?: DelightMotionOptions,
+): string {
+  if (!result) return ''
+  if (!resolveEnabled(opts)) return ''
+  if (resolveReduce(opts) || opts?.seriousContext) {
+    return result === 'correct' ? delightMotionClass.correctStatic : delightMotionClass.incorrectStatic
+  }
+  return result === 'correct' ? delightMotionClass.correctPop : delightMotionClass.incorrectShake
+}
+
+/** Particle cap scaled for viewport / low-end (FR-9 / mobile NFR). */
+export function particleCapForViewport(widthPx: number, lowEnd = false): number {
+  if (lowEnd) return Math.min(12, DELIGHT_PARTICLE_CAP)
+  if (widthPx < 480) return Math.min(16, DELIGHT_PARTICLE_CAP)
+  return DELIGHT_PARTICLE_CAP
+}
+
+/** CSS class tokens for delight surfaces. */
+export const delightMotionClass = {
+  progressBar: 'lx-delight-progress',
+  progressRing: 'lx-delight-ring',
+  correctPop: 'lx-delight-correct-pop',
+  incorrectShake: 'lx-delight-incorrect-shake',
+  correctStatic: 'lx-delight-correct-static',
+  incorrectStatic: 'lx-delight-incorrect-static',
+  burst: 'lx-delight-burst',
+  badgeIn: 'lx-delight-badge-in',
+  countUp: 'lx-delight-count-up',
+} as const
+
+/**
+ * Queue that coalesces rapid achievements into a single active moment (AC-6).
+ * Pure / unit-testable — no DOM.
+ */
+export class DelightQueue {
+  private queue: DelightEvent[] = []
+  private active: DelightEvent | null = null
+  private lastEnqueueAt = 0
+
+  get size(): number {
+    return this.queue.length + (this.active ? 1 : 0)
+  }
+
+  get current(): DelightEvent | null {
+    return this.active
+  }
+
+  /**
+   * Enqueue an event. Same-kind events within COALESCE_MS replace the pending
+   * tail (coalesce) rather than stacking.
+   */
+  enqueue(event: DelightEvent, now = Date.now()): void {
+    const coalesce =
+      this.queue.length > 0 &&
+      now - this.lastEnqueueAt <= DELIGHT_COALESCE_MS &&
+      this.queue[this.queue.length - 1]!.kind === event.kind
+
+    if (coalesce) {
+      this.queue[this.queue.length - 1] = event
+    } else {
+      this.queue.push(event)
+    }
+    this.lastEnqueueAt = now
+  }
+
+  /** Promote next queued event to active, or clear when empty. */
+  advance(): DelightEvent | null {
+    this.active = this.queue.shift() ?? null
+    return this.active
+  }
+
+  /** Tear down everything (interruption / unmount) — AC-6. */
+  clear(): void {
+    this.queue = []
+    this.active = null
+    this.lastEnqueueAt = 0
+  }
+}
+
+/**
+ * Build capped particle specs for a burst (transform/opacity only).
+ * Deterministic when `seed` is provided (tests).
+ */
+export function buildBurstParticles(opts: {
+  count?: number
+  seed?: number
+}): Array<{ dx: number; dy: number; hue: number; delayMs: number }> {
+  const count = Math.min(opts.count ?? DELIGHT_PARTICLE_CAP, DELIGHT_PARTICLE_CAP)
+  let seed = opts.seed ?? 1
+  const next = () => {
+    seed = (seed * 1664525 + 1013904223) >>> 0
+    return seed / 0xffffffff
+  }
+  const particles: Array<{ dx: number; dy: number; hue: number; delayMs: number }> = []
+  for (let i = 0; i < count; i++) {
+    const angle = next() * Math.PI * 2
+    const dist = 24 + next() * 56
+    particles.push({
+      dx: Math.cos(angle) * dist,
+      dy: Math.sin(angle) * dist,
+      hue: Math.floor(next() * 360),
+      // Stagger ≤ 1/MAX_FLASH_HZ so we never exceed 3Hz flashing (FR-7).
+      delayMs: Math.floor((i / Math.max(1, count)) * (1000 / DELIGHT_MAX_FLASH_HZ)),
+    })
+  }
+  return particles
+}

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -47,6 +47,7 @@ export type PlatformFeaturesSnapshot = {
   ffMotionLists?: boolean
   ffMotionOverlays?: boolean
   ffMotionControls?: boolean
+  ffMotionDelight?: boolean
   ffMobileCreateCourse?: boolean
   ffMobileCourseCreateV2?: boolean
   ffMobileCanvasImport?: boolean
@@ -182,6 +183,7 @@ const defaults: PlatformFeaturesSnapshot = {
   ffMotionLists: true,
   ffMotionOverlays: true,
   ffMotionControls: true,
+  ffMotionDelight: true,
   ffMobileCreateCourse: false,
   ffMobileCourseCreateV2: false,
   ffMobileCanvasImport: false,
@@ -476,4 +478,13 @@ export function motionControlsEnabled(s?: PlatformFeaturesSnapshot): boolean {
     return true
   }
   return snap.ffMotionControls !== false
+}
+
+/** AN.7: delight & progress moments (default on; kill-switch via Settings). */
+export function motionDelightEnabled(s?: PlatformFeaturesSnapshot): boolean {
+  const snap = s ?? snapshot
+  if (!s && !loaded) {
+    return true
+  }
+  return snap.ffMotionDelight !== false
 }

--- a/clients/web/src/lib/use-count-up.ts
+++ b/clients/web/src/lib/use-count-up.ts
@@ -1,0 +1,59 @@
+/**
+ * AN.7 — `useCountUp()` for locale-aware numeric count-up (≤ deliberate).
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  countUpValue,
+  formatCountUp,
+  progressDurationMs,
+  shouldAnimateProgress,
+} from './delight-motion'
+import { usePrefersReducedMotion } from './motion'
+import { usePlatformFeatures } from '../context/platform-features-context'
+
+export function useCountUp(
+  value: number,
+  opts?: {
+    enabled?: boolean
+    locale?: string
+    from?: number
+  },
+): { display: number; formatted: string } {
+  const { ffMotionDelight } = usePlatformFeatures()
+  const reduceMotion = usePrefersReducedMotion()
+  const motionOn = opts?.enabled ?? ffMotionDelight !== false
+  const [display, setDisplay] = useState(value)
+  const fromRef = useRef(opts?.from ?? value)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const motionOpts = { enabled: motionOn, reduceMotion }
+    if (!shouldAnimateProgress(motionOpts)) {
+      fromRef.current = value
+      setDisplay(value)
+      return
+    }
+    const from = fromRef.current
+    const to = value
+    if (from === to) return
+    const duration = progressDurationMs(motionOpts)
+    const start = performance.now()
+    const tick = (now: number) => {
+      const t = duration <= 0 ? 1 : Math.min(1, (now - start) / duration)
+      setDisplay(countUpValue(from, to, t))
+      if (t < 1) rafRef.current = requestAnimationFrame(tick)
+      else fromRef.current = to
+    }
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+      fromRef.current = to
+    }
+  }, [value, motionOn, reduceMotion])
+
+  return {
+    display,
+    formatted: formatCountUp(display, opts?.locale),
+  }
+}

--- a/docs/completed/animations/AN.7-delight-progress-moments.md
+++ b/docs/completed/animations/AN.7-delight-progress-moments.md
@@ -1,6 +1,6 @@
 # AN.7 — Delight & Progress Moments
 
-> Implementation plan. Source: [docs/plan/animations/README.md](README.md) (Motion & Animation Polish initiative).
+> Implementation plan (completed). Source: [docs/plan/animations/README.md](../../plan/animations/README.md) (Motion & Animation Polish initiative).
 
 ## Metadata
 
@@ -10,7 +10,7 @@
 | **Section** | Motion & Animation Polish |
 | **Severity** | MINOR |
 | **Markets** | K12 / HE / SL |
-| **Status (today)** | PARTIAL — intro-completion celebration exists and is reduced-motion aware; most progress/gamification/quiz feedback is static |
+| **Status (today)** | DONE — web `delight-motion` + `AnimatedProgress`/`DelightMoment`/`useCountUp`, quiz answer feedback, leaderboard count-up, gamification/progress adoption, iOS/Android `LXDelightMotion` helpers, `ff_motion_delight` kill-switch (collapsed into motion master) |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Frontend Platform (web) + Mobile + Learning/Gamification |
 | **Depends on** | AN.1, AN.6 |
@@ -231,5 +231,5 @@ follow existing AI-content policies — out of scope here.
   iOS `Features/Gamification` & `Features/Mastery`, Android `features/gamification` & `features/quiz`.
 - Standards: WCAG 2.3.1 (Three Flashes), 1.4.1 (Use of Color), 2.2.2 (Pause/Stop/Hide), 4.1.3;
   Apple HIG "Feedback"; Material 3 motion.
-- Related plans: [AN.1](../../completed/animations/AN.1-motion-foundation-tokens.md), [AN.4](../../completed/animations/AN.4-lists-collections-motion.md),
+- Related plans: [AN.1](AN.1-motion-foundation-tokens.md), [AN.4](AN.4-lists-collections-motion.md),
   [AN.6](AN.6-micro-interactions-controls.md).

--- a/docs/completed/animations/README.md
+++ b/docs/completed/animations/README.md
@@ -11,3 +11,4 @@ Completed implementation plans for the cross-platform motion language. Active pl
 | AN.4 | [Lists, grids & collection motion](AN.4-lists-collections-motion.md) |
 | AN.5 | [Overlays & surfaces](AN.5-overlays-surfaces.md) |
 | AN.6 | [Micro-interactions & controls](AN.6-micro-interactions-controls.md) |
+| AN.7 | [Delight & progress moments](AN.7-delight-progress-moments.md) |

--- a/docs/plan/animations/README.md
+++ b/docs/plan/animations/README.md
@@ -64,7 +64,7 @@ The full specification lives in **[AN.1](../../completed/animations/AN.1-motion-
 | **AN.4** | ~~Lists, grids & collection motion~~ → [completed](../../completed/animations/AN.4-lists-collections-motion.md) | MINOR | Every list/feed/board | Done — insert/remove/reorder, drag lift, `ff_motion_lists` |
 | **AN.5** | ~~Overlays & surfaces~~ → [completed](../../completed/animations/AN.5-overlays-surfaces.md) | MINOR | Modals, sheets, drawers, toasts, menus | Done — dialog/sheet/menu/toast/tooltip enter-exit, `ff_motion_overlays` |
 | **AN.6** | ~~Micro-interactions & controls~~ → [completed](../../completed/animations/AN.6-micro-interactions-controls.md) | MINOR | Every interactive control | Done — press/toggle/tab/validation/loading + haptics, `ff_motion_controls` |
-| **AN.7** | [Delight & progress moments](AN.7-delight-progress-moments.md) | MINOR | Gamification, quizzes, progress, mastery | Celebrations, streaks/badges/XP, quiz answer feedback, progress-ring & mastery fills |
+| **AN.7** | ~~Delight & progress moments~~ → [completed](../../completed/animations/AN.7-delight-progress-moments.md) | MINOR | Gamification, quizzes, progress, mastery | Done — progress fills, `DelightMoment`, quiz feedback, leaderboard count-up, `ff_motion_delight` |
 
 ## Sequencing
 

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -4440,6 +4440,24 @@
       "reviewed": true
     },
     {
+      "id": "AN.7",
+      "path": "docs/completed/animations/AN.7-delight-progress-moments.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "minor",
+      "client": "web",
+      "coverage": "smoke",
+      "rationale": "Playwright smoke for delight CSS hooks, data-motion-delight kill-switch, reduced-motion particle suppression, and animated progress fill.",
+      "owner": "Web Platform",
+      "specs": [
+        {
+          "path": "e2e/tests/delight-motion.spec.ts"
+        }
+      ],
+      "reviewed": true
+    },
+    {
       "id": "attendance",
       "path": "docs/completed/attendance.md",
       "markets": [

--- a/e2e/lib/feature-lifecycle-manifest.ts
+++ b/e2e/lib/feature-lifecycle-manifest.ts
@@ -680,6 +680,11 @@ export const FEATURE_LIFECYCLE_FAMILIES: readonly LifecycleFamily[] = [
         key: 'ffMotionControls',
         notes: 'COLLAPSE (docs/plan/flags.md): merged into ffMotionNavigation, the single motion kill-switch',
       },
+      {
+        kind: 'platform',
+        key: 'ffMotionDelight',
+        notes: 'COLLAPSE (docs/plan/flags.md): merged into ffMotionNavigation, the single motion kill-switch',
+      },
     ],
     edges: [
       {
@@ -700,6 +705,11 @@ export const FEATURE_LIFECYCLE_FAMILIES: readonly LifecycleFamily[] = [
       {
         parent: { kind: 'platform', key: 'ffMotionNavigation' },
         child: { kind: 'platform', key: 'ffMotionControls' },
+        parentAuthoritative: true,
+      },
+      {
+        parent: { kind: 'platform', key: 'ffMotionNavigation' },
+        child: { kind: 'platform', key: 'ffMotionDelight' },
         parentAuthoritative: true,
       },
     ],

--- a/e2e/tests/delight-motion.spec.ts
+++ b/e2e/tests/delight-motion.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * AN.7 — Delight & progress moments.
+ *
+ * Coverage:
+ *   [x] Delight CSS + data-motion-delight kill-switch present
+ *   [x] Progress fill transition tokens available
+ *   [x] Reduced-motion emulation suppresses particle burst path
+ *   [x] Correct/incorrect feedback classes present in stylesheet
+ */
+import { test, expect } from '../fixtures/test.js'
+
+test.describe('AN.7 delight motion', () => {
+  test('dashboard exposes delight motion hooks', async ({ authedPage: page }) => {
+    await expect(page.getByRole('navigation', { name: /main/i })).toBeVisible({ timeout: 15000 })
+
+    const motionAttr = await page.evaluate(
+      () => document.documentElement.dataset.motionDelight ?? 'missing',
+    )
+    expect(motionAttr).toBe('on')
+
+    const hasCss = await page.evaluate(() => {
+      const needles = ['lx-delight-progress', 'lx-delight-correct-pop', 'lx-delight-particle']
+      const found = new Set<string>()
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList
+        try {
+          rules = sheet.cssRules
+        } catch {
+          continue
+        }
+        for (const rule of Array.from(rules)) {
+          if ('selectorText' in rule && typeof rule.selectorText === 'string') {
+            for (const n of needles) {
+              if (rule.selectorText.includes(n)) found.add(n)
+            }
+          }
+        }
+      }
+      return needles.every((n) => found.has(n))
+    })
+    expect(hasCss).toBe(true)
+  })
+
+  test('reduced motion: particle burst path is suppressed in stylesheet', async ({
+    authedPage: page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.reload()
+    await expect(page.getByRole('navigation', { name: /main/i })).toBeVisible({ timeout: 15000 })
+
+    const particleHidden = await page.evaluate(() => {
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList
+        try {
+          rules = sheet.cssRules
+        } catch {
+          continue
+        }
+        for (const rule of Array.from(rules)) {
+          if ('cssText' in rule && typeof rule.cssText === 'string') {
+            if (
+              rule.cssText.includes('lx-delight-particle') &&
+              (rule.cssText.includes('display: none') || rule.cssText.includes('display:none'))
+            ) {
+              return true
+            }
+          }
+        }
+      }
+      return false
+    })
+    expect(particleHidden).toBe(true)
+  })
+
+  test('animated progress fill exists when gamification card renders', async ({
+    authedPage: page,
+  }) => {
+    await expect(page.getByRole('navigation', { name: /main/i })).toBeVisible({ timeout: 15000 })
+    const fill = page.getByTestId('animated-progress-fill').first()
+    if ((await fill.count()) === 0) {
+      test.skip(true, 'No animated progress on dashboard in this environment')
+      return
+    }
+    await expect(fill).toBeVisible()
+  })
+})

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -333,6 +333,8 @@ type Config struct {
 	// FFMotionOverlays enables dialog/sheet/menu/toast/tooltip enter-exit motion (AN.5). Default ON; kill-switch.
 	FFMotionOverlays bool
 	// FFMotionControls enables control micro-interactions (press, toggle/tabs, validation, haptics) (AN.6). Default ON; kill-switch.
+	// FFMotionDelight enables delight & progress moments (progress fills, quiz feedback, achievement bursts) (AN.7). Default ON; kill-switch.
+	FFMotionDelight bool
 	FFMotionControls bool
 	// FFMobileCreateCourse enables the mobile New course entry and basic create wizard (M11.5). Default OFF.
 	FFMobileCreateCourse bool

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -59,6 +59,7 @@ type platformFeaturesJSON struct {
 	FFMotionLists                      bool `json:"ffMotionLists"`
 	FFMotionOverlays                   bool `json:"ffMotionOverlays"`
 	FFMotionControls                   bool `json:"ffMotionControls"`
+	FFMotionDelight                    bool `json:"ffMotionDelight"`
 	FFMobileCreateCourse               bool `json:"ffMobileCreateCourse"`
 	FFMobileCourseCreateV2             bool `json:"ffMobileCourseCreateV2"`
 	FFMobileCanvasImport               bool `json:"ffMobileCanvasImport"`
@@ -222,6 +223,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		FFMotionLists:                      cfg.FFMotionLists,
 		FFMotionOverlays:                   cfg.FFMotionOverlays,
 		FFMotionControls:                   cfg.FFMotionControls,
+		FFMotionDelight:                    cfg.FFMotionDelight,
 		FFMobileCreateCourse:               cfg.FFMobileCreateCourse,
 		FFMobileCourseCreateV2:             cfg.FFMobileCourseCreateV2,
 		FFMobileCanvasImport:               cfg.FFMobileCanvasImport,

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -213,6 +213,7 @@ type platformSettingsJSON struct {
 	FFMotionLists                bool    `json:"ffMotionLists"`
 	FFMotionOverlays             bool    `json:"ffMotionOverlays"`
 	FFMotionControls             bool    `json:"ffMotionControls"`
+	FFMotionDelight              bool    `json:"ffMotionDelight"`
 	FFMobileCreateCourse         bool    `json:"ffMobileCreateCourse"`
 	FFMobileCourseCreateV2       bool    `json:"ffMobileCourseCreateV2"`
 	FFMobileCanvasImport         bool    `json:"ffMobileCanvasImport"`
@@ -484,6 +485,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			FFMotionLists:                      merged.FFMotionLists,
 			FFMotionOverlays:                   merged.FFMotionOverlays,
 			FFMotionControls:                   merged.FFMotionControls,
+			FFMotionDelight:                    merged.FFMotionDelight,
 			FFMobileCreateCourse:               merged.FFMobileCreateCourse,
 			FFMobileCourseCreateV2:             merged.FFMobileCourseCreateV2,
 			FFMobileCanvasImport:               merged.FFMobileCanvasImport,
@@ -729,6 +731,7 @@ type putPlatformBody struct {
 	FFMotionLists                *bool    `json:"ffMotionLists"`
 	FFMotionOverlays             *bool    `json:"ffMotionOverlays"`
 	FFMotionControls             *bool    `json:"ffMotionControls"`
+	FFMotionDelight              *bool    `json:"ffMotionDelight"`
 	FFMobileCreateCourse         *bool    `json:"ffMobileCreateCourse"`
 	FFMobileCourseCreateV2       *bool    `json:"ffMobileCourseCreateV2"`
 	FFMobileCanvasImport         *bool    `json:"ffMobileCanvasImport"`
@@ -1177,12 +1180,14 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			wr.FFMotionLists = &v
 			wr.FFMotionOverlays = &v
 			wr.FFMotionControls = &v
+			wr.FFMotionDelight = &v
 		}
 		setBool("ffmotionnavigation", body.FFMotionNavigation, setMotion)
 		setBool("ffmotionreveal", body.FFMotionReveal, setMotion)
 		setBool("ffmotionlists", body.FFMotionLists, setMotion)
 		setBool("ffmotionoverlays", body.FFMotionOverlays, setMotion)
 		setBool("ffmotioncontrols", body.FFMotionControls, setMotion)
+		setBool("ffmotiondelight", body.FFMotionDelight, setMotion)
 		setMobileCreate := func(v bool) {
 			wr.FFMobileCreateCourse = &v
 			wr.FFMobileCourseCreateV2 = &v
@@ -1426,6 +1431,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			FFMotionLists:                      merged.FFMotionLists,
 			FFMotionOverlays:                   merged.FFMotionOverlays,
 			FFMotionControls:                   merged.FFMotionControls,
+			FFMotionDelight:                    merged.FFMotionDelight,
 			FFMobileCreateCourse:               merged.FFMobileCreateCourse,
 			FFMobileCourseCreateV2:             merged.FFMobileCourseCreateV2,
 			FFMobileCanvasImport:               merged.FFMobileCanvasImport,

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -99,6 +99,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFMotionLists = motion
 	out.FFMotionOverlays = motion
 	out.FFMotionControls = motion
+	out.FFMotionDelight = motion
 
 	// COLLAPSE mobile create V1/V2: either column enables create; V2 wizard is the only path.
 	mobileCreate := mergeBool(db.FFMobileCreateCourse, false) || mergeBool(db.FFMobileCourseCreateV2, false)

--- a/server/internal/repos/platformconfig/merge_test.go
+++ b/server/internal/repos/platformconfig/merge_test.go
@@ -176,21 +176,21 @@ func TestMerge_VisualBoardsAlwaysOn(t *testing.T) {
 	}
 }
 
-// Motion kill-switches collapsed to FFMotionNavigation (Reveal/Lists/Overlays/Controls follow).
+// Motion kill-switches collapsed to FFMotionNavigation (Reveal/Lists/Overlays/Controls/Delight follow).
 func TestMerge_FFMotionCollapsedKillSwitch(t *testing.T) {
 	got := Merge(config.Config{}, &Row{})
-	if !got.FFMotionNavigation || !got.FFMotionReveal || !got.FFMotionLists || !got.FFMotionOverlays || !got.FFMotionControls {
+	if !got.FFMotionNavigation || !got.FFMotionReveal || !got.FFMotionLists || !got.FFMotionOverlays || !got.FFMotionControls || !got.FFMotionDelight {
 		t.Fatal("expected all motion flags true (default ON) when DB unset")
 	}
 	off := false
 	got = Merge(config.Config{}, &Row{FFMotionNavigation: &off})
-	if got.FFMotionNavigation || got.FFMotionReveal || got.FFMotionLists || got.FFMotionOverlays || got.FFMotionControls {
+	if got.FFMotionNavigation || got.FFMotionReveal || got.FFMotionLists || got.FFMotionOverlays || got.FFMotionControls || got.FFMotionDelight {
 		t.Fatal("expected navigation kill-switch to disable all motion flags")
 	}
 	on := true
 	got = Merge(config.Config{}, &Row{FFMotionNavigation: &on, FFMotionReveal: &off})
-	if !got.FFMotionNavigation || !got.FFMotionReveal || !got.FFMotionLists || !got.FFMotionOverlays || !got.FFMotionControls {
-		t.Fatal("expected navigation master to fan out ON to reveal/lists/overlays/controls")
+	if !got.FFMotionNavigation || !got.FFMotionReveal || !got.FFMotionLists || !got.FFMotionOverlays || !got.FFMotionControls || !got.FFMotionDelight {
+		t.Fatal("expected navigation master to fan out ON to reveal/lists/overlays/controls/delight")
 	}
 }
 

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -150,6 +150,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_motion_lists", w.FFMotionLists)
 	addBool("ff_motion_overlays", w.FFMotionOverlays)
 	addBool("ff_motion_controls", w.FFMotionControls)
+	addBool("ff_motion_delight", w.FFMotionDelight)
 	addBool("ff_mobile_create_course", w.FFMobileCreateCourse)
 	addBool("ff_mobile_course_create_v2", w.FFMobileCourseCreateV2)
 	addBool("ff_mobile_canvas_import", w.FFMobileCanvasImport)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -115,6 +115,7 @@ type Row struct {
 	FFMotionLists                      *bool
 	FFMotionOverlays                   *bool
 	FFMotionControls                   *bool
+	FFMotionDelight                    *bool
 	FFMobileCreateCourse               *bool
 	FFMobileCourseCreateV2             *bool
 	FFMobileCanvasImport               *bool
@@ -335,6 +336,7 @@ type Write struct {
 	FFMotionLists                      *bool
 	FFMotionOverlays                   *bool
 	FFMotionControls                   *bool
+	FFMotionDelight                    *bool
 	FFMobileCreateCourse               *bool
 	FFMobileCourseCreateV2             *bool
 	FFMobileCanvasImport               *bool
@@ -552,6 +554,7 @@ SELECT
 	ff_motion_lists,
 	ff_motion_overlays,
 	ff_motion_controls,
+	ff_motion_delight,
 	ff_mobile_create_course,
 	ff_mobile_course_create_v2,
 	ff_mobile_canvas_import,
@@ -761,6 +764,7 @@ WHERE id = 1
 		&r.FFMotionLists,
 		&r.FFMotionOverlays,
 		&r.FFMotionControls,
+		&r.FFMotionDelight,
 		&r.FFMobileCreateCourse,
 		&r.FFMobileCourseCreateV2,
 		&r.FFMobileCanvasImport,
@@ -1021,6 +1025,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_motion_lists,
 	ff_motion_overlays,
 	ff_motion_controls,
+	ff_motion_delight,
 	ff_mobile_create_course,
 	ff_mobile_course_create_v2,
 	ff_mobile_canvas_import,
@@ -1122,7 +1127,7 @@ INSERT INTO settings.platform_app_settings (
 	$121, $122, $123, $124, $125, $126, $127, $128, $129, $130, $131, $132, $133, $134, $135, $136, $137, $138, $139, $140,
 	$141, $142, $143, $144, $145, $146, $147, $148, $149, $150, $151, $152, $153, $154, $155, $156, $157, $158, $159, $160,
 	$161, $162, $163, $164, $165, $166, $167, $168, $169, $170, $171, $172, $173, $174, $175,
-	$176, $177, $178, $179, $180, $181, $182, $183, $184, $185, $186,
+	$176, $177, $178, $179, $180, $181, $182, $183, $184, $185, $186, $187,
 	NOW()
 )
 ON CONFLICT (id) DO UPDATE SET
@@ -1223,6 +1228,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_motion_lists = COALESCE(EXCLUDED.ff_motion_lists, settings.platform_app_settings.ff_motion_lists),
 	ff_motion_overlays = COALESCE(EXCLUDED.ff_motion_overlays, settings.platform_app_settings.ff_motion_overlays),
 	ff_motion_controls = COALESCE(EXCLUDED.ff_motion_controls, settings.platform_app_settings.ff_motion_controls),
+	ff_motion_delight = COALESCE(EXCLUDED.ff_motion_delight, settings.platform_app_settings.ff_motion_delight),
 	ff_mobile_create_course = COALESCE(EXCLUDED.ff_mobile_create_course, settings.platform_app_settings.ff_mobile_create_course),
 	ff_mobile_course_create_v2 = COALESCE(EXCLUDED.ff_mobile_course_create_v2, settings.platform_app_settings.ff_mobile_course_create_v2),
 	ff_mobile_canvas_import = COALESCE(EXCLUDED.ff_mobile_canvas_import, settings.platform_app_settings.ff_mobile_canvas_import),
@@ -1414,6 +1420,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFMotionLists,
 		w.FFMotionOverlays,
 		w.FFMotionControls,
+		w.FFMotionDelight,
 		w.FFMobileCreateCourse,
 		w.FFMobileCourseCreateV2,
 		w.FFMobileCanvasImport,

--- a/server/migrations/429_motion_delight.down.sql
+++ b/server/migrations/429_motion_delight.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE settings.platform_app_settings
+    DROP COLUMN IF EXISTS ff_motion_delight;

--- a/server/migrations/429_motion_delight.sql
+++ b/server/migrations/429_motion_delight.sql
@@ -1,0 +1,6 @@
+-- AN.7: kill-switch for delight & progress moments (progress fills, quiz feedback, achievements).
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS ff_motion_delight BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_motion_delight IS
+    'AN.7: Delight & progress moments (animated progress, quiz answer feedback, achievement bursts, leaderboard count-up). Default ON; set false to disable instantly. Collapsed into ff_motion_navigation.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **AN.7 — Delight & Progress Moments**: shared progress/count-up/celebration primitives behind `ff_motion_delight` (collapsed into the motion master kill-switch), with quiz answer feedback, leaderboard motion, and gamification/progress adoption on web plus matching iOS/Android helpers.

### What’s included
- **Web**: `delight-motion` helpers, `<AnimatedProgress>`, `<DelightMoment>` (capped burst + teardown), `useCountUp()`
- **Adoption**: intro/self-paced progress, gamification XP/badges, live-quiz `ResultCard` + leaderboard, intro completion celebration
- **Mobile**: `LXDelightMotion` / Android delight helpers + unit tests; `ffMotionDelight` feature wiring
- **Platform**: migration `429_motion_delight`, collapsed into `ffMotionNavigation`
- **Tests**: Vitest helpers/components, Playwright `delight-motion.spec.ts`, docs moved to `docs/completed/animations/`

### Acceptance mapping
- AC-1 progress old→new (reduced → snap)
- AC-2 quiz correct pop / incorrect shake, non-blocking
- AC-3 shared `DelightMoment` with capped burst
- AC-4 leaderboard row transitions + score count-up
- AC-5 reduced-motion / exam / gamification-off → static
- AC-6 queue coalesce + full teardown

## Test plan
- [x] `cd clients/web && npm run test`
- [x] `cd clients/web && npm run typecheck`
- [x] `cd clients/web && npm run lint`
- [x] `cd server && go test ./... -count=1 -short`
- [x] `e2e:coverage:check`
- [x] CI green (including iOS SwiftLint fix)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7d46-8bf0-7432-ad91-19416b3f8ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7d46-8bf0-7432-ad91-19416b3f8ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

