### PR TITLE
fix(iac): strip HCP sensitivity from SES outputs

### DIFF
--- a/iac/self-aws/iam.tf
+++ b/iac/self-aws/iam.tf
@@ -130,8 +130,8 @@ resource "aws_iam_role_policy" "ecs_task_ses" {
         Effect = "Allow"
         Action = ["ses:SendEmail", "ses:SendRawEmail"]
         Resource = [
-          "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/${var.ses_domain}",
-          "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/*@${var.ses_domain}",
+          "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/${local.ses_domain}",
+          "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/*@${local.ses_domain}",
           "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:configuration-set/${local.ses_config_name}",
         ]
       },

--- a/iac/self-aws/outputs.tf
+++ b/iac/self-aws/outputs.tf
@@ -122,7 +122,7 @@ output "ses_enabled" {
 
 output "ses_domain" {
   description = "SES domain identity (null when SES is disabled)."
-  value       = local.ses_enabled ? var.ses_domain : null
+  value       = local.ses_enabled ? local.ses_domain : null
 }
 
 output "ses_from_email" {
@@ -151,7 +151,7 @@ output "ses_dkim_tokens" {
 
 output "ses_mail_from_domain" {
   description = "Custom MAIL FROM domain when ses_mail_from_subdomain is set (null otherwise)."
-  value       = local.ses_enabled && var.ses_mail_from_subdomain != "" ? "${var.ses_mail_from_subdomain}.${var.ses_domain}" : null
+  value       = local.ses_enabled && local.ses_mail_from_subdomain != "" ? "${local.ses_mail_from_subdomain}.${local.ses_domain}" : null
 }
 
 output "ses_dns_records" {
@@ -164,21 +164,21 @@ output "ses_dns_records" {
       for token in try(aws_sesv2_email_identity.domain[0].dkim_signing_attributes[0].tokens, []) : {
         purpose = "dkim"
         type    = "CNAME"
-        name    = "${token}._domainkey.${var.ses_domain}"
+        name    = "${token}._domainkey.${local.ses_domain}"
         value   = "${token}.dkim.amazonses.com"
       }
     ],
-    var.ses_mail_from_subdomain != "" ? [
+    local.ses_mail_from_subdomain != "" ? [
       {
         purpose = "mail_from_mx"
         type    = "MX"
-        name    = "${var.ses_mail_from_subdomain}.${var.ses_domain}"
+        name    = "${local.ses_mail_from_subdomain}.${local.ses_domain}"
         value   = "10 feedback-smtp.${data.aws_region.current.name}.amazonses.com"
       },
       {
         purpose = "mail_from_spf"
         type    = "TXT"
-        name    = "${var.ses_mail_from_subdomain}.${var.ses_domain}"
+        name    = "${local.ses_mail_from_subdomain}.${local.ses_domain}"
         value   = "v=spf1 include:amazonses.com ~all"
       },
     ] : [],

--- a/iac/self-aws/ses.tf
+++ b/iac/self-aws/ses.tf
@@ -2,15 +2,26 @@
 # The API uses EMAIL_PROVIDER=ses and the default AWS credential chain (ECS task role).
 
 locals {
-  ses_enabled     = var.enable_ses && var.ses_domain != ""
-  ses_from_email  = var.ses_from_email != "" ? var.ses_from_email : (local.ses_enabled ? "no-reply@${var.ses_domain}" : "")
-  ses_config_name = var.ses_configuration_set_name != "" ? var.ses_configuration_set_name : "${local.name_prefix}-default"
+  # HCP / Terraform Cloud often marks workspace variables sensitive. SES domain and
+  # From address are operational (DNS, IAM), not secrets — strip marks so count/for_each
+  # and root outputs (ses_dns_records) work. Same nonsensitive(sensitive(...)) pattern
+  # as use_api_container in locals.tf.
+  ses_enabled = nonsensitive(sensitive(var.enable_ses && var.ses_domain != ""))
+  ses_domain  = nonsensitive(sensitive(var.ses_domain))
+  ses_from_email = nonsensitive(sensitive(
+    var.ses_from_email != "" ? var.ses_from_email : (local.ses_enabled ? "no-reply@${local.ses_domain}" : "")
+  ))
+  ses_config_name = nonsensitive(sensitive(
+    var.ses_configuration_set_name != "" ? var.ses_configuration_set_name : "${local.name_prefix}-default"
+  ))
+  ses_mail_from_subdomain = nonsensitive(sensitive(var.ses_mail_from_subdomain))
+  ses_verify_from_email   = nonsensitive(sensitive(var.ses_verify_from_email))
 }
 
 resource "aws_sesv2_email_identity" "domain" {
   count = local.ses_enabled ? 1 : 0
 
-  email_identity = var.ses_domain
+  email_identity = local.ses_domain
 
   tags = {
     Name = "${local.name_prefix}-ses-domain"
@@ -19,10 +30,10 @@ resource "aws_sesv2_email_identity" "domain" {
 
 # Easy DKIM (RSA 2048) — publish the three CNAME records from outputs.
 resource "aws_sesv2_email_identity_mail_from_attributes" "domain" {
-  count = local.ses_enabled && var.ses_mail_from_subdomain != "" ? 1 : 0
+  count = local.ses_enabled && local.ses_mail_from_subdomain != "" ? 1 : 0
 
   email_identity         = aws_sesv2_email_identity.domain[0].email_identity
-  mail_from_domain       = "${var.ses_mail_from_subdomain}.${var.ses_domain}"
+  mail_from_domain       = "${local.ses_mail_from_subdomain}.${local.ses_domain}"
   behavior_on_mx_failure = "USE_DEFAULT_VALUE"
 }
 
@@ -38,7 +49,7 @@ resource "aws_sesv2_configuration_set" "main" {
 
 # Optional: verify a specific From address (useful while domain DKIM is pending).
 resource "aws_sesv2_email_identity" "from_address" {
-  count = local.ses_enabled && var.ses_verify_from_email && local.ses_from_email != "" ? 1 : 0
+  count = local.ses_enabled && local.ses_verify_from_email && local.ses_from_email != "" ? 1 : 0
 
   email_identity = local.ses_from_email
 


### PR DESCRIPTION
## Summary
- Clear sensitivity marks on SES operational locals (`ses_enabled`, domain, from, config set, mail-from) using the existing `nonsensitive(sensitive(...))` pattern.
- Wire SES resources, IAM, and outputs through those locals so root outputs no longer fail with “Output refers to sensitive values” when workspace vars are marked sensitive in Terraform Cloud.

Domain / DKIM / From are operational DNS config, not secrets; keeping outputs non-sensitive preserves `terraform output ses_dns_records` for Cloudflare setup.

## Test plan
- [ ] Re-run the failed Terraform Cloud apply/plan for self-aws
- [ ] Confirm SES outputs plan without the sensitive-output errors
- [ ] `terraform output ses_dns_records` prints DKIM CNAMEs (not redacted)
- [ ] SES resources still create when `enable_ses` + `ses_domain` are set