### PR TITLE
fix(web): keep course hero banner crop stable on resize

### DIFF
--- a/clients/web/src/components/__tests__/course-hero-banner.test.tsx
+++ b/clients/web/src/components/__tests__/course-hero-banner.test.tsx
@@ -31,4 +31,23 @@ describe('CourseHeroBanner', () => {
     expect(screen.getByRole('heading', { name: 'Welcome to Lextures' })).toBeInTheDocument()
     expect(screen.getByText('A guided introduction to Lextures.')).toBeInTheDocument()
   })
+
+  it('uses a fixed aspect ratio so the hero crop stays stable when width changes', () => {
+    const { container } = render(
+      <CourseHeroBanner
+        course={{
+          title: 'AI Essentials',
+          courseCode: 'C-AIESS',
+          heroImageUrl: '/api/v1/courses/C-AIESS/course-files/00000000-0000-4000-8000-000000000099/content',
+          heroImageObjectPosition: '50% 40%',
+        }}
+      />,
+    )
+    const frame = container.firstElementChild
+    expect(frame).toHaveClass('aspect-[4/1]')
+    expect(frame).not.toHaveClass('h-44', 'h-56', 'sm:h-56')
+    const img = container.querySelector('img')
+    expect(img).toHaveClass('absolute', 'inset-0', 'object-cover')
+    expect(img).toHaveStyle({ objectPosition: '50% 40%' })
+  })
 })

--- a/clients/web/src/components/course-hero-banner.tsx
+++ b/clients/web/src/components/course-hero-banner.tsx
@@ -20,12 +20,14 @@ export function CourseHeroBanner({
 
   return (
     <div
-      className={`relative h-44 w-full overflow-hidden rounded-2xl border border-slate-200 shadow-sm sm:h-56 dark:border-neutral-700 ${className}`}
+      // Fixed aspect ratio (not fixed height) so object-cover keeps the same crop as the
+      // banner width changes — otherwise widening the window re-crops the hero image.
+      className={`relative aspect-[4/1] w-full overflow-hidden rounded-2xl border border-slate-200 shadow-sm dark:border-neutral-700 ${className}`}
     >
       <CourseHeroImage
         src={course.heroImageUrl}
         alt=""
-        className="h-full w-full object-cover"
+        className="absolute inset-0 h-full w-full object-cover"
         style={heroImageObjectStyle(course.heroImageObjectPosition)}
       />
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/20 to-transparent" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The course hero banner (`CourseHeroBanner` on Modules / course home) used a fixed height (`h-44` / `sm:h-56`) with `object-cover`. As the viewport widened, the container aspect ratio changed, so the browser re-cropped the image and the background appeared to jump.

Switch the banner frame to a fixed `aspect-[4/1]` and absolutely position the image so the visible crop (including saved `heroImageObjectPosition`) stays consistent when the window is resized.

## Checklist

- [x] Tests added/updated as appropriate
- [ ] If moving a plan into `docs/completed/`, added a disposition in `e2e/coverage/completed-feature-manifest.json` and ran `npm run e2e:coverage:check` (E2E.4)
- [ ] Flagged features link settings-toggle / disabled / enabled / authz / dependency / rollback coverage (or an E2E.1–E2E.3 family)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f93819d-f69e-4ddb-8e33-22102f0e8543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f93819d-f69e-4ddb-8e33-22102f0e8543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

