### PR TITLE
feat(web): insert tables as TipTap nodes with in-table controls

### DIFF
--- a/clients/web/src/components/editor/block-editor/__tests__/markdown-body-slash.test.ts
+++ b/clients/web/src/components/editor/block-editor/__tests__/markdown-body-slash.test.ts
@@ -76,6 +76,12 @@ describe('filterSlashCommands', () => {
     expect(commands.some((c) => c.id === 'board')).toBe(false)
   })
 
+  it('filters table by grid keyword', () => {
+    const commands = slashCommandsForEditor()
+    expect(filterSlashCommands(commands, 'table').map((c) => c.id)).toEqual(['table'])
+    expect(filterSlashCommands(commands, 'grid').map((c) => c.id)).toEqual(['table'])
+  })
+
   it('filters task by todo keyword', () => {
     const commands = slashCommandsForEditor({ equation: false })
     expect(filterSlashCommands(commands, 'todo').map((c) => c.id)).toEqual(['task'])

--- a/clients/web/src/components/editor/block-editor/__tests__/markdown-body-table.test.ts
+++ b/clients/web/src/components/editor/block-editor/__tests__/markdown-body-table.test.ts
@@ -3,6 +3,8 @@ import { Markdown } from '@tiptap/markdown'
 import { TableKit } from '@tiptap/extension-table'
 import StarterKit from '@tiptap/starter-kit'
 import { afterEach, describe, expect, it } from 'vitest'
+import { adjustSelectedColumnWidth, insertDefaultTable } from '../markdown-table-commands'
+import { normalizeMarkdownTables } from '../../../syllabus/normalize-markdown-tables'
 
 const sample = `Traditional software works like a detailed recipe.
 
@@ -19,10 +21,10 @@ function createEditor(content: string) {
   return new Editor({
     extensions: [
       StarterKit,
-      TableKit.configure({ table: { resizable: false, renderWrapper: true } }),
+      TableKit.configure({ table: { resizable: true, renderWrapper: true } }),
       Markdown.configure({ markedOptions: { gfm: true } }),
     ],
-    content,
+    content: normalizeMarkdownTables(content),
     contentType: 'markdown',
   })
 }
@@ -48,8 +50,41 @@ describe('MarkdownBodyEditor table support', () => {
 
   it('inserts pasted markdown tables as table nodes', () => {
     editor = createEditor('Before')
-    editor.commands.insertContent(sample, { contentType: 'markdown' })
+    editor.commands.insertContent(normalizeMarkdownTables(sample), { contentType: 'markdown' })
     expect(editor.getJSON().content?.some((n) => n.type === 'table')).toBe(true)
     expect(editor.getMarkdown()).toContain('Traditional Software')
+  })
+
+  it('heals blank-line-broken pipe tables into real table nodes', () => {
+    const broken = `Intro
+
+| Feature | A | B |
+
+|---|---|---|
+
+| row | 1 | 2 |
+`
+    editor = createEditor(broken)
+    expect(editor.getJSON().content?.some((n) => n.type === 'table')).toBe(true)
+    expect(editor.getMarkdown()).not.toMatch(/\|\s*\n\n\s*\|/)
+  })
+
+  it('insertDefaultTable creates a table node (not pipe text)', () => {
+    editor = createEditor('Hello')
+    expect(insertDefaultTable(editor)).toBe(true)
+    expect(editor.getJSON().content?.some((n) => n.type === 'table')).toBe(true)
+    expect(editor.isActive('table')).toBe(true)
+  })
+
+  it('addColumnAfter grows the table and widen adjusts colwidth', () => {
+    editor = createEditor('| A | B |\n| --- | --- |\n| 1 | 2 |')
+    // Place caret in first body cell
+    editor.commands.setTextSelection(editor.state.doc.content.size - 4)
+    expect(editor.isActive('table')).toBe(true)
+    const colsBefore = editor.getMarkdown().split('\n').find((l) => l.startsWith('| A'))
+    expect(colsBefore).toBeTruthy()
+    editor.chain().focus().addColumnAfter().run()
+    expect(editor.getMarkdown()).toMatch(/\| A\s+\| B\s+\|/)
+    expect(adjustSelectedColumnWidth(editor, 40)).toBe(true)
   })
 })

--- a/clients/web/src/components/editor/block-editor/__tests__/markdown-insert.test.ts
+++ b/clients/web/src/components/editor/block-editor/__tests__/markdown-insert.test.ts
@@ -63,4 +63,11 @@ describe('applyMarkdownEdit', () => {
     const r = applyMarkdownEdit('ab', -5, 99, 'bold')
     expect(r.value).toBe('**ab**')
   })
+
+  it('inserts a GFM markdown table', () => {
+    const r = applyMarkdownEdit('hi', 2, 2, 'table')
+    expect(r.value).toContain('| Column 1 | Column 2 | Column 3 |')
+    expect(r.value).toContain('| -------- | -------- | -------- |')
+    expect(r.value.startsWith('hi')).toBe(true)
+  })
 })

--- a/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
@@ -23,6 +23,8 @@ import {
 } from './markdown-body-slash'
 import { shouldPasteClipboardAsMarkdown } from './markdown-clipboard-paste'
 import { stripPastedHtmlColors } from './strip-pasted-html-colors'
+import { MarkdownTableControls } from './markdown-table-controls'
+import { normalizeMarkdownTables } from '../../syllabus/normalize-markdown-tables'
 import { CourseAwareTipTapImage } from './course-aware-tip-tap-image'
 import { MarkdownImageUploadModal } from './markdown-image-upload-modal'
 import { MathBlock, MathInline } from '../extensions/math-tip-tap'
@@ -283,7 +285,9 @@ export function MarkdownBodyEditor({
           const { from, to } = view.state.selection
           ed.chain()
             .focus()
-            .insertContentAt({ from, to }, text, { contentType: 'markdown' })
+            .insertContentAt({ from, to }, normalizeMarkdownTables(text), {
+              contentType: 'markdown',
+            })
             .run()
           return true
         }
@@ -454,8 +458,10 @@ export function MarkdownBodyEditor({
         NotebookTask.configure({ notebookTaskContext }),
         TableKit.configure({
           table: {
-            resizable: false,
+            resizable: true,
             renderWrapper: true,
+            lastColumnResizable: true,
+            cellMinWidth: 80,
           },
         }),
         Markdown.configure({ markedOptions: { gfm: true } }),
@@ -476,7 +482,7 @@ export function MarkdownBodyEditor({
           emptyEditorClass: 'is-editor-empty',
         }),
       ],
-      content: value ?? '',
+      content: normalizeMarkdownTables(value ?? ''),
       contentType: 'markdown',
       editable: !disabled,
       editorProps: {
@@ -815,10 +821,11 @@ export function MarkdownBodyEditor({
 
   useEffect(() => {
     if (!editor) return
+    const normalized = normalizeMarkdownTables(value ?? '')
     const cur = editor.getMarkdown()
-    if (cur === value) return
+    if (cur === normalized || cur === value) return
     skipEmit.current = true
-    editor.commands.setContent(value, { contentType: 'markdown' })
+    editor.commands.setContent(normalized, { contentType: 'markdown' })
   }, [value, editor])
 
   useEffect(() => {
@@ -930,6 +937,7 @@ export function MarkdownBodyEditor({
       ) : null}
       <div className="w-full [&_.ProseMirror]:min-h-[100px]">
         <EditorContent editor={editor} className="w-full" />
+        {!disabled ? <MarkdownTableControls editor={editor} disabled={disabled} /> : null}
       </div>
       {slashListOpen && slashUi
         ? createPortal(

--- a/clients/web/src/components/editor/block-editor/markdown-body-slash.ts
+++ b/clients/web/src/components/editor/block-editor/markdown-body-slash.ts
@@ -15,6 +15,7 @@ export type SlashCommandId =
   | 'task'
   | 'bulletList'
   | 'orderedList'
+  | 'table'
   | 'codeBlock'
   | 'blockquote'
   | 'horizontalRule'
@@ -87,6 +88,12 @@ const BASE_SLASH_COMMANDS: SlashCommand[] = [
     label: 'Numbered list',
     description: 'Ordered list',
     keywords: ['ol', 'list', 'numbers'],
+  },
+  {
+    id: 'table',
+    label: 'Table',
+    description: 'Insert a 3×3 table',
+    keywords: ['table', 'grid', 'spreadsheet', 'columns'],
   },
   {
     id: 'codeBlock',
@@ -247,6 +254,9 @@ export function applySlashCommand(
       break
     case 'orderedList':
       chain.toggleOrderedList().run()
+      break
+    case 'table':
+      chain.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run()
       break
     case 'codeBlock':
       chain.toggleCodeBlock().run()

--- a/clients/web/src/components/editor/block-editor/markdown-format-toolbar.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-format-toolbar.tsx
@@ -8,6 +8,7 @@ import {
   List,
   ListOrdered,
   Sigma,
+  Table,
 } from 'lucide-react'
 import type { MouseEvent } from 'react'
 import type { MarkdownEditKind } from './markdown-insert'
@@ -118,6 +119,17 @@ export function MarkdownFormatToolbar({ disabled, onApply, dictation, courseImag
         title="Link"
       >
         <LinkIcon className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        onMouseDown={preventBlur}
+        onClick={() => onApply('table')}
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+        aria-label="Insert table"
+        title="Insert table"
+      >
+        <Table className="h-4 w-4" />
       </button>
       {mathInsert ? (
         <button

--- a/clients/web/src/components/editor/block-editor/markdown-insert.ts
+++ b/clients/web/src/components/editor/block-editor/markdown-insert.ts
@@ -8,6 +8,16 @@ export type MarkdownEditKind =
   | 'bulletList'
   | 'orderedList'
   | 'link'
+  | 'table'
+
+const DEFAULT_MARKDOWN_TABLE = [
+  '',
+  '| Column 1 | Column 2 | Column 3 |',
+  '| -------- | -------- | -------- |',
+  '|          |          |          |',
+  '|          |          |          |',
+  '',
+].join('\n')
 
 export function applyMarkdownEdit(
   markdown: string,
@@ -34,9 +44,26 @@ export function applyMarkdownEdit(
       return orderedList(markdown, start, end)
     case 'link':
       return insertLink(markdown, start, end, linkUrl)
-    default:
+    case 'table':
+      return insertTableMarkdown(markdown, start, end)
+    default: {
+      const _exhaustive: never = kind
+      void _exhaustive
       return { value: markdown, selStart: start, selEnd: end }
+    }
   }
+}
+
+function insertTableMarkdown(
+  text: string,
+  start: number,
+  end: number,
+): { value: string; selStart: number; selEnd: number } {
+  const insertion = text.slice(0, start) + DEFAULT_MARKDOWN_TABLE + text.slice(end)
+  // Place caret in the first body cell.
+  const cellOffset = DEFAULT_MARKDOWN_TABLE.indexOf('|          |')
+  const caret = start + (cellOffset >= 0 ? cellOffset + 2 : DEFAULT_MARKDOWN_TABLE.length)
+  return { value: insertion, selStart: caret, selEnd: caret }
 }
 
 function wrap(

--- a/clients/web/src/components/editor/block-editor/markdown-table-commands.ts
+++ b/clients/web/src/components/editor/block-editor/markdown-table-commands.ts
@@ -1,0 +1,89 @@
+import type { Editor } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+
+const DEFAULT_COL_WIDTH = 120
+const MIN_COL_WIDTH = 48
+const MAX_COL_WIDTH = 640
+
+function tableInfoAtSelection(editor: Editor): {
+  tablePos: number
+  tableNode: ProseMirrorNode
+  colIndex: number
+} | null {
+  const { state } = editor
+  const $from = state.selection.$from
+  let tableDepth = -1
+  let cellDepth = -1
+  for (let d = $from.depth; d > 0; d--) {
+    const name = $from.node(d).type.name
+    if ((name === 'tableCell' || name === 'tableHeader') && cellDepth < 0) {
+      cellDepth = d
+    }
+    if (name === 'table') {
+      tableDepth = d
+      break
+    }
+  }
+  if (tableDepth < 0 || cellDepth < 0) return null
+
+  const tablePos = $from.before(tableDepth)
+  const tableNode = $from.node(tableDepth)
+  const cellPos = $from.before(cellDepth)
+
+  // Column index = number of cells before this one in the same row.
+  const $cell = state.doc.resolve(cellPos)
+  const row = $cell.parent
+  let colIndex = 0
+  for (let i = 0; i < $cell.index($cell.depth); i++) {
+    const cell = row.child(i)
+    colIndex += cell.attrs.colspan ?? 1
+  }
+
+  return { tablePos, tableNode, colIndex }
+}
+
+/** Grow or shrink the selected column via `colwidth` on every cell in that column. */
+export function adjustSelectedColumnWidth(editor: Editor, delta: number): boolean {
+  const info = tableInfoAtSelection(editor)
+  if (!info) return false
+
+  const { tablePos, tableNode, colIndex } = info
+  let tr = editor.state.tr
+  let changed = false
+  let pos = tablePos + 1
+
+  for (let r = 0; r < tableNode.childCount; r++) {
+    const row = tableNode.child(r)
+    pos += 1 // enter row
+    let col = 0
+    for (let c = 0; c < row.childCount; c++) {
+      const cell = row.child(c)
+      const span = cell.attrs.colspan ?? 1
+      if (col === colIndex && span === 1) {
+        const prev: number[] | null = Array.isArray(cell.attrs.colwidth)
+          ? (cell.attrs.colwidth as number[])
+          : null
+        const current = prev?.[0] && prev[0] > 0 ? prev[0] : DEFAULT_COL_WIDTH
+        const next = Math.min(MAX_COL_WIDTH, Math.max(MIN_COL_WIDTH, current + delta))
+        if (next !== current) {
+          tr = tr.setNodeMarkup(pos, undefined, {
+            ...cell.attrs,
+            colwidth: [next],
+          })
+          changed = true
+        }
+      }
+      pos += cell.nodeSize
+      col += span
+    }
+    pos += 1 // leave row
+  }
+
+  if (!changed) return false
+  editor.view.dispatch(tr)
+  return true
+}
+
+export function insertDefaultTable(editor: Editor): boolean {
+  return editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run()
+}

--- a/clients/web/src/components/editor/block-editor/markdown-table-controls.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-table-controls.tsx
@@ -1,0 +1,171 @@
+import type { Editor } from '@tiptap/core'
+import {
+  BetweenHorizonalEnd,
+  BetweenVerticalEnd,
+  Columns3,
+  Minus,
+  Plus,
+  Rows3,
+  TableProperties,
+  Trash2,
+} from 'lucide-react'
+import { useEffect, useState, type MouseEvent } from 'react'
+import { createPortal } from 'react-dom'
+import { adjustSelectedColumnWidth } from './markdown-table-commands'
+
+export type MarkdownTableControlsProps = {
+  editor: Editor
+  disabled?: boolean
+}
+
+type Anchor = { left: number; top: number }
+
+/**
+ * Contextual table controls anchored above the active table while the caret is inside it.
+ */
+export function MarkdownTableControls({ editor, disabled }: MarkdownTableControlsProps) {
+  const [anchor, setAnchor] = useState<Anchor | null>(null)
+
+  useEffect(() => {
+    const sync = () => {
+      if (disabled || !editor.isEditable || !editor.isActive('table')) {
+        setAnchor(null)
+        return
+      }
+      const { view, state } = editor
+      const $from = state.selection.$from
+      let tablePos = -1
+      for (let d = $from.depth; d > 0; d--) {
+        if ($from.node(d).type.name === 'table') {
+          tablePos = $from.before(d)
+          break
+        }
+      }
+      if (tablePos < 0) {
+        setAnchor(null)
+        return
+      }
+      const dom = view.nodeDOM(tablePos)
+      const el = dom instanceof HTMLElement ? dom : null
+      const rect = el?.getBoundingClientRect()
+      if (!rect) {
+        setAnchor(null)
+        return
+      }
+      setAnchor({
+        left: Math.max(8, Math.min(rect.left, window.innerWidth - 360)),
+        top: Math.max(8, rect.top - 44),
+      })
+    }
+
+    sync()
+    editor.on('selectionUpdate', sync)
+    editor.on('update', sync)
+    window.addEventListener('scroll', sync, true)
+    window.addEventListener('resize', sync)
+    return () => {
+      editor.off('selectionUpdate', sync)
+      editor.off('update', sync)
+      window.removeEventListener('scroll', sync, true)
+      window.removeEventListener('resize', sync)
+    }
+  }, [editor, disabled])
+
+  if (!anchor || disabled) return null
+
+  function preventBlur(e: MouseEvent) {
+    e.preventDefault()
+  }
+
+  const btn =
+    'flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700'
+
+  return createPortal(
+    <div
+      data-toolbar-anchor
+      role="toolbar"
+      aria-label="Table controls"
+      className="pointer-events-auto flex h-9 w-max max-w-[calc(100vw-1rem)] items-center gap-0.5 rounded-lg border border-slate-200 bg-white px-1 py-0.5 shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40"
+      style={{ position: 'fixed', left: anchor.left, top: anchor.top, zIndex: 55 }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <span className="me-0.5 flex items-center gap-1 px-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:text-neutral-500">
+        <TableProperties className="h-3.5 w-3.5" aria-hidden />
+        Table
+      </span>
+      <button
+        type="button"
+        className={btn}
+        aria-label="Add column"
+        title="Add column"
+        onMouseDown={preventBlur}
+        onClick={() => editor.chain().focus().addColumnAfter().run()}
+      >
+        <BetweenVerticalEnd className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        className={btn}
+        aria-label="Remove column"
+        title="Remove column"
+        onMouseDown={preventBlur}
+        onClick={() => editor.chain().focus().deleteColumn().run()}
+      >
+        <Columns3 className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        className={btn}
+        aria-label="Widen column"
+        title="Widen column (or drag the column edge)"
+        onMouseDown={preventBlur}
+        onClick={() => adjustSelectedColumnWidth(editor, 40)}
+      >
+        <Plus className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        className={btn}
+        aria-label="Narrow column"
+        title="Narrow column (or drag the column edge)"
+        onMouseDown={preventBlur}
+        onClick={() => adjustSelectedColumnWidth(editor, -40)}
+      >
+        <Minus className="h-4 w-4" />
+      </button>
+      <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
+      <button
+        type="button"
+        className={btn}
+        aria-label="Add row"
+        title="Add row"
+        onMouseDown={preventBlur}
+        onClick={() => editor.chain().focus().addRowAfter().run()}
+      >
+        <BetweenHorizonalEnd className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        className={btn}
+        aria-label="Remove row"
+        title="Remove row"
+        onMouseDown={preventBlur}
+        onClick={() => editor.chain().focus().deleteRow().run()}
+      >
+        <Rows3 className="h-4 w-4" />
+      </button>
+      <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
+      <button
+        type="button"
+        className={`${btn} text-rose-600 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-950/40`}
+        aria-label="Delete table"
+        title="Delete table"
+        onMouseDown={preventBlur}
+        onClick={() => editor.chain().focus().deleteTable().run()}
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
+    </div>,
+    document.body,
+  )
+}

--- a/clients/web/src/components/syllabus/__tests__/normalize-markdown-tables.test.ts
+++ b/clients/web/src/components/syllabus/__tests__/normalize-markdown-tables.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeMarkdownTables } from '../normalize-markdown-tables'
+
+const sample = `Traditional software works like a detailed recipe.
+
+| Feature | Traditional Software | AI Systems |
+|-----------------|---------------------------------|---------------------------------|
+| How it works | Follows fixed rules written by people | Learns patterns from data |
+| Handling new situations | Only works if the situation was programmed | Can handle new situations that resemble training data |
+
+**Quick check:**
+In one sentence.
+`
+
+describe('normalizeMarkdownTables', () => {
+  it('leaves valid GFM tables unchanged', () => {
+    expect(normalizeMarkdownTables(sample)).toBe(sample)
+  })
+
+  it('collapses blank lines between table rows so GFM can parse them', () => {
+    const broken = `Intro
+
+| Feature | Traditional Software | AI Systems |
+
+|-----------------|---------------------------------|---------------------------------|
+
+| How it works | Follows fixed rules | Learns patterns |
+
+| Example | Calculator | Spam filter |
+
+**Quick check:**
+Done.
+`
+    const out = normalizeMarkdownTables(broken)
+    expect(out).toContain(
+      [
+        '| Feature | Traditional Software | AI Systems |',
+        '|-----------------|---------------------------------|---------------------------------|',
+        '| How it works | Follows fixed rules | Learns patterns |',
+        '| Example | Calculator | Spam filter |',
+      ].join('\n'),
+    )
+    expect(out).toContain('**Quick check:**')
+    expect(out).not.toMatch(/\|\s*\n\n\s*\|/)
+  })
+
+  it('does not merge unrelated pipe-ish paragraphs', () => {
+    const md = `Use | as OR in regex.
+
+Then write more.`
+    expect(normalizeMarkdownTables(md)).toBe(md)
+  })
+})

--- a/clients/web/src/components/syllabus/normalize-markdown-lists.ts
+++ b/clients/web/src/components/syllabus/normalize-markdown-lists.ts
@@ -1,3 +1,5 @@
+import { normalizeMarkdownTables } from './normalize-markdown-tables'
+
 /**
  * CommonMark requires indentation for nested lists. Canvas / LMS exports often leave
  * bullets and sub-numbered lines at column 0, so the parser emits flat <ol>/<ul> siblings
@@ -90,5 +92,7 @@ function indentNestedOrderedAfterTwo(markdown: string): string {
 }
 
 export function normalizeMarkdownLists(markdown: string): string {
-  return indentNestedOrderedAfterTwo(indentBulletsAfterOrderedOne(markdown))
+  return normalizeMarkdownTables(
+    indentNestedOrderedAfterTwo(indentBulletsAfterOrderedOne(markdown)),
+  )
 }

--- a/clients/web/src/components/syllabus/normalize-markdown-tables.ts
+++ b/clients/web/src/components/syllabus/normalize-markdown-tables.ts
@@ -1,0 +1,81 @@
+/** Pipe row that looks like a GFM table line (at least one cell separator). */
+function isTableRowLine(line: string): boolean {
+  const t = line.trim()
+  if (!t.includes('|')) return false
+  // Reject bare separator lines here; they are handled separately.
+  if (/^\|?[\s:|-]+$/.test(t) && /-/.test(t)) return false
+  return /\|/.test(t.slice(1, -1)) || (t.startsWith('|') && t.endsWith('|'))
+}
+
+/** GFM table separator: `| --- | :---: | ---: |` (pipes optional at edges). */
+function isTableSeparatorLine(line: string): boolean {
+  const t = line.trim()
+  if (!t.includes('-')) return false
+  return /^\|?(\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?$/.test(t) || /^\|?(\s*:?-{3,}:?\s*\|?)+\s*$/.test(t)
+}
+
+function isTableRelatedLine(line: string): boolean {
+  return isTableRowLine(line) || isTableSeparatorLine(line)
+}
+
+function nextNonEmptyIndex(lines: string[], from: number): number {
+  let j = from
+  while (j < lines.length && lines[j]!.trim() === '') j++
+  return j
+}
+
+/**
+ * Collapse blank lines inside GitHub-flavored markdown tables.
+ *
+ * TipTap / CommonMark treat blank lines as paragraph breaks, so a table typed or
+ * AI-generated with empty lines between rows becomes plain pipe text. Healing those
+ * gaps restores a real `<table>` in both the editor and ReactMarkdown reader.
+ */
+export function normalizeMarkdownTables(markdown: string): string {
+  if (!markdown.includes('|')) return markdown
+
+  const lines = markdown.split('\n')
+  const out: string[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]!
+    const sepIdx = nextNonEmptyIndex(lines, i + 1)
+    const looksLikeHeader =
+      isTableRowLine(line) && sepIdx < lines.length && isTableSeparatorLine(lines[sepIdx]!)
+
+    if (!looksLikeHeader) {
+      out.push(line)
+      i++
+      continue
+    }
+
+    const tableLines: string[] = [line]
+    i++
+    while (i < lines.length) {
+      const L = lines[i]!
+      if (L.trim() === '') {
+        const next = nextNonEmptyIndex(lines, i + 1)
+        if (next < lines.length && isTableRelatedLine(lines[next]!)) {
+          i = next
+          continue
+        }
+        break
+      }
+      if (!isTableRelatedLine(L)) break
+      tableLines.push(L)
+      i++
+    }
+
+    if (tableLines.length >= 2 && isTableSeparatorLine(tableLines[1]!)) {
+      out.push(...tableLines)
+    } else {
+      // Not a valid table after all — emit original lines without collapsing.
+      out.push(line)
+      // Rewind was not kept; emit collected non-header lines as-is if any.
+      for (let k = 1; k < tableLines.length; k++) out.push(tableLines[k]!)
+    }
+  }
+
+  return out.join('\n')
+}

--- a/clients/web/src/components/syllabus/syllabus-block-editor.tsx
+++ b/clients/web/src/components/syllabus/syllabus-block-editor.tsx
@@ -615,8 +615,14 @@ function SyllabusBlockEditorInner({
         setLinkDialogOpen(true)
         break
       }
-      default:
+      case 'table':
+        chain.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run()
         break
+      default: {
+        const _exhaustive: never = kind
+        void _exhaustive
+        break
+      }
     }
   }
 

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -3,6 +3,7 @@
 @import "./styles/high-contrast.css";
 @import "./styles/ui-modes/k2.css";
 @import "./styles/ui-modes/elementary.css";
+@import "./styles/tiptap-tables.css";
 
 /* Lextures — our humanist sans for learning surfaces and brand moments. */
 @font-face {

--- a/clients/web/src/styles/tiptap-tables.css
+++ b/clients/web/src/styles/tiptap-tables.css
@@ -1,0 +1,52 @@
+/* Column resize handles for TipTap TableKit (from prosemirror-tables, themed). */
+.tiptap .tableWrapper {
+  overflow-x: auto;
+}
+
+.tiptap table {
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+  overflow: hidden;
+}
+
+.tiptap td,
+.tiptap th {
+  position: relative;
+  box-sizing: border-box;
+  vertical-align: top;
+}
+
+.tiptap td:not([data-colwidth]):not(.column-resize-dragging),
+.tiptap th:not([data-colwidth]):not(.column-resize-dragging) {
+  min-width: var(--default-cell-min-width, 80px);
+}
+
+.tiptap .column-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -2px;
+  bottom: 0;
+  z-index: 20;
+  width: 4px;
+  pointer-events: none;
+  background-color: rgb(99 102 241); /* indigo-500 */
+}
+
+.tiptap.resize-cursor {
+  cursor: ew-resize;
+  cursor: col-resize;
+}
+
+.tiptap .selectedCell::after {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  content: '';
+  background: rgb(199 210 254 / 0.45); /* indigo-200 */
+}
+
+.dark .tiptap .selectedCell::after {
+  background: rgb(99 102 241 / 0.28);
+}

--- a/docs/completed/08-content-media-files/8.12-editor-table-insert-and-controls.md
+++ b/docs/completed/08-content-media-files/8.12-editor-table-insert-and-controls.md
@@ -1,0 +1,22 @@
+# 8.12 — Editor table insert and controls
+
+> Status: COMPLETED
+
+## Summary
+
+TipTap markdown bodies (assignments, content pages, syllabus sections) insert and edit real HTML tables—not raw GFM pipe text. The formatting toolbar includes an **Insert table** action; while the caret is inside a table, contextual controls support add/remove column and row, widen/narrow column, and delete table. Column edges are also draggable (TableKit `resizable`).
+
+Blank lines between pipe-table rows (common from AI generation or line-by-line typing) are normalized before parse so both the editor and the ReactMarkdown reader render a `<table>`.
+
+## Surfaces
+
+- `MarkdownFormatToolbar` — Insert table button beside bold/italic/link
+- `MarkdownBodyEditor` + `SyllabusBlockEditor` — TipTap `insertTable` / TableKit
+- `MarkdownTableControls` — floating controls anchored to the active table
+- `/table` slash command
+- `normalizeMarkdownTables` — heal broken GFM tables for editor + reader
+
+## Tests
+
+- Unit: table parse/insert/heal, markdown insert, slash filter, normalize helpers
+- E2E: `e2e/tests/editor-tables.spec.ts` — toolbar insert, column controls, healed reader render

--- a/docs/completed/08-content-media-files/8.13-editor-table-insert-and-controls.md
+++ b/docs/completed/08-content-media-files/8.13-editor-table-insert-and-controls.md
@@ -1,4 +1,4 @@
-# 8.12 — Editor table insert and controls
+# 8.13 — Editor table insert and controls
 
 > Status: COMPLETED
 

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -1496,6 +1496,24 @@
       "reviewed": true
     },
     {
+      "id": "8.13",
+      "path": "docs/completed/08-content-media-files/8.13-editor-table-insert-and-controls.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "major",
+      "client": "web",
+      "coverage": "journey",
+      "rationale": "Playwright journey covers toolbar insert, in-table column controls, save/reload render, and healing blank-line pipe tables in the reader.",
+      "owner": "Content / Media",
+      "specs": [
+        {
+          "path": "e2e/tests/editor-tables.spec.ts"
+        }
+      ],
+      "reviewed": true
+    },
+    {
       "id": "8.2",
       "path": "docs/completed/08-content-media-files/8.2-resumable-chunked-uploads.md",
       "markets": [

--- a/e2e/tests/editor-tables.spec.ts
+++ b/e2e/tests/editor-tables.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * TipTap markdown editor tables: insert renders as <table>, toolbar + controls.
+ */
+import { test, expect } from '../fixtures/test.js'
+import {
+  apiCreateContentPage,
+  apiCreateModule,
+  apiPatchContentPage,
+} from '../fixtures/api.js'
+
+test.describe('Editor tables', () => {
+  test('insert table from toolbar renders a real table and supports column controls', async ({
+    coursePage: page,
+    seededCourse,
+  }) => {
+    const module = await apiCreateModule(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      'Tables Module',
+    )
+    const contentPage = await apiCreateContentPage(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      module.id,
+      'Table Authoring',
+    )
+
+    await page.goto(
+      `/courses/${seededCourse.courseCode}/modules/content/${contentPage.id}`,
+    )
+    const editBtn = page.getByRole('button', { name: /^edit$/i })
+    await expect(editBtn).toBeVisible({ timeout: 15000 })
+    await editBtn.click()
+
+    const sectionBody = page.locator('[id^="canvas-md-"]').first()
+    await sectionBody.click()
+
+    const insertTable = page.getByRole('button', { name: /insert table/i })
+    await expect(insertTable).toBeVisible({ timeout: 8000 })
+    await insertTable.click()
+
+    const editorTable = sectionBody.locator('table')
+    await expect(editorTable).toBeVisible({ timeout: 5000 })
+    await expect(editorTable.locator('th')).toHaveCount(3)
+
+    await editorTable.locator('td').first().click()
+    const addColumn = page.getByRole('button', { name: /^add column$/i })
+    await expect(addColumn).toBeVisible({ timeout: 5000 })
+    await addColumn.click()
+    await expect(editorTable.locator('th')).toHaveCount(4)
+
+    const widen = page.getByRole('button', { name: /widen column/i })
+    await expect(widen).toBeVisible()
+    await widen.click()
+
+    await page.getByRole('button', { name: /^save$/i }).click()
+    await expect(page.getByText(/saved|updated/i).first()).toBeVisible({ timeout: 12000 })
+
+    await page.reload()
+    await expect(page.locator('.syllabus-md table').first()).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('.syllabus-md th')).toHaveCount(4)
+  })
+
+  test('assignment body with blank-line pipe tables renders as a table for students', async ({
+    coursePage: page,
+    seededCourse,
+  }) => {
+    const contentPage = await apiCreateContentPage(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      seededCourse.moduleId,
+      'Broken Table Heal',
+    )
+
+    await apiPatchContentPage(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      contentPage.id,
+      {
+        markdown: `Traditional software vs AI.
+
+| Feature | Traditional Software | AI Systems |
+
+|-----------------|---------------------------------|---------------------------------|
+
+| How it works | Follows fixed rules | Learns patterns |
+
+**Quick check:**
+Explain the difference.
+`,
+      },
+    )
+
+    await page.goto(
+      `/courses/${seededCourse.courseCode}/modules/content/${contentPage.id}`,
+    )
+    await expect(page.locator('.syllabus-md table').first()).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('columnheader', { name: /feature/i })).toBeVisible()
+    await expect(page.getByText(/\| Feature \|/)).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TipTap markdown bodies (assignments, content pages, syllabus) now insert and edit real HTML tables instead of raw GFM pipe text.

- **Insert table** button in the format toolbar (next to bold/italic/link) and `/table` slash command call TipTap `insertTable`
- Contextual **table controls** appear on the active table: add/remove column, widen/narrow column, add/remove row, delete table
- Column edges are draggable (`TableKit` resizable + themed resize-handle CSS)
- `normalizeMarkdownTables` heals blank lines between pipe rows so broken AI/typed tables render as `<table>` in both the editor and ReactMarkdown reader

## Test plan

- [x] Unit tests for table parse/insert/heal, markdown insert, slash filter, normalize helpers
- [x] Frontend lint + typecheck
- [x] E2E `e2e/tests/editor-tables.spec.ts` — toolbar insert, column controls, healed reader render (local pass)
- [x] E2E.4 coverage manifest entry for `8.13-editor-table-insert-and-controls.md`
- [ ] CI green

## Docs

`docs/completed/08-content-media-files/8.13-editor-table-insert-and-controls.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d88aa026-00f4-46da-867b-ed12e894d408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d88aa026-00f4-46da-867b-ed12e894d408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

