### PR TITLE
feat(ace): AC.9 analytics, reporting, and operability

### DIFF
--- a/clients/web/src/components/lms/adaptive-content/__tests__/course-report-panel.test.tsx
+++ b/clients/web/src/components/lms/adaptive-content/__tests__/course-report-panel.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { CourseReportPanel } from '../reports/course-report-panel'
+
+vi.mock('../../../../lib/courses-api', () => ({
+  fetchAdaptiveContentCourseReport: vi.fn(),
+  exportAdaptiveContentCourseReportCsv: vi.fn(),
+  refreshAdaptiveContentEffectiveness: vi.fn(),
+}))
+
+import { fetchAdaptiveContentCourseReport } from '../../../../lib/courses-api'
+
+const fetchReport = vi.mocked(fetchAdaptiveContentCourseReport)
+
+describe('CourseReportPanel', () => {
+  beforeEach(() => {
+    fetchReport.mockReset()
+  })
+
+  it('renders empty state when no ACE activity', async () => {
+    fetchReport.mockResolvedValue({
+      courseId: 'c1',
+      courseCode: 'DEMO',
+      empty: true,
+      coverage: {
+        eligibleContentItems: 0,
+        adaptedUnits: 0,
+        coveragePct: 0,
+        studentsProfiled: 0,
+        studentsServedVariant: 0,
+        studentsHoldout: 0,
+      },
+      nUnits: 0,
+      nActiveUnits: 0,
+      nHelping: 0,
+      nRegressing: 0,
+      nInsufficient: 0,
+      nNoEffect: 0,
+      cost: {
+        monthlyTokenBudget: 0,
+        tokensUsedPeriod: 0,
+        unlimited: true,
+        periodStart: '2026-07-01',
+      },
+      unitsToReview: [],
+      units: [],
+      byMode: [],
+      smallCellMinN: 5,
+      minNPerArm: 10,
+    })
+
+    render(
+      <MemoryRouter>
+        <CourseReportPanel courseCode="DEMO" />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ace-report-empty')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/No adaptive data yet/i)).toBeInTheDocument()
+  })
+
+  it('shows KPIs and ranks regressing unit first', async () => {
+    fetchReport.mockResolvedValue({
+      courseId: 'c1',
+      courseCode: 'DEMO',
+      empty: false,
+      coverage: {
+        eligibleContentItems: 2,
+        adaptedUnits: 1,
+        coveragePct: 50,
+        studentsProfiled: 4,
+        studentsServedVariant: 3,
+        studentsHoldout: 1,
+      },
+      meanLiftVsControl: -2,
+      nUnits: 2,
+      nActiveUnits: 2,
+      nHelping: 0,
+      nRegressing: 1,
+      nInsufficient: 1,
+      nNoEffect: 0,
+      cost: {
+        monthlyTokenBudget: 1000,
+        tokensUsedPeriod: 200,
+        budgetRemaining: 800,
+        unlimited: false,
+        periodStart: '2026-07-01',
+      },
+      unitsToReview: [
+        {
+          unitId: '11111111-1111-1111-1111-111111111111',
+          reason: 'regressing',
+          verdict: 'regressing',
+          meanLift: -8,
+          workspaceUrl: '/courses/DEMO/settings/adaptive-content?unit=11111111-1111-1111-1111-111111111111',
+        },
+      ],
+      units: [
+        {
+          unitId: '11111111-1111-1111-1111-111111111111',
+          nTreatment: 12,
+          nHoldout: 12,
+          treatmentMinusHoldout: -8,
+          verdict: 'regressing',
+          byMode: [],
+          byVariant: [],
+          smallCellMinN: 5,
+          minNPerArm: 10,
+        },
+      ],
+      byMode: [{ emphasisMode: 'remediate', n: 12, meanLift: -8 }],
+      smallCellMinN: 5,
+      minNPerArm: 10,
+    })
+
+    render(
+      <MemoryRouter>
+        <CourseReportPanel courseCode="DEMO" />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ace-course-report')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('ace-report-kpis')).toBeInTheDocument()
+    expect(screen.getByTestId('ace-report-top-review-unit')).toHaveTextContent(/Regressing/i)
+    expect(screen.getByTestId('ace-report-export')).toBeInTheDocument()
+  })
+})

--- a/clients/web/src/components/lms/adaptive-content/adaptive-content-workspace.tsx
+++ b/clients/web/src/components/lms/adaptive-content/adaptive-content-workspace.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../../lib/courses-api'
 import { useConfirm } from '../../use-confirm'
 import { EffectivenessChip, EffectivenessSummaryTable } from './effectiveness-chip'
+import { CourseReportPanel } from './reports/course-report-panel'
 import { VariantDiff } from './variant-diff'
 
 const ALL_AXES = [
@@ -63,7 +64,7 @@ type Props = {
   canConfigure?: boolean
 }
 
-type WorkspaceTab = 'units' | 'queue' | 'contests'
+type WorkspaceTab = 'units' | 'queue' | 'contests' | 'report'
 
 function statusBadgeClass(status: string): string {
   switch (status) {
@@ -96,7 +97,13 @@ export function AdaptiveContentWorkspace({
   canConfigure = true,
 }: Props) {
   const { confirm, ConfirmDialogHost } = useConfirm()
-  const [tab, setTab] = useState<WorkspaceTab>('units')
+  const initialTab = ((): WorkspaceTab => {
+    if (typeof window === 'undefined') return 'units'
+    const q = new URLSearchParams(window.location.search).get('tab')
+    if (q === 'queue' || q === 'contests' || q === 'report' || q === 'units') return q
+    return 'units'
+  })()
+  const [tab, setTab] = useState<WorkspaceTab>(initialTab)
   const [units, setUnits] = useState<AdaptiveContentUnit[]>([])
   const [structure, setStructure] = useState<CourseStructureItem[]>([])
   const [budget, setBudget] = useState<AdaptiveContentBudget | null>(null)
@@ -652,6 +659,20 @@ export function AdaptiveContentWorkspace({
           Contests
           {contests.length > 0 ? ` (${contests.length})` : ''}
         </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'report'}
+          onClick={() => setTab('report')}
+          data-testid="ace-report-tab"
+          className={`px-3 py-2 text-sm font-medium ${
+            tab === 'report'
+              ? 'border-b-2 border-indigo-600 text-indigo-700 dark:text-indigo-300'
+              : 'text-slate-600 dark:text-neutral-400'
+          }`}
+        >
+          Report
+        </button>
       </div>
 
       {error && (
@@ -988,6 +1009,10 @@ export function AdaptiveContentWorkspace({
               ))}
             </ul>
           )}
+        </section>
+      ) : tab === 'report' ? (
+        <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+          <CourseReportPanel courseCode={courseCode} />
         </section>
       ) : (
         <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">

--- a/clients/web/src/components/lms/adaptive-content/reports/admin-report-panel.tsx
+++ b/clients/web/src/components/lms/adaptive-content/reports/admin-report-panel.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Download, Loader2, RefreshCw } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import {
+  exportAdaptiveContentAdminReportCsv,
+  fetchAdaptiveContentAdminReport,
+  type AdaptiveContentAdminReport,
+} from '../../../../lib/courses-api'
+
+function formatLift(v: number | null | undefined): string {
+  if (v == null || Number.isNaN(v)) return '—'
+  const sign = v > 0 ? '+' : ''
+  return `${sign}${v.toFixed(1)} pts`
+}
+
+/**
+ * AC.9 — Admin org rollup for Adaptive Content (adoption, spend, disparities, incidents).
+ */
+export function AdminAdaptiveContentReportPanel() {
+  const [report, setReport] = useState<AdaptiveContentAdminReport | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setReport(await fetchAdaptiveContentAdminReport())
+    } catch (e) {
+      setReport(null)
+      setError(e instanceof Error ? e.message : 'Failed to load org report.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (loading) {
+    return (
+      <div className="mt-8 space-y-2" aria-busy="true">
+        <div className="h-10 animate-pulse rounded-xl bg-slate-100 dark:bg-neutral-800" />
+        <div className="h-24 animate-pulse rounded-xl bg-slate-100 dark:bg-neutral-800" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="mt-8 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800" role="alert">
+        {error}
+      </p>
+    )
+  }
+
+  if (!report) return null
+
+  return (
+    <section
+      aria-labelledby="ace-admin-report-heading"
+      className="mt-8"
+      data-testid="ace-admin-report-panel"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2
+            id="ace-admin-report-heading"
+            className="text-base font-semibold text-slate-900 dark:text-neutral-100"
+          >
+            Adaptive content org report
+          </h2>
+          <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+            Adoption, spend, aggregate lift, disparity flags, and incident state across courses.
+          </p>
+          {report.dataAsOf ? (
+            <p className="mt-0.5 text-xs text-slate-500">
+              Data as of {new Date(report.dataAsOf).toLocaleString()}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 px-3 py-1.5 text-sm font-medium dark:border-neutral-600"
+            onClick={() => {
+              void (async () => {
+                setBusy(true)
+                try {
+                  await load()
+                } finally {
+                  setBusy(false)
+                }
+              })()
+            }}
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            Refresh
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="ace-admin-report-export"
+            className="inline-flex items-center gap-1.5 rounded-xl bg-slate-900 px-3 py-1.5 text-sm font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900"
+            onClick={() => {
+              void (async () => {
+                setBusy(true)
+                try {
+                  await exportAdaptiveContentAdminReportCsv()
+                } catch (e) {
+                  setError(e instanceof Error ? e.message : 'Export failed.')
+                } finally {
+                  setBusy(false)
+                }
+              })()
+            }}
+          >
+            <Download className="h-4 w-4" />
+            Export CSV
+          </button>
+        </div>
+      </div>
+
+      <dl className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="ace-admin-report-kpis">
+        {[
+          ['Courses using ACE', String(report.coursesUsingAce)],
+          ['Students impacted', String(report.studentsImpacted)],
+          ['Spend (30d)', `$${report.costUsd30d.toFixed(2)}`],
+          ['Budget headroom', `${report.budgetHeadroomTokens.toLocaleString()} tokens`],
+          ['Aggregate lift', formatLift(report.aggregateLift)],
+          ['Disparity flags', String(report.disparityFlags)],
+          ['Open contests', String(report.openContests)],
+          ['Regressing units', String(report.regressingUnits)],
+          ['Kill-switch', report.killSwitch ? 'Engaged' : 'Disengaged'],
+          ['Queue depth', String(report.queueDepth)],
+        ].map(([label, value]) => (
+          <div
+            key={label}
+            className="rounded-lg border border-slate-200 px-3 py-2 dark:border-neutral-700"
+          >
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+            <dd className="mt-0.5 text-sm font-semibold text-slate-900 dark:text-neutral-100">
+              {value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <h3 className="mt-6 text-sm font-semibold text-slate-900 dark:text-neutral-100">
+        Courses
+      </h3>
+      {report.courses.length === 0 ? (
+        <p className="mt-2 text-sm text-slate-500" data-testid="ace-admin-report-empty">
+          No courses have Adaptive Content enabled yet.
+        </p>
+      ) : (
+        <div className="mt-2 overflow-x-auto">
+          <table className="w-full min-w-[40rem] text-left text-sm">
+            <caption className="sr-only">Adaptive content courses</caption>
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-neutral-700">
+                <th scope="col" className="py-2 pe-2 font-medium">
+                  Course
+                </th>
+                <th scope="col" className="py-2 pe-2 font-medium">
+                  Coverage
+                </th>
+                <th scope="col" className="py-2 pe-2 font-medium">
+                  Lift
+                </th>
+                <th scope="col" className="py-2 pe-2 font-medium">
+                  Regressing
+                </th>
+                <th scope="col" className="py-2 pe-2 font-medium">
+                  Disparity
+                </th>
+                <th scope="col" className="py-2 font-medium">
+                  Drill-down
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.courses.map((c) => (
+                <tr
+                  key={c.courseId}
+                  className="border-b border-slate-100 dark:border-neutral-800"
+                  data-testid="ace-admin-report-course-row"
+                >
+                  <td className="py-2 pe-2">
+                    <span className="font-medium">{c.courseCode}</span>
+                    <span className="ms-2 text-slate-500">{c.title}</span>
+                  </td>
+                  <td className="py-2 pe-2 tabular-nums">{c.coveragePct.toFixed(0)}%</td>
+                  <td className="py-2 pe-2 tabular-nums">{formatLift(c.meanLiftVsControl)}</td>
+                  <td className="py-2 pe-2 tabular-nums">{c.nRegressing}</td>
+                  <td className="py-2 pe-2 tabular-nums">{c.disparityFlags}</td>
+                  <td className="py-2">
+                    <Link
+                      to={`/courses/${encodeURIComponent(c.courseCode)}/settings/adaptive-content?tab=report`}
+                      className="font-medium text-indigo-700 hover:underline dark:text-indigo-300"
+                    >
+                      Open report
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/clients/web/src/components/lms/adaptive-content/reports/course-report-panel.tsx
+++ b/clients/web/src/components/lms/adaptive-content/reports/course-report-panel.tsx
@@ -1,0 +1,486 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { Download, Loader2, RefreshCw } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import {
+  exportAdaptiveContentCourseReportCsv,
+  fetchAdaptiveContentCourseReport,
+  refreshAdaptiveContentEffectiveness,
+  type AdaptiveContentCourseReport,
+  type AdaptiveContentUnitToReview,
+} from '../../../../lib/courses-api'
+import { EffectivenessChip } from '../effectiveness-chip'
+
+type Props = {
+  courseCode: string
+}
+
+function formatLift(v: number | null | undefined): string {
+  if (v == null || Number.isNaN(v)) return '—'
+  const sign = v > 0 ? '+' : ''
+  return `${sign}${v.toFixed(1)} pts`
+}
+
+function formatPct(v: number): string {
+  if (!Number.isFinite(v)) return '—'
+  return `${v.toFixed(0)}%`
+}
+
+function reasonLabel(reason: string): string {
+  switch (reason) {
+    case 'regressing':
+      return 'Regressing'
+    case 'low_fidelity':
+      return 'Low fidelity'
+    case 'insufficient_data':
+      return 'Insufficient data'
+    default:
+      return reason
+  }
+}
+
+function Kpi({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-xl border border-slate-200 px-3 py-2 dark:border-neutral-700">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+        {label}
+      </p>
+      <p className="mt-0.5 text-lg font-semibold tabular-nums text-slate-900 dark:text-neutral-100">
+        {value}
+      </p>
+      {hint ? <p className="mt-0.5 text-xs text-slate-500 dark:text-neutral-400">{hint}</p> : null}
+    </div>
+  )
+}
+
+function ModeBarChart({
+  modes,
+}: {
+  modes: AdaptiveContentCourseReport['byMode']
+}) {
+  const tableId = useId()
+  const [showTable, setShowTable] = useState(false)
+  const maxN = Math.max(1, ...modes.map((m) => m.n))
+  if (modes.length === 0) {
+    return <p className="text-sm text-slate-500 dark:text-neutral-400">No mode breakdown yet.</p>
+  }
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm text-slate-600 dark:text-neutral-300">
+          Mean lift by emphasis mode (suppressed when n &lt; small-cell minimum).
+        </p>
+        <button
+          type="button"
+          className="text-xs font-medium text-indigo-700 underline dark:text-indigo-300"
+          aria-controls={tableId}
+          aria-expanded={showTable}
+          onClick={() => setShowTable((v) => !v)}
+        >
+          {showTable ? 'Hide data table' : 'Show data table'}
+        </button>
+      </div>
+      <ul className="mt-3 space-y-2" aria-hidden={showTable}>
+        {modes.map((m) => (
+          <li key={m.emphasisMode} className="flex items-center gap-3 text-sm">
+            <span className="w-24 shrink-0 font-medium text-slate-700 dark:text-neutral-200">
+              {m.emphasisMode}
+            </span>
+            <div
+              className="h-3 flex-1 rounded bg-slate-100 dark:bg-neutral-800"
+              role="presentation"
+            >
+              <div
+                className="h-3 rounded bg-teal-600 dark:bg-teal-500"
+                style={{ width: `${(m.n / maxN) * 100}%` }}
+              />
+            </div>
+            <span className="w-28 shrink-0 tabular-nums text-slate-600 dark:text-neutral-300">
+              n={m.n} · {formatLift(m.meanLift)}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {showTable ? (
+        <table id={tableId} className="mt-3 w-full text-left text-sm">
+          <caption className="sr-only">Effectiveness by emphasis mode</caption>
+          <thead>
+            <tr className="border-b border-slate-200 dark:border-neutral-700">
+              <th scope="col" className="py-1 pe-2 font-medium">
+                Mode
+              </th>
+              <th scope="col" className="py-1 pe-2 font-medium">
+                N
+              </th>
+              <th scope="col" className="py-1 font-medium">
+                Mean lift
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {modes.map((m) => (
+              <tr key={m.emphasisMode} className="border-b border-slate-100 dark:border-neutral-800">
+                <td className="py-1 pe-2">{m.emphasisMode}</td>
+                <td className="py-1 pe-2 tabular-nums">{m.n}</td>
+                <td className="py-1 tabular-nums">{formatLift(m.meanLift)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : null}
+    </div>
+  )
+}
+
+function UnitsToReviewList({
+  courseCode,
+  items,
+}: {
+  courseCode: string
+  items: AdaptiveContentUnitToReview[]
+}) {
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-neutral-400">
+        No units currently need review.
+      </p>
+    )
+  }
+  return (
+    <ol className="space-y-2">
+      {items.map((u, idx) => (
+        <li
+          key={`${u.unitId}-${u.reason}`}
+          className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 px-3 py-2 dark:border-neutral-700"
+          data-testid={idx === 0 ? 'ace-report-top-review-unit' : undefined}
+        >
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-slate-900 dark:text-neutral-100">
+              {reasonLabel(u.reason)}
+              <span className="ms-2 font-mono text-xs text-slate-500">
+                {u.unitId.slice(0, 8)}…
+              </span>
+            </p>
+            <p className="mt-0.5 text-xs text-slate-500 dark:text-neutral-400">
+              Verdict: {u.verdict.replaceAll('_', ' ')}
+              {u.meanLift != null ? ` · lift ${formatLift(u.meanLift)}` : ''}
+              {u.meanFidelity != null
+                ? ` · fidelity ${Math.round(u.meanFidelity * 100)}%`
+                : ''}
+            </p>
+          </div>
+          <Link
+            to={`/courses/${encodeURIComponent(courseCode)}/settings/adaptive-content?unit=${encodeURIComponent(u.unitId)}`}
+            className="text-sm font-medium text-indigo-700 hover:underline dark:text-indigo-300"
+          >
+            Open in workspace
+          </Link>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+/**
+ * AC.9 — Instructor Adaptive Content course report (coverage, lift, units to review, cost).
+ */
+export function CourseReportPanel({ courseCode }: Props) {
+  const [report, setReport] = useState<AdaptiveContentCourseReport | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [showUnitTable, setShowUnitTable] = useState(false)
+  const unitTableId = useId()
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const r = await fetchAdaptiveContentCourseReport(courseCode)
+      setReport(r)
+    } catch (e) {
+      setReport(null)
+      setError(e instanceof Error ? e.message : 'Failed to load report.')
+    } finally {
+      setLoading(false)
+    }
+  }, [courseCode])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (loading) {
+    return (
+      <div className="space-y-2" aria-busy="true" data-testid="ace-report-loading">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-14 animate-pulse rounded-xl bg-slate-100 dark:bg-neutral-800" />
+        ))}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800" role="alert">
+        {error}
+      </p>
+    )
+  }
+
+  if (!report) return null
+
+  if (report.empty) {
+    return (
+      <section
+        className="rounded-2xl border border-dashed border-slate-300 px-6 py-10 text-center dark:border-neutral-700"
+        data-testid="ace-report-empty"
+      >
+        <h3 className="text-base font-semibold text-slate-900 dark:text-neutral-50">
+          No adaptive data yet
+        </h3>
+        <p className="mx-auto mt-2 max-w-md text-sm text-slate-600 dark:text-neutral-400">
+          Set up an adaptive content unit and collect servings and post-assessment outcomes to see
+          coverage, lift vs. control, and units to review here.
+        </p>
+      </section>
+    )
+  }
+
+  const budgetHint = report.cost.unlimited
+    ? 'Unlimited budget'
+    : `Remaining ${report.cost.budgetRemaining ?? 0} tokens`
+
+  return (
+    <div className="space-y-6" data-testid="ace-course-report">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900 dark:text-neutral-50">
+            Adaptive Content report
+          </h3>
+          {report.dataAsOf ? (
+            <p className="mt-0.5 text-xs text-slate-500 dark:text-neutral-400">
+              Data as of {new Date(report.dataAsOf).toLocaleString()}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="ace-report-refresh"
+            className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 dark:border-neutral-600 dark:text-neutral-200"
+            onClick={() => {
+              void (async () => {
+                setBusy(true)
+                try {
+                  await refreshAdaptiveContentEffectiveness(courseCode)
+                  await load()
+                } catch (e) {
+                  setError(e instanceof Error ? e.message : 'Refresh failed.')
+                } finally {
+                  setBusy(false)
+                }
+              })()
+            }}
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            Refresh
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="ace-report-export"
+            className="inline-flex items-center gap-1.5 rounded-xl bg-slate-900 px-3 py-1.5 text-sm font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900"
+            onClick={() => {
+              void (async () => {
+                setBusy(true)
+                try {
+                  await exportAdaptiveContentCourseReportCsv(courseCode)
+                } catch (e) {
+                  setError(e instanceof Error ? e.message : 'Export failed.')
+                } finally {
+                  setBusy(false)
+                }
+              })()
+            }}
+          >
+            <Download className="h-4 w-4" />
+            Export CSV
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="ace-report-kpis">
+        <Kpi
+          label="Coverage"
+          value={formatPct(report.coverage.coveragePct)}
+          hint={`${report.coverage.adaptedUnits} / ${report.coverage.eligibleContentItems} units adapted`}
+        />
+        <Kpi
+          label="Students impacted"
+          value={String(report.coverage.studentsServedVariant)}
+          hint={`${report.coverage.studentsProfiled} profiled · ${report.coverage.studentsHoldout} holdout`}
+        />
+        <Kpi
+          label="Mean lift vs control"
+          value={formatLift(report.meanLiftVsControl)}
+          hint={`${report.nHelping} helping · ${report.nRegressing} regressing`}
+        />
+        <Kpi
+          label="Spend this period"
+          value={`${report.cost.tokensUsedPeriod.toLocaleString()} tokens`}
+          hint={budgetHint}
+        />
+      </div>
+
+      <section aria-labelledby="ace-units-to-review-heading">
+        <h4
+          id="ace-units-to-review-heading"
+          className="text-sm font-semibold text-slate-900 dark:text-neutral-50"
+        >
+          Units to review
+        </h4>
+        <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+          Ranked regressing → low fidelity → insufficient data. Open a unit in the authoring
+          workspace to act.
+        </p>
+        <div className="mt-3">
+          <UnitsToReviewList courseCode={courseCode} items={report.unitsToReview} />
+        </div>
+      </section>
+
+      <section aria-labelledby="ace-mode-heading">
+        <h4
+          id="ace-mode-heading"
+          className="text-sm font-semibold text-slate-900 dark:text-neutral-50"
+        >
+          Effectiveness by emphasis mode
+        </h4>
+        <div className="mt-3">
+          <ModeBarChart modes={report.byMode} />
+        </div>
+      </section>
+
+      <section aria-labelledby="ace-unit-eff-heading">
+        <div className="flex items-center justify-between gap-2">
+          <h4
+            id="ace-unit-eff-heading"
+            className="text-sm font-semibold text-slate-900 dark:text-neutral-50"
+          >
+            Effectiveness by unit
+          </h4>
+          <button
+            type="button"
+            className="text-xs font-medium text-indigo-700 underline dark:text-indigo-300"
+            aria-controls={unitTableId}
+            aria-expanded={showUnitTable}
+            onClick={() => setShowUnitTable((v) => !v)}
+          >
+            {showUnitTable ? 'Hide data table' : 'Show data table'}
+          </button>
+        </div>
+        <ul className="mt-3 space-y-2">
+          {report.units.map((u) => (
+            <li
+              key={u.unitId}
+              className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 px-3 py-2 dark:border-neutral-700"
+            >
+              <span className="font-mono text-xs text-slate-500">{u.unitId.slice(0, 8)}…</span>
+              <EffectivenessChip effectiveness={u} />
+              <span className="text-sm tabular-nums text-slate-600 dark:text-neutral-300">
+                {formatLift(u.treatmentMinusHoldout)}
+              </span>
+            </li>
+          ))}
+          {report.units.length === 0 ? (
+            <li className="text-sm text-slate-500">No effectiveness rows yet.</li>
+          ) : null}
+        </ul>
+        {showUnitTable ? (
+          <table id={unitTableId} className="mt-3 w-full text-left text-sm">
+            <caption className="sr-only">Per-unit effectiveness</caption>
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-neutral-700">
+                <th scope="col" className="py-1 pe-2">
+                  Unit
+                </th>
+                <th scope="col" className="py-1 pe-2">
+                  Verdict
+                </th>
+                <th scope="col" className="py-1 pe-2">
+                  N treatment
+                </th>
+                <th scope="col" className="py-1 pe-2">
+                  N holdout
+                </th>
+                <th scope="col" className="py-1">
+                  Lift vs control
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.units.map((u) => (
+                <tr key={u.unitId} className="border-b border-slate-100 dark:border-neutral-800">
+                  <td className="py-1 pe-2 font-mono text-xs">{u.unitId}</td>
+                  <td className="py-1 pe-2">{u.verdict}</td>
+                  <td className="py-1 pe-2 tabular-nums">{u.nTreatment}</td>
+                  <td className="py-1 pe-2 tabular-nums">{u.nHoldout}</td>
+                  <td className="py-1 tabular-nums">{formatLift(u.treatmentMinusHoldout)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : null}
+      </section>
+
+      <section aria-labelledby="ace-cost-heading">
+        <h4
+          id="ace-cost-heading"
+          className="text-sm font-semibold text-slate-900 dark:text-neutral-50"
+        >
+          Cost &amp; budget
+        </h4>
+        <div className="mt-3">
+          {report.cost.unlimited ? (
+            <p className="text-sm text-slate-600 dark:text-neutral-300">
+              {report.cost.tokensUsedPeriod.toLocaleString()} tokens used this period (unlimited
+              budget). Period start {report.cost.periodStart}.
+            </p>
+          ) : (
+            <>
+              <div
+                className="h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-neutral-800"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={report.cost.monthlyTokenBudget}
+                aria-valuenow={report.cost.tokensUsedPeriod}
+                aria-label="Token budget used this period"
+              >
+                <div
+                  className="h-3 rounded-full bg-amber-600 dark:bg-amber-500"
+                  style={{
+                    width: `${Math.min(
+                      100,
+                      (report.cost.tokensUsedPeriod / Math.max(1, report.cost.monthlyTokenBudget)) *
+                        100,
+                    )}%`,
+                  }}
+                />
+              </div>
+              <p className="mt-2 text-sm text-slate-600 dark:text-neutral-300">
+                {report.cost.tokensUsedPeriod.toLocaleString()} /{' '}
+                {report.cost.monthlyTokenBudget.toLocaleString()} tokens ·{' '}
+                {(report.cost.budgetRemaining ?? 0).toLocaleString()} remaining · period start{' '}
+                {report.cost.periodStart}
+              </p>
+            </>
+          )}
+          <p className="mt-2 text-xs text-slate-500 dark:text-neutral-400">
+            Platform AI reports include the same spend under feature{' '}
+            <code className="rounded bg-slate-100 px-1 dark:bg-neutral-800">adaptive_content</code>.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/clients/web/src/components/settings/ai-governance-panel.tsx
+++ b/clients/web/src/components/settings/ai-governance-panel.tsx
@@ -3,6 +3,7 @@ import { authorizedFetch } from '../../lib/api'
 import { readApiErrorMessage } from '../../lib/errors'
 import { aiDisclosureI18n } from '../../lib/ai-disclosure-i18n'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+import { AdminAdaptiveContentReportPanel } from '../lms/adaptive-content/reports/admin-report-panel'
 import { AdaptiveContentOversightPanel } from './adaptive-content-oversight-panel'
 
 const FEATURE_KEYS = [
@@ -123,6 +124,7 @@ export function AiGovernancePanel() {
         {saving ? 'Saving…' : aiDisclosureI18n.adminSave}
       </button>
       <AdaptiveContentOversightPanel />
+      <AdminAdaptiveContentReportPanel />
     </section>
   )
 }

--- a/clients/web/src/components/settings/ai-reports-panel.tsx
+++ b/clients/web/src/components/settings/ai-reports-panel.tsx
@@ -72,10 +72,15 @@ export function AiReportsPanel() {
   }, [load])
 
   const featureOptions = useMemo(() => {
-    const keys = new Set<string>()
+    const keys = new Set<string>(['adaptive_content'])
     for (const row of report?.cost.byFeature ?? []) keys.add(row.feature)
     return Array.from(keys).sort()
   }, [report])
+
+  const aceCost = useMemo(
+    () => report?.cost.byFeature.find((r) => r.feature === 'adaptive_content') ?? null,
+    [report],
+  )
 
   const providerOptions = useMemo(() => {
     const keys = new Set<string>(report?.providers ?? [])
@@ -246,6 +251,54 @@ export function AiReportsPanel() {
                 </table>
               </div>
             )}
+
+            <section
+              aria-labelledby="ace-ai-cost-heading"
+              className="mt-6 rounded-xl border border-slate-200 px-4 py-3 dark:border-neutral-700"
+              data-testid="ace-ai-reports-slice"
+            >
+              <h4
+                id="ace-ai-cost-heading"
+                className="text-sm font-semibold text-slate-900 dark:text-neutral-100"
+              >
+                Adaptive Content Engine
+              </h4>
+              <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+                Cost slice for feature <code>adaptive_content</code> (AC.9). Filter the reports above
+                by this feature for course/user drill-down.
+              </p>
+              {aceCost ? (
+                <dl className="mt-3 grid gap-2 sm:grid-cols-3">
+                  <div>
+                    <dt className="text-xs uppercase text-slate-500">Cost</dt>
+                    <dd className="text-sm font-semibold tabular-nums">{formatUsd(aceCost.costUsd)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase text-slate-500">Calls</dt>
+                    <dd className="text-sm font-semibold tabular-nums">
+                      {formatNumber(aceCost.calls)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs uppercase text-slate-500">Tokens</dt>
+                    <dd className="text-sm font-semibold tabular-nums">
+                      {formatNumber(aceCost.tokens)}
+                    </dd>
+                  </div>
+                </dl>
+              ) : (
+                <p className="mt-2 text-sm text-slate-500 dark:text-neutral-400">
+                  No Adaptive Content usage in this window.
+                </p>
+              )}
+              <button
+                type="button"
+                className="mt-3 text-sm font-medium text-indigo-700 underline dark:text-indigo-300"
+                onClick={() => setFeature('adaptive_content')}
+              >
+                Filter reports to Adaptive content
+              </button>
+            </section>
 
             {report.cost.summary.totalCalls === 0 && (
               <p className="mt-4 text-sm text-slate-500 dark:text-neutral-400">

--- a/clients/web/src/lib/ai-reports-api.ts
+++ b/clients/web/src/lib/ai-reports-api.ts
@@ -87,6 +87,7 @@ export const AI_FEATURE_LABELS: Record<string, string> = {
   grader_agent: 'Grading agent',
   lesson_generation: 'Lesson generator',
   ai_study_buddy: 'AI study buddy',
+  adaptive_content: 'Adaptive content',
   unknown: 'Unknown',
 }
 

--- a/clients/web/src/lib/courses-api-schemas.ts
+++ b/clients/web/src/lib/courses-api-schemas.ts
@@ -1257,24 +1257,36 @@ export const adaptiveContentCourseReportSchema = z.object({
     unlimited: z.boolean(),
     periodStart: z.string(),
   }),
-  unitsToReview: z.array(
-    z.object({
-      unitId: z.string(),
-      reason: z.string(),
-      verdict: z.string(),
-      meanFidelity: z.number().nullable().optional(),
-      meanLift: z.number().nullable().optional(),
-      workspaceUrl: z.string(),
-    }),
-  ),
-  units: z.array(z.record(z.string(), z.unknown())),
-  byMode: z.array(
-    z.object({
-      emphasisMode: z.string(),
-      n: z.number(),
-      meanLift: z.number().nullable().optional(),
-    }),
-  ),
+  unitsToReview: z
+    .array(
+      z.object({
+        unitId: z.string(),
+        reason: z.string(),
+        verdict: z.string(),
+        meanFidelity: z.number().nullable().optional(),
+        meanLift: z.number().nullable().optional(),
+        workspaceUrl: z.string(),
+      }),
+    )
+    .nullable()
+    .optional()
+    .transform((v) => v ?? []),
+  units: z
+    .array(z.record(z.string(), z.unknown()))
+    .nullable()
+    .optional()
+    .transform((v) => v ?? []),
+  byMode: z
+    .array(
+      z.object({
+        emphasisMode: z.string(),
+        n: z.number(),
+        meanLift: z.number().nullable().optional(),
+      }),
+    )
+    .nullable()
+    .optional()
+    .transform((v) => v ?? []),
   dataAsOf: z.string().nullable().optional(),
   smallCellMinN: z.number(),
   minNPerArm: z.number(),
@@ -1293,25 +1305,29 @@ export const adaptiveContentAdminReportSchema = z.object({
   killSwitch: z.boolean(),
   generationPaused: z.boolean(),
   queueDepth: z.number(),
-  courses: z.array(
-    z.object({
-      courseId: z.string(),
-      courseCode: z.string(),
-      title: z.string(),
-      nUnits: z.number(),
-      nActiveUnits: z.number(),
-      meanLiftVsControl: z.number().nullable().optional(),
-      nRegressing: z.number(),
-      nHelping: z.number(),
-      tokensUsedPeriod: z.number(),
-      monthlyTokenBudget: z.number(),
-      coveragePct: z.number(),
-      studentsServedVariant: z.number(),
-      disparityFlags: z.number(),
-      openContests: z.number(),
-      reportUrl: z.string(),
-    }),
-  ),
+  courses: z
+    .array(
+      z.object({
+        courseId: z.string(),
+        courseCode: z.string(),
+        title: z.string(),
+        nUnits: z.number(),
+        nActiveUnits: z.number(),
+        meanLiftVsControl: z.number().nullable().optional(),
+        nRegressing: z.number(),
+        nHelping: z.number(),
+        tokensUsedPeriod: z.number(),
+        monthlyTokenBudget: z.number(),
+        coveragePct: z.number(),
+        studentsServedVariant: z.number(),
+        disparityFlags: z.number(),
+        openContests: z.number(),
+        reportUrl: z.string(),
+      }),
+    )
+    .nullable()
+    .optional()
+    .transform((v) => v ?? []),
   dataAsOf: z.string().nullable().optional(),
   smallCellMinN: z.number(),
 })

--- a/clients/web/src/lib/courses-api-schemas.ts
+++ b/clients/web/src/lib/courses-api-schemas.ts
@@ -1230,6 +1230,92 @@ export const adaptiveContentFairnessSchema = z.object({
   fairnessMinN: z.number(),
 })
 
+/** AC.9 — instructor course report. */
+export const adaptiveContentCourseReportSchema = z.object({
+  courseId: z.string(),
+  courseCode: z.string(),
+  empty: z.boolean(),
+  coverage: z.object({
+    eligibleContentItems: z.number(),
+    adaptedUnits: z.number(),
+    coveragePct: z.number(),
+    studentsProfiled: z.number(),
+    studentsServedVariant: z.number(),
+    studentsHoldout: z.number(),
+  }),
+  meanLiftVsControl: z.number().nullable().optional(),
+  nUnits: z.number(),
+  nActiveUnits: z.number(),
+  nHelping: z.number(),
+  nRegressing: z.number(),
+  nInsufficient: z.number(),
+  nNoEffect: z.number(),
+  cost: z.object({
+    monthlyTokenBudget: z.number(),
+    tokensUsedPeriod: z.number(),
+    budgetRemaining: z.number().nullable().optional(),
+    unlimited: z.boolean(),
+    periodStart: z.string(),
+  }),
+  unitsToReview: z.array(
+    z.object({
+      unitId: z.string(),
+      reason: z.string(),
+      verdict: z.string(),
+      meanFidelity: z.number().nullable().optional(),
+      meanLift: z.number().nullable().optional(),
+      workspaceUrl: z.string(),
+    }),
+  ),
+  units: z.array(z.record(z.string(), z.unknown())),
+  byMode: z.array(
+    z.object({
+      emphasisMode: z.string(),
+      n: z.number(),
+      meanLift: z.number().nullable().optional(),
+    }),
+  ),
+  dataAsOf: z.string().nullable().optional(),
+  smallCellMinN: z.number(),
+  minNPerArm: z.number(),
+})
+
+/** AC.9 — admin org rollup. */
+export const adaptiveContentAdminReportSchema = z.object({
+  coursesUsingAce: z.number(),
+  studentsImpacted: z.number(),
+  costUsd30d: z.number(),
+  budgetHeadroomTokens: z.number(),
+  aggregateLift: z.number().nullable().optional(),
+  disparityFlags: z.number(),
+  openContests: z.number(),
+  regressingUnits: z.number(),
+  killSwitch: z.boolean(),
+  generationPaused: z.boolean(),
+  queueDepth: z.number(),
+  courses: z.array(
+    z.object({
+      courseId: z.string(),
+      courseCode: z.string(),
+      title: z.string(),
+      nUnits: z.number(),
+      nActiveUnits: z.number(),
+      meanLiftVsControl: z.number().nullable().optional(),
+      nRegressing: z.number(),
+      nHelping: z.number(),
+      tokensUsedPeriod: z.number(),
+      monthlyTokenBudget: z.number(),
+      coveragePct: z.number(),
+      studentsServedVariant: z.number(),
+      disparityFlags: z.number(),
+      openContests: z.number(),
+      reportUrl: z.string(),
+    }),
+  ),
+  dataAsOf: z.string().nullable().optional(),
+  smallCellMinN: z.number(),
+})
+
 export const cohortProfilesSchema = z.object({
   byEmphasis: z.array(
     z.object({

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -36,6 +36,8 @@ import {
   adaptiveContentContestsListSchema,
   adaptiveContentOversightSchema,
   adaptiveContentFairnessSchema,
+  adaptiveContentCourseReportSchema,
+  adaptiveContentAdminReportSchema,
   adaptationProfileSchema,
   cohortProfilesSchema,
   courseScopedRolesResponseSchema,
@@ -1623,6 +1625,68 @@ export async function fetchAdaptiveContentOversight(): Promise<AdaptiveContentOv
   const raw = await parseJson(res)
   if (!res.ok) throw new Error(readApiErrorMessage(raw))
   return parseApiResponse('fetchAdaptiveContentOversight', adaptiveContentOversightSchema, raw)
+}
+
+/** AC.9 — instructor Adaptive Content course report. */
+export async function fetchAdaptiveContentCourseReport(
+  courseCode: string,
+): Promise<AdaptiveContentCourseReport> {
+  const res = await authorizedFetch(
+    `/api/v1/courses/${encodeURIComponent(courseCode)}/adaptive-content/report`,
+  )
+  const raw = await parseJson(res)
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  const parsed = parseApiResponse(
+    'fetchAdaptiveContentCourseReport',
+    adaptiveContentCourseReportSchema,
+    raw,
+  )
+  return {
+    ...parsed,
+    units: (parsed.units as AdaptiveContentEffectiveness[]) ?? [],
+  }
+}
+
+/** AC.9 — download instructor report CSV (same suppression as on-screen). */
+export async function exportAdaptiveContentCourseReportCsv(courseCode: string): Promise<void> {
+  const res = await authorizedFetch(
+    `/api/v1/courses/${encodeURIComponent(courseCode)}/adaptive-content/report/export`,
+  )
+  if (!res.ok) {
+    const raw = await parseJson(res)
+    throw new Error(readApiErrorMessage(raw))
+  }
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `adaptive-content-report-${courseCode}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+/** AC.9 — admin org Adaptive Content report. */
+export async function fetchAdaptiveContentAdminReport(): Promise<AdaptiveContentAdminReport> {
+  const res = await authorizedFetch('/api/v1/admin/adaptive-content/report')
+  const raw = await parseJson(res)
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return parseApiResponse('fetchAdaptiveContentAdminReport', adaptiveContentAdminReportSchema, raw)
+}
+
+/** AC.9 — download admin org report CSV. */
+export async function exportAdaptiveContentAdminReportCsv(): Promise<void> {
+  const res = await authorizedFetch('/api/v1/admin/adaptive-content/report/export')
+  if (!res.ok) {
+    const raw = await parseJson(res)
+    throw new Error(readApiErrorMessage(raw))
+  }
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'adaptive-content-org-report.csv'
+  a.click()
+  URL.revokeObjectURL(url)
 }
 
 /** AC.8 — fairness audit cells for a course. */
@@ -3298,6 +3362,82 @@ export type AdaptiveContentOversight = {
   costUsd30d: number
   dpiaDocPath?: string
   aiActChecklistPath?: string
+}
+
+export type AdaptiveContentUnitToReview = {
+  unitId: string
+  reason: string
+  verdict: string
+  meanFidelity?: number | null
+  meanLift?: number | null
+  workspaceUrl: string
+}
+
+export type AdaptiveContentCourseReport = {
+  courseId: string
+  courseCode: string
+  empty: boolean
+  coverage: {
+    eligibleContentItems: number
+    adaptedUnits: number
+    coveragePct: number
+    studentsProfiled: number
+    studentsServedVariant: number
+    studentsHoldout: number
+  }
+  meanLiftVsControl?: number | null
+  nUnits: number
+  nActiveUnits: number
+  nHelping: number
+  nRegressing: number
+  nInsufficient: number
+  nNoEffect: number
+  cost: {
+    monthlyTokenBudget: number
+    tokensUsedPeriod: number
+    budgetRemaining?: number | null
+    unlimited: boolean
+    periodStart: string
+  }
+  unitsToReview: AdaptiveContentUnitToReview[]
+  units: AdaptiveContentEffectiveness[]
+  byMode: Array<{ emphasisMode: string; n: number; meanLift?: number | null }>
+  dataAsOf?: string | null
+  smallCellMinN: number
+  minNPerArm: number
+}
+
+export type AdaptiveContentAdminReport = {
+  coursesUsingAce: number
+  studentsImpacted: number
+  costUsd30d: number
+  budgetHeadroomTokens: number
+  aggregateLift?: number | null
+  disparityFlags: number
+  openContests: number
+  regressingUnits: number
+  killSwitch: boolean
+  generationPaused: boolean
+  queueDepth: number
+  courses: Array<{
+    courseId: string
+    courseCode: string
+    title: string
+    nUnits: number
+    nActiveUnits: number
+    meanLiftVsControl?: number | null
+    nRegressing: number
+    nHelping: number
+    tokensUsedPeriod: number
+    monthlyTokenBudget: number
+    coveragePct: number
+    studentsServedVariant: number
+    disparityFlags: number
+    openContests: number
+    reportUrl: string
+  }>
+  dataAsOf?: string | null
+  smallCellMinN: number
 }
 
 export type AdaptiveContentFairness = {

--- a/deploy/observability/grafana/dashboards/adaptive-content.json
+++ b/deploy/observability/grafana/dashboards/adaptive-content.json
@@ -1,0 +1,151 @@
+{
+  "uid": "lextures-adaptive-content",
+  "title": "Lextures — Adaptive Content Engine (AC.9)",
+  "tags": ["lextures", "ace", "adaptive-content"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Queue depth",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "targets": [{ "refId": "A", "expr": "lextures_adaptive_content_queue_depth", "legendFormat": "pending" }]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "In-flight jobs",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "targets": [{ "refId": "A", "expr": "lextures_adaptive_content_inflight", "legendFormat": "inflight" }]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Kill-switch",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "targets": [{ "refId": "A", "expr": "lextures_adaptive_content_kill_switch_engaged", "legendFormat": "engaged" }]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Courses enabled",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "targets": [{ "refId": "A", "expr": "lextures_adaptive_content_courses_enabled", "legendFormat": "courses" }]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Serve latency p95 (ms)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(lextures_adaptive_content_serve_latency_ms_bucket[5m])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Generation latency p95 (ms)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(lextures_adaptive_content_generate_ms_bucket[5m])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Cache hit vs miss rate",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(lextures_adaptive_content_cache_hit_total[5m]))",
+          "legendFormat": "hit"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(lextures_adaptive_content_cache_miss_total[5m]))",
+          "legendFormat": "miss"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Served outcomes (variant / base / holdout / fallback)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(lextures_adaptive_content_served_variant_total[5m]))", "legendFormat": "variant" },
+        { "refId": "B", "expr": "sum(rate(lextures_adaptive_content_served_base_total[5m]))", "legendFormat": "base" },
+        { "refId": "C", "expr": "sum(rate(lextures_adaptive_content_served_holdout_total[5m]))", "legendFormat": "holdout" },
+        { "refId": "D", "expr": "sum(rate(lextures_adaptive_content_served_fallback_total[5m]))", "legendFormat": "fallback" }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Gate rejections (fidelity / safety)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(lextures_adaptive_content_rejected_fidelity_total[5m]))", "legendFormat": "fidelity" },
+        { "refId": "B", "expr": "sum(rate(lextures_adaptive_content_rejected_safety_total[5m]))", "legendFormat": "safety" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Fidelity score distribution (rate)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(lextures_adaptive_content_fidelity_score_bucket[5m])) by (le)",
+          "legendFormat": "le={{le}}"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "SLO — generation success rate",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - (sum(rate(lextures_adaptive_content_job_retry_total[15m])) / clamp_min(sum(rate(lextures_adaptive_content_job_latency_ms_count[15m])), 1))",
+          "legendFormat": "success"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "SLO — adapted availability with base fallback",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(rate(lextures_adaptive_content_served_variant_total[15m])) + sum(rate(lextures_adaptive_content_served_base_total[15m])) + sum(rate(lextures_adaptive_content_served_holdout_total[15m])) + sum(rate(lextures_adaptive_content_served_fallback_total[15m]))) / clamp_min(sum(rate(lextures_adaptive_content_served_variant_total[15m])) + sum(rate(lextures_adaptive_content_served_base_total[15m])) + sum(rate(lextures_adaptive_content_served_holdout_total[15m])) + sum(rate(lextures_adaptive_content_served_fallback_total[15m])), 1)",
+          "legendFormat": "availability"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/observability/prometheus/alerts.yml
+++ b/deploy/observability/prometheus/alerts.yml
@@ -111,3 +111,105 @@ groups:
           summary: "Lextures API metrics target is down"
           description: "Prometheus cannot scrape {{ $labels.instance }} (/metrics unreachable for 2m)."
           runbook: "docs/runbooks/observability-oncall.md#apitargetdown"
+
+  # AC.9 — Adaptive Content Engine operability (FR-5).
+  - name: lextures-adaptive-content
+    rules:
+      - alert: ACEQueueDepthHigh
+        expr: lextures_adaptive_content_queue_depth > 100
+        for: 10m
+        labels:
+          severity: warning
+          statuspage_component: api
+        annotations:
+          summary: "ACE generation queue depth above 100"
+          description: "Adaptive content job queue depth is {{ $value }} (threshold 100 for 10m)."
+          runbook: "docs/runbooks/adaptive-content-operability.md#acequeuedepthhigh"
+
+      - alert: ACECacheHitRateLow
+        expr: |
+          sum(rate(lextures_adaptive_content_cache_hit_total[15m]))
+            /
+          clamp_min(
+            sum(rate(lextures_adaptive_content_cache_hit_total[15m]))
+              + sum(rate(lextures_adaptive_content_cache_miss_total[15m])),
+            1
+          ) < 0.5
+        for: 15m
+        labels:
+          severity: warning
+          statuspage_component: api
+        annotations:
+          summary: "ACE cache hit rate below 50%"
+          description: "Adaptive content cache hit rate is {{ $value | humanizePercentage }} over 15m (target ≥ 50%)."
+          runbook: "docs/runbooks/adaptive-content-operability.md#acecachehitratelow"
+
+      - alert: ACEGenerationRetryStorm
+        expr: sum(rate(lextures_adaptive_content_job_retry_total[5m])) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          statuspage_component: api
+        annotations:
+          summary: "ACE generation retry storm"
+          description: "Adaptive content job retries are {{ $value | humanize }} /s over 5m."
+          runbook: "docs/runbooks/adaptive-content-operability.md#acegenerationretrystorm"
+
+      - alert: ACEBudgetExhausted
+        expr: increase(lextures_adaptive_content_budget_exhausted_total[15m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          statuspage_component: api
+        annotations:
+          summary: "ACE monthly token budget exhausted"
+          description: "At least one adaptive content generation was skipped due to budget in the last 15m."
+          runbook: "docs/runbooks/adaptive-content-operability.md#acebudgetexhausted"
+
+      - alert: ACEFidelityRejectionSpike
+        expr: |
+          sum(rate(lextures_adaptive_content_rejected_fidelity_total[10m]))
+            /
+          clamp_min(sum(rate(lextures_adaptive_content_generated_total[10m])), 1)
+            > 0.25
+        for: 10m
+        labels:
+          severity: warning
+          statuspage_component: api
+        annotations:
+          summary: "ACE fidelity rejection rate above 25%"
+          description: "Fidelity gate rejection rate is {{ $value | humanizePercentage }} over 10m."
+          runbook: "docs/runbooks/adaptive-content-operability.md#acefidelityrejectionspike"
+
+      - alert: ACEUnitRegressing
+        expr: increase(lextures_adaptive_content_verdict_regressing_total[30m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          statuspage_component: api
+        annotations:
+          summary: "ACE unit verdict regressing"
+          description: "At least one adaptive content unit transitioned to verdict=regressing."
+          runbook: "docs/runbooks/adaptive-content-operability.md#aceunitregressing"
+
+      - alert: ACEDisparityFlag
+        expr: increase(lextures_adaptive_content_fairness_disparity_flag_total[30m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          statuspage_component: api
+        annotations:
+          summary: "ACE fairness disparity flag raised"
+          description: "Fairness audit flagged at least one disparity cell in the last 30m."
+          runbook: "docs/runbooks/adaptive-content-operability.md#acedisparityflag"
+
+      - alert: ACEKillSwitchEngaged
+        expr: lextures_adaptive_content_kill_switch_engaged == 1
+        for: 1m
+        labels:
+          severity: critical
+          statuspage_component: api
+        annotations:
+          summary: "ACE kill-switch engaged"
+          description: "Adaptive Content Engine kill-switch is engaged; generation and adapted serving are halted."
+          runbook: "docs/runbooks/adaptive-content-kill-switch.md"

--- a/docs/completed/adaptive/AC.9-analytics-reporting-and-operability.md
+++ b/docs/completed/adaptive/AC.9-analytics-reporting-and-operability.md
@@ -10,7 +10,7 @@
 | **Section** | Adaptive Content Engine (ACE) |
 | **Severity** | MAJOR |
 | **Markets** | K12 / HE / HS |
-| **Status (today)** | MISSING |
+| **Status (today)** | DONE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Data/analytics + frontend + SRE |
 | **Depends on** | AC.4 (cost/cache metrics), AC.7 (effectiveness aggregates) |
@@ -80,22 +80,24 @@ ACE now runs end-to-end, but its value and health are invisible: an instructor c
 
 ## 8. Data Model
 
-Reserves `447_adaptive_content_reports.sql`. Mostly views over AC.4/AC.7/AC.8 tables.
+Shipped as `448_adaptive_content_reports.sql` (447 was taken by AC.8 governance). Mostly views over AC.4/AC.7/AC.8 tables.
 
 ```sql
--- 447_adaptive_content_reports.sql
+-- 448_adaptive_content_reports.sql
 -- Course-level rollup (refreshed with AC.7 effectiveness).
 CREATE MATERIALIZED VIEW analytics.adaptive_content_course_report AS
 SELECT
     u.course_id,
-    COUNT(*)                                            AS n_units,
-    COUNT(*) FILTER (WHERE u.status = 'active')         AS n_active_units,
-    AVG(e.treatment_minus_holdout)                      AS mean_lift_vs_control,
-    COUNT(*) FILTER (WHERE e.verdict = 'helping')       AS n_helping,
-    COUNT(*) FILTER (WHERE e.verdict = 'regressing')    AS n_regressing,
-    COUNT(*) FILTER (WHERE e.verdict = 'insufficient_data') AS n_insufficient,
-    s.tokens_used_period,
-    s.monthly_token_budget
+    COUNT(*)::INTEGER                                            AS n_units,
+    COUNT(*) FILTER (WHERE u.status = 'active')::INTEGER         AS n_active_units,
+    AVG(e.treatment_minus_holdout)::REAL                         AS mean_lift_vs_control,
+    COUNT(*) FILTER (WHERE e.verdict = 'helping')::INTEGER       AS n_helping,
+    COUNT(*) FILTER (WHERE e.verdict = 'regressing')::INTEGER    AS n_regressing,
+    COUNT(*) FILTER (WHERE e.verdict = 'insufficient_data')::INTEGER AS n_insufficient,
+    COUNT(*) FILTER (WHERE e.verdict = 'no_effect')::INTEGER     AS n_no_effect,
+    COALESCE(s.tokens_used_period, 0)::BIGINT                    AS tokens_used_period,
+    COALESCE(s.monthly_token_budget, 0)::BIGINT                  AS monthly_token_budget,
+    NOW()                                                        AS refreshed_at
 FROM course.adaptive_content_units u
 LEFT JOIN analytics.adaptive_content_effectiveness e ON e.unit_id = u.id
 LEFT JOIN course.adaptive_content_settings s ON s.course_id = u.course_id
@@ -153,8 +155,8 @@ No model calls. This story reports on the AI system's behavior — including **f
 - `clients/web/src/lib/ai-reports-api.ts` (existing) — ACE cost slice.
 - `server/internal/httpserver/adaptive_content_reports.go` (new); `repos/adaptivecontent/reports.go`.
 - `clients/web/src/components/lms/adaptive-content/reports/*` — reuse chart primitives + `dataviz` conventions.
-- `server/migrations/447_adaptive_content_reports.sql` (+ down).
-- Related: [AC.4](../../completed/adaptive/AC.4-generation-pipeline-caching-cost.md), [AC.7](../../completed/adaptive/AC.7-post-assessment-and-effectiveness.md), [AC.8](AC.8-governance-safety-fairness-privacy.md).
+- `server/migrations/448_adaptive_content_reports.sql` (+ down).
+- Related: [AC.4](AC.4-generation-pipeline-caching-cost.md), [AC.7](AC.7-post-assessment-and-effectiveness.md), [AC.8](AC.8-governance-safety-fairness-privacy.md).
 
 ## 13. Dependencies & Sequencing
 

--- a/docs/completed/adaptive/README.md
+++ b/docs/completed/adaptive/README.md
@@ -12,3 +12,4 @@ Shipped ACE plans. Active backlog: [`docs/plan/adaptive/`](../../plan/adaptive/)
 | **AC.6** | [Student runtime experience & transparency](AC.6-student-runtime-and-transparency.md) | DONE |
 | **AC.7** | [Post-assessment, effectiveness & holdout experiments](AC.7-post-assessment-and-effectiveness.md) | DONE |
 | **AC.8** | [Governance, safety, fairness, privacy & compliance](AC.8-governance-safety-fairness-privacy.md) | DONE |
+| **AC.9** | [Analytics, reporting & operability](AC.9-analytics-reporting-and-operability.md) | DONE |

--- a/docs/plan/adaptive/README.md
+++ b/docs/plan/adaptive/README.md
@@ -71,7 +71,7 @@ feature be flagged at the course level and not at the global platform level. Ful
 | **AC.6** | [Student runtime experience & transparency](../../completed/adaptive/AC.6-student-runtime-and-transparency.md) ✅ | BLOCKER | AC.2, AC.3, AC.5 | Serving variants, "adapted for you" disclosure, opt-out, a11y |
 | **AC.7** | [Post-assessment, effectiveness & holdout experiments](../../completed/adaptive/AC.7-post-assessment-and-effectiveness.md) ✅ | BLOCKER | AC.2, AC.6 | Exit-ticket lift, mastery delta, control-group causal measurement |
 | **AC.8** | [Governance, safety, fairness & privacy](../../completed/adaptive/AC.8-governance-safety-fairness-privacy.md) ✅ | BLOCKER | AC.3 | AI disclosure, FERPA/COPPA/EU-AI-Act, bias audit, oversight, DSAR |
-| **AC.9** | [Analytics, reporting & operability](AC.9-analytics-reporting-and-operability.md) | MAJOR | AC.4, AC.7 | Instructor/admin dashboards, observability, alerts, rollout |
+| **AC.9** | [Analytics, reporting & operability](../../completed/adaptive/AC.9-analytics-reporting-and-operability.md) ✅ | MAJOR | AC.4, AC.7 | Instructor/admin dashboards, observability, alerts, rollout |
 
 ## Sequencing at a glance
 

--- a/docs/runbooks/adaptive-content-operability.md
+++ b/docs/runbooks/adaptive-content-operability.md
@@ -1,0 +1,84 @@
+# Runbook — Adaptive Content Operability (AC.9)
+
+SRE dashboards: Grafana → **Lextures — Adaptive Content Engine (AC.9)** (`deploy/observability/grafana/dashboards/adaptive-content.json`).
+
+Instructor report: Course settings → Adaptive content → **Report** tab.  
+Admin org rollup: Settings → AI governance → Adaptive content oversight / org report API.
+
+## Alerts
+
+### ACEQueueDepthHigh
+
+Pending `adaptive_content_jobs` > 100 for 10m.
+
+1. Check worker is running (`go run ./cmd/server` / API process with job workers).
+2. Inspect `lextures_adaptive_content_inflight` and generation pause (`GET /api/v1/admin/adaptive-content`).
+3. Look for `ACEGenerationRetryStorm` or provider errors on the AI Provider dashboard.
+4. Optionally pause generation: `PATCH /api/v1/admin/adaptive-content` `{ "generationPaused": true }`.
+
+### ACECacheHitRateLow
+
+Cache hit/(hit+miss) < 50% for 15m.
+
+1. Check for mass content-version bumps (base edits) causing regenerations.
+2. Confirm prewarm is running for active units.
+3. Review holdout % — high holdout reduces adapted cache usefulness but should not tank hit rate alone.
+
+### ACEGenerationRetryStorm
+
+Job retries > 0.5/s for 10m.
+
+1. Check AI provider error rate (`lextures_ai_provider_calls_total{outcome="error"}`).
+2. Verify rate limiter / budget not thrashing.
+3. Inspect dead-letter / cancelled jobs in `course.adaptive_content_jobs`.
+
+### ACEBudgetExhausted
+
+Budget-skip counter increased in the last 15m.
+
+1. Identify course(s) via instructor budget meter / `ai_usage_log` (`feature=adaptive_content`).
+2. Raise `monthlyTokenBudget` or wait for period rollover.
+3. Pause generation if spend is unexpected.
+
+### ACEFidelityRejectionSpike
+
+Fidelity rejects / generations > 25% for 10m.
+
+1. Sample rejected variants in the review queue.
+2. Check prompt/key-term changes and model routing.
+3. Quarantine a unit if quality is unsafe: `POST /api/v1/admin/adaptive-content/quarantine`.
+
+### ACEUnitRegressing
+
+A unit transitioned to `verdict=regressing` (AC.7).
+
+1. Open the instructor report → Units to review (regressing first).
+2. Review variants / pause the unit; consider quarantine.
+3. Link methodology: AC.7 effectiveness docs.
+
+### ACEDisparityFlag
+
+Fairness audit raised a disparity flag (AC.8).
+
+1. `GET /api/v1/admin/adaptive-content/fairness?course=…`
+2. Follow [adaptive-content-governance.md](adaptive-content-governance.md).
+
+### ACEKillSwitchEngaged
+
+See [adaptive-content-kill-switch.md](adaptive-content-kill-switch.md).
+
+## SLOs (GA)
+
+| SLO | Target | Panel |
+|---|---|---|
+| Serve latency p95 | ≤ 50 ms resolution (page still dominated by content fetch) | Serve latency p95 |
+| Adapted availability with base fallback | ≥ 99.9% of serve decisions return content | SLO — adapted availability |
+| Generation success (non-retry) | ≥ 95% over 15m | SLO — generation success rate |
+| Report read p95 | ≤ 300 ms from caches | API route group for `/adaptive-content/report` |
+
+## Refresh-job health
+
+- Effectiveness: `scheduled.adaptive_content_effectiveness` → also refreshes coverage + course report matview (AC.9).
+- Fairness: `scheduled.adaptive_content_fairness`.
+- Instructor on-demand: `POST …/effectiveness/refresh`.
+- Report “data as of” timestamp comes from the latest coverage/matview refresh.

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -4200,6 +4200,33 @@
       }
     },
     {
+      "id": "AC.9",
+      "path": "docs/completed/adaptive/AC.9-analytics-reporting-and-operability.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "major",
+      "client": "web",
+      "coverage": "smoke",
+      "rationale": "Instructor report + CSV export, student authz deny, admin org rollup drill-down, and Report tab UI; deeper chart a11y and alert drills remain ops/manual.",
+      "owner": "Learning Platform",
+      "specs": [
+        {
+          "path": "e2e/tests/adaptive-content-reports.spec.ts"
+        }
+      ],
+      "reviewed": true,
+      "flags": {
+        "settingsToggle": "n/a",
+        "disabledState": "n/a",
+        "enabledJourney": true,
+        "authorization": true,
+        "dependency": true,
+        "rollback": false,
+        "notes": "Depends on course adaptiveContentEnabled + AC.7 caches; student denied report; admin report gated by PERM_RBAC_MANAGE."
+      }
+    },
+    {
       "id": "node-code-test-runner",
       "path": "docs/completed/agent-grader/node-code-test-runner.md",
       "markets": [

--- a/e2e/tests/adaptive-content-reports.spec.ts
+++ b/e2e/tests/adaptive-content-reports.spec.ts
@@ -46,10 +46,17 @@ async function apiCreateAdaptiveUnit(
 }
 
 function bootstrapGlobalAdmin(email: string) {
+  const databaseURL =
+    process.env.DATABASE_URL ??
+    'postgres://studydrift:studydrift@localhost:5432/studydrift?sslmode=disable'
   execSync(`go run ./cmd/bootstrap-admin -email=${email}`, {
     cwd: path.join(repoRoot, 'server'),
     stdio: 'pipe',
-    env: { ...process.env, PATH: `/usr/local/go/bin:${process.env.PATH ?? ''}` },
+    env: {
+      ...process.env,
+      PATH: `/usr/local/go/bin:${process.env.PATH ?? ''}`,
+      DATABASE_URL: databaseURL,
+    },
   })
 }
 

--- a/e2e/tests/adaptive-content-reports.spec.ts
+++ b/e2e/tests/adaptive-content-reports.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * AC.9 — Analytics, reporting & operability.
+ *
+ * Checklist:
+ *   [x] Instructor report empty/KPI surface + CSV export
+ *   [x] Student denied report (403)
+ *   [x] Admin org report + drill-down link
+ *   [x] Report tab visible in workspace UI
+ */
+import { execSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test, expect, injectToken, uniqueEmail } from '../fixtures/test.js'
+import {
+  apiCreateContentPage,
+  apiCreateTimedQuiz,
+  apiLogin,
+  apiPatchCourseFeatures,
+  apiSignup,
+} from '../fixtures/api.js'
+
+const apiBase = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const ADMIN_PASSWORD = 'E2eTestPass1!LongRandomAceReports'
+
+async function apiCreateAdaptiveUnit(
+  token: string,
+  courseCode: string,
+  body: Record<string, unknown>,
+): Promise<{ id: string }> {
+  const res = await fetch(
+    `${apiBase}/api/v1/courses/${encodeURIComponent(courseCode)}/adaptive-content/units`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    },
+  )
+  if (!res.ok) {
+    throw new Error(`Create ACE unit failed (${res.status}): ${await res.text()}`)
+  }
+  return res.json() as Promise<{ id: string }>
+}
+
+function bootstrapGlobalAdmin(email: string) {
+  execSync(`go run ./cmd/bootstrap-admin -email=${email}`, {
+    cwd: path.join(repoRoot, 'server'),
+    stdio: 'pipe',
+    env: { ...process.env, PATH: `/usr/local/go/bin:${process.env.PATH ?? ''}` },
+  })
+}
+
+test.describe('Adaptive content reports (AC.9)', () => {
+  test('API: instructor report + CSV; student denied; admin org report', async ({
+    seededCourse,
+  }) => {
+    await apiPatchCourseFeatures(seededCourse.instructorToken, seededCourse.courseCode, {
+      adaptiveContentEnabled: true,
+    })
+
+    const page = await apiCreateContentPage(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      seededCourse.moduleId,
+      'ACE Report Content',
+    )
+    const pre = await apiCreateTimedQuiz(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      seededCourse.moduleId,
+      10,
+    )
+    const post = await apiCreateTimedQuiz(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      seededCourse.moduleId,
+      10,
+    )
+    await apiCreateAdaptiveUnit(seededCourse.instructorToken, seededCourse.courseCode, {
+      targetKind: 'module',
+      targetModuleItemId: seededCourse.moduleId,
+      baseContentItemId: page.id,
+      preAssessmentItemId: pre.id,
+      postAssessmentItemId: post.id,
+      allowedAxes: ['emphasis'],
+      status: 'active',
+      triggerMode: 'pre_quiz',
+    })
+
+    await fetch(
+      `${apiBase}/api/v1/courses/${encodeURIComponent(seededCourse.courseCode)}/adaptive-content/effectiveness/refresh`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${seededCourse.instructorToken}` },
+      },
+    )
+
+    const reportRes = await fetch(
+      `${apiBase}/api/v1/courses/${encodeURIComponent(seededCourse.courseCode)}/adaptive-content/report`,
+      { headers: { Authorization: `Bearer ${seededCourse.instructorToken}` } },
+    )
+    expect(reportRes.status).toBe(200)
+    const report = (await reportRes.json()) as {
+      empty: boolean
+      nUnits: number
+      coverage: { eligibleContentItems: number }
+      unitsToReview: unknown[]
+      cost: { tokensUsedPeriod: number }
+    }
+    expect(report.nUnits).toBeGreaterThanOrEqual(1)
+    expect(report.coverage.eligibleContentItems).toBeGreaterThanOrEqual(1)
+    expect(Array.isArray(report.unitsToReview)).toBe(true)
+
+    const exportRes = await fetch(
+      `${apiBase}/api/v1/courses/${encodeURIComponent(seededCourse.courseCode)}/adaptive-content/report/export`,
+      { headers: { Authorization: `Bearer ${seededCourse.instructorToken}` } },
+    )
+    expect(exportRes.status).toBe(200)
+    expect(exportRes.headers.get('content-type') ?? '').toContain('text/csv')
+    const csv = await exportRes.text()
+    expect(csv).toContain('section')
+    expect(csv).toContain('summary')
+
+    const studentRes = await fetch(
+      `${apiBase}/api/v1/courses/${encodeURIComponent(seededCourse.courseCode)}/adaptive-content/report`,
+      { headers: { Authorization: `Bearer ${seededCourse.studentToken}` } },
+    )
+    expect(studentRes.status).toBe(403)
+
+    const adminEmail = uniqueEmail('ace-report-admin')
+    await apiSignup({
+      email: adminEmail,
+      password: ADMIN_PASSWORD,
+      displayName: 'ACE Report Admin',
+    })
+    try {
+      bootstrapGlobalAdmin(adminEmail)
+    } catch (err) {
+      test.skip(true, `bootstrap unavailable: ${err}`)
+    }
+    const { access_token: adminToken } = await apiLogin({
+      email: adminEmail,
+      password: ADMIN_PASSWORD,
+    })
+
+    const adminReportRes = await fetch(`${apiBase}/api/v1/admin/adaptive-content/report`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(adminReportRes.status).toBe(200)
+    const adminReport = (await adminReportRes.json()) as {
+      coursesUsingAce: number
+      courses: Array<{ courseCode: string; reportUrl: string }>
+    }
+    expect(adminReport.coursesUsingAce).toBeGreaterThanOrEqual(1)
+    const row = adminReport.courses.find((c) => c.courseCode === seededCourse.courseCode)
+    expect(row?.reportUrl).toContain('tab=report')
+
+    const adminExport = await fetch(`${apiBase}/api/v1/admin/adaptive-content/report/export`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(adminExport.status).toBe(200)
+    expect(await adminExport.text()).toContain('courses_using_ace')
+  })
+
+  test('UI: instructor report tab shows KPIs or empty state', async ({ page, seededCourse }) => {
+    await apiPatchCourseFeatures(seededCourse.instructorToken, seededCourse.courseCode, {
+      adaptiveContentEnabled: true,
+    })
+    await injectToken(page, seededCourse.instructorToken)
+    await page.goto(
+      `/courses/${encodeURIComponent(seededCourse.courseCode)}/settings/adaptive-content?tab=report`,
+    )
+    await expect(page.getByTestId('ace-report-tab')).toBeVisible()
+    await page.getByTestId('ace-report-tab').click()
+    await expect(
+      page.getByTestId('ace-course-report').or(page.getByTestId('ace-report-empty')),
+    ).toBeVisible({ timeout: 15000 })
+  })
+})

--- a/server/internal/httpserver/adaptive_content_nodb_test.go
+++ b/server/internal/httpserver/adaptive_content_nodb_test.go
@@ -243,3 +243,32 @@ func TestAdaptiveContent_OversightRoute_Registered_NoDB(t *testing.T) {
 		t.Fatalf("oversight route not registered: %d", rr.Code)
 	}
 }
+
+func TestAdaptiveContent_CourseReportRoute_Registered_NoDB(t *testing.T) {
+	d := Deps{}
+	r := chi.NewRouter()
+	d.registerAdaptiveContentRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/demo/adaptive-content/report", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code == http.StatusNotFound {
+		t.Fatalf("course report route not registered: %d", rr.Code)
+	}
+}
+
+func TestAdaptiveContent_AdminReportRoute_Registered_NoDB(t *testing.T) {
+	d := Deps{}
+	r := chi.NewRouter()
+	d.registerAdaptiveContentRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/adaptive-content/report", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code == http.StatusNotFound {
+		t.Fatalf("admin report route not registered: %d", rr.Code)
+	}
+	if rr.Code == http.StatusOK {
+		t.Fatalf("expected auth gate on admin report, got 200")
+	}
+}

--- a/server/internal/httpserver/adaptive_content_reports.go
+++ b/server/internal/httpserver/adaptive_content_reports.go
@@ -1,0 +1,124 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	acsvc "github.com/lextures/lextures/server/internal/service/adaptivecontent"
+)
+
+func (d Deps) registerAdaptiveContentReportRoutes(r chi.Router) {
+	r.Get("/api/v1/courses/{course_code}/adaptive-content/report", d.handleAdaptiveContentCourseReportGet())
+	r.Get("/api/v1/courses/{course_code}/adaptive-content/report/export", d.handleAdaptiveContentCourseReportExport())
+	r.Get("/api/v1/admin/adaptive-content/report", d.handleAdminAdaptiveContentReportGet())
+	r.Get("/api/v1/admin/adaptive-content/report/export", d.handleAdminAdaptiveContentReportExport())
+}
+
+// handleAdaptiveContentCourseReportGet is GET .../adaptive-content/report (instructor, AC.9 FR-1).
+func (d Deps) handleAdaptiveContentCourseReportGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseItemCreate(w, r)
+		if !ok {
+			return
+		}
+		cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+			return
+		}
+		if cid == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+			return
+		}
+		report, err := acsvc.BuildCourseReport(r.Context(), d.Pool, *cid, courseCode)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load Adaptive Content report.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(report)
+	}
+}
+
+// handleAdaptiveContentCourseReportExport is GET .../adaptive-content/report/export (CSV, AC.9 FR-3).
+func (d Deps) handleAdaptiveContentCourseReportExport() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseItemCreate(w, r)
+		if !ok {
+			return
+		}
+		cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+			return
+		}
+		if cid == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+			return
+		}
+		report, err := acsvc.BuildCourseReport(r.Context(), d.Pool, *cid, courseCode)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load Adaptive Content report.")
+			return
+		}
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		w.Header().Set("Content-Disposition", `attachment; filename="adaptive-content-report-`+courseCode+`.csv"`)
+		if err := acsvc.WriteCourseReportCSV(w, report); err != nil {
+			// Headers may already be flushed; best-effort log via status if possible.
+			return
+		}
+	}
+}
+
+// handleAdminAdaptiveContentReportGet is GET /api/v1/admin/adaptive-content/report (AC.9 FR-2).
+func (d Deps) handleAdminAdaptiveContentReportGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		report, err := acsvc.BuildAdminReport(r.Context(), d.Pool)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load Adaptive Content org report.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(report)
+	}
+}
+
+// handleAdminAdaptiveContentReportExport is GET /api/v1/admin/adaptive-content/report/export (CSV).
+func (d Deps) handleAdminAdaptiveContentReportExport() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		report, err := acsvc.BuildAdminReport(r.Context(), d.Pool)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load Adaptive Content org report.")
+			return
+		}
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		w.Header().Set("Content-Disposition", `attachment; filename="adaptive-content-org-report.csv"`)
+		_ = acsvc.WriteAdminReportCSV(w, report)
+	}
+}

--- a/server/internal/httpserver/adaptive_content_settings.go
+++ b/server/internal/httpserver/adaptive_content_settings.go
@@ -40,6 +40,8 @@ func (d Deps) registerAdaptiveContentRoutes(r chi.Router) {
 	d.registerAdaptiveContentEffectivenessRoutes(r)
 	// AC.8
 	d.registerAdaptiveContentGovernanceRoutes(r)
+	// AC.9
+	d.registerAdaptiveContentReportRoutes(r)
 }
 
 func writeACEKillSwitch(w http.ResponseWriter) {

--- a/server/internal/models/adaptivecontent/types.go
+++ b/server/internal/models/adaptivecontent/types.go
@@ -1,4 +1,4 @@
-// Package adaptivecontent holds JSON shapes for Adaptive Content Engine HTTP APIs (plans AC.1–AC.8).
+// Package adaptivecontent holds JSON shapes for Adaptive Content Engine HTTP APIs (plans AC.1–AC.9).
 package adaptivecontent
 
 import (
@@ -494,4 +494,99 @@ type QuarantineRequest struct {
 // KillSwitchRequest is POST /api/v1/admin/adaptive-content/kill-switch.
 type KillSwitchRequest struct {
 	Engage bool `json:"engage"`
+}
+
+// CourseReportCoverage is coverage KPIs for the instructor Adaptive Content report (AC.9).
+type CourseReportCoverage struct {
+	EligibleContentItems  int     `json:"eligibleContentItems"`
+	AdaptedUnits          int     `json:"adaptedUnits"`
+	CoveragePct           float64 `json:"coveragePct"`
+	StudentsProfiled      int     `json:"studentsProfiled"`
+	StudentsServedVariant int     `json:"studentsServedVariant"`
+	StudentsHoldout       int     `json:"studentsHoldout"`
+}
+
+// CourseReportCost is budget/spend for the instructor report (AC.9 / AC.4).
+type CourseReportCost struct {
+	MonthlyTokenBudget int64  `json:"monthlyTokenBudget"`
+	TokensUsedPeriod   int64  `json:"tokensUsedPeriod"`
+	BudgetRemaining    *int64 `json:"budgetRemaining"`
+	Unlimited          bool   `json:"unlimited"`
+	PeriodStart        string `json:"periodStart"`
+}
+
+// UnitToReview is a ranked unit needing instructor attention (AC.9).
+type UnitToReview struct {
+	UnitID       uuid.UUID `json:"unitId"`
+	Reason       string    `json:"reason"` // regressing | low_fidelity | insufficient_data
+	Verdict      string    `json:"verdict"`
+	MeanFidelity *float32  `json:"meanFidelity,omitempty"`
+	MeanLift     *float32  `json:"meanLift,omitempty"`
+	WorkspaceURL string    `json:"workspaceUrl"`
+}
+
+// ModeBreakdown is effectiveness aggregated by emphasis mode across the course (AC.9).
+type ModeBreakdown struct {
+	EmphasisMode string   `json:"emphasisMode"`
+	N            int      `json:"n"`
+	MeanLift     *float32 `json:"meanLift"`
+}
+
+// CourseReportResponse is GET .../adaptive-content/report (AC.9 FR-1).
+type CourseReportResponse struct {
+	CourseID           uuid.UUID              `json:"courseId"`
+	CourseCode         string                 `json:"courseCode"`
+	Empty              bool                   `json:"empty"`
+	Coverage           CourseReportCoverage   `json:"coverage"`
+	MeanLiftVsControl  *float32               `json:"meanLiftVsControl"`
+	NUnits             int                    `json:"nUnits"`
+	NActiveUnits       int                    `json:"nActiveUnits"`
+	NHelping           int                    `json:"nHelping"`
+	NRegressing        int                    `json:"nRegressing"`
+	NInsufficient      int                    `json:"nInsufficient"`
+	NNoEffect          int                    `json:"nNoEffect"`
+	Cost               CourseReportCost       `json:"cost"`
+	UnitsToReview      []UnitToReview         `json:"unitsToReview"`
+	Units              []UnitEffectiveness    `json:"units"`
+	ByMode             []ModeBreakdown        `json:"byMode"`
+	DataAsOf           *time.Time             `json:"dataAsOf,omitempty"`
+	SmallCellMinN      int                    `json:"smallCellMinN"`
+	MinNPerArm         int                    `json:"minNPerArm"`
+}
+
+// AdminReportCourse is one course drill-down row in the org rollup (AC.9 FR-2).
+type AdminReportCourse struct {
+	CourseID              uuid.UUID `json:"courseId"`
+	CourseCode            string    `json:"courseCode"`
+	Title                 string    `json:"title"`
+	NUnits                int       `json:"nUnits"`
+	NActiveUnits          int       `json:"nActiveUnits"`
+	MeanLiftVsControl     *float32  `json:"meanLiftVsControl"`
+	NRegressing           int       `json:"nRegressing"`
+	NHelping              int       `json:"nHelping"`
+	TokensUsedPeriod      int64     `json:"tokensUsedPeriod"`
+	MonthlyTokenBudget    int64     `json:"monthlyTokenBudget"`
+	CoveragePct           float64   `json:"coveragePct"`
+	StudentsServedVariant int       `json:"studentsServedVariant"`
+	DisparityFlags        int64     `json:"disparityFlags"`
+	OpenContests          int64     `json:"openContests"`
+	ReportURL             string    `json:"reportUrl"`
+}
+
+// AdminReportResponse is GET /api/v1/admin/adaptive-content/report (AC.9 FR-2).
+type AdminReportResponse struct {
+	CoursesUsingACE       int64               `json:"coursesUsingAce"`
+	StudentsImpacted      int64               `json:"studentsImpacted"`
+	CostUSD30d            float64             `json:"costUsd30d"`
+	BudgetHeadroomTokens  int64               `json:"budgetHeadroomTokens"`
+	AggregateLift         *float32            `json:"aggregateLift"`
+	DisparityFlags        int64               `json:"disparityFlags"`
+	OpenContests          int64               `json:"openContests"`
+	RegressingUnits       int64               `json:"regressingUnits"`
+	KillSwitch            bool                `json:"killSwitch"`
+	GenerationPaused      bool                `json:"generationPaused"`
+	QueueDepth            int64               `json:"queueDepth"`
+	Courses               []AdminReportCourse `json:"courses"`
+	DataAsOf              *time.Time          `json:"dataAsOf,omitempty"`
+	SmallCellMinN         int                 `json:"smallCellMinN"`
 }

--- a/server/internal/repos/adaptivecontent/reports.go
+++ b/server/internal/repos/adaptivecontent/reports.go
@@ -164,7 +164,7 @@ SELECT
      FROM course.adaptation_servings s
      INNER JOIN course.adaptive_content_units u ON u.id = s.unit_id
      WHERE u.course_id = $1
-       AND s.served_variant_id IS NOT NULL
+       AND s.variant_id IS NOT NULL
        AND COALESCE(s.was_holdout, FALSE) = FALSE
        AND COALESCE(s.was_fallback, FALSE) = FALSE),
   (SELECT COUNT(DISTINCT s.enrollment_id)::INTEGER

--- a/server/internal/repos/adaptivecontent/reports.go
+++ b/server/internal/repos/adaptivecontent/reports.go
@@ -1,0 +1,330 @@
+package adaptivecontent
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CourseReportRollupRow is analytics.adaptive_content_course_report.
+type CourseReportRollupRow struct {
+	CourseID           uuid.UUID
+	NUnits             int
+	NActiveUnits       int
+	MeanLiftVsControl  *float32
+	NHelping           int
+	NRegressing        int
+	NInsufficient      int
+	NNoEffect          int
+	TokensUsedPeriod   int64
+	MonthlyTokenBudget int64
+	RefreshedAt        time.Time
+}
+
+// CoverageRow is analytics.adaptive_content_coverage.
+type CoverageRow struct {
+	CourseID               uuid.UUID
+	EligibleContentItems   int
+	AdaptedUnits           int
+	StudentsProfiled       int
+	StudentsServedVariant  int
+	StudentsHoldout        int
+	RefreshedAt            time.Time
+}
+
+// UnitFidelityRow is mean fidelity for a unit's ready variants (AC.9 units-to-review).
+type UnitFidelityRow struct {
+	UnitID       uuid.UUID
+	MeanFidelity *float32
+	MinFidelity  float64
+	NVariants    int
+}
+
+// AdminCourseRollupRow is one course row in the admin org report drill-down.
+type AdminCourseRollupRow struct {
+	CourseID              uuid.UUID
+	CourseCode            string
+	Title                 string
+	NUnits                int
+	NActiveUnits          int
+	MeanLiftVsControl     *float32
+	NRegressing           int
+	NHelping              int
+	TokensUsedPeriod      int64
+	MonthlyTokenBudget    int64
+	EligibleContentItems  int
+	AdaptedUnits          int
+	StudentsProfiled      int
+	StudentsServedVariant int
+	StudentsHoldout       int
+	DisparityFlags        int64
+	OpenContests          int64
+	CoverageRefreshedAt   *time.Time
+	ReportRefreshedAt     *time.Time
+}
+
+// RefreshCourseReportMaterializedView refreshes the AC.9 course report matview.
+func RefreshCourseReportMaterializedView(ctx context.Context, pool *pgxpool.Pool) error {
+	if pool == nil {
+		return errors.New("adaptivecontent: nil pool")
+	}
+	_, err := pool.Exec(ctx, `REFRESH MATERIALIZED VIEW CONCURRENTLY analytics.adaptive_content_course_report`)
+	return err
+}
+
+// GetCourseReportRollup returns the cached course rollup, or nil when missing.
+func GetCourseReportRollup(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (*CourseReportRollupRow, error) {
+	var r CourseReportRollupRow
+	err := pool.QueryRow(ctx, `
+SELECT course_id, n_units, n_active_units, mean_lift_vs_control,
+       n_helping, n_regressing, n_insufficient, n_no_effect,
+       tokens_used_period, monthly_token_budget, refreshed_at
+FROM analytics.adaptive_content_course_report
+WHERE course_id = $1
+`, courseID).Scan(
+		&r.CourseID, &r.NUnits, &r.NActiveUnits, &r.MeanLiftVsControl,
+		&r.NHelping, &r.NRegressing, &r.NInsufficient, &r.NNoEffect,
+		&r.TokensUsedPeriod, &r.MonthlyTokenBudget, &r.RefreshedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// UpsertCoverage writes a coverage snapshot for a course.
+func UpsertCoverage(ctx context.Context, pool *pgxpool.Pool, row CoverageRow) error {
+	_, err := pool.Exec(ctx, `
+INSERT INTO analytics.adaptive_content_coverage (
+  course_id, eligible_content_items, adapted_units,
+  students_profiled, students_served_variant, students_holdout, refreshed_at
+) VALUES ($1, $2, $3, $4, $5, $6, NOW())
+ON CONFLICT (course_id) DO UPDATE SET
+  eligible_content_items = EXCLUDED.eligible_content_items,
+  adapted_units = EXCLUDED.adapted_units,
+  students_profiled = EXCLUDED.students_profiled,
+  students_served_variant = EXCLUDED.students_served_variant,
+  students_holdout = EXCLUDED.students_holdout,
+  refreshed_at = NOW()
+`, row.CourseID, row.EligibleContentItems, row.AdaptedUnits,
+		row.StudentsProfiled, row.StudentsServedVariant, row.StudentsHoldout)
+	return err
+}
+
+// GetCoverage returns the coverage snapshot, or nil when missing.
+func GetCoverage(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (*CoverageRow, error) {
+	var r CoverageRow
+	err := pool.QueryRow(ctx, `
+SELECT course_id, eligible_content_items, adapted_units,
+       students_profiled, students_served_variant, students_holdout, refreshed_at
+FROM analytics.adaptive_content_coverage
+WHERE course_id = $1
+`, courseID).Scan(
+		&r.CourseID, &r.EligibleContentItems, &r.AdaptedUnits,
+		&r.StudentsProfiled, &r.StudentsServedVariant, &r.StudentsHoldout, &r.RefreshedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// ComputeCoverageSnapshot aggregates live coverage facts for a course (not served to clients directly).
+func ComputeCoverageSnapshot(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (CoverageRow, error) {
+	var r CoverageRow
+	r.CourseID = courseID
+	err := pool.QueryRow(ctx, `
+SELECT
+  (SELECT COUNT(DISTINCT base_content_item_id)::INTEGER
+     FROM course.adaptive_content_units WHERE course_id = $1),
+  (SELECT COUNT(*)::INTEGER
+     FROM course.adaptive_content_units u
+     WHERE u.course_id = $1
+       AND EXISTS (
+         SELECT 1 FROM course.content_variants v
+         WHERE v.unit_id = u.id
+           AND v.status IN ('approved', 'auto_served')
+           AND v.content_version = u.content_version
+       )),
+  (SELECT COUNT(DISTINCT p.enrollment_id)::INTEGER
+     FROM course.adaptation_profiles p
+     INNER JOIN course.adaptive_content_units u ON u.id = p.unit_id
+     WHERE u.course_id = $1),
+  (SELECT COUNT(DISTINCT s.enrollment_id)::INTEGER
+     FROM course.adaptation_servings s
+     INNER JOIN course.adaptive_content_units u ON u.id = s.unit_id
+     WHERE u.course_id = $1
+       AND s.served_variant_id IS NOT NULL
+       AND COALESCE(s.was_holdout, FALSE) = FALSE
+       AND COALESCE(s.was_fallback, FALSE) = FALSE),
+  (SELECT COUNT(DISTINCT s.enrollment_id)::INTEGER
+     FROM course.adaptation_servings s
+     INNER JOIN course.adaptive_content_units u ON u.id = s.unit_id
+     WHERE u.course_id = $1 AND COALESCE(s.was_holdout, FALSE) = TRUE)
+`, courseID).Scan(
+		&r.EligibleContentItems, &r.AdaptedUnits,
+		&r.StudentsProfiled, &r.StudentsServedVariant, &r.StudentsHoldout,
+	)
+	if err != nil {
+		return r, err
+	}
+	r.RefreshedAt = time.Now().UTC()
+	return r, nil
+}
+
+// RefreshCoverageForCourse recomputes and upserts coverage for one course.
+func RefreshCoverageForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) error {
+	snap, err := ComputeCoverageSnapshot(ctx, pool, courseID)
+	if err != nil {
+		return err
+	}
+	return UpsertCoverage(ctx, pool, snap)
+}
+
+// ListUnitMeanFidelity returns mean fidelity of ready variants per unit in a course.
+func ListUnitMeanFidelity(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) ([]UnitFidelityRow, error) {
+	rows, err := pool.Query(ctx, `
+SELECT u.id, u.min_fidelity,
+       AVG(v.fidelity_score)::REAL AS mean_fidelity,
+       COUNT(v.id)::INTEGER AS n_variants
+FROM course.adaptive_content_units u
+LEFT JOIN course.content_variants v
+  ON v.unit_id = u.id
+ AND v.status IN ('approved', 'auto_served', 'pending_review')
+ AND v.content_version = u.content_version
+WHERE u.course_id = $1
+GROUP BY u.id, u.min_fidelity
+`, courseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UnitFidelityRow
+	for rows.Next() {
+		var r UnitFidelityRow
+		if err := rows.Scan(&r.UnitID, &r.MinFidelity, &r.MeanFidelity, &r.NVariants); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// CountEnabledACECourses returns courses with adaptive_content_enabled.
+func CountEnabledACECourses(ctx context.Context, pool *pgxpool.Pool) (int64, error) {
+	var n int64
+	err := pool.QueryRow(ctx, `
+SELECT COUNT(*) FROM course.courses WHERE adaptive_content_enabled = TRUE
+`).Scan(&n)
+	return n, err
+}
+
+// SumCoverageStudentsImpacted returns sum of students_served_variant across coverage rows.
+func SumCoverageStudentsImpacted(ctx context.Context, pool *pgxpool.Pool) (int64, error) {
+	var n int64
+	err := pool.QueryRow(ctx, `
+SELECT COALESCE(SUM(students_served_variant), 0)
+FROM analytics.adaptive_content_coverage
+`).Scan(&n)
+	return n, err
+}
+
+// SumBudgetHeadroomTokens returns remaining tokens across courses with a finite monthly budget.
+// Unlimited (budget=0) courses contribute 0 headroom.
+func SumBudgetHeadroomTokens(ctx context.Context, pool *pgxpool.Pool) (int64, error) {
+	var n int64
+	err := pool.QueryRow(ctx, `
+SELECT COALESCE(SUM(
+  CASE
+    WHEN monthly_token_budget <= 0 THEN 0
+    WHEN monthly_token_budget > tokens_used_period
+      THEN monthly_token_budget - tokens_used_period
+    ELSE 0
+  END
+), 0)
+FROM course.adaptive_content_settings s
+INNER JOIN course.courses c ON c.id = s.course_id
+WHERE c.adaptive_content_enabled = TRUE
+`).Scan(&n)
+	return n, err
+}
+
+// MeanAggregateLiftVsControl averages treatment_minus_holdout across effectiveness cache.
+func MeanAggregateLiftVsControl(ctx context.Context, pool *pgxpool.Pool) (*float32, error) {
+	var v *float32
+	err := pool.QueryRow(ctx, `
+SELECT AVG(treatment_minus_holdout)::REAL
+FROM analytics.adaptive_content_effectiveness
+WHERE treatment_minus_holdout IS NOT NULL
+`).Scan(&v)
+	return v, err
+}
+
+// ListAdminCourseRollups returns per-course drill-down rows for the org report.
+func ListAdminCourseRollups(ctx context.Context, pool *pgxpool.Pool, limit int) ([]AdminCourseRollupRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := pool.Query(ctx, `
+SELECT c.id, c.course_code, c.title,
+       COALESCE(r.n_units, 0), COALESCE(r.n_active_units, 0), r.mean_lift_vs_control,
+       COALESCE(r.n_regressing, 0), COALESCE(r.n_helping, 0),
+       COALESCE(r.tokens_used_period, s.tokens_used_period, 0),
+       COALESCE(r.monthly_token_budget, s.monthly_token_budget, 0),
+       COALESCE(cov.eligible_content_items, 0), COALESCE(cov.adapted_units, 0),
+       COALESCE(cov.students_profiled, 0), COALESCE(cov.students_served_variant, 0),
+       COALESCE(cov.students_holdout, 0),
+       COALESCE(f.disparity_flags, 0),
+       COALESCE(ct.open_contests, 0),
+       cov.refreshed_at, r.refreshed_at
+FROM course.courses c
+LEFT JOIN analytics.adaptive_content_course_report r ON r.course_id = c.id
+LEFT JOIN analytics.adaptive_content_coverage cov ON cov.course_id = c.id
+LEFT JOIN course.adaptive_content_settings s ON s.course_id = c.id
+LEFT JOIN LATERAL (
+  SELECT COUNT(*)::BIGINT AS disparity_flags
+  FROM analytics.adaptive_content_fairness af
+  WHERE af.course_id = c.id AND af.disparity_flag = TRUE
+) f ON TRUE
+LEFT JOIN LATERAL (
+  SELECT COUNT(*)::BIGINT AS open_contests
+  FROM course.adaptive_content_contests ac
+  WHERE ac.course_id = c.id AND ac.status = 'open'
+) ct ON TRUE
+WHERE c.adaptive_content_enabled = TRUE
+ORDER BY COALESCE(r.n_regressing, 0) DESC, COALESCE(f.disparity_flags, 0) DESC, c.course_code ASC
+LIMIT $1
+`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AdminCourseRollupRow
+	for rows.Next() {
+		var r AdminCourseRollupRow
+		if err := rows.Scan(
+			&r.CourseID, &r.CourseCode, &r.Title,
+			&r.NUnits, &r.NActiveUnits, &r.MeanLiftVsControl,
+			&r.NRegressing, &r.NHelping,
+			&r.TokensUsedPeriod, &r.MonthlyTokenBudget,
+			&r.EligibleContentItems, &r.AdaptedUnits,
+			&r.StudentsProfiled, &r.StudentsServedVariant, &r.StudentsHoldout,
+			&r.DisparityFlags, &r.OpenContests,
+			&r.CoverageRefreshedAt, &r.ReportRefreshedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/server/internal/service/adaptivecontent/effectiveness.go
+++ b/server/internal/service/adaptivecontent/effectiveness.go
@@ -570,6 +570,10 @@ func RefreshCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, 
 		}
 		n++
 	}
+	// AC.9: keep coverage + course report matview in sync with effectiveness refresh.
+	if err := RefreshCourseReport(ctx, pool, courseID); err != nil {
+		slog.Warn("adaptivecontent: course report refresh failed", "course_id", courseID, "err", err)
+	}
 	return n, nil
 }
 

--- a/server/internal/service/adaptivecontent/generate.go
+++ b/server/internal/service/adaptivecontent/generate.go
@@ -10,9 +10,11 @@ import (
 	"unicode/utf8"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/lextures/lextures/server/internal/service/aiprovider"
 	"github.com/lextures/lextures/server/internal/service/contentpagegeneration"
+	"github.com/lextures/lextures/server/internal/telemetry"
 )
 
 // Prompt keys and versions.
@@ -154,6 +156,8 @@ func GenerateVariant(
 	client aiprovider.ScopedCompleter,
 	in GenerateInput,
 ) (Variant, aiprovider.CallMeta, error) {
+	ctx, span := telemetry.Tracer("adaptivecontent").Start(ctx, "adaptivecontent.generate")
+	defer span.End()
 	start := time.Now()
 	defer func() {
 		ObserveGenerate(float64(time.Since(start).Milliseconds()))
@@ -310,6 +314,8 @@ func GenerateVariant(
 	}
 
 	// Gate decision (FR-4 / FR-5 / AC.8 FR-2).
+	_, gateSpan := telemetry.Tracer("adaptivecontent").Start(ctx, "adaptivecontent.gate_check")
+	gateSpan.SetAttributes(attribute.Float64("ace.fidelity_score", fid.Score))
 	if len(safetyFlags) > 0 {
 		v.Status = "rejected"
 		v.Fallback = true
@@ -317,6 +323,8 @@ func GenerateVariant(
 		v.SafetyFlags = append(v.SafetyFlags, fid.Flags...)
 		IncRejectedSafety()
 		IncGenerated("rejected_safety")
+		gateSpan.SetAttributes(attribute.String("ace.gate_result", "rejected_safety"))
+		gateSpan.End()
 		return v, meta, ErrRejectedSafety
 	}
 	if !fid.HardPass || fid.Score < minFid {
@@ -326,8 +334,12 @@ func GenerateVariant(
 		v.SafetyFlags = append(v.SafetyFlags, fid.Flags...)
 		IncRejectedFidelity()
 		IncGenerated("rejected_fidelity")
+		gateSpan.SetAttributes(attribute.String("ace.gate_result", "rejected_fidelity"))
+		gateSpan.End()
 		return v, meta, ErrRejectedFidelity
 	}
+	gateSpan.SetAttributes(attribute.String("ace.gate_result", "pass"))
+	gateSpan.End()
 	// Blocking a11y flags prevent auto-serve; force pending_review (or reject when
 	// instructor approval is not available and policy is strict). AC.8 enforces at serve time too.
 	if HasBlockingA11yFlag(a11yFlags) {

--- a/server/internal/service/adaptivecontent/pipeline.go
+++ b/server/internal/service/adaptivecontent/pipeline.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/userai"
 	"github.com/lextures/lextures/server/internal/service/aiprovider"
 	coppasvc "github.com/lextures/lextures/server/internal/service/coppa"
+	"github.com/lextures/lextures/server/internal/telemetry"
 )
 
 // Job priority bands (higher = preferred at claim).
@@ -299,6 +300,8 @@ func (d WorkerDeps) RunOnce(ctx context.Context) (processed int) {
 }
 
 func (d WorkerDeps) processJob(ctx context.Context, job acrepo.JobRow) {
+	ctx, span := telemetry.Tracer("adaptivecontent").Start(ctx, "adaptivecontent.pipeline.process_job")
+	defer span.End()
 	start := time.Now()
 	defer func() {
 		ObserveJobLatency(float64(time.Since(start).Milliseconds()))
@@ -372,7 +375,9 @@ func (d WorkerDeps) processJob(ctx context.Context, job acrepo.JobRow) {
 		return
 	}
 
-	profile := d.profileForJob(ctx, *unit, job.ProfileSignature)
+	profileCtx, profileSpan := telemetry.Tracer("adaptivecontent").Start(ctx, "adaptivecontent.profile")
+	profile := d.profileForJob(profileCtx, *unit, job.ProfileSignature)
+	profileSpan.End()
 	if profile.IsNeutral || profile.ProfileSignature == NeutralSignature {
 		_ = acrepo.CompleteJob(ctx, d.Pool, job.ID, d.now())
 		return
@@ -427,7 +432,9 @@ func (d WorkerDeps) processJob(ctx context.Context, job acrepo.JobRow) {
 		BudgetExhausted:           false,
 	}
 
-	variant, callMeta, genErr := GenerateVariant(ctx, d.Client, genIn)
+	genCtx, genSpan := telemetry.Tracer("adaptivecontent").Start(ctx, "adaptivecontent.cache_generate")
+	variant, callMeta, genErr := GenerateVariant(genCtx, d.Client, genIn)
+	genSpan.End()
 
 	// Log usage when the model was involved.
 	tokens := int64(variant.PromptTokens + variant.CompletionTokens)

--- a/server/internal/service/adaptivecontent/reports.go
+++ b/server/internal/service/adaptivecontent/reports.go
@@ -1,0 +1,555 @@
+package adaptivecontent
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	acmodel "github.com/lextures/lextures/server/internal/models/adaptivecontent"
+	acrepo "github.com/lextures/lextures/server/internal/repos/adaptivecontent"
+)
+
+// Review reason labels for units-to-review ranking (AC.9 FR-1).
+const (
+	ReviewReasonRegressing      = "regressing"
+	ReviewReasonLowFidelity     = "low_fidelity"
+	ReviewReasonInsufficientData = "insufficient_data"
+)
+
+// RefreshCourseReport refreshes coverage + course report matview for one course (AC.9).
+func RefreshCourseReport(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) error {
+	if pool == nil {
+		return nil
+	}
+	if err := acrepo.RefreshCoverageForCourse(ctx, pool, courseID); err != nil {
+		return err
+	}
+	if err := acrepo.RefreshCourseReportMaterializedView(ctx, pool); err != nil {
+		// Concurrent refresh can fail on empty/first populate — fall back to non-concurrent.
+		if _, err2 := pool.Exec(ctx, `REFRESH MATERIALIZED VIEW analytics.adaptive_content_course_report`); err2 != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RefreshAllCourseReports refreshes coverage for every ACE-enabled course and the matview.
+func RefreshAllCourseReports(ctx context.Context, pool *pgxpool.Pool) error {
+	if pool == nil {
+		return nil
+	}
+	ids, err := acrepo.ListCourseIDsWithAdaptiveContentEnabled(ctx, pool)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := acrepo.RefreshCoverageForCourse(ctx, pool, id); err != nil {
+			slog.Error("adaptivecontent: coverage refresh failed", "course_id", id, "err", err)
+		}
+	}
+	if err := acrepo.RefreshCourseReportMaterializedView(ctx, pool); err != nil {
+		if _, err2 := pool.Exec(ctx, `REFRESH MATERIALIZED VIEW analytics.adaptive_content_course_report`); err2 != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func coveragePct(adapted, eligible int) float64 {
+	if eligible <= 0 {
+		return 0
+	}
+	return float64(adapted) / float64(eligible) * 100
+}
+
+func mapUnitEffectiveness(
+	cache *acrepo.EffectivenessCacheRow,
+	modes []acrepo.ModeEffectivenessRow,
+	variants []acrepo.VariantEffectivenessRow,
+	unitID uuid.UUID,
+) acmodel.UnitEffectiveness {
+	out := acmodel.UnitEffectiveness{
+		UnitID:        unitID,
+		Verdict:       VerdictInsufficientData,
+		ByMode:        []acmodel.ModeEffectiveness{},
+		ByVariant:     []acmodel.VariantEffectiveness{},
+		SmallCellMinN: SmallCellMinN,
+		MinNPerArm:    MinNPerArm,
+	}
+	if cache != nil {
+		out.NTreatment = cache.NTreatment
+		out.NHoldout = cache.NHoldout
+		out.MeanLiftTreatment = cache.MeanLiftTreatment
+		out.MeanLiftHoldout = cache.MeanLiftHoldout
+		out.TreatmentMinusHoldout = cache.TreatmentMinusHoldout
+		out.DiffStdError = cache.DiffStdError
+		out.MeanMasteryDeltaTreatment = cache.MeanMasteryDeltaTreatment
+		out.MeanMasteryDeltaHoldout = cache.MeanMasteryDeltaHoldout
+		out.Verdict = cache.Verdict
+		t := cache.RefreshedAt
+		out.RefreshedAt = &t
+	}
+	for _, m := range modes {
+		out.ByMode = append(out.ByMode, acmodel.ModeEffectiveness{
+			EmphasisMode: m.EmphasisMode,
+			N:            m.N,
+			MeanLift:     m.MeanLift,
+		})
+	}
+	for _, v := range variants {
+		out.ByVariant = append(out.ByVariant, acmodel.VariantEffectiveness{
+			VariantID: v.VariantID,
+			N:         v.N,
+			MeanLift:  v.MeanLift,
+		})
+	}
+	return out
+}
+
+func rankUnitsToReview(
+	courseCode string,
+	units []acmodel.UnitEffectiveness,
+	fidelity []acrepo.UnitFidelityRow,
+) []acmodel.UnitToReview {
+	fidByUnit := make(map[uuid.UUID]acrepo.UnitFidelityRow, len(fidelity))
+	for _, f := range fidelity {
+		fidByUnit[f.UnitID] = f
+	}
+	var out []acmodel.UnitToReview
+	seen := make(map[uuid.UUID]bool)
+	workspaceBase := "/courses/" + courseCode + "/settings/adaptive-content"
+
+	// 1) Regressing first.
+	for _, u := range units {
+		if u.Verdict != VerdictRegressing {
+			continue
+		}
+		out = append(out, acmodel.UnitToReview{
+			UnitID:       u.UnitID,
+			Reason:       ReviewReasonRegressing,
+			Verdict:      u.Verdict,
+			MeanLift:     u.TreatmentMinusHoldout,
+			WorkspaceURL: workspaceBase + "?unit=" + u.UnitID.String(),
+		})
+		seen[u.UnitID] = true
+	}
+	// 2) Low fidelity (mean fidelity below unit min when variants exist).
+	for _, f := range fidelity {
+		if seen[f.UnitID] || f.NVariants == 0 || f.MeanFidelity == nil {
+			continue
+		}
+		if float64(*f.MeanFidelity) >= f.MinFidelity {
+			continue
+		}
+		verdict := VerdictInsufficientData
+		var lift *float32
+		for _, u := range units {
+			if u.UnitID == f.UnitID {
+				verdict = u.Verdict
+				lift = u.TreatmentMinusHoldout
+				break
+			}
+		}
+		mf := *f.MeanFidelity
+		out = append(out, acmodel.UnitToReview{
+			UnitID:       f.UnitID,
+			Reason:       ReviewReasonLowFidelity,
+			Verdict:      verdict,
+			MeanFidelity: &mf,
+			MeanLift:     lift,
+			WorkspaceURL: workspaceBase + "?unit=" + f.UnitID.String(),
+		})
+		seen[f.UnitID] = true
+	}
+	// 3) Insufficient data (units with cache rows).
+	for _, u := range units {
+		if seen[u.UnitID] || u.Verdict != VerdictInsufficientData {
+			continue
+		}
+		out = append(out, acmodel.UnitToReview{
+			UnitID:       u.UnitID,
+			Reason:       ReviewReasonInsufficientData,
+			Verdict:      u.Verdict,
+			MeanLift:     u.TreatmentMinusHoldout,
+			WorkspaceURL: workspaceBase + "?unit=" + u.UnitID.String(),
+		})
+		seen[u.UnitID] = true
+	}
+	return out
+}
+
+func aggregateModes(units []acmodel.UnitEffectiveness) []acmodel.ModeBreakdown {
+	type acc struct {
+		n    int
+		sum  float64
+		has  bool
+	}
+	by := map[string]*acc{}
+	for _, u := range units {
+		for _, m := range u.ByMode {
+			a := by[m.EmphasisMode]
+			if a == nil {
+				a = &acc{}
+				by[m.EmphasisMode] = a
+			}
+			a.n += m.N
+			if m.MeanLift != nil && m.N >= SmallCellMinN {
+				a.sum += float64(*m.MeanLift) * float64(m.N)
+				a.has = true
+			}
+		}
+	}
+	keys := make([]string, 0, len(by))
+	for k := range by {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]acmodel.ModeBreakdown, 0, len(keys))
+	for _, k := range keys {
+		a := by[k]
+		row := acmodel.ModeBreakdown{EmphasisMode: k, N: a.n}
+		if a.has && a.n >= SmallCellMinN {
+			v := float32(a.sum / float64(a.n))
+			row.MeanLift = &v
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// BuildCourseReport assembles the instructor Adaptive Content report from caches (AC.9 FR-1/FR-7).
+func BuildCourseReport(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, courseCode string) (acmodel.CourseReportResponse, error) {
+	out := acmodel.CourseReportResponse{
+		CourseID:      courseID,
+		CourseCode:    courseCode,
+		Empty:         true,
+		UnitsToReview: []acmodel.UnitToReview{},
+		Units:         []acmodel.UnitEffectiveness{},
+		ByMode:        []acmodel.ModeBreakdown{},
+		SmallCellMinN: SmallCellMinN,
+		MinNPerArm:    MinNPerArm,
+		Cost: acmodel.CourseReportCost{
+			Unlimited: true,
+			PeriodStart: func() string {
+				now := time.Now().UTC()
+				return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+			}(),
+		},
+	}
+
+	unitsRows, err := acrepo.ListUnits(ctx, pool, courseID)
+	if err != nil {
+		return out, err
+	}
+	out.NUnits = len(unitsRows)
+	for _, u := range unitsRows {
+		if u.Status == "active" {
+			out.NActiveUnits++
+		}
+	}
+
+	rollup, err := acrepo.GetCourseReportRollup(ctx, pool, courseID)
+	if err != nil {
+		return out, err
+	}
+	if rollup != nil {
+		out.NUnits = rollup.NUnits
+		out.NActiveUnits = rollup.NActiveUnits
+		out.MeanLiftVsControl = rollup.MeanLiftVsControl
+		out.NHelping = rollup.NHelping
+		out.NRegressing = rollup.NRegressing
+		out.NInsufficient = rollup.NInsufficient
+		out.NNoEffect = rollup.NNoEffect
+		t := rollup.RefreshedAt
+		out.DataAsOf = &t
+		out.Cost.TokensUsedPeriod = rollup.TokensUsedPeriod
+		out.Cost.MonthlyTokenBudget = rollup.MonthlyTokenBudget
+	}
+
+	cov, err := acrepo.GetCoverage(ctx, pool, courseID)
+	if err != nil {
+		return out, err
+	}
+	if cov != nil {
+		out.Coverage = acmodel.CourseReportCoverage{
+			EligibleContentItems:  cov.EligibleContentItems,
+			AdaptedUnits:          cov.AdaptedUnits,
+			CoveragePct:           coveragePct(cov.AdaptedUnits, cov.EligibleContentItems),
+			StudentsProfiled:      cov.StudentsProfiled,
+			StudentsServedVariant: cov.StudentsServedVariant,
+			StudentsHoldout:       cov.StudentsHoldout,
+		}
+		if out.DataAsOf == nil || cov.RefreshedAt.After(*out.DataAsOf) {
+			t := cov.RefreshedAt
+			out.DataAsOf = &t
+		}
+	}
+
+	settings, err := acrepo.GetSettings(ctx, pool, courseID)
+	if err != nil {
+		return out, err
+	}
+	if settings == nil {
+		def := acrepo.DefaultSettings(courseID)
+		settings = &def
+	}
+	out.Cost.MonthlyTokenBudget = settings.MonthlyTokenBudget
+	out.Cost.TokensUsedPeriod = settings.TokensUsedPeriod
+	if settings.BudgetPeriodStart != nil {
+		out.Cost.PeriodStart = settings.BudgetPeriodStart.UTC().Format("2006-01-02")
+	} else {
+		now := time.Now().UTC()
+		out.Cost.PeriodStart = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+	}
+	if settings.MonthlyTokenBudget <= 0 {
+		out.Cost.Unlimited = true
+		out.Cost.BudgetRemaining = nil
+	} else {
+		out.Cost.Unlimited = false
+		rem := settings.MonthlyTokenBudget - settings.TokensUsedPeriod
+		if rem < 0 {
+			rem = 0
+		}
+		out.Cost.BudgetRemaining = &rem
+	}
+
+	caches, err := acrepo.ListEffectivenessForCourse(ctx, pool, courseID)
+	if err != nil {
+		return out, err
+	}
+	units := make([]acmodel.UnitEffectiveness, 0, len(caches))
+	for i := range caches {
+		c := caches[i]
+		modes, err := acrepo.ListModeEffectiveness(ctx, pool, c.UnitID)
+		if err != nil {
+			return out, err
+		}
+		variants, err := acrepo.ListVariantEffectiveness(ctx, pool, c.UnitID)
+		if err != nil {
+			return out, err
+		}
+		units = append(units, mapUnitEffectiveness(&c, modes, variants, c.UnitID))
+	}
+	out.Units = units
+	out.ByMode = aggregateModes(units)
+
+	fid, err := acrepo.ListUnitMeanFidelity(ctx, pool, courseID)
+	if err != nil {
+		return out, err
+	}
+	out.UnitsToReview = rankUnitsToReview(courseCode, units, fid)
+
+	out.Empty = out.NUnits == 0 &&
+		out.Coverage.StudentsProfiled == 0 &&
+		out.Coverage.StudentsServedVariant == 0 &&
+		len(out.Units) == 0
+
+	return out, nil
+}
+
+// WriteCourseReportCSV streams the instructor report as CSV (AC.9 FR-3).
+func WriteCourseReportCSV(w io.Writer, report acmodel.CourseReportResponse) error {
+	cw := csv.NewWriter(w)
+	_ = cw.Write([]string{
+		"section", "unit_id", "verdict", "reason", "n_treatment", "n_holdout",
+		"treatment_minus_holdout", "mean_lift", "emphasis_mode", "n", "mean_fidelity",
+		"coverage_pct", "students_served_variant", "tokens_used_period", "monthly_token_budget",
+		"data_as_of",
+	})
+	asOf := ""
+	if report.DataAsOf != nil {
+		asOf = report.DataAsOf.UTC().Format(time.RFC3339)
+	}
+	liftStr := ""
+	if report.MeanLiftVsControl != nil {
+		liftStr = fmt.Sprintf("%g", *report.MeanLiftVsControl)
+	}
+	_ = cw.Write([]string{
+		"summary", "", "", "", "", "",
+		liftStr, "", "", "", "",
+		fmt.Sprintf("%g", report.Coverage.CoveragePct),
+		fmt.Sprintf("%d", report.Coverage.StudentsServedVariant),
+		fmt.Sprintf("%d", report.Cost.TokensUsedPeriod),
+		fmt.Sprintf("%d", report.Cost.MonthlyTokenBudget),
+		asOf,
+	})
+	for _, u := range report.UnitsToReview {
+		ml := ""
+		if u.MeanLift != nil {
+			ml = fmt.Sprintf("%g", *u.MeanLift)
+		}
+		mf := ""
+		if u.MeanFidelity != nil {
+			mf = fmt.Sprintf("%g", *u.MeanFidelity)
+		}
+		_ = cw.Write([]string{
+			"units_to_review", u.UnitID.String(), u.Verdict, u.Reason, "", "",
+			ml, "", "", "", mf, "", "", "", "", asOf,
+		})
+	}
+	for _, u := range report.Units {
+		tmh := ""
+		if u.TreatmentMinusHoldout != nil {
+			// Preserve small-cell suppression: omit when either arm below min.
+			if u.NTreatment >= SmallCellMinN && u.NHoldout >= SmallCellMinN {
+				tmh = fmt.Sprintf("%g", *u.TreatmentMinusHoldout)
+			}
+		}
+		_ = cw.Write([]string{
+			"unit", u.UnitID.String(), u.Verdict, "",
+			fmt.Sprintf("%d", u.NTreatment), fmt.Sprintf("%d", u.NHoldout),
+			tmh, "", "", "", "", "", "", "", "", asOf,
+		})
+		for _, m := range u.ByMode {
+			ml := ""
+			if m.MeanLift != nil && m.N >= SmallCellMinN {
+				ml = fmt.Sprintf("%g", *m.MeanLift)
+			}
+			_ = cw.Write([]string{
+				"mode", u.UnitID.String(), "", "", "", "",
+				"", ml, m.EmphasisMode, fmt.Sprintf("%d", m.N), "",
+				"", "", "", "", asOf,
+			})
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// BuildAdminReport assembles the org-wide Adaptive Content rollup (AC.9 FR-2).
+func BuildAdminReport(ctx context.Context, pool *pgxpool.Pool) (acmodel.AdminReportResponse, error) {
+	out := acmodel.AdminReportResponse{
+		Courses:       []acmodel.AdminReportCourse{},
+		SmallCellMinN: SmallCellMinN,
+		KillSwitch:    KillSwitchEngaged(),
+	}
+	SyncDurableKillSwitchFromDB(ctx, pool)
+	out.KillSwitch = KillSwitchEngaged()
+
+	var err error
+	out.CoursesUsingACE, err = acrepo.CountEnabledACECourses(ctx, pool)
+	if err != nil {
+		return out, err
+	}
+	out.StudentsImpacted, err = acrepo.SumCoverageStudentsImpacted(ctx, pool)
+	if err != nil {
+		return out, err
+	}
+	out.CostUSD30d, err = acrepo.SumAdaptiveContentCostUSD(ctx, pool)
+	if err != nil {
+		return out, err
+	}
+	out.BudgetHeadroomTokens, err = acrepo.SumBudgetHeadroomTokens(ctx, pool)
+	if err != nil {
+		return out, err
+	}
+	out.AggregateLift, err = acrepo.MeanAggregateLiftVsControl(ctx, pool)
+	if err != nil {
+		return out, err
+	}
+	out.DisparityFlags, err = acrepo.CountDisparityFlags(ctx, pool, nil)
+	if err != nil {
+		return out, err
+	}
+	out.OpenContests, err = acrepo.CountOpenContestsPlatform(ctx, pool)
+	if err != nil {
+		return out, err
+	}
+	out.RegressingUnits, err = acrepo.CountRegressingUnits(ctx, pool)
+	if err != nil {
+		return out, err
+	}
+	out.GenerationPaused, _ = acrepo.GetPlatformGenerationPaused(ctx, pool)
+	out.QueueDepth, _ = acrepo.CountPendingJobs(ctx, pool)
+
+	rows, err := acrepo.ListAdminCourseRollups(ctx, pool, 200)
+	if err != nil {
+		return out, err
+	}
+	var latest *time.Time
+	for _, r := range rows {
+		pct := coveragePct(r.AdaptedUnits, r.EligibleContentItems)
+		out.Courses = append(out.Courses, acmodel.AdminReportCourse{
+			CourseID:              r.CourseID,
+			CourseCode:            r.CourseCode,
+			Title:                 r.Title,
+			NUnits:                r.NUnits,
+			NActiveUnits:          r.NActiveUnits,
+			MeanLiftVsControl:     r.MeanLiftVsControl,
+			NRegressing:           r.NRegressing,
+			NHelping:              r.NHelping,
+			TokensUsedPeriod:      r.TokensUsedPeriod,
+			MonthlyTokenBudget:    r.MonthlyTokenBudget,
+			CoveragePct:           pct,
+			StudentsServedVariant: r.StudentsServedVariant,
+			DisparityFlags:        r.DisparityFlags,
+			OpenContests:          r.OpenContests,
+			ReportURL:             "/courses/" + r.CourseCode + "/settings/adaptive-content?tab=report",
+		})
+		if r.ReportRefreshedAt != nil && (latest == nil || r.ReportRefreshedAt.After(*latest)) {
+			t := *r.ReportRefreshedAt
+			latest = &t
+		}
+		if r.CoverageRefreshedAt != nil && (latest == nil || r.CoverageRefreshedAt.After(*latest)) {
+			t := *r.CoverageRefreshedAt
+			latest = &t
+		}
+	}
+	out.DataAsOf = latest
+	return out, nil
+}
+
+// WriteAdminReportCSV streams the admin org report as CSV (AC.9 FR-3).
+func WriteAdminReportCSV(w io.Writer, report acmodel.AdminReportResponse) error {
+	cw := csv.NewWriter(w)
+	_ = cw.Write([]string{
+		"section", "course_code", "title", "n_units", "n_active_units",
+		"mean_lift_vs_control", "n_regressing", "n_helping",
+		"coverage_pct", "students_served_variant", "tokens_used_period",
+		"monthly_token_budget", "disparity_flags", "open_contests",
+		"courses_using_ace", "students_impacted", "cost_usd_30d",
+		"budget_headroom_tokens", "aggregate_lift", "kill_switch", "data_as_of",
+	})
+	asOf := ""
+	if report.DataAsOf != nil {
+		asOf = report.DataAsOf.UTC().Format(time.RFC3339)
+	}
+	agg := ""
+	if report.AggregateLift != nil {
+		agg = fmt.Sprintf("%g", *report.AggregateLift)
+	}
+	_ = cw.Write([]string{
+		"summary", "", "", "", "",
+		"", fmt.Sprintf("%d", report.RegressingUnits), "",
+		"", fmt.Sprintf("%d", report.StudentsImpacted), "",
+		"", fmt.Sprintf("%d", report.DisparityFlags), fmt.Sprintf("%d", report.OpenContests),
+		fmt.Sprintf("%d", report.CoursesUsingACE), fmt.Sprintf("%d", report.StudentsImpacted),
+		fmt.Sprintf("%g", report.CostUSD30d),
+		fmt.Sprintf("%d", report.BudgetHeadroomTokens), agg,
+		fmt.Sprintf("%t", report.KillSwitch), asOf,
+	})
+	for _, c := range report.Courses {
+		ml := ""
+		if c.MeanLiftVsControl != nil {
+			ml = fmt.Sprintf("%g", *c.MeanLiftVsControl)
+		}
+		_ = cw.Write([]string{
+			"course", c.CourseCode, c.Title,
+			fmt.Sprintf("%d", c.NUnits), fmt.Sprintf("%d", c.NActiveUnits),
+			ml, fmt.Sprintf("%d", c.NRegressing), fmt.Sprintf("%d", c.NHelping),
+			fmt.Sprintf("%g", c.CoveragePct), fmt.Sprintf("%d", c.StudentsServedVariant),
+			fmt.Sprintf("%d", c.TokensUsedPeriod), fmt.Sprintf("%d", c.MonthlyTokenBudget),
+			fmt.Sprintf("%d", c.DisparityFlags), fmt.Sprintf("%d", c.OpenContests),
+			"", "", "", "", "", "", asOf,
+		})
+	}
+	cw.Flush()
+	return cw.Error()
+}

--- a/server/internal/service/adaptivecontent/reports.go
+++ b/server/internal/service/adaptivecontent/reports.go
@@ -122,7 +122,7 @@ func rankUnitsToReview(
 	for _, f := range fidelity {
 		fidByUnit[f.UnitID] = f
 	}
-	var out []acmodel.UnitToReview
+	out := make([]acmodel.UnitToReview, 0)
 	seen := make(map[uuid.UUID]bool)
 	workspaceBase := "/courses/" + courseCode + "/settings/adaptive-content"
 
@@ -338,13 +338,39 @@ func BuildCourseReport(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UU
 		units = append(units, mapUnitEffectiveness(&c, modes, variants, c.UnitID))
 	}
 	out.Units = units
+	if out.Units == nil {
+		out.Units = []acmodel.UnitEffectiveness{}
+	}
 	out.ByMode = aggregateModes(units)
+	if out.ByMode == nil {
+		out.ByMode = []acmodel.ModeBreakdown{}
+	}
 
 	fid, err := acrepo.ListUnitMeanFidelity(ctx, pool, courseID)
 	if err != nil {
 		return out, err
 	}
 	out.UnitsToReview = rankUnitsToReview(courseCode, units, fid)
+	if out.UnitsToReview == nil {
+		out.UnitsToReview = []acmodel.UnitToReview{}
+	}
+
+	// Self-heal coverage when the snapshot was never refreshed (first report open).
+	if cov == nil && out.NUnits > 0 {
+		if snap, err := acrepo.ComputeCoverageSnapshot(ctx, pool, courseID); err == nil {
+			_ = acrepo.UpsertCoverage(ctx, pool, snap)
+			out.Coverage = acmodel.CourseReportCoverage{
+				EligibleContentItems:  snap.EligibleContentItems,
+				AdaptedUnits:          snap.AdaptedUnits,
+				CoveragePct:           coveragePct(snap.AdaptedUnits, snap.EligibleContentItems),
+				StudentsProfiled:      snap.StudentsProfiled,
+				StudentsServedVariant: snap.StudentsServedVariant,
+				StudentsHoldout:       snap.StudentsHoldout,
+			}
+			t := snap.RefreshedAt
+			out.DataAsOf = &t
+		}
+	}
 
 	out.Empty = out.NUnits == 0 &&
 		out.Coverage.StudentsProfiled == 0 &&
@@ -426,7 +452,7 @@ func WriteCourseReportCSV(w io.Writer, report acmodel.CourseReportResponse) erro
 // BuildAdminReport assembles the org-wide Adaptive Content rollup (AC.9 FR-2).
 func BuildAdminReport(ctx context.Context, pool *pgxpool.Pool) (acmodel.AdminReportResponse, error) {
 	out := acmodel.AdminReportResponse{
-		Courses:       []acmodel.AdminReportCourse{},
+		Courses:       make([]acmodel.AdminReportCourse, 0),
 		SmallCellMinN: SmallCellMinN,
 		KillSwitch:    KillSwitchEngaged(),
 	}

--- a/server/internal/service/adaptivecontent/reports_test.go
+++ b/server/internal/service/adaptivecontent/reports_test.go
@@ -1,0 +1,107 @@
+package adaptivecontent
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	acmodel "github.com/lextures/lextures/server/internal/models/adaptivecontent"
+	acrepo "github.com/lextures/lextures/server/internal/repos/adaptivecontent"
+)
+
+func TestRankUnitsToReview_RegressingFirst(t *testing.T) {
+	u1 := uuid.New()
+	u2 := uuid.New()
+	u3 := uuid.New()
+	liftNeg := float32(-8)
+	liftPos := float32(6)
+	lowFid := float32(0.5)
+	units := []acmodel.UnitEffectiveness{
+		{UnitID: u1, Verdict: VerdictInsufficientData, TreatmentMinusHoldout: &liftPos},
+		{UnitID: u2, Verdict: VerdictRegressing, TreatmentMinusHoldout: &liftNeg},
+		{UnitID: u3, Verdict: VerdictHelping, TreatmentMinusHoldout: &liftPos},
+	}
+	fid := []acrepo.UnitFidelityRow{
+		{UnitID: u3, MeanFidelity: &lowFid, MinFidelity: 0.85, NVariants: 2},
+	}
+	out := rankUnitsToReview("DEMO", units, fid)
+	if len(out) < 2 {
+		t.Fatalf("expected at least 2 review rows, got %d", len(out))
+	}
+	if out[0].UnitID != u2 || out[0].Reason != ReviewReasonRegressing {
+		t.Fatalf("expected regressing unit first, got %+v", out[0])
+	}
+	if out[1].UnitID != u3 || out[1].Reason != ReviewReasonLowFidelity {
+		t.Fatalf("expected low_fidelity second, got %+v", out[1])
+	}
+	if !strings.Contains(out[0].WorkspaceURL, "unit="+u2.String()) {
+		t.Fatalf("workspace url missing unit id: %s", out[0].WorkspaceURL)
+	}
+}
+
+func TestWriteCourseReportCSV_PreservesSuppression(t *testing.T) {
+	unitID := uuid.New()
+	lift := float32(12.5)
+	report := acmodel.CourseReportResponse{
+		CourseCode: "DEMO",
+		Coverage:   acmodel.CourseReportCoverage{CoveragePct: 50, StudentsServedVariant: 3},
+		Cost:       acmodel.CourseReportCost{TokensUsedPeriod: 100, MonthlyTokenBudget: 1000},
+		Units: []acmodel.UnitEffectiveness{
+			{
+				UnitID:                unitID,
+				Verdict:               VerdictHelping,
+				NTreatment:            2, // below SmallCellMinN
+				NHoldout:              2,
+				TreatmentMinusHoldout: &lift,
+				ByMode: []acmodel.ModeEffectiveness{
+					{EmphasisMode: "introduce", N: 2, MeanLift: &lift},
+				},
+			},
+		},
+		SmallCellMinN: SmallCellMinN,
+	}
+	var buf bytes.Buffer
+	if err := WriteCourseReportCSV(&buf, report); err != nil {
+		t.Fatal(err)
+	}
+	csv := buf.String()
+	if strings.Contains(csv, "12.5") {
+		t.Fatalf("expected small-cell lift to be suppressed, got:\n%s", csv)
+	}
+	if !strings.Contains(csv, unitID.String()) {
+		t.Fatalf("expected unit id in csv, got:\n%s", csv)
+	}
+}
+
+func TestCoveragePct(t *testing.T) {
+	if got := coveragePct(0, 0); got != 0 {
+		t.Fatalf("empty eligible => 0, got %v", got)
+	}
+	if got := coveragePct(1, 4); got != 25 {
+		t.Fatalf("want 25, got %v", got)
+	}
+}
+
+func TestWriteAdminReportCSV_SummaryRow(t *testing.T) {
+	agg := float32(3.5)
+	report := acmodel.AdminReportResponse{
+		CoursesUsingACE:  2,
+		StudentsImpacted: 10,
+		CostUSD30d:       1.25,
+		AggregateLift:    &agg,
+		KillSwitch:       false,
+		Courses: []acmodel.AdminReportCourse{
+			{CourseCode: "C1", Title: "Course 1", CoveragePct: 40},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteAdminReportCSV(&buf, report); err != nil {
+		t.Fatal(err)
+	}
+	csv := buf.String()
+	if !strings.Contains(csv, "summary") || !strings.Contains(csv, "C1") {
+		t.Fatalf("unexpected csv:\n%s", csv)
+	}
+}

--- a/server/internal/service/adaptivecontent/serve.go
+++ b/server/internal/service/adaptivecontent/serve.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/attribute"
 
 	acrepo "github.com/lextures/lextures/server/internal/repos/adaptivecontent"
+	"github.com/lextures/lextures/server/internal/telemetry"
 )
 
 // Event names for serving audit.
@@ -89,15 +91,22 @@ type ServeResult struct {
 // ResolveServing decides which content to show a student for a unit's base content page.
 // Never blocks: any error or miss yields base content. Serving-record writes are best-effort.
 func ResolveServing(ctx context.Context, pool *pgxpool.Pool, req ServeRequest) ServeResult {
+	ctx, span := telemetry.Tracer("adaptivecontent").Start(ctx, "adaptivecontent.serve")
 	start := time.Now()
-	defer func() {
-		ObserveServeLatency(float64(time.Since(start).Milliseconds()))
-	}()
-
 	out := ServeResult{
 		AxesApplied: []string{},
 		Reason:      ServeReasonNoUnit,
 	}
+	defer func() {
+		span.SetAttributes(
+			attribute.String("ace.serve_reason", string(out.Reason)),
+			attribute.Bool("ace.is_adapted", out.IsAdapted),
+			attribute.Bool("ace.is_holdout", out.IsHoldout),
+			attribute.Bool("ace.was_fallback", out.WasFallback),
+		)
+		span.End()
+		ObserveServeLatency(float64(time.Since(start).Milliseconds()))
+	}()
 
 	if pool == nil || req.UserID == uuid.Nil || req.CourseID == uuid.Nil {
 		return out

--- a/server/internal/telemetry/metrics.go
+++ b/server/internal/telemetry/metrics.go
@@ -8,10 +8,12 @@ package telemetry
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // namespace prefixes every Lextures-authored metric so operators can filter
@@ -282,13 +284,57 @@ func (m *Metrics) RegisterCollector(c prometheus.Collector) error {
 	return m.registry.Register(c)
 }
 
+// skipDefaultPrefixes are metric families already registered on the private
+// telemetry registry (Go/process collectors). When merging the default registry
+// for ACE metrics (AC.9), these must be filtered out to avoid scrape conflicts.
+var skipDefaultPrefixes = []string{"go_", "process_"}
+
+// filteringGatherer wraps a Gatherer and drops metric families whose names start
+// with any of denyPrefixes.
+type filteringGatherer struct {
+	inner        prometheus.Gatherer
+	denyPrefixes []string
+}
+
+func (f filteringGatherer) Gather() ([]*dto.MetricFamily, error) {
+	families, err := f.inner.Gather()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*dto.MetricFamily, 0, len(families))
+	for _, fam := range families {
+		name := fam.GetName()
+		skip := false
+		for _, p := range f.denyPrefixes {
+			if strings.HasPrefix(name, p) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, fam)
+		}
+	}
+	return out, nil
+}
+
 // Handler returns the Prometheus exposition handler for GET /metrics. It is
 // served on the internal metrics port, never the public LB port (plan 17.7
 // FR-1 / NFR Security).
+//
+// AC.9: also gathers the default Prometheus registry (minus go_/process_ which
+// the private registry already exposes) so Adaptive Content Engine metrics
+// registered via prometheus.MustRegister (service/adaptivecontent) appear on
+// the scraped /metrics endpoint.
 func (m *Metrics) Handler() http.Handler {
-	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{
+	return promhttp.HandlerFor(prometheus.Gatherers{
+		m.registry,
+		filteringGatherer{
+			inner:        prometheus.DefaultGatherer,
+			denyPrefixes: skipDefaultPrefixes,
+		},
+	}, promhttp.HandlerOpts{
 		EnableOpenMetrics: false,
-		Registry:          m.registry,
 	})
 }
 

--- a/server/internal/telemetry/metrics_test.go
+++ b/server/internal/telemetry/metrics_test.go
@@ -88,3 +88,17 @@ func TestMetrics_SetBannerActive(t *testing.T) {
 		t.Errorf("expected active global warning gauge, got: %s", body)
 	}
 }
+
+func TestMetricsHandler_IncludesDefaultRegistryGatherer(t *testing.T) {
+	// AC.9: Handler must gather prometheus.DefaultGatherer so ACE metrics appear.
+	m := NewMetrics()
+	rr := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "lextures_http_requests_total") &&
+		!strings.Contains(rr.Body.String(), "go_goroutines") {
+		t.Error("expected private registry metrics in exposition")
+	}
+}

--- a/server/migrations/448_adaptive_content_reports.down.sql
+++ b/server/migrations/448_adaptive_content_reports.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS analytics.adaptive_content_coverage;
+DROP MATERIALIZED VIEW IF EXISTS analytics.adaptive_content_course_report;

--- a/server/migrations/448_adaptive_content_reports.sql
+++ b/server/migrations/448_adaptive_content_reports.sql
@@ -1,0 +1,40 @@
+-- AC.9: Analytics, reporting & operability — course report rollups + coverage snapshot.
+
+-- Course-level rollup (refreshed with AC.7 effectiveness / AC.9 report refresh).
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics.adaptive_content_course_report AS
+SELECT
+    u.course_id,
+    COUNT(*)::INTEGER                                            AS n_units,
+    COUNT(*) FILTER (WHERE u.status = 'active')::INTEGER         AS n_active_units,
+    AVG(e.treatment_minus_holdout)::REAL                         AS mean_lift_vs_control,
+    COUNT(*) FILTER (WHERE e.verdict = 'helping')::INTEGER       AS n_helping,
+    COUNT(*) FILTER (WHERE e.verdict = 'regressing')::INTEGER    AS n_regressing,
+    COUNT(*) FILTER (WHERE e.verdict = 'insufficient_data')::INTEGER AS n_insufficient,
+    COUNT(*) FILTER (WHERE e.verdict = 'no_effect')::INTEGER     AS n_no_effect,
+    COALESCE(s.tokens_used_period, 0)::BIGINT                    AS tokens_used_period,
+    COALESCE(s.monthly_token_budget, 0)::BIGINT                  AS monthly_token_budget,
+    NOW()                                                        AS refreshed_at
+FROM course.adaptive_content_units u
+LEFT JOIN analytics.adaptive_content_effectiveness e ON e.unit_id = u.id
+LEFT JOIN course.adaptive_content_settings s ON s.course_id = u.course_id
+GROUP BY u.course_id, s.tokens_used_period, s.monthly_token_budget;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ac_course_report
+    ON analytics.adaptive_content_course_report (course_id);
+
+COMMENT ON MATERIALIZED VIEW analytics.adaptive_content_course_report IS
+    'AC.9: Cached course-level Adaptive Content report KPIs (effectiveness + budget).';
+
+-- Coverage snapshot: eligible content items vs. adapted, students profiled/served (refreshed by job).
+CREATE TABLE IF NOT EXISTS analytics.adaptive_content_coverage (
+    course_id UUID PRIMARY KEY REFERENCES course.courses (id) ON DELETE CASCADE,
+    eligible_content_items INTEGER NOT NULL DEFAULT 0,
+    adapted_units INTEGER NOT NULL DEFAULT 0,
+    students_profiled INTEGER NOT NULL DEFAULT 0,
+    students_served_variant INTEGER NOT NULL DEFAULT 0,
+    students_holdout INTEGER NOT NULL DEFAULT 0,
+    refreshed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE analytics.adaptive_content_coverage IS
+    'AC.9: Per-course coverage snapshot for Adaptive Content instructor/admin reports.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **AC.9 — Analytics, Reporting & Operability** for the Adaptive Content Engine.

### Backend
- Migration `448_adaptive_content_reports.sql`: course report materialized view + coverage snapshot table (447 was taken by AC.8)
- Instructor report API: `GET …/adaptive-content/report` (+ CSV export)
- Admin org rollup: `GET /api/v1/admin/adaptive-content/report` (+ CSV export)
- Reads from AC.7 effectiveness caches / AC.4 budget / AC.8 fairness counters (no live heavy aggregation)
- Coverage + matview refresh hooked into effectiveness refresh; self-heals coverage on first report read
- OTel spans on serve / profile / generate / gate paths
- Prometheus `/metrics` gathers ACE default-registry metrics (filtering duplicate go_/process_)
- Alert rules + Grafana dashboard + SRE runbook

### Frontend
- Instructor **Report** tab in Adaptive Content workspace (KPIs, units-to-review, mode chart, cost meter, CSV export, empty state)
- Admin org report panel on AI governance settings
- AI reports `adaptive_content` feature label + ACE cost slice

### Tests
- Go unit/nodb tests for ranking, CSV suppression, routes, metrics gatherer
- Vitest for report panel empty/KPI states
- Playwright e2e: instructor report + CSV, student 403, admin rollup, UI tab
- E2E.4 disposition in `e2e/coverage/completed-feature-manifest.json`

### Checklist
- [x] Tests added/updated as appropriate
- [x] Disposition added in `e2e/coverage/completed-feature-manifest.json` and `npm run e2e:coverage:check` OK
- [x] Flagged-feature notes covered via course `adaptiveContentEnabled` dependency + authz deny for students

Plan moved to `docs/completed/adaptive/AC.9-analytics-reporting-and-operability.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9ada-d241-7341-bd05-afcd8ea2896a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9ada-d241-7341-bd05-afcd8ea2896a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

