### PR TITLE
feat(web): polish block editor chrome and module settings tabs

### DIFF
--- a/clients/web/src/components/__tests__/course-hero-banner.test.tsx
+++ b/clients/web/src/components/__tests__/course-hero-banner.test.tsx
@@ -44,7 +44,7 @@ describe('CourseHeroBanner', () => {
       />,
     )
     const frame = container.firstElementChild
-    expect(frame).toHaveClass('aspect-[4/1]')
+    expect(frame).toHaveClass('aspect-[5/1]')
     expect(frame).not.toHaveClass('h-44', 'h-56', 'sm:h-56')
     const img = container.querySelector('img')
     expect(img).toHaveClass('absolute', 'inset-0', 'object-cover')

--- a/clients/web/src/components/course-hero-banner.tsx
+++ b/clients/web/src/components/course-hero-banner.tsx
@@ -22,7 +22,7 @@ export function CourseHeroBanner({
     <div
       // Fixed aspect ratio (not fixed height) so object-cover keeps the same crop as the
       // banner width changes — otherwise widening the window re-crops the hero image.
-      className={`relative aspect-[4/1] w-full overflow-hidden rounded-2xl border border-slate-200 shadow-sm dark:border-neutral-700 ${className}`}
+      className={`relative aspect-[5/1] w-full overflow-hidden rounded-2xl border border-slate-200 shadow-sm dark:border-neutral-700 ${className}`}
     >
       <CourseHeroImage
         src={course.heroImageUrl}

--- a/clients/web/src/components/editor/block-editor/block-floating-toolbar.tsx
+++ b/clients/web/src/components/editor/block-editor/block-floating-toolbar.tsx
@@ -1,37 +1,21 @@
-import { ChevronDown, ChevronUp, GripVertical, Trash2 } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 export type BlockFloatingToolbarProps = {
-  /** e.g. block type icon */
-  icon: ReactNode
-  /** Shown next to the icon (block type name). */
-  label: string
-  onMoveUp?: () => void
-  onMoveDown?: () => void
-  moveUpDisabled?: boolean
-  moveDownDisabled?: boolean
-  onRemove?: () => void
-  removeLabel?: string
-  disabled?: boolean
+  /** Describes the toolbar for assistive tech. */
+  label?: string
   /** When true, omits outer chrome for use inside a parent card (e.g. generate panel stack). */
   embedded?: boolean
-  /** Extra controls (e.g. formatting) before remove. */
-  children?: ReactNode
+  children: ReactNode
 }
 
 /**
- * Compact horizontal toolbar that sits above the active block (Gutenberg-style).
+ * Pill that holds text-formatting controls next to the caret while writing.
+ *
+ * Block management (reorder, delete) deliberately lives in the block header
+ * instead, so this bar only ever changes the text you are typing.
  */
 export function BlockFloatingToolbar({
-  icon,
-  label,
-  onMoveUp,
-  onMoveDown,
-  moveUpDisabled,
-  moveDownDisabled,
-  onRemove,
-  removeLabel = 'Remove block',
-  disabled,
+  label = 'Text formatting',
   embedded = false,
   children,
 }: BlockFloatingToolbarProps) {
@@ -42,63 +26,14 @@ export function BlockFloatingToolbar({
         'pointer-events-auto flex h-9 w-max max-w-[calc(100vw-2rem)] items-center gap-0.5 px-1 py-0.5',
         embedded
           ? 'w-full rounded-none border-0 bg-transparent shadow-none'
-          : 'rounded-md border border-slate-200 bg-white shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40',
+          : 'rounded-lg border border-slate-200 bg-white shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40',
       ].join(' ')}
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
       role="toolbar"
-      aria-label={`${label} block tools`}
+      aria-label={label}
     >
-      <span
-        className="flex h-7 max-w-[148px] items-center gap-1 rounded px-1.5 text-slate-600 dark:text-neutral-300 sm:max-w-[200px]"
-        title={label}
-      >
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center text-slate-500 dark:text-neutral-400" aria-hidden>
-          {icon}
-        </span>
-        <span className="truncate text-xs font-medium text-slate-700 dark:text-neutral-200">{label}</span>
-      </span>
-      <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
-      <span
-        className="flex h-7 w-7 shrink-0 cursor-grab items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-600 active:cursor-grabbing dark:hover:bg-neutral-700 dark:hover:text-neutral-200"
-        aria-hidden
-      >
-        <GripVertical className="h-4 w-4" />
-      </span>
-      {onMoveUp && (
-        <button
-          type="button"
-          disabled={disabled || moveUpDisabled}
-          onClick={onMoveUp}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
-          aria-label="Move block up"
-        >
-          <ChevronUp className="h-4 w-4" />
-        </button>
-      )}
-      {onMoveDown && (
-        <button
-          type="button"
-          disabled={disabled || moveDownDisabled}
-          onClick={onMoveDown}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
-          aria-label="Move block down"
-        >
-          <ChevronDown className="h-4 w-4" />
-        </button>
-      )}
       {children}
-      {onRemove && (
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={onRemove}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-rose-50 hover:text-rose-700 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-400 dark:hover:bg-rose-950/50 dark:hover:text-rose-400"
-          aria-label={removeLabel}
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
-      )}
     </div>
   )
 }

--- a/clients/web/src/components/editor/block-editor/block-frame.tsx
+++ b/clients/web/src/components/editor/block-editor/block-frame.tsx
@@ -1,32 +1,72 @@
+import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useBlockEditor } from './block-editor-provider'
 
 export type BlockFrameProps = {
   blockId: string
-  /** Toolbar shown above the block on hover, focus, or selection. */
+  /** e.g. “Section 1 of 4” — always visible so the writer knows where they are. */
+  positionLabel: string
+  onMoveUp?: () => void
+  onMoveDown?: () => void
+  moveUpDisabled?: boolean
+  moveDownDisabled?: boolean
+  onRemove?: () => void
+  /** Explains why remove is unavailable (e.g. last remaining block). */
+  removeDisabledReason?: string
+  /**
+   * Formatting controls pinned into the header while this block is being
+   * written in. Present means the action labels collapse to icons to make room.
+   */
   toolbar?: ReactNode
-  /** When false, toolbar is rendered elsewhere (e.g. caret-anchored portal). */
-  inlineToolbar?: boolean
   children: ReactNode
   className?: string
 }
 
+const ACTION_BUTTON =
+  'flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-40 motion-safe:transition-colors'
+
 /**
- * Wraps a single block: Gutenberg-style left accent, floating toolbar above, hover/focus affordances.
+ * Wraps a single block as a card with a persistent header.
+ *
+ * The header keeps its height at all times and the actions inside it only fade
+ * in, so moving the pointer across the document never reflows the page.
  */
 export function BlockFrame({
   blockId,
+  positionLabel,
+  onMoveUp,
+  onMoveDown,
+  moveUpDisabled,
+  moveDownDisabled,
+  onRemove,
+  removeDisabledReason,
   toolbar,
-  inlineToolbar = true,
   children,
   className,
 }: BlockFrameProps) {
   const { selectedId, setSelectedId, disabled } = useBlockEditor()
   const selected = selectedId === blockId
 
+  // Actions are revealed by opacity only — never by height or margin.
+  const reveal = selected
+    ? 'opacity-100'
+    : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
+
+  // With the toolbar present there is no room for words next to the icons.
+  const actionLabel = toolbar ? 'sr-only' : 'hidden sm:inline'
+
   return (
     <div
-      className={['group relative mb-2', className].filter(Boolean).join(' ')}
+      className={[
+        '@container group relative mb-3 rounded-xl border bg-white motion-safe:transition-[border-color,box-shadow] dark:bg-neutral-900',
+        selected
+          ? 'border-indigo-400 shadow-sm shadow-indigo-900/10 ring-1 ring-indigo-400/25 dark:border-indigo-500 dark:ring-indigo-500/25'
+          : 'border-slate-200 hover:border-slate-300 dark:border-neutral-700 dark:hover:border-neutral-600',
+        disabled ? 'opacity-60' : '',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
       onClick={(e) => {
         e.stopPropagation()
         setSelectedId(blockId)
@@ -38,31 +78,72 @@ export function BlockFrame({
         }
       }}
       role="group"
-      aria-label="Content block"
+      aria-label={positionLabel}
     >
       <div
         className={[
-          'border-s-2 border-transparent ps-3 transition-colors',
-          selected ? 'border-indigo-600 dark:border-indigo-400' : '',
-          disabled ? 'opacity-60' : '',
+          'sticky top-0 z-20 flex h-10 items-center gap-2 rounded-t-xl border-b px-3',
+          'bg-white/95 backdrop-blur-sm dark:bg-neutral-900/95',
+          selected
+            ? 'border-slate-200 dark:border-neutral-700'
+            : 'border-transparent group-hover:border-slate-100 group-focus-within:border-slate-100 dark:group-hover:border-neutral-800 dark:group-focus-within:border-neutral-800',
         ].join(' ')}
       >
-        {toolbar && inlineToolbar && (
-          <div
-            className={[
-              'sticky top-0 z-20 w-full overflow-hidden transition-[height,opacity,margin-bottom] duration-150',
-              selected
-                ? 'mb-2 h-9 opacity-100'
-                : 'h-0 opacity-0 group-hover:mb-2 group-hover:h-9 group-hover:opacity-100 group-focus-within:mb-2 group-focus-within:h-9 group-focus-within:opacity-100',
-            ].join(' ')}
-          >
-            <div className="flex justify-start">
-              {toolbar}
-            </div>
+        <span
+          className={[
+            'min-w-0 truncate text-xs font-medium text-slate-500 dark:text-neutral-400',
+            // With the toolbar in the row, drop the label rather than ellipsing it.
+            toolbar ? 'hidden @[34rem]:block' : 'block',
+          ].join(' ')}
+        >
+          {positionLabel}
+        </span>
+        <div className="ms-auto flex shrink-0 items-center gap-1">
+          {toolbar}
+          {toolbar && (
+            <span className="mx-0.5 h-5 w-px bg-slate-200 dark:bg-neutral-600" aria-hidden />
+          )}
+          <div className={`flex items-center gap-0.5 duration-150 motion-safe:transition-opacity ${reveal}`}>
+            {onMoveUp && (
+              <button
+                type="button"
+                disabled={disabled || moveUpDisabled}
+                onClick={onMoveUp}
+                className={`${ACTION_BUTTON} text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-neutral-50`}
+                title="Move this section up"
+              >
+                <ChevronUp className="h-4 w-4" aria-hidden />
+                <span className={actionLabel}>Move up</span>
+              </button>
+            )}
+            {onMoveDown && (
+              <button
+                type="button"
+                disabled={disabled || moveDownDisabled}
+                onClick={onMoveDown}
+                className={`${ACTION_BUTTON} text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-neutral-50`}
+                title="Move this section down"
+              >
+                <ChevronDown className="h-4 w-4" aria-hidden />
+                <span className={actionLabel}>Move down</span>
+              </button>
+            )}
+            {onRemove && (
+              <button
+                type="button"
+                disabled={disabled || Boolean(removeDisabledReason)}
+                onClick={onRemove}
+                className={`${ACTION_BUTTON} text-slate-600 hover:bg-rose-50 hover:text-rose-700 dark:text-neutral-300 dark:hover:bg-rose-950/50 dark:hover:text-rose-400`}
+                title={removeDisabledReason ?? 'Delete this section'}
+              >
+                <Trash2 className="h-4 w-4" aria-hidden />
+                <span className={actionLabel}>Delete</span>
+              </button>
+            )}
           </div>
-        )}
-        {children}
+        </div>
       </div>
+      <div className="px-5 pb-6 pt-4">{children}</div>
     </div>
   )
 }

--- a/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
@@ -34,7 +34,7 @@ import type { Board } from '../../../lib/boards-api'
 
 const editorShellClass = [
   'tiptap',
-  'min-h-[100px] w-full px-0 py-1 text-[15px] leading-[1.65] text-slate-800',
+  'min-h-[100px] w-full px-0 py-1 text-[15px] leading-[1.65] text-slate-800 dark:text-neutral-200',
   'focus:outline-none',
   '[&_p]:mt-3 [&_p:first-child]:mt-0',
   '[&_h1]:mt-6 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-slate-900 [&_h1]:first:mt-0',

--- a/clients/web/src/components/editor/block-editor/markdown-format-toolbar.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-format-toolbar.tsx
@@ -42,7 +42,6 @@ export function MarkdownFormatToolbar({ disabled, onApply, dictation, courseImag
 
   return (
     <>
-      <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
       <button
         type="button"
         disabled={disabled}

--- a/clients/web/src/components/modules/module-requirements-panel.tsx
+++ b/clients/web/src/components/modules/module-requirements-panel.tsx
@@ -4,6 +4,8 @@ import {
   type ModuleCompletionMode,
 } from '../../lib/conditional-release-api'
 
+export const MODULE_REQUIREMENTS_FORM_ID = 'module-requirements-form'
+
 const MODES: { value: ModuleCompletionMode; label: string }[] = [
   { value: 'all_items', label: 'All items required' },
   { value: 'one_item', label: 'Complete any one item' },
@@ -14,20 +16,29 @@ type Props = {
   courseCode: string
   moduleId: string
   allModules: { id: string; title: string }[]
+  onSavingChange?: (saving: boolean) => void
+  onErrorChange?: (error: string | null) => void
+  onSaved?: () => void
 }
 
-export function ModuleRequirementsPanel({ courseCode, moduleId, allModules }: Props) {
-  const [open, setOpen] = useState(false)
+export function ModuleRequirementsPanel({
+  courseCode,
+  moduleId,
+  allModules,
+  onSavingChange,
+  onErrorChange,
+  onSaved,
+}: Props) {
   const [mode, setMode] = useState<ModuleCompletionMode>('all_items')
   const [prereqs, setPrereqs] = useState<string[]>([])
   const [unlockAt, setUnlockAt] = useState('')
-  const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
 
   const save = useCallback(async () => {
-    setSaving(true)
+    onSavingChange?.(true)
     setErr(null)
+    onErrorChange?.(null)
     setSaved(false)
     try {
       await putModuleRequirements(courseCode, moduleId, {
@@ -36,93 +47,89 @@ export function ModuleRequirementsPanel({ courseCode, moduleId, allModules }: Pr
         unlockAt: unlockAt.trim() ? new Date(unlockAt).toISOString() : null,
       })
       setSaved(true)
+      onSaved?.()
     } catch (e) {
-      setErr(e instanceof Error ? e.message : 'Could not save requirements.')
+      const message = e instanceof Error ? e.message : 'Could not save requirements.'
+      setErr(message)
+      onErrorChange?.(message)
     } finally {
-      setSaving(false)
+      onSavingChange?.(false)
     }
-  }, [courseCode, mode, moduleId, prereqs, unlockAt])
+  }, [courseCode, mode, moduleId, onErrorChange, onSaved, onSavingChange, prereqs, unlockAt])
 
   useEffect(() => {
-    if (!open) return
     setSaved(false)
-  }, [open, mode, prereqs, unlockAt])
+  }, [mode, prereqs, unlockAt])
 
   const otherModules = allModules.filter((m) => m.id !== moduleId)
 
   return (
-    <div className="mt-3 rounded-xl border border-sky-100 bg-sky-50/40 px-3 py-2 text-start dark:border-sky-900/40 dark:bg-sky-950/30">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="text-xs font-semibold text-sky-800 hover:text-sky-600 dark:text-sky-200 dark:hover:text-sky-100"
-      >
-        {open ? '▼' : '▶'} Module requirements
-      </button>
-      {open ? (
-        <div className="mt-2 space-y-2 text-xs text-slate-700 dark:text-neutral-200">
-          {err ? <p className="text-rose-700 dark:text-rose-300">{err}</p> : null}
-          {saved ? (
-            <p className="text-emerald-700 dark:text-emerald-300" role="status">
-              Requirements saved.
-            </p>
-          ) : null}
-          <label className="block">
-            <span className="font-medium text-slate-600 dark:text-neutral-300">Completion mode</span>
-            <select
-              value={mode}
-              onChange={(e) => setMode(e.target.value as ModuleCompletionMode)}
-              className="mt-1 w-full rounded border border-slate-200 bg-white px-2 py-1 text-xs dark:border-neutral-600 dark:bg-neutral-900"
-            >
-              {MODES.map((m) => (
-                <option key={m.value} value={m.value}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          {otherModules.length > 0 ? (
-            <fieldset>
-              <legend className="font-medium text-slate-600 dark:text-neutral-300">Prerequisites</legend>
-              <ul className="mt-1 space-y-1">
-                {otherModules.map((m) => (
-                  <li key={m.id}>
-                    <label className="inline-flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        checked={prereqs.includes(m.id)}
-                        onChange={(e) => {
-                          setPrereqs((prev) =>
-                            e.target.checked ? [...prev, m.id] : prev.filter((id) => id !== m.id),
-                          )
-                        }}
-                      />
-                      <span>{m.title}</span>
-                    </label>
-                  </li>
-                ))}
-              </ul>
-            </fieldset>
-          ) : null}
-          <label className="block">
-            <span className="font-medium text-slate-600 dark:text-neutral-300">Lock until (optional)</span>
-            <input
-              type="datetime-local"
-              value={unlockAt}
-              onChange={(e) => setUnlockAt(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-200 bg-white px-2 py-1 text-xs dark:border-neutral-600 dark:bg-neutral-900"
-            />
-          </label>
-          <button
-            type="button"
-            disabled={saving}
-            onClick={() => void save()}
-            className="rounded bg-sky-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-sky-600 disabled:opacity-50 dark:bg-sky-600"
-          >
-            {saving ? 'Saving…' : 'Save requirements'}
-          </button>
-        </div>
+    <form
+      id={MODULE_REQUIREMENTS_FORM_ID}
+      className="space-y-3 text-start"
+      onSubmit={(e) => {
+        e.preventDefault()
+        void save()
+      }}
+    >
+      <p className="text-xs text-slate-500">
+        Choose how students complete this module and any modules they must finish first.
+      </p>
+      {err ? <p className="text-sm text-rose-700">{err}</p> : null}
+      {saved ? (
+        <p className="text-sm text-emerald-700" role="status">
+          Requirements saved.
+        </p>
       ) : null}
-    </div>
+      <label className="block">
+        <span className="text-xs font-medium text-slate-600">Completion mode</span>
+        <select
+          value={mode}
+          onChange={(e) => setMode(e.target.value as ModuleCompletionMode)}
+          className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2"
+        >
+          {MODES.map((m) => (
+            <option key={m.value} value={m.value}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {otherModules.length > 0 ? (
+        <fieldset>
+          <legend className="text-xs font-medium text-slate-600">Prerequisites</legend>
+          <ul className="mt-1.5 max-h-36 space-y-1.5 overflow-y-auto rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-2">
+            {otherModules.map((m) => (
+              <li key={m.id}>
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={prereqs.includes(m.id)}
+                    onChange={(e) => {
+                      setPrereqs((prev) =>
+                        e.target.checked ? [...prev, m.id] : prev.filter((id) => id !== m.id),
+                      )
+                    }}
+                    className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <span className="text-sm text-slate-700">{m.title}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+      ) : (
+        <p className="text-xs text-slate-500">No other modules available as prerequisites.</p>
+      )}
+      <label className="block">
+        <span className="text-xs font-medium text-slate-600">Lock until (optional)</span>
+        <input
+          type="datetime-local"
+          value={unlockAt}
+          onChange={(e) => setUnlockAt(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2"
+        />
+      </label>
+    </form>
   )
 }

--- a/clients/web/src/components/syllabus/syllabus-block-editor.tsx
+++ b/clients/web/src/components/syllabus/syllabus-block-editor.tsx
@@ -17,7 +17,6 @@ import {
   BlockEditorShell,
   BlockFloatingToolbar,
   BlockFrame,
-  CaretAnchoredToolbarPortal,
   EditorSidebar,
   MarkdownBodyEditor,
   MarkdownFormatToolbar,
@@ -43,6 +42,7 @@ import {
 import { summarizeSectionsAltText } from '../../lib/image-alt-validation'
 import { toastMutationError } from '../../lib/lms-toast'
 import { InputDialog } from '../input-dialog'
+import { useConfirm } from '../use-confirm'
 
 function newLocalId(): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
@@ -269,10 +269,12 @@ function SyllabusDocumentPanel({
 function SyllabusBlockPanel({
   section,
   index,
+  total,
   updateAt,
 }: {
   section: SyllabusSection
   index: number
+  total: number
   updateAt: (index: number, patch: Partial<SyllabusSection>) => void
 }) {
   const { disabled } = useBlockEditor()
@@ -287,8 +289,12 @@ function SyllabusBlockPanel({
           <FileText className="h-4 w-4" aria-hidden />
         </span>
         <div className="min-w-0">
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Section</h3>
-          <p className="text-xs text-slate-500 dark:text-neutral-400">Optional heading plus Markdown content.</p>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+            Section {index + 1} of {total}
+          </h3>
+          <p className="truncate text-xs text-slate-500 dark:text-neutral-400">
+            {section.heading.trim() || 'Untitled section'}
+          </p>
         </div>
       </div>
       <SidebarSection title="Content" defaultOpen>
@@ -366,38 +372,52 @@ function SyllabusSidebar({
           <SyllabusBlockPanel
             section={section}
             index={index}
+            total={sections.length}
             updateAt={updateAt}
           />
         ) : null
       }
       blockDisabled={!section}
-      blockDisabledMessage="Click a section in the editor to change its settings here."
+      blockDisabledMessage="Click any section to edit its settings here."
     />
+  )
+}
+
+/** Slim gap between two cards. Keeps its height so revealing the button never reflows. */
+function SectionDivider({ onAdd, disabled }: { onAdd: () => void; disabled?: boolean }) {
+  return (
+    <div
+      className="group/divider relative flex h-8 items-center justify-center"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <span
+        className="absolute inset-x-0 top-1/2 h-px bg-slate-200 opacity-0 motion-safe:transition-opacity group-hover/divider:opacity-100 group-focus-within/divider:opacity-100 dark:bg-neutral-700"
+        aria-hidden
+      />
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onAdd}
+        className="pointer-events-none relative z-10 flex h-7 items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 text-xs font-medium text-slate-600 opacity-0 shadow-sm hover:text-slate-900 disabled:cursor-not-allowed motion-safe:transition-opacity group-hover/divider:pointer-events-auto group-hover/divider:opacity-100 group-focus-within/divider:pointer-events-auto group-focus-within/divider:opacity-100 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-50"
+      >
+        <Plus className="h-3.5 w-3.5" aria-hidden />
+        Add section here
+      </button>
+    </div>
   )
 }
 
 function BlockInsertionRow({ onAdd, disabled }: { onAdd: () => void; disabled?: boolean }) {
   return (
-    <div className="relative py-6" onClick={(e) => e.stopPropagation()}>
-      <div className="relative flex items-center justify-center">
-        <div className="absolute inset-x-0 top-1/2 h-px bg-slate-300/80 dark:bg-neutral-600" aria-hidden />
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={onAdd}
-          className="relative z-10 flex h-9 w-9 items-center justify-center rounded-full border border-slate-300 bg-[#f0f0f0] text-slate-600 shadow-sm transition-[background-color,color,border-color] hover:border-slate-400 hover:bg-white hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-500 dark:hover:bg-neutral-700 dark:hover:text-neutral-50"
-          aria-label="Add section"
-        >
-          <Plus className="h-5 w-5" strokeWidth={2} aria-hidden />
-        </button>
-      </div>
+    <div className="pt-2" onClick={(e) => e.stopPropagation()}>
       <button
         type="button"
         disabled={disabled}
         onClick={onAdd}
-        className="mt-4 w-full border-0 bg-transparent py-1 text-start text-[13px] text-slate-400 transition-[background-color,color,border-color] hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-500 dark:hover:text-neutral-300"
+        className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 px-4 py-4 text-sm font-medium text-slate-600 motion-safe:transition-[background-color,color,border-color] hover:border-indigo-400 hover:bg-white hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:border-indigo-500 dark:hover:bg-neutral-900 dark:hover:text-indigo-400"
       >
-        Type / to add a section
+        <Plus className="h-4 w-4" aria-hidden />
+        Add a section
       </button>
     </div>
   )
@@ -417,6 +437,7 @@ function SyllabusBlockEditorInner({
 }: SyllabusBlockEditorInnerProps) {
   const { t } = useTranslation('common')
   const { selectedId, setSelectedId } = useBlockEditor()
+  const { confirm, ConfirmDialogHost } = useConfirm()
   const equationEditor = useEquationEditor()
   const [activeField, setActiveField] = useState<ActiveField | null>(null)
   const editorRefs = useRef<Record<string, Editor | null>>({})
@@ -454,10 +475,8 @@ function SyllabusBlockEditorInner({
     [altTextOn],
   )
 
-  const [editorVersion, setEditorVersion] = useState(0)
   const handleEditorChange = useCallback((sectionId: string, editor: Editor | null) => {
     editorRefs.current[sectionId] = editor
-    setEditorVersion((v) => v + 1)
   }, [])
 
   const insertImagesIntoSection = useCallback(
@@ -522,9 +541,25 @@ function SyllabusBlockEditorInner({
     onChange(next)
   }
 
-  function removeAt(index: number) {
-    if (sections.length <= 1) return
+  async function removeAt(index: number) {
+    const section = sections[index]
+    if (!section || sections.length <= 1) return
+
+    // Only interrupt when there is written work to lose.
+    const hasContent = Boolean(section.heading.trim() || section.markdown.trim())
+    if (hasContent) {
+      const name = section.heading.trim()
+      const ok = await confirm({
+        title: name ? `Delete “${name}”?` : `Delete section ${index + 1}?`,
+        description: 'This removes the heading and everything written in this section.',
+        confirmLabel: 'Delete section',
+        variant: 'danger',
+      })
+      if (!ok) return
+    }
+
     onChange(sections.filter((_, i) => i !== index))
+    setSelectedId(null)
   }
 
   function move(index: number, dir: -1 | 1) {
@@ -537,8 +572,13 @@ function SyllabusBlockEditorInner({
     onChange(next)
   }
 
-  function addSection() {
-    onChange([...sections, { id: newLocalId(), heading: '', markdown: '' }])
+  /** Inserts at `index`; pass `sections.length` to append. */
+  function addSectionAt(index: number) {
+    const section: SyllabusSection = { id: newLocalId(), heading: '', markdown: '' }
+    const next = [...sections]
+    next.splice(index, 0, section)
+    onChange(next)
+    setSelectedId(section.id)
   }
 
   function applyMarkdownForSection(sectionId: string, kind: MarkdownEditKind) {
@@ -612,30 +652,13 @@ function SyllabusBlockEditorInner({
     }
   }
 
-  const caretAnchoredSectionIndex = useMemo(() => {
-    if (!showMarkdownToolbar || !selectedId) return -1
-    return sections.findIndex((s) => s.id === selectedId)
-  }, [showMarkdownToolbar, selectedId, sections])
-
-  const caretAnchoredEditor = useMemo(() => {
-    if (caretAnchoredSectionIndex < 0 || !selectedId) return null
-    void editorVersion
-    return editorRefs.current[selectedId] ?? null
-  }, [caretAnchoredSectionIndex, selectedId, editorVersion])
-
-  function renderGeneratePanel(
-    section: SyllabusSection,
-    index: number,
-    placement: 'inline' | 'anchored' = 'inline',
-  ) {
+  function renderGeneratePanel(section: SyllabusSection, index: number) {
     if (!courseCode) return null
 
     const inputClassName = [
       'w-full py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none disabled:opacity-60 dark:text-neutral-100 dark:placeholder:text-neutral-500',
-      placement === 'anchored'
-        ? 'border-0 bg-transparent px-2 focus:ring-0'
-        : 'rounded-md border border-slate-200 bg-white px-2.5 focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400 dark:border-neutral-600 dark:bg-neutral-950 dark:focus:border-indigo-500 dark:focus:ring-indigo-500',
-      generateSubmittingId === section.id ? (placement === 'anchored' ? 'ps-2 pe-14' : 'ps-2.5 pe-14') : placement === 'anchored' ? 'px-2' : 'px-2.5',
+      'rounded-md border border-slate-200 bg-white px-2.5 focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400 dark:border-neutral-600 dark:bg-neutral-950 dark:focus:border-indigo-500 dark:focus:ring-indigo-500',
+      generateSubmittingId === section.id ? 'ps-2.5 pe-14' : 'px-2.5',
     ].join(' ')
 
     const panel = (
@@ -688,25 +711,10 @@ function SyllabusBlockEditorInner({
           ) : null}
         </div>
         {generateError ? (
-          <p className={`text-xs text-rose-600 dark:text-rose-400 ${placement === 'anchored' ? 'px-2 pb-1.5 pt-0.5' : 'mt-1.5'}`}>
-            {generateError}
-          </p>
+          <p className="mt-1.5 text-xs text-rose-600 dark:text-rose-400">{generateError}</p>
         ) : null}
       </>
     )
-
-    if (placement === 'anchored') {
-      return (
-        <div
-          id={`section-generate-${section.id}`}
-          data-generate-anchor
-          className="border-t border-slate-200 py-1 dark:border-neutral-600"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {panel}
-        </div>
-      )
-    }
 
     return (
       <div
@@ -720,110 +728,93 @@ function SyllabusBlockEditorInner({
     )
   }
 
-  function renderToolbar(section: SyllabusSection, index: number, embedded = false) {
-    const showMarkdownTools = showMarkdownToolbar && selectedId === section.id
-    const label = showMarkdownTools ? 'Markdown' : 'Section'
+  function renderFormatToolbar(section: SyllabusSection, embedded = false) {
     const genBusy = generateSubmittingId === section.id
 
     return (
-      <BlockFloatingToolbar
-        embedded={embedded}
-        icon={<FileText className="h-4 w-4" />}
-        label={label}
-        onMoveUp={() => move(index, -1)}
-        onMoveDown={() => move(index, 1)}
-        moveUpDisabled={index === 0}
-        moveDownDisabled={index === sections.length - 1}
-        onRemove={() => removeAt(index)}
-        removeLabel="Remove section"
-        disabled={disabled}
-      >
-        {showMarkdownTools && (
+      <BlockFloatingToolbar embedded={embedded}>
+        <MarkdownFormatToolbar
+          disabled={disabled || genBusy}
+          onApply={(kind) => applyMarkdownForSection(section.id, kind)}
+          mathInsert={
+            equationEditorEnabled && equationEditor
+              ? {
+                  onOpen: () => {
+                    setSelectedId(section.id)
+                    setActiveField({ blockId: section.id, field: 'markdown' })
+                    const ed = editorRefs.current[section.id]
+                    ed?.chain().focus().run()
+                    if (ed) equationEditor.openInsert(ed)
+                  },
+                  registerMathAnchor: (node) => {
+                    mathToolbarAnchorRef.current = node
+                  },
+                }
+              : undefined
+          }
+          courseImage={
+            courseCode
+              ? {
+                  onPickClick: () => {
+                    pendingToolbarImageSectionRef.current = section.id
+                    setSelectedId(section.id)
+                    setActiveField({ blockId: section.id, field: 'markdown' })
+                    editorRefs.current[section.id]?.chain().focus().run()
+                    requestAnimationFrame(() => toolbarImageInputRef.current?.click())
+                  },
+                  onFiles: (files) => {
+                    setSelectedId(section.id)
+                    setActiveField({ blockId: section.id, field: 'markdown' })
+                    editorRefs.current[section.id]?.chain().focus().run()
+                    insertImagesIntoSection(section.id, files)
+                  },
+                }
+              : undefined
+          }
+          dictation={
+            sttAvailability.enabled
+              ? {
+                  language: sttAvailability.language,
+                  accommodationTooltip: sttAvailability.accommodationTooltip,
+                  onInterimResult: (text) => {
+                    const editor = editorRefs.current[section.id]
+                    if (!editor) return
+                    dictationInterimRef.current[section.id] = insertTipTapDictationInterim(
+                      editor,
+                      text,
+                      dictationInterimRef.current[section.id] ?? null,
+                    )
+                  },
+                  onFinalResult: (text) => {
+                    const editor = editorRefs.current[section.id]
+                    if (!editor) return
+                    commitTipTapDictationFinal(
+                      editor,
+                      text,
+                      dictationInterimRef.current[section.id] ?? null,
+                    )
+                    dictationInterimRef.current[section.id] = null
+                  },
+                }
+              : undefined
+          }
+        />
+        {courseCode ? (
           <>
-            <MarkdownFormatToolbar
+            <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
+            <button
+              type="button"
               disabled={disabled || genBusy}
-              onApply={(kind) => applyMarkdownForSection(section.id, kind)}
-              mathInsert={
-                equationEditorEnabled && equationEditor
-                  ? {
-                      onOpen: () => {
-                        setSelectedId(section.id)
-                        setActiveField({ blockId: section.id, field: 'markdown' })
-                        const ed = editorRefs.current[section.id]
-                        ed?.chain().focus().run()
-                        if (ed) equationEditor.openInsert(ed)
-                      },
-                      registerMathAnchor: (node) => {
-                        mathToolbarAnchorRef.current = node
-                      },
-                    }
-                  : undefined
-              }
-              courseImage={
-                courseCode
-                  ? {
-                      onPickClick: () => {
-                        pendingToolbarImageSectionRef.current = section.id
-                        setSelectedId(section.id)
-                        setActiveField({ blockId: section.id, field: 'markdown' })
-                        editorRefs.current[section.id]?.chain().focus().run()
-                        requestAnimationFrame(() => toolbarImageInputRef.current?.click())
-                      },
-                      onFiles: (files) => {
-                        setSelectedId(section.id)
-                        setActiveField({ blockId: section.id, field: 'markdown' })
-                        editorRefs.current[section.id]?.chain().focus().run()
-                        insertImagesIntoSection(section.id, files)
-                      },
-                    }
-                  : undefined
-              }
-              dictation={
-                sttAvailability.enabled
-                  ? {
-                      language: sttAvailability.language,
-                      accommodationTooltip: sttAvailability.accommodationTooltip,
-                      onInterimResult: (text) => {
-                        const editor = editorRefs.current[section.id]
-                        if (!editor) return
-                        dictationInterimRef.current[section.id] = insertTipTapDictationInterim(
-                          editor,
-                          text,
-                          dictationInterimRef.current[section.id] ?? null,
-                        )
-                      },
-                      onFinalResult: (text) => {
-                        const editor = editorRefs.current[section.id]
-                        if (!editor) return
-                        commitTipTapDictationFinal(
-                          editor,
-                          text,
-                          dictationInterimRef.current[section.id] ?? null,
-                        )
-                        dictationInterimRef.current[section.id] = null
-                      },
-                    }
-                  : undefined
-              }
-            />
-            {courseCode ? (
-              <>
-                <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
-                <button
-                  type="button"
-                  disabled={disabled || genBusy}
-                  aria-expanded={generateSectionId === section.id}
-                  aria-controls={`section-generate-${section.id}`}
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => toggleGeneratePanel(section.id)}
-                  className="shrink-0 rounded px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-200 dark:hover:bg-neutral-700"
-                >
-                  Generate
-                </button>
-              </>
-            ) : null}
+              aria-expanded={generateSectionId === section.id}
+              aria-controls={`section-generate-${section.id}`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => toggleGeneratePanel(section.id)}
+              className="shrink-0 rounded px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-200 dark:hover:bg-neutral-700"
+            >
+              Generate
+            </button>
           </>
-        )}
+        ) : null}
       </BlockFloatingToolbar>
     )
   }
@@ -873,7 +864,7 @@ function SyllabusBlockEditorInner({
         />
       }
     >
-      <BlockCanvas className="pt-10">
+      <BlockCanvas>
         <input
           ref={toolbarImageInputRef}
           type="file"
@@ -894,33 +885,26 @@ function SyllabusBlockEditorInner({
         {altTextOn ? (
           <AltTextWarningBanner coverage={altCoverage} hardBlock={altTextHardBlock} />
         ) : null}
-        {caretAnchoredSectionIndex >= 0 ? (
-          <CaretAnchoredToolbarPortal editor={caretAnchoredEditor} enabled>
-            {generateSectionId === selectedId ? (
-              <div className="flex w-max max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40">
-                {renderToolbar(sections[caretAnchoredSectionIndex]!, caretAnchoredSectionIndex, true)}
-                {renderGeneratePanel(
-                  sections[caretAnchoredSectionIndex]!,
-                  caretAnchoredSectionIndex,
-                  'anchored',
-                )}
-              </div>
-            ) : (
-              renderToolbar(sections[caretAnchoredSectionIndex]!, caretAnchoredSectionIndex)
-            )}
-          </CaretAnchoredToolbarPortal>
-        ) : null}
         {sections.map((section, index) => {
-          const caretAnchored = caretAnchoredSectionIndex === index
+          const writing = showMarkdownToolbar && selectedId === section.id
           return (
-          <BlockFrame
-            key={section.id}
-            blockId={section.id}
-            toolbar={caretAnchored ? undefined : renderToolbar(section, index)}
-            inlineToolbar={!caretAnchored}
-          >
-            <div className="pb-8 pt-0.5">
-              {generateSectionId === section.id && courseCode && !caretAnchored
+          <div key={section.id}>
+            {index > 0 && <SectionDivider onAdd={() => addSectionAt(index)} disabled={disabled} />}
+            <BlockFrame
+              blockId={section.id}
+              positionLabel={`Section ${index + 1} of ${sections.length}`}
+              onMoveUp={() => move(index, -1)}
+              onMoveDown={() => move(index, 1)}
+              moveUpDisabled={index === 0}
+              moveDownDisabled={index === sections.length - 1}
+              onRemove={() => void removeAt(index)}
+              removeDisabledReason={
+                sections.length <= 1 ? 'You need at least one section' : undefined
+              }
+              toolbar={writing ? renderFormatToolbar(section, true) : undefined}
+            >
+            <div>
+              {generateSectionId === section.id && courseCode
                 ? renderGeneratePanel(section, index)
                 : null}
               <label className="sr-only" htmlFor={`canvas-heading-${section.id}`}>
@@ -985,13 +969,15 @@ function SyllabusBlockEditorInner({
                 />
               </div>
             </div>
-          </BlockFrame>
+            </BlockFrame>
+          </div>
           )
         })}
 
-        <BlockInsertionRow onAdd={addSection} disabled={disabled} />
+        <BlockInsertionRow onAdd={() => addSectionAt(sections.length)} disabled={disabled} />
       </BlockCanvas>
     </BlockEditorShell>
+    {ConfirmDialogHost}
     </AltTextEnforcementProvider>
   )
 }

--- a/clients/web/src/pages/lms/course-modules.tsx
+++ b/clients/web/src/pages/lms/course-modules.tsx
@@ -1446,8 +1446,6 @@ type SortableModuleCardProps = {
   onOpenEditChildTitle: (child: CourseStructureItem) => void
   onArchiveChild: (child: CourseStructureItem) => void
   courseAdaptivePathsEnabled: boolean
-  conditionalReleaseEnabled: boolean
-  allModules: { id: string; title: string }[]
   studentGradeContext: { columns: CourseGradebookGridColumn[]; grades: Record<string, string> } | null
 }
 
@@ -1480,8 +1478,6 @@ function SortableModuleCard({
   onOpenEditChildTitle,
   onArchiveChild,
   courseAdaptivePathsEnabled,
-  conditionalReleaseEnabled,
-  allModules,
   studentGradeContext,
 }: SortableModuleCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -1569,18 +1565,9 @@ function SortableModuleCard({
           ) : null
         }
         footerExtra={
-          <>
-            {canEditModules && conditionalReleaseEnabled && !minified ? (
-              <ModuleRequirementsPanel
-                courseCode={courseCode}
-                moduleId={item.id}
-                allModules={allModules}
-              />
-            ) : null}
-            {canEditModules && courseAdaptivePathsEnabled && !minified ? (
-              <ModuleAdaptivePathPanel courseCode={courseCode} moduleId={item.id} />
-            ) : null}
-          </>
+          canEditModules && courseAdaptivePathsEnabled && !minified ? (
+            <ModuleAdaptivePathPanel courseCode={courseCode} moduleId={item.id} />
+          ) : null
         }
         childrenList={childrenList}
       />
@@ -1742,6 +1729,7 @@ export default function CourseModules() {
   const [moduleSettingsModuleId, setModuleSettingsModuleId] = useState<string | null>(null)
   const [moduleSettingsSaving, setModuleSettingsSaving] = useState(false)
   const [moduleSettingsSaveError, setModuleSettingsSaveError] = useState<string | null>(null)
+  const [moduleRequirementsSaving, setModuleRequirementsSaving] = useState(false)
   const [archiveConfirmItem, setArchiveConfirmItem] = useState<CourseStructureItem | null>(null)
   /** Module pending hard-delete (or archive when graded). Null when no confirm is open. */
   const [moduleDeleteTarget, setModuleDeleteTarget] = useState<CourseStructureItem | null>(null)
@@ -2846,8 +2834,6 @@ export default function CourseModules() {
                     onOpenEditChildTitle={openEditChildTitle}
                     onArchiveChild={requestArchiveChild}
                     courseAdaptivePathsEnabled={courseMeta?.adaptivePathsEnabled === true}
-                    conditionalReleaseEnabled={ffConditionalRelease}
-                    allModules={allModules}
                     studentGradeContext={studentGradeContext}
                   />
                 ))}
@@ -3120,7 +3106,7 @@ export default function CourseModules() {
         initialPublished={settingsTargetItem?.published ?? true}
         initialVisibleFrom={settingsTargetItem?.visibleFrom ?? null}
         onClose={() => {
-          if (!moduleSettingsSaving) {
+          if (!moduleSettingsSaving && !moduleRequirementsSaving) {
             setModuleSettingsOpen(false)
             setModuleSettingsModuleId(null)
           }
@@ -3129,6 +3115,17 @@ export default function CourseModules() {
         onDelete={() => void requestDeleteModule()}
         saving={moduleSettingsSaving}
         errorMessage={moduleSettingsSaveError}
+        requirementsSaving={moduleRequirementsSaving}
+        requirementsSection={
+          ffConditionalRelease && courseCode && settingsTargetItem ? (
+            <ModuleRequirementsPanel
+              courseCode={courseCode}
+              moduleId={settingsTargetItem.id}
+              allModules={allModules}
+              onSavingChange={setModuleRequirementsSaving}
+            />
+          ) : null
+        }
       />
 
       {moduleDeleteTarget ? (

--- a/clients/web/src/pages/lms/module-settings-modal.tsx
+++ b/clients/web/src/pages/lms/module-settings-modal.tsx
@@ -1,5 +1,8 @@
-import { useEffect, useId, useState } from 'react'
+import { useEffect, useId, useState, type ReactNode } from 'react'
 import { X } from 'lucide-react'
+import { MODULE_REQUIREMENTS_FORM_ID } from '../../components/modules/module-requirements-panel'
+
+const MODULE_SETTINGS_FORM_ID = 'module-settings-form'
 
 function isoToDatetimeLocalValue(iso: string | null): string {
   if (!iso) return ''
@@ -17,6 +20,8 @@ function datetimeLocalValueToIso(value: string): string | null {
   return d.toISOString()
 }
 
+type SettingsTab = 'general' | 'requirements'
+
 type ModuleSettingsModalProps = {
   open: boolean
   initialTitle: string
@@ -27,6 +32,9 @@ type ModuleSettingsModalProps = {
   onDelete?: () => void
   saving?: boolean
   errorMessage?: string | null
+  /** When set, shows a Requirements tab with this content. */
+  requirementsSection?: ReactNode
+  requirementsSaving?: boolean
 }
 
 export function ModuleSettingsModal(props: ModuleSettingsModalProps) {
@@ -43,24 +51,45 @@ function ModuleSettingsModalInner({
   onDelete,
   saving = false,
   errorMessage,
+  requirementsSection,
+  requirementsSaving = false,
 }: ModuleSettingsModalProps) {
   const titleId = useId()
   const nameInputId = useId()
   const dateInputId = useId()
+  const generalTabId = useId()
+  const requirementsTabId = useId()
+  const generalPanelId = useId()
+  const requirementsPanelId = useId()
   const [title, setTitle] = useState(initialTitle)
   const [published, setPublished] = useState(initialPublished)
   const [visibleLocal, setVisibleLocal] = useState(() => isoToDatetimeLocalValue(initialVisibleFrom))
+  const [tab, setTab] = useState<SettingsTab>('general')
+  const showRequirementsTab = requirementsSection != null
+  const busy = saving || requirementsSaving
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
-      if (saving) return
+      if (busy) return
       e.preventDefault()
       onClose()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [onClose, saving])
+  }, [busy, onClose])
+
+  const activeFormId = tab === 'requirements' ? MODULE_REQUIREMENTS_FORM_ID : MODULE_SETTINGS_FORM_ID
+  const saveDisabled =
+    busy || (tab === 'general' && !title.trim()) || (tab === 'requirements' && !showRequirementsTab)
+  const saveLabel =
+    tab === 'requirements'
+      ? requirementsSaving
+        ? 'Saving…'
+        : 'Save requirements'
+      : saving
+        ? 'Saving…'
+        : 'Save'
 
   return (
     <div
@@ -69,116 +98,177 @@ function ModuleSettingsModalInner({
       aria-modal="true"
       aria-labelledby={titleId}
       onClick={(e) => {
-        if (e.target === e.currentTarget && !saving) onClose()
+        if (e.target === e.currentTarget && !busy) onClose()
       }}
     >
-      <div className="w-full max-w-lg overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl">
-        <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+      <div className="flex w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl">
+        <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3">
           <h3 id={titleId} className="text-sm font-semibold text-slate-900">
             Module settings
           </h3>
           <button
             type="button"
             onClick={() => onClose()}
-            disabled={saving}
+            disabled={busy}
             className="rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Close"
           >
             <X className="h-5 w-5" />
           </button>
         </div>
-        <form
-          className="p-4"
-          onSubmit={(e) => {
-            e.preventDefault()
-            const t = title.trim()
-            if (!t || saving) return
-            void onSave({
-              title: t,
-              published,
-              visibleFrom: datetimeLocalValueToIso(visibleLocal),
-            })
-          }}
-        >
-          <label htmlFor={nameInputId} className="text-xs font-medium text-slate-600">
-            Module name
-          </label>
-          <input
-            id={nameInputId}
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="e.g. Week 1 — Introduction"
-            autoFocus
-            disabled={saving}
-            className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 placeholder:text-slate-400 focus:border-indigo-400 focus:ring-2 disabled:cursor-not-allowed disabled:opacity-60"
-          />
 
-          <div className="mt-4 flex items-center gap-3">
-            <input
-              id="module-settings-published"
-              type="checkbox"
-              checked={published}
-              onChange={(e) => setPublished(e.target.checked)}
-              disabled={saving}
-              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-            />
-            <label htmlFor="module-settings-published" className="text-sm text-slate-700">
-              Published to students
-            </label>
+        {showRequirementsTab ? (
+          <div
+            className="flex shrink-0 gap-1 border-b border-slate-200 px-2"
+            role="tablist"
+            aria-label="Module settings sections"
+          >
+            <button
+              type="button"
+              role="tab"
+              id={generalTabId}
+              aria-controls={generalPanelId}
+              aria-selected={tab === 'general'}
+              onClick={() => setTab('general')}
+              className={`px-3 py-2.5 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                tab === 'general'
+                  ? 'border-b-2 border-indigo-600 text-indigo-700'
+                  : 'text-slate-600 hover:text-slate-900'
+              }`}
+            >
+              General
+            </button>
+            <button
+              type="button"
+              role="tab"
+              id={requirementsTabId}
+              aria-controls={requirementsPanelId}
+              aria-selected={tab === 'requirements'}
+              onClick={() => setTab('requirements')}
+              className={`px-3 py-2.5 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                tab === 'requirements'
+                  ? 'border-b-2 border-indigo-600 text-indigo-700'
+                  : 'text-slate-600 hover:text-slate-900'
+              }`}
+            >
+              Requirements
+            </button>
+          </div>
+        ) : null}
+
+        <div className="p-4">
+          <div
+            id={generalPanelId}
+            role="tabpanel"
+            aria-labelledby={generalTabId}
+            hidden={showRequirementsTab && tab !== 'general'}
+          >
+            <form
+              id={MODULE_SETTINGS_FORM_ID}
+              onSubmit={(e) => {
+                e.preventDefault()
+                const t = title.trim()
+                if (!t || busy) return
+                void onSave({
+                  title: t,
+                  published,
+                  visibleFrom: datetimeLocalValueToIso(visibleLocal),
+                })
+              }}
+            >
+              <label htmlFor={nameInputId} className="text-xs font-medium text-slate-600">
+                Module name
+              </label>
+              <input
+                id={nameInputId}
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="e.g. Week 1 — Introduction"
+                autoFocus={!showRequirementsTab || tab === 'general'}
+                disabled={busy}
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 placeholder:text-slate-400 focus:border-indigo-400 focus:ring-2 disabled:cursor-not-allowed disabled:opacity-60"
+              />
+
+              <div className="mt-4 flex items-center gap-3">
+                <input
+                  id="module-settings-published"
+                  type="checkbox"
+                  checked={published}
+                  onChange={(e) => setPublished(e.target.checked)}
+                  disabled={busy}
+                  className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <label htmlFor="module-settings-published" className="text-sm text-slate-700">
+                  Published to students
+                </label>
+              </div>
+
+              <label htmlFor={dateInputId} className="mt-4 block text-xs font-medium text-slate-600">
+                Visible from (optional)
+              </label>
+              <p className="mt-0.5 text-xs text-slate-500">
+                Leave empty to show when published. Uses your local timezone.
+              </p>
+              <input
+                id={dateInputId}
+                type="datetime-local"
+                value={visibleLocal}
+                onChange={(e) => setVisibleLocal(e.target.value)}
+                disabled={busy}
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 disabled:cursor-not-allowed disabled:opacity-60"
+              />
+            </form>
           </div>
 
-          <label htmlFor={dateInputId} className="mt-4 block text-xs font-medium text-slate-600">
-            Visible from (optional)
-          </label>
-          <p className="mt-0.5 text-xs text-slate-500">
-            Leave empty to show as soon as the module is published. Otherwise students see it starting at
-            this date and time (your local timezone).
-          </p>
-          <input
-            id={dateInputId}
-            type="datetime-local"
-            value={visibleLocal}
-            onChange={(e) => setVisibleLocal(e.target.value)}
-            disabled={saving}
-            className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 disabled:cursor-not-allowed disabled:opacity-60"
-          />
+          {showRequirementsTab ? (
+            <div
+              id={requirementsPanelId}
+              role="tabpanel"
+              aria-labelledby={requirementsTabId}
+              hidden={tab !== 'requirements'}
+            >
+              {requirementsSection}
+            </div>
+          ) : null}
 
-          {errorMessage && (
+          {errorMessage && tab === 'general' ? (
             <p className="mt-3 text-sm text-rose-700" role="status">
               {errorMessage}
             </p>
-          )}
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            {onDelete ? (
-              <button
-                type="button"
-                onClick={() => onDelete()}
-                disabled={saving}
-                className="rounded-xl px-3 py-2 text-sm font-medium text-rose-700 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-rose-300 dark:hover:bg-rose-950/40"
-              >
-                Delete module
-              </button>
-            ) : null}
-            <div className="ml-auto flex flex-wrap justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => onClose()}
-                disabled={saving}
-                className="rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={saving || !title.trim()}
-                className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {saving ? 'Saving…' : 'Save'}
-              </button>
-            </div>
+          ) : null}
+        </div>
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-t border-slate-200 px-4 py-3">
+          {onDelete && tab === 'general' ? (
+            <button
+              type="button"
+              onClick={() => onDelete()}
+              disabled={busy}
+              className="rounded-xl px-3 py-2 text-sm font-medium text-rose-700 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Delete module
+            </button>
+          ) : null}
+          <div className="ml-auto flex flex-wrap justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => onClose()}
+              disabled={busy}
+              className="rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              form={activeFormId}
+              disabled={saveDisabled}
+              className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saveLabel}
+            </button>
           </div>
-        </form>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Restructure the syllabus/block editor so reorder and delete live in a persistent block header; the floating toolbar is format-only, section insert uses hover dividers, and deleting content confirms first.
- Move module requirements into the module settings modal as a Requirements tab with shared footer save actions.
- Widen the course hero banner aspect ratio from 4:1 to 5:1 and fix dark-mode text color in the markdown body editor.

## Test plan
- [ ] Open a syllabus block editor: hover a section — header actions fade in without layout shift; formatting toolbar appears when editing body text
- [ ] Reorder sections with Move up/down; delete empty vs content-filled sections (confirm only when content exists)
- [ ] Use “Add section here” between cards and the bottom “Add a section” control
- [ ] Open module settings: General tab still saves name/publish/visibility; Requirements tab saves completion mode, prerequisites, and lock-until
- [ ] Confirm course hero banner uses 5:1 crop and remains stable on window resize
- [ ] Spot-check dark mode on block editor body text and module settings modal