### PR TITLE
fix(web): Enter in section title focuses section content

### DIFF
--- a/clients/web/src/components/syllabus/__tests__/section-heading-enter.test.ts
+++ b/clients/web/src/components/syllabus/__tests__/section-heading-enter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { isSectionHeadingEnterToContentKey } from '../section-heading-enter'
+
+describe('isSectionHeadingEnterToContentKey', () => {
+  it('returns true for plain Enter', () => {
+    expect(
+      isSectionHeadingEnterToContentKey({ key: 'Enter', shiftKey: false, isComposing: false }),
+    ).toBe(true)
+  })
+
+  it('returns false for Shift+Enter', () => {
+    expect(
+      isSectionHeadingEnterToContentKey({ key: 'Enter', shiftKey: true, isComposing: false }),
+    ).toBe(false)
+  })
+
+  it('returns false while IME is composing', () => {
+    expect(
+      isSectionHeadingEnterToContentKey({ key: 'Enter', shiftKey: false, isComposing: true }),
+    ).toBe(false)
+    expect(
+      isSectionHeadingEnterToContentKey({
+        key: 'Enter',
+        shiftKey: false,
+        nativeEvent: { isComposing: true },
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false for other keys', () => {
+    expect(
+      isSectionHeadingEnterToContentKey({ key: 'Tab', shiftKey: false, isComposing: false }),
+    ).toBe(false)
+  })
+})

--- a/clients/web/src/components/syllabus/__tests__/syllabus-block-editor-heading-enter.test.tsx
+++ b/clients/web/src/components/syllabus/__tests__/syllabus-block-editor-heading-enter.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { I18nProvider } from '../../../context/i18n-provider'
+import type { SyllabusSection } from '../../../lib/courses-api'
+import { SyllabusBlockEditor } from '../syllabus-block-editor'
+
+vi.mock('../../../hooks/use-speech-to-text-availability', () => ({
+  useSpeechToTextAvailability: () => ({
+    enabled: false,
+    language: 'en-US',
+    loading: false,
+  }),
+}))
+
+vi.mock('../../../context/course-nav-features-context', () => ({
+  useCourseNavFeatures: () => ({
+    visualBoardsEnabled: false,
+  }),
+}))
+
+vi.mock('../../../lib/platform-features', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/platform-features')>()
+  return {
+    ...actual,
+    altTextEnforcementFeatureEnabled: () => false,
+    altTextHardBlockEnabled: () => false,
+    speechToTextFeatureEnabled: () => false,
+  }
+})
+
+function EditorHarness() {
+  const [sections, setSections] = useState<SyllabusSection[]>([
+    { id: 'sec-1', heading: 'Intro', markdown: 'Body text here.' },
+  ])
+  return (
+    <MemoryRouter>
+      <I18nProvider>
+        <SyllabusBlockEditor sections={sections} onChange={setSections} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('SyllabusBlockEditor — heading Enter focuses content', () => {
+  it('moves focus from the section heading into the body editor on Enter', async () => {
+    const user = userEvent.setup()
+    render(<EditorHarness />)
+
+    const heading = await screen.findByRole('textbox', { name: /section heading/i })
+    await user.click(heading)
+    expect(heading).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      const body = document.querySelector('#canvas-md-sec-1 [contenteditable="true"]')
+      expect(body).toBeTruthy()
+      expect(body).toHaveFocus()
+    })
+  })
+})

--- a/clients/web/src/components/syllabus/section-heading-enter.ts
+++ b/clients/web/src/components/syllabus/section-heading-enter.ts
@@ -1,0 +1,10 @@
+/** Enter in a section heading moves focus into that section's body editor. */
+export function isSectionHeadingEnterToContentKey(e: {
+  key: string
+  shiftKey: boolean
+  isComposing?: boolean
+  nativeEvent?: { isComposing?: boolean }
+}): boolean {
+  const composing = e.isComposing ?? e.nativeEvent?.isComposing ?? false
+  return e.key === 'Enter' && !e.shiftKey && !composing
+}

--- a/clients/web/src/components/syllabus/syllabus-block-editor.tsx
+++ b/clients/web/src/components/syllabus/syllabus-block-editor.tsx
@@ -10,6 +10,7 @@ import {
   type SyllabusSection,
 } from '../../lib/courses-api'
 import { sectionsToMarkdown, markdownToSectionsForEditor } from './syllabus-section-markdown'
+import { isSectionHeadingEnterToContentKey } from './section-heading-enter'
 import TurndownService from 'turndown'
 import { gfm } from 'turndown-plugin-gfm'
 import { stripPastedHtmlColors } from '../editor/block-editor/strip-pasted-html-colors'
@@ -487,6 +488,21 @@ function SyllabusBlockEditorInner({
     editorRefs.current[sectionId] = editor
   }, [])
 
+  const focusSectionContent = useCallback(
+    (sectionId: string) => {
+      setSelectedId(sectionId)
+      setActiveField({ blockId: sectionId, field: 'markdown' })
+      // TipTap may not be registered on the first paint after mount; retry once.
+      const focus = () =>
+        editorRefs.current[sectionId]?.chain().focus('end', { scrollIntoView: false }).run()
+      focus()
+      if (!editorRefs.current[sectionId]) {
+        requestAnimationFrame(focus)
+      }
+    },
+    [setSelectedId],
+  )
+
   const openToolbarImageModal = useCallback((sectionId: string, files?: File[]) => {
     pendingToolbarImageSectionRef.current = sectionId
     setSelectedId(sectionId)
@@ -943,6 +959,11 @@ function SyllabusBlockEditorInner({
                 value={section.heading}
                 onChange={(e) => updateAt(index, { heading: e.target.value })}
                 onFocus={() => setActiveField({ blockId: section.id, field: 'heading' })}
+                onKeyDown={(e) => {
+                  if (!isSectionHeadingEnterToContentKey(e)) return
+                  e.preventDefault()
+                  focusSectionContent(section.id)
+                }}
                 onBlur={(e) => {
                   const next = e.relatedTarget as HTMLElement | null
                   if (next?.closest('[data-toolbar-anchor]')) return

--- a/docs/completed/web/W09-section-heading-enter-focuses-content.md
+++ b/docs/completed/web/W09-section-heading-enter-focuses-content.md
@@ -1,0 +1,23 @@
+# W09 — Section heading Enter focuses content
+
+> UX polish. Source: content / syllabus block editor section title field in
+> `clients/web/src/components/syllabus/syllabus-block-editor.tsx`.
+
+## Implementation notes
+
+- **Problem:** In the content editor, pressing Enter while editing a section title did nothing
+  useful; authors expect the caret to move into the section body so they can keep writing.
+- **Fix:** On Enter (without Shift, and not during IME composition) in the canvas section heading
+  input, prevent default and focus the TipTap body editor for that section (`focus('end')`).
+- **Tests:** Vitest `section-heading-enter.test.ts` +
+  `syllabus-block-editor-heading-enter.test.tsx`; Playwright
+  `e2e/tests/section-heading-enter-focus.spec.ts`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | W09 |
+| **Section** | Web / Content editor |
+| **Severity** | MINOR — authoring keyboard flow |
+| **Status** | DONE |

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -8358,6 +8358,24 @@
         }
       ],
       "reviewed": true
+    },
+    {
+      "id": "W09",
+      "path": "docs/completed/web/W09-section-heading-enter-focuses-content.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "minor",
+      "client": "web",
+      "coverage": "journey",
+      "rationale": "Playwright journey edits a content-page section title and asserts Enter moves focus into the section body editor.",
+      "owner": "Web Platform",
+      "specs": [
+        {
+          "path": "e2e/tests/section-heading-enter-focus.spec.ts"
+        }
+      ],
+      "reviewed": true
     }
   ]
 }

--- a/e2e/tests/section-heading-enter-focus.spec.ts
+++ b/e2e/tests/section-heading-enter-focus.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Content editor: Enter in the section title focuses the section body.
+ */
+import { test, expect } from '../fixtures/test.js'
+import { apiCreateContentPage } from '../fixtures/api.js'
+
+test.describe('Section heading Enter focuses content', () => {
+  test('pressing Enter in the section title moves the caret into the body', async ({
+    coursePage: page,
+    seededCourse,
+  }) => {
+    test.setTimeout(60_000)
+
+    const contentPage = await apiCreateContentPage(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      seededCourse.moduleId,
+      'Heading enter focus page',
+    )
+
+    await page.goto(
+      `/courses/${seededCourse.courseCode}/modules/content/${contentPage.id}`,
+    )
+    const editBtn = page.getByRole('button', { name: /^edit$/i })
+    await expect(editBtn).toBeVisible({ timeout: 15000 })
+    await editBtn.click()
+
+    const heading = page.locator('[id^="canvas-heading-"]').first()
+    await expect(heading).toBeVisible({ timeout: 8000 })
+    await heading.click()
+    await heading.fill('My section title')
+    await expect(heading).toBeFocused()
+
+    await heading.press('Enter')
+
+    const body = page.locator('[id^="canvas-md-"] [contenteditable="true"]').first()
+    await expect(body).toBeFocused({ timeout: 5000 })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When editing a section title in the content/syllabus block editor, pressing **Enter** now moves focus into that section’s body editor so authors can keep writing without reaching for the mouse.

## Changes

- Canvas section heading `onKeyDown`: Enter (no Shift, not during IME composition) focuses the TipTap body at the end of the content.
- Small helper `isSectionHeadingEnterToContentKey` for the key guard.
- Unit tests + Playwright e2e coverage.
- Spec notes in `docs/completed/web/W09-section-heading-enter-focuses-content.md`.
- Registered W09 in `e2e/coverage/completed-feature-manifest.json`.

## Test plan

- [x] `npx vitest run` for the new syllabus heading Enter tests
- [x] `npm run typecheck` / oxlint on touched files
- [x] Playwright `e2e/tests/section-heading-enter-focus.spec.ts` (passed locally)
- [x] `npm run e2e:coverage:check`
- [ ] Manual: open a content page → Edit → click section title → Enter → caret in body

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fefaa82-eb2f-49da-ae2a-bc8ea79238ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fefaa82-eb2f-49da-ae2a-bc8ea79238ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

