### PR TITLE
fix(e2e): register AC/PS completed stories in E2E.4 coverage manifest

### DIFF
--- a/e2e/coverage/REPORT.md
+++ b/e2e/coverage/REPORT.md
@@ -1,34 +1,34 @@
 # Completed feature E2E coverage report
 
-Total stories: **498**
+Total stories: **515**
 
 ## Coverage levels
 
 | Level | Count |
 |---|---:|
-| journey | 82 |
-| smoke | 172 |
+| journey | 86 |
+| smoke | 173 |
 | api-contract | 1 |
 | covered-by-parent | 11 |
 | manual | 8 |
-| not-applicable | 165 |
-| missing | 59 |
+| not-applicable | 168 |
+| missing | 68 |
 
 ## By client
 
 | Client | Count |
 |---|---:|
 | cli | 48 |
-| docs | 13 |
+| docs | 15 |
 | mobile | 92 |
-| ops | 15 |
-| web | 330 |
+| ops | 16 |
+| web | 344 |
 
 ## By market tag
 
 | Market | Count |
 |---|---:|
-| ALL | 451 |
+| ALL | 468 |
 | HE | 15 |
 | HS | 19 |
 | K12 | 13 |
@@ -70,6 +70,11 @@ Total stories: **498**
 | 14.9 | major | HE Product | E2E-coverage-backlog | [docs/completed/14-higher-ed-specific/14.9-proctoring-integration.md](../../docs/completed/14-higher-ed-specific/14.9-proctoring-integration.md) |
 | 15.9 | major | Homeschool Product | E2E-coverage-backlog | [docs/completed/15-self-learner-specific/15.9-gamification.md](../../docs/completed/15-self-learner-specific/15.9-gamification.md) |
 | 18.4 | major | Admin Experience | E2E-coverage-backlog | [docs/completed/18-admin-experience/18.4-org-wide-search.md](../../docs/completed/18-admin-experience/18.4-org-wide-search.md) |
+| AC.2 | critical | Learning Platform | E2E-coverage-backlog | [docs/completed/adaptive/AC.2-pre-assessment-and-adaptation-profile.md](../../docs/completed/adaptive/AC.2-pre-assessment-and-adaptation-profile.md) |
+| AC.3 | critical | Learning Platform | E2E-coverage-backlog | [docs/completed/adaptive/AC.3-content-generation-engine.md](../../docs/completed/adaptive/AC.3-content-generation-engine.md) |
+| AC.4 | major | Learning Platform | E2E-coverage-backlog | [docs/completed/adaptive/AC.4-generation-pipeline-caching-cost.md](../../docs/completed/adaptive/AC.4-generation-pipeline-caching-cost.md) |
+| AC.5 | critical | Learning Platform | E2E-coverage-backlog | [docs/completed/adaptive/AC.5-instructor-authoring-and-approval.md](../../docs/completed/adaptive/AC.5-instructor-authoring-and-approval.md) |
+| AC.6 | critical | Learning Platform | E2E-coverage-backlog | [docs/completed/adaptive/AC.6-student-runtime-and-transparency.md](../../docs/completed/adaptive/AC.6-student-runtime-and-transparency.md) |
 | node-code-test-runner | major | Grading Agent | E2E-coverage-backlog | [docs/completed/agent-grader/node-code-test-runner.md](../../docs/completed/agent-grader/node-code-test-runner.md) |
 | node-reference-material | major | Grading Agent | E2E-coverage-backlog | [docs/completed/agent-grader/node-reference-material.md](../../docs/completed/agent-grader/node-reference-material.md) |
 | node-score-aggregator | major | Grading Agent | E2E-coverage-backlog | [docs/completed/agent-grader/node-score-aggregator.md](../../docs/completed/agent-grader/node-score-aggregator.md) |
@@ -95,6 +100,10 @@ Total stories: **498**
 | LP03 | major | Learner Profile | E2E-coverage-backlog | [docs/completed/learner-profile/LP03-content-modality-preferences.md](../../docs/completed/learner-profile/LP03-content-modality-preferences.md) |
 | LP04 | major | Learner Profile | E2E-coverage-backlog | [docs/completed/learner-profile/LP04-strengths-growth-areas.md](../../docs/completed/learner-profile/LP04-strengths-growth-areas.md) |
 | LP05 | major | Learner Profile | E2E-coverage-backlog | [docs/completed/learner-profile/LP05-interests-topic-affinity.md](../../docs/completed/learner-profile/LP05-interests-topic-affinity.md) |
+| PS.1 | minor | Web Platform | E2E-coverage-backlog | [docs/completed/settings/PS.1-settings-registry-and-addressable-controls.md](../../docs/completed/settings/PS.1-settings-registry-and-addressable-controls.md) |
+| PS.2 | minor | Web Platform | E2E-coverage-backlog | [docs/completed/settings/PS.2-pinned-settings-data-model-and-api.md](../../docs/completed/settings/PS.2-pinned-settings-data-model-and-api.md) |
+| PS.3 | minor | Web Platform | E2E-coverage-backlog | [docs/completed/settings/PS.3-pin-and-reorder-ux-in-editor-panels.md](../../docs/completed/settings/PS.3-pin-and-reorder-ux-in-editor-panels.md) |
+| PS.4 | minor | Web Platform | E2E-coverage-backlog | [docs/completed/settings/PS.4-suggested-pins-telemetry-and-rollout.md](../../docs/completed/settings/PS.4-suggested-pins-telemetry-and-rollout.md) |
 | W05 | major | Web Platform | E2E-coverage-backlog | [docs/completed/web/W05-human-readable-entity-labels.md](../../docs/completed/web/W05-human-readable-entity-labels.md) |
 
 ## Flag lifecycle gaps
@@ -105,7 +114,9 @@ Total stories: **498**
 | 6.7 | disabledState, authorization, dependency, rollback | [docs/completed/06-communication-collaboration/6.7-office-hours.md](../../docs/completed/06-communication-collaboration/6.7-office-hours.md) |
 | 09 | disabledState, authorization, dependency, rollback | [docs/completed/09-platform-feature-flags-without-admin-toggle.md](../../docs/completed/09-platform-feature-flags-without-admin-toggle.md) |
 | 15.8 | disabledState, authorization, dependency, rollback | [docs/completed/15-self-learner-specific/15.8-affiliate-revenue-share.md](../../docs/completed/15-self-learner-specific/15.8-affiliate-revenue-share.md) |
+| AC.1 | enabledJourney, rollback | [docs/completed/adaptive/AC.1-foundations-flag-and-data-model.md](../../docs/completed/adaptive/AC.1-foundations-flag-and-data-model.md) |
 | IQ.1 | disabledState, authorization, dependency, rollback | [docs/completed/interactive-quizzes/IQ.1-foundation-and-feature-flag.md](../../docs/completed/interactive-quizzes/IQ.1-foundation-and-feature-flag.md) |
+| PS.4 | disabledState, enabledJourney, rollback | [docs/completed/settings/PS.4-suggested-pins-telemetry-and-rollout.md](../../docs/completed/settings/PS.4-suggested-pins-telemetry-and-rollout.md) |
 | T01 | disabledState, authorization, dependency, rollback | [docs/completed/transcripts/T01-official-transcript-generation.md](../../docs/completed/transcripts/T01-official-transcript-generation.md) |
 | VC.1 | disabledState, authorization, dependency, rollback | [docs/completed/visual-collaboration/VC.1-foundation-and-feature-flag.md](../../docs/completed/visual-collaboration/VC.1-foundation-and-feature-flag.md) |
 
@@ -120,7 +131,7 @@ Total stories: **498**
 | 05-multi-tenancy-org-roles | 3 | 5 | 0 | 0 | 0 | 0 | 3 |
 | 06-communication-collaboration | 7 | 4 | 0 | 0 | 0 | 0 | 0 |
 | 07-mobile-offline-cross-platform | 0 | 0 | 0 | 0 | 0 | 1 | 0 |
-| 08-content-media-files | 6 | 4 | 0 | 0 | 0 | 0 | 2 |
+| 08-content-media-files | 8 | 4 | 0 | 0 | 0 | 0 | 2 |
 | 09-analytics-reporting | 5 | 5 | 0 | 0 | 0 | 0 | 0 |
 | 10-compliance-privacy-security | 7 | 4 | 0 | 0 | 6 | 0 | 0 |
 | 11-i18n-l10n | 0 | 5 | 0 | 0 | 0 | 0 | 1 |
@@ -135,6 +146,7 @@ Total stories: **498**
 | 20-docs-trust | 0 | 0 | 0 | 0 | 2 | 0 | 0 |
 | 21-cli | 0 | 0 | 0 | 0 | 0 | 8 | 0 |
 | _root | 6 | 5 | 0 | 0 | 0 | 5 | 1 |
+| adaptive | 0 | 1 | 0 | 0 | 0 | 0 | 5 |
 | agent-grader | 0 | 6 | 0 | 0 | 0 | 0 | 3 |
 | ai-providers | 0 | 8 | 0 | 0 | 0 | 0 | 1 |
 | animations | 0 | 4 | 0 | 0 | 0 | 0 | 3 |
@@ -154,6 +166,7 @@ Total stories: **498**
 | mobile | 0 | 0 | 0 | 0 | 0 | 84 | 0 |
 | parent-portal | 1 | 0 | 0 | 0 | 0 | 0 | 0 |
 | screenshare | 0 | 1 | 0 | 0 | 0 | 0 | 0 |
+| settings | 0 | 0 | 0 | 0 | 0 | 3 | 4 |
 | transcripts | 2 | 7 | 0 | 3 | 0 | 0 | 0 |
 | visual-collaboration | 0 | 7 | 0 | 3 | 0 | 7 | 0 |
-| web | 4 | 2 | 0 | 0 | 0 | 0 | 1 |
+| web | 6 | 2 | 0 | 0 | 0 | 0 | 1 |

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -4038,6 +4038,114 @@
       "reviewed": true
     },
     {
+      "id": "AC.1",
+      "path": "docs/completed/adaptive/AC.1-foundations-flag-and-data-model.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "critical",
+      "client": "web",
+      "coverage": "smoke",
+      "rationale": "Course feature matrix covers adaptiveContentEnabled toggle/authz/disabled state; deepen to ACE journey coverage when risk warrants.",
+      "owner": "Learning Platform",
+      "specs": [
+        {
+          "path": "e2e/tests/course-features-matrix-meta.spec.ts"
+        },
+        {
+          "path": "e2e/tests/course-features-authz.spec.ts"
+        },
+        {
+          "path": "e2e/tests/course-features-ui-matrix-a.spec.ts"
+        }
+      ],
+      "reviewed": true,
+      "flags": {
+        "settingsToggle": true,
+        "disabledState": true,
+        "enabledJourney": false,
+        "authorization": true,
+        "dependency": "n/a",
+        "rollback": false,
+        "notes": "Matrix covers course flag; generation/serving journeys tracked under AC.2\u2013AC.6 gaps."
+      }
+    },
+    {
+      "id": "AC.2",
+      "path": "docs/completed/adaptive/AC.2-pre-assessment-and-adaptation-profile.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "critical",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Learning Platform",
+      "severity": "critical",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
+      "id": "AC.3",
+      "path": "docs/completed/adaptive/AC.3-content-generation-engine.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "critical",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Learning Platform",
+      "severity": "critical",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
+      "id": "AC.4",
+      "path": "docs/completed/adaptive/AC.4-generation-pipeline-caching-cost.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "major",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Learning Platform",
+      "severity": "major",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
+      "id": "AC.5",
+      "path": "docs/completed/adaptive/AC.5-instructor-authoring-and-approval.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "critical",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Learning Platform",
+      "severity": "critical",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
+      "id": "AC.6",
+      "path": "docs/completed/adaptive/AC.6-student-runtime-and-transparency.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "critical",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Learning Platform",
+      "severity": "critical",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
       "id": "node-code-test-runner",
       "path": "docs/completed/agent-grader/node-code-test-runner.md",
       "markets": [
@@ -7714,6 +7822,114 @@
       "reviewed": true
     },
     {
+      "id": "PS.1",
+      "path": "docs/completed/settings/PS.1-settings-registry-and-addressable-controls.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "minor",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Web Platform",
+      "severity": "minor",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
+      "id": "PS.2",
+      "path": "docs/completed/settings/PS.2-pinned-settings-data-model-and-api.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "minor",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Web Platform",
+      "severity": "minor",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
+      "id": "PS.3",
+      "path": "docs/completed/settings/PS.3-pin-and-reorder-ux-in-editor-panels.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "minor",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Web Platform",
+      "severity": "minor",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true
+    },
+    {
+      "id": "PS.4",
+      "path": "docs/completed/settings/PS.4-suggested-pins-telemetry-and-rollout.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "minor",
+      "client": "web",
+      "coverage": "missing",
+      "rationale": "No durable Playwright journey linked yet; tracked as an owned coverage gap.",
+      "owner": "Web Platform",
+      "severity": "minor",
+      "targetMilestone": "E2E-coverage-backlog",
+      "reviewed": true,
+      "flags": {
+        "settingsToggle": true,
+        "disabledState": false,
+        "enabledJourney": false,
+        "authorization": "n/a",
+        "dependency": "n/a",
+        "rollback": false,
+        "notes": "ffPinnedSettings platform kill-switch; Playwright flag lifecycle not yet linked."
+      }
+    },
+    {
+      "id": "pinned-settings-analytics-inventory",
+      "path": "docs/completed/settings/pinned-settings-analytics-inventory.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "none",
+      "client": "docs",
+      "coverage": "not-applicable",
+      "rationale": "Privacy/analytics inventory mapping doc; not a user-journey surface.",
+      "owner": "Web Platform",
+      "reviewed": true
+    },
+    {
+      "id": "pinned-settings-event-dictionary",
+      "path": "docs/completed/settings/pinned-settings-event-dictionary.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "none",
+      "client": "docs",
+      "coverage": "not-applicable",
+      "rationale": "Client event dictionary for product analytics; not a user-journey surface.",
+      "owner": "Web Platform",
+      "reviewed": true
+    },
+    {
+      "id": "pinned-settings-reporting",
+      "path": "docs/completed/settings/pinned-settings-reporting.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "none",
+      "client": "ops",
+      "coverage": "not-applicable",
+      "rationale": "Ops reporting queries and FR-15 review checklist; not a Playwright journey.",
+      "owner": "Web Platform",
+      "reviewed": true
+    },
+    {
       "id": "T01",
       "path": "docs/completed/transcripts/T01-official-transcript-generation.md",
       "markets": [
@@ -8350,7 +8566,7 @@
       "risk": "minor",
       "client": "web",
       "coverage": "journey",
-      "rationale": "Playwright journey selects across paragraphs on a content page and asserts ⌘/Ctrl+C copies every paragraph.",
+      "rationale": "Playwright journey selects across paragraphs on a content page and asserts \u2318/Ctrl+C copies every paragraph.",
       "owner": "Web Platform",
       "specs": [
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #538 CI failed on **E2E coverage gate (E2E.4)** because adaptive content (`AC.1`–`AC.6`) and pinned settings (`PS.1`–`PS.4` + analytics docs) were moved into `docs/completed/` without disposition rows in `e2e/coverage/completed-feature-manifest.json`.

This PR adds reviewed manifest entries and refreshes `REPORT.md`:

- **AC.1** → `smoke` via course feature matrix specs (covers `adaptiveContentEnabled` flag lifecycle partially)
- **AC.2–AC.6** → `missing` owned gaps (`E2E-coverage-backlog`)
- **PS.1–PS.4** → `missing` owned gaps (`E2E-coverage-backlog`); PS.4 includes flag dimensions for `ffPinnedSettings`
- **pinned-settings analytics/event-dictionary/reporting** → `not-applicable` (docs/ops)

Verified locally with `npm run e2e:coverage:check` (515 stories OK).

## Checklist

- [x] Tests added/updated as appropriate
- [x] If moving a plan into `docs/completed/`, added a disposition in `e2e/coverage/completed-feature-manifest.json` and ran `npm run e2e:coverage:check` (E2E.4)
- [x] Flagged features link settings-toggle / disabled / enabled / authz / dependency / rollback coverage (or an E2E.1–E2E.3 family)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f715413-bcda-428f-b6d8-9593b195e9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f715413-bcda-428f-b6d8-9593b195e9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

