### PR TITLE
fix(iac): import existing SES domain identity lextures.com

### DIFF
--- a/iac/self-aws/ses_import.tf
+++ b/iac/self-aws/ses_import.tf
@@ -1,0 +1,6 @@
+# One-shot: adopt existing SES domain created in the console.
+# Remove this file after a successful apply that imports the identity.
+import {
+  to = aws_sesv2_email_identity.domain[0]
+  id = "lextures.com"
+}


### PR DESCRIPTION
## Summary
- Add a one-shot `import` block for `aws_sesv2_email_identity.domain[0]` → `lextures.com`.
- Lets Terraform Cloud adopt the SES domain identity already created in the console, avoiding `AlreadyExistsException` on apply.

After a successful apply that imports the identity, remove `iac/self-aws/ses_import.tf` in a follow-up commit.

## Test plan
- [ ] Merge and let HCP workspace `lextures-self-aws-production` plan (or queue a plan in the UI)
- [ ] Confirm plan shows **import** of `aws_sesv2_email_identity.domain[0]` (not create)
- [ ] Apply in HCP UI
- [ ] Confirm SES domain is in state and subsequent applies no longer try to create it
- [ ] Follow-up: delete `ses_import.tf`