### PR TITLE
fix(android): drawer access, edge chrome, and planner calendar layout

### DIFF
--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/catalog/CourseLandingScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/catalog/CourseLandingScreen.kt
@@ -120,6 +120,7 @@ fun CourseLandingScreen(
                 openCourse = null
                 onBack()
             },
+            shell = shell,
             modifier = modifier.fillMaxSize(),
         )
         return

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/CourseDetailScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/CourseDetailScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
@@ -388,14 +387,12 @@ fun CourseDetailScreen(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 8.dp, end = 16.dp),
+                .padding(start = 4.dp, top = 8.dp, end = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = textPrimary())
-            }
+            // System / gesture back is handled by BackHandler — no in-app back arrow.
             if (shell != null) {
-                IconButton(onClick = { shell.drawerState = com.lextures.android.core.navigation.DrawerState.Course }) {
+                IconButton(onClick = { shell.openCourseDrawer() }) {
                     Icon(Icons.Default.Menu, contentDescription = L.text(R.string.mobile_drawer_courseMenu), tint = textPrimary())
                 }
             }
@@ -750,12 +747,10 @@ private fun CourseInvitationScreen(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 8.dp, end = 16.dp),
+                .padding(start = 16.dp, top = 8.dp, end = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = textPrimary())
-            }
+            // System / gesture back is handled by BackHandler — no in-app back arrow.
             Text(
                 text = course.displayTitle,
                 fontSize = 18.sp,

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/dashboard/DashboardTab.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/dashboard/DashboardTab.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.AssignmentTurnedIn
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.FactCheck
 import androidx.compose.material.icons.filled.Inbox
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
@@ -65,6 +66,7 @@ import com.lextures.android.core.design.lxListMotion
 import com.lextures.android.core.design.lxReveal
 import com.lextures.android.core.design.textPrimary
 import com.lextures.android.core.design.textSecondary
+import com.lextures.android.core.i18n.L
 import com.lextures.android.core.lms.Broadcast
 import com.lextures.android.core.lms.CourseStructureItem
 import com.lextures.android.core.lms.CourseSummary
@@ -274,6 +276,7 @@ fun DashboardTab(
             session = session,
             course = course,
             onBack = { openPathCourse = null },
+            shell = shell,
             modifier = modifier,
         )
         return
@@ -356,6 +359,7 @@ fun DashboardTab(
             session = session,
             course = course,
             onBack = { openCourse = null },
+            shell = shell,
             modifier = modifier,
         )
         return
@@ -435,6 +439,7 @@ fun DashboardTab(
             isOnline = isOnline,
             initialTab = PlannerTab.Todos,
             onBack = { showPlanner = false },
+            shell = shell,
             modifier = modifier,
         )
         return
@@ -457,6 +462,7 @@ fun DashboardTab(
                 avatarInitials = shell.accountProfile?.resolvedInitials()
                     ?: shell.profile?.initials ?: "··",
                 avatarUrl = shell.accountProfile?.avatarUrl,
+                onOpenMenu = { shell.openGlobalDrawer() },
                 onOpenNotifications = { showNotifications = true },
                 onOpenProfile = onOpenProfile,
                 showSearch = shell.iaRedesignEnabled && shell.universalSearchEnabled,
@@ -779,7 +785,7 @@ fun DashboardTab(
     }
 }
 
-/** Deep-teal gradient greeting panel with bell + avatar — the brand statement. */
+/** Deep-teal gradient greeting panel with drawer, search, bell + avatar — the brand statement. */
 @Composable
 private fun HeroPanel(
     greeting: String,
@@ -789,6 +795,7 @@ private fun HeroPanel(
     unreadNotifications: Int,
     avatarInitials: String,
     avatarUrl: String? = null,
+    onOpenMenu: () -> Unit,
     onOpenNotifications: () -> Unit,
     onOpenProfile: () -> Unit,
     showSearch: Boolean = false,
@@ -822,7 +829,27 @@ private fun HeroPanel(
                 .padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            Row(verticalAlignment = Alignment.Top) {
+            Row(
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                // iOS-parity hamburger — opens the app-wide navigation drawer.
+                Box(
+                    modifier = Modifier
+                        .padding(top = 2.dp)
+                        .size(34.dp)
+                        .clip(CircleShape)
+                        .background(Color.White.copy(alpha = 0.16f))
+                        .clickable(onClick = onOpenMenu),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Default.Menu,
+                        contentDescription = L.text(R.string.mobile_drawer_menu),
+                        tint = Color.White,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
                 Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(
                         text = "$greeting,",

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/home/HomeScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -210,6 +211,7 @@ class HomeShellState {
     }
 
     fun openGlobalDrawer() { drawerState = DrawerState.Global }
+    fun openCourseDrawer() { drawerState = DrawerState.Course }
     fun closeDrawer() { drawerState = DrawerState.None }
 
     private fun sharesRootPane(lhs: RootDestination, rhs: RootDestination): Boolean {
@@ -523,12 +525,13 @@ fun HomeScreen(
             onDrawerProgress = { drawerOpenProgress = it },
             globalPanel = { com.lextures.android.features.navigation.GlobalDrawer(shell, accessToken) },
             coursePanel = { com.lextures.android.features.navigation.CourseDrawer(shell) },
+            // Edge-to-edge: keep chrome clear of status/nav bars and display cutouts.
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding(),
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .navigationBarsPadding(),
-            ) {
+            Box(modifier = Modifier.fillMaxSize()) {
                 RootContent(
                     destination = shell.rootDestination,
                     drawerOpenProgress = drawerOpenProgress,
@@ -727,6 +730,7 @@ private fun RootPane(
             isOnline = isOnline,
             initialTab = PlannerTab.Calendar,
             onBack = { shell.select(RootDestination.Dashboard) },
+            shell = shell,
             modifier = modifier,
         )
         RootDestination.Todos -> PlannerScreen(
@@ -735,6 +739,7 @@ private fun RootPane(
             isOnline = isOnline,
             initialTab = PlannerTab.Todos,
             onBack = { shell.select(RootDestination.Dashboard) },
+            shell = shell,
             modifier = modifier,
         )
         RootDestination.Review -> com.lextures.android.features.review.ReviewHomeScreen(

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/home/TeachHubScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/home/TeachHubScreen.kt
@@ -63,6 +63,7 @@ fun TeachHubScreen(
             session = session,
             course = course,
             onBack = { openCourse = null },
+            shell = shell,
             modifier = modifier,
         )
         return

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/marketplace/MarketplaceDetailScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/marketplace/MarketplaceDetailScreen.kt
@@ -106,6 +106,7 @@ fun MarketplaceDetailScreen(
                 openCourse = null
                 onBack()
             },
+            shell = shell,
             modifier = modifier.fillMaxSize(),
         )
         return

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/marketplace/MyPurchasesScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/marketplace/MyPurchasesScreen.kt
@@ -92,6 +92,7 @@ fun MyPurchasesScreen(
                 openCourse = null
                 onBack()
             },
+            shell = shell,
             modifier = modifier.fillMaxSize(),
         )
         return

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/navigation/DrawerScaffold.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/navigation/DrawerScaffold.kt
@@ -64,9 +64,10 @@ fun DrawerScaffold(
     onDrawerProgress: (Float) -> Unit = {},
     globalPanel: @Composable () -> Unit,
     coursePanel: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    BoxWithConstraints(Modifier.fillMaxSize()) {
+    BoxWithConstraints(modifier.fillMaxSize()) {
         val density = LocalDensity.current
         val panelW = min(maxWidth.value * 0.82f, 360f).dp
         val panelPx = with(density) { panelW.toPx() }
@@ -134,11 +135,14 @@ fun DrawerScaffold(
             }
 
             // Leading-edge catcher: opens (closed) or escalates (course menu open).
+            // Transparent + explicit size so the zone still receives hits (system gesture
+            // nav competes for the same edge; course chrome also exposes a menu button).
             if (state == DrawerState.None || state == DrawerState.Course) {
                 Box(
                     Modifier
+                        .align(Alignment.CenterStart)
                         .fillMaxHeight()
-                        .width(24.dp)
+                        .width(28.dp)
                         .pointerInput(state, courseAvailable) {
                             var acc = 0f
                             detectHorizontalDragGestures(

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/planner/CalendarScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/planner/CalendarScreen.kt
@@ -12,9 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -33,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lextures.android.core.design.LexturesColors
@@ -52,6 +50,8 @@ import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
 
+private val WEEKDAY_LABELS = listOf("M", "T", "W", "T", "F", "S", "S")
+
 @Composable
 fun CalendarScreen(
     events: List<PlannerCalendarEvent>,
@@ -68,6 +68,7 @@ fun CalendarScreen(
         events.filter { it.courseCode == null || it.courseCode == code }
     } ?: events
     val counts = PlannerLogic.eventCountsByDay(filtered, zone)
+    // Always 42 cells (6 weeks × 7 days) — small enough for a non-lazy grid.
     val cells = PlannerLogic.monthGridCells(month.atDay(1), zone)
     val dayEvents = PlannerLogic.eventsOnDay(selectedDay, filtered, zone)
 
@@ -104,47 +105,15 @@ fun CalendarScreen(
             }
         }
         item {
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(7),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(18.dp))
-                    .background(cardBackground())
-                    .padding(12.dp),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                items(listOf("M", "T", "W", "T", "F", "S", "S")) { label ->
-                    Text(label, fontSize = 11.sp, color = textSecondary(), modifier = Modifier.fillMaxWidth())
-                }
-                items(cells) { day ->
-                    val inMonth = day.month == month.month
-                    val selected = day == selectedDay
-                    val count = counts[PlannerLogic.dateKeyLocal(day)] ?: 0
-                    Column(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(10.dp))
-                            .background(if (selected) accentColor() else cardBackground())
-                            .clickable { selectedDay = day }
-                            .padding(vertical = 6.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(
-                            text = "${day.dayOfMonth}",
-                            fontSize = 14.sp,
-                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                            color = if (selected) LexturesColors.PrimaryDeep
-                            else if (inMonth) textPrimary() else textSecondary(),
-                        )
-                        Box(
-                            modifier = Modifier
-                                .size(5.dp)
-                                .clip(CircleShape)
-                                .background(if (count > 0) LexturesColors.Coral else cardBackground()),
-                        )
-                    }
-                }
-            }
+            // Non-lazy month grid: LazyVerticalGrid inside LazyColumn is illegal
+            // (infinite max height on the nested scrollable).
+            MonthGrid(
+                month = month,
+                cells = cells,
+                selectedDay = selectedDay,
+                counts = counts,
+                onSelectDay = { selectedDay = it },
+            )
         }
         item {
             LmsSectionHeader(
@@ -167,6 +136,78 @@ fun CalendarScreen(
                         }
                         Text(calendarKindLabel(event.kind), fontSize = 11.sp, color = textSecondary())
                     }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MonthGrid(
+    month: YearMonth,
+    cells: List<LocalDate>,
+    selectedDay: LocalDate,
+    counts: Map<String, Int>,
+    onSelectDay: (LocalDate) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(cardBackground())
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            WEEKDAY_LABELS.forEach { label ->
+                Text(
+                    text = label,
+                    fontSize = 11.sp,
+                    color = textSecondary(),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+        cells.chunked(7).forEach { week ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                week.forEach { day ->
+                    val inMonth = day.month == month.month
+                    val selected = day == selectedDay
+                    val count = counts[PlannerLogic.dateKeyLocal(day)] ?: 0
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(if (selected) accentColor() else cardBackground())
+                            .clickable { onSelectDay(day) }
+                            .padding(vertical = 6.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = "${day.dayOfMonth}",
+                            fontSize = 14.sp,
+                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                            color = if (selected) LexturesColors.PrimaryDeep
+                            else if (inMonth) textPrimary() else textSecondary(),
+                        )
+                        Box(
+                            modifier = Modifier
+                                .size(5.dp)
+                                .clip(CircleShape)
+                                .background(if (count > 0) LexturesColors.Coral else cardBackground()),
+                        )
+                    }
+                }
+                // Pad incomplete trailing weeks (shouldn't happen with 42 cells).
+                repeat(7 - week.size) {
+                    Box(modifier = Modifier.weight(1f))
                 }
             }
         }

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/planner/PlannerScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/planner/PlannerScreen.kt
@@ -53,6 +53,7 @@ import com.lextures.android.core.lms.StudentTodoItem
 import com.lextures.android.core.offline.OfflineService
 import com.lextures.android.features.courses.CourseDetailScreen
 import com.lextures.android.features.courses.ItemDetailScreen
+import com.lextures.android.features.home.HomeShellState
 import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsErrorBanner
 import kotlinx.coroutines.launch
@@ -67,6 +68,7 @@ fun PlannerScreen(
     isOnline: Boolean,
     initialTab: PlannerTab = PlannerTab.Todos,
     onBack: (() -> Unit)? = null,
+    shell: HomeShellState? = null,
     modifier: Modifier = Modifier,
 ) {
     val accessToken by session.accessToken.collectAsState()
@@ -118,7 +120,12 @@ fun PlannerScreen(
             return
         }
         course?.let {
-            CourseDetailScreen(session = session, course = it, onBack = { openTodo = null })
+            CourseDetailScreen(
+                session = session,
+                course = it,
+                onBack = { openTodo = null },
+                shell = shell,
+            )
             return
         }
         openTodo = null
@@ -168,6 +175,7 @@ fun PlannerScreen(
                 onShowCompletedChange = { showCompleted = it },
                 onOpenItem = { item, course -> openTodo = item to course },
                 courses = courses,
+                modifier = Modifier.weight(1f),
             )
             else -> CalendarScreen(
                 events = events,
@@ -175,6 +183,7 @@ fun PlannerScreen(
                 selectedCourseCode = selectedCourseCode,
                 onCourseSelected = { selectedCourseCode = it },
                 onEventSelected = { event -> addEventToDeviceCalendar(context, event) },
+                modifier = Modifier.weight(1f),
             )
         }
         OutlinedButton(

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/profile/ProfileTab.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/profile/ProfileTab.kt
@@ -634,6 +634,7 @@ fun ProfileTab(
                             session = session,
                             course = openPathCourse!!,
                             onBack = { openPathCourse = null },
+                            shell = shell,
                             modifier = Modifier.fillMaxSize(),
                         )
                         openPathLandingSlug != null -> com.lextures.android.features.paths.PathLandingScreen(

--- a/clients/android/gradle.properties
+++ b/clients/android/gradle.properties
@@ -18,3 +18,6 @@ android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## Summary
- Thread `HomeShellState` into course/planner entry points (dashboard, teach hub, marketplace, catalog, profile, planner) so nested screens can open the course drawer and use shared chrome.
- Add a dashboard hero hamburger for global drawer access (iOS parity), drop redundant in-app back arrows in favor of system/gesture back, and apply status/nav bar padding at the drawer scaffold for edge-to-edge layout.
- Fix planner calendar crash by replacing nested `LazyVerticalGrid` inside `LazyColumn` with a fixed non-lazy `MonthGrid`; enable Gradle parallel tooling.

## Test plan
- [ ] Open dashboard → hamburger opens global drawer; edge swipe still works
- [ ] Open a course from dashboard/teach hub/marketplace/purchases/catalog/profile → course menu button opens course drawer
- [ ] System back navigates without in-app back arrow on course detail / invitation
- [ ] Planner calendar month grid renders and selects days without crash
- [ ] Status bar and nav bar do not overlap drawer chrome content