### PR TITLE
feat(ct.m1): mobile markdown engine for tables, code, math & lex-tool

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -84,6 +84,10 @@ Access and refresh tokens are stored in EncryptedSharedPreferences. MFA-required
 
 Notebooks are device-local (same model as the web app's localStorage notebooks, format v2), keyed per signed-in user.
 
+## Markdown engine (CT.M1)
+
+Course and notebook readers share one parser (`core/notebook/NotebookMarkdown.kt` + `MarkdownTableLogic.kt`) and one renderer (`NotebookContentView` plus `features/courses/markdown/*`). The engine handles GFM tables (blank-line healing parity to web `normalizeMarkdownTables`), fenced code (language + copy), `$`/`$$` math (monospace fallback with a11y labels), GFM task lists, inline formatting (bold/italic/strike/code/links — `stripInline` removed), and ` ```lex-tool ` placeholders. Shared golden fixtures: `clients/mobile/fixtures/markdown/corpus.json`. Unit coverage: `app/src/test/kotlin/.../core/notebook/*Test.kt`. Feature flag: `ffMobileRichMarkdown` (default on). Legacy `MarkdownText` is a thin shim over `NotebookContentView` for CT.M2 migration.
+
 ## Realtime sockets
 
 Per-screen sockets use `core/realtime/WebSocketClient` (JSON `{"authToken":…}` handshake, 2s reconnect):

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsFeatureModels.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsFeatureModels.kt
@@ -446,6 +446,8 @@ data class PlatformFeatures(
     val ffMobileProfileDepth: Boolean? = null,
     val ffMobileLibraryEreserves: Boolean? = null,
     val ffMobileImmersiveReader: Boolean? = null,
+    /** CT.M1 rich markdown engine (tables/code/math/toolFence). Default on when unset. */
+    val ffMobileRichMarkdown: Boolean? = null,
     val ffMobileLiveMeetings: Boolean? = null,
     val readAloudEnabled: Boolean? = null,
     val ffReadAloud: Boolean? = null,

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/navigation/MobileDestinations.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/navigation/MobileDestinations.kt
@@ -185,6 +185,8 @@ data class MobilePlatformFeatures(
     val ffMobileProfileDepth: Boolean = false,
     val ffMobileLibraryEreserves: Boolean = true,
     val ffMobileImmersiveReader: Boolean = true,
+    /** CT.M1 rich markdown engine; default on when unset. */
+    val ffMobileRichMarkdown: Boolean = true,
     val ffMobileLiveMeetings: Boolean = true,
     val readAloudEnabled: Boolean = false,
     val ffReadAloud: Boolean = false,
@@ -294,6 +296,7 @@ data class MobilePlatformFeatures(
             ffMobileProfileDepth = features?.ffMobileProfileDepth == true,
             ffMobileLibraryEreserves = features?.ffMobileLibraryEreserves != false,
             ffMobileImmersiveReader = features?.ffMobileImmersiveReader != false,
+            ffMobileRichMarkdown = features?.ffMobileRichMarkdown != false,
             ffMobileLiveMeetings = features?.ffMobileLiveMeetings != false,
             readAloudEnabled = features?.readAloudEnabled == true,
             ffReadAloud = features?.ffReadAloud == true,

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/MarkdownTableLogic.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/MarkdownTableLogic.kt
@@ -1,0 +1,168 @@
+package com.lextures.android.core.notebook
+
+/** Column alignment for a GFM pipe table. */
+enum class MarkdownTableAlign {
+    Default,
+    Left,
+    Center,
+    Right,
+}
+
+/**
+ * Pure table detection / blank-line healing / cell split
+ * (parity with web `normalize-markdown-tables`).
+ */
+object MarkdownTableLogic {
+    private val bareSeparator = Regex("""^\|?[\s:|-]+$""")
+    private val sepA = Regex("""^\|?(\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?$""")
+    private val sepB = Regex("""^\|?(\s*:?-{3,}:?\s*\|?)+\s*$""")
+
+    /** Collapse blank lines inside GitHub-flavored markdown tables (web FR-3 parity). */
+    fun normalizeMarkdownTables(markdown: String): String {
+        if (!markdown.contains("|")) return markdown
+        val lines = markdown.replace("\r\n", "\n").split("\n")
+        val out = mutableListOf<String>()
+        var i = 0
+        while (i < lines.size) {
+            val line = lines[i]
+            val sepIdx = nextNonEmptyIndex(lines, i + 1)
+            val looksLikeHeader =
+                isTableRowLine(line) &&
+                    sepIdx < lines.size &&
+                    isTableSeparatorLine(lines[sepIdx])
+            if (!looksLikeHeader) {
+                out.add(line)
+                i++
+                continue
+            }
+            val tableLines = mutableListOf(line)
+            i++
+            while (i < lines.size) {
+                val L = lines[i]
+                if (L.trim().isEmpty()) {
+                    val next = nextNonEmptyIndex(lines, i + 1)
+                    if (next < lines.size && isTableRelatedLine(lines[next])) {
+                        i = next
+                        continue
+                    }
+                    break
+                }
+                if (!isTableRelatedLine(L)) break
+                tableLines.add(L)
+                i++
+            }
+            if (tableLines.size >= 2 && isTableSeparatorLine(tableLines[1])) {
+                out.addAll(tableLines)
+            } else {
+                out.add(line)
+                if (tableLines.size > 1) out.addAll(tableLines.drop(1))
+            }
+        }
+        return out.joinToString("\n")
+    }
+
+    /**
+     * Try to parse a GFM table starting at [start].
+     * Returns null when the candidate is not a valid table.
+     */
+    fun parseTable(
+        lines: List<String>,
+        start: Int,
+    ): ParsedMarkdownTable? {
+        if (start >= lines.size || !isTableRowLine(lines[start])) return null
+        val sepIdx = nextNonEmptyIndex(lines, start + 1)
+        if (sepIdx >= lines.size || !isTableSeparatorLine(lines[sepIdx])) return null
+
+        val header = splitCells(lines[start])
+        val align = parseAlignments(lines[sepIdx], header.size)
+        val rows = mutableListOf<List<String>>()
+        var i = sepIdx + 1
+        while (i < lines.size) {
+            val trimmed = lines[i].trim()
+            if (trimmed.isEmpty()) break
+            if (!isTableRowLine(lines[i])) break
+            if (isTableSeparatorLine(lines[i])) break
+            rows.add(padCells(splitCells(lines[i]), header.size))
+            i++
+        }
+        return ParsedMarkdownTable(align = align, header = header, rows = rows, end = i)
+    }
+
+    fun isTableRowLine(line: String): Boolean {
+        val t = line.trim()
+        if (!t.contains("|")) return false
+        if (bareSeparator.matches(t) && t.contains("-")) return false
+        if (t.length >= 2 && t.substring(1, t.length - 1).contains("|")) return true
+        return t.startsWith("|") && t.endsWith("|")
+    }
+
+    fun isTableSeparatorLine(line: String): Boolean {
+        val t = line.trim()
+        if (!t.contains("-")) return false
+        return sepA.matches(t) || sepB.matches(t)
+    }
+
+    fun isTableRelatedLine(line: String): Boolean =
+        isTableRowLine(line) || isTableSeparatorLine(line)
+
+    fun splitCells(line: String): List<String> {
+        var t = line.trim()
+        if (t.startsWith("|")) t = t.drop(1)
+        if (t.endsWith("|")) t = t.dropLast(1)
+        return t.split("|").map { it.trim() }
+    }
+
+    fun parseAlignments(separator: String, columnCount: Int): List<MarkdownTableAlign> {
+        val cells = splitCells(separator)
+        val parsed = cells.map { cell ->
+            val c = cell.trim()
+            val left = c.startsWith(":")
+            val right = c.endsWith(":")
+            when {
+                left && right -> MarkdownTableAlign.Center
+                right -> MarkdownTableAlign.Right
+                left -> MarkdownTableAlign.Left
+                else -> MarkdownTableAlign.Default
+            }
+        }
+        return if (parsed.size >= columnCount) {
+            parsed.take(columnCount)
+        } else {
+            parsed + List(columnCount - parsed.size) { MarkdownTableAlign.Default }
+        }
+    }
+
+    fun padCells(cells: List<String>, count: Int): List<String> =
+        if (cells.size >= count) cells.take(count)
+        else cells + List(count - cells.size) { "" }
+
+    fun nextNonEmptyIndex(lines: List<String>, from: Int): Int {
+        var j = from
+        while (j < lines.size && lines[j].trim().isEmpty()) j++
+        return j
+    }
+
+    fun serialize(align: List<MarkdownTableAlign>, header: List<String>, rows: List<List<String>>): String {
+        fun row(cells: List<String>) = "| " + cells.joinToString(" | ") + " |"
+        val sep = align.map {
+            when (it) {
+                MarkdownTableAlign.Left -> ":---"
+                MarkdownTableAlign.Center -> ":---:"
+                MarkdownTableAlign.Right -> "---:"
+                MarkdownTableAlign.Default -> "---"
+            }
+        }
+        return buildList {
+            add(row(header))
+            add("| " + sep.joinToString(" | ") + " |")
+            addAll(rows.map(::row))
+        }.joinToString("\n")
+    }
+}
+
+data class ParsedMarkdownTable(
+    val align: List<MarkdownTableAlign>,
+    val header: List<String>,
+    val rows: List<List<String>>,
+    val end: Int,
+)

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookMarkdown.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookMarkdown.kt
@@ -26,14 +26,24 @@ data class NotebookSlashCommand(
     val keywords: List<String>,
 )
 
-/** Renderable markdown block for the notebook reading view. */
+/** Renderable markdown block for the notebook / course reading view (CT.M1). */
 sealed interface NotebookBlock {
     data class Heading(val level: Int, val text: String) : NotebookBlock
     data class Paragraph(val text: String) : NotebookBlock
-    data class BulletItem(val text: String) : NotebookBlock
-    data class OrderedItem(val number: String, val text: String) : NotebookBlock
+    data class BulletItem(val text: String, val depth: Int = 0) : NotebookBlock
+    data class OrderedItem(val number: String, val text: String, val depth: Int = 0) : NotebookBlock
+    /** GFM task-list item (`- [ ]` / `- [x]`), read-only in reader contexts. */
+    data class TaskItem(val checked: Boolean, val text: String, val depth: Int = 0) : NotebookBlock
     data class Quote(val text: String) : NotebookBlock
-    data class Code(val text: String) : NotebookBlock
+    data class Code(val text: String, val language: String? = null) : NotebookBlock
+    data class Math(val latex: String, val display: Boolean = true) : NotebookBlock
+    data class Table(
+        val align: List<MarkdownTableAlign>,
+        val header: List<String>,
+        val rows: List<List<String>>,
+    ) : NotebookBlock
+    /** ```lex-tool pointer; raw JSON must never be shown to learners (CT.M3 hosts it). */
+    data class ToolFence(val instanceId: String, val toolId: String, val version: Int) : NotebookBlock
     data object Divider : NotebookBlock
     data class TaskBlock(val task: ParsedNotebookTask) : NotebookBlock
     data class Image(val alt: String, val url: String) : NotebookBlock
@@ -72,6 +82,7 @@ data class NotebookEditBlock(
 object NotebookMarkdown {
     private val taskBlockRegex = Regex("```task[ \\t]*\\n([\\s\\S]*?)```")
     private val orderedItemRegex = Regex("^(\\d+)[.)] (.*)$")
+    private val taskListRegex = Regex("^[-*]\\s+\\[([ xX])]\\s+(.*)$")
     private val imageRegex = Regex("^!\\[([^\\]]*)]\\(([^)]+)\\)$")
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -126,6 +137,24 @@ object NotebookMarkdown {
     fun setTaskDueAt(contentMd: String, taskId: String, dueAt: String?): String =
         rewriteTask(contentMd, taskId) { it.checked to dueAt }
 
+    /** Kind labels used by the shared golden-fixture corpus (`clients/mobile/fixtures/markdown`). */
+    fun fixtureKindName(block: NotebookBlock): String = when (block) {
+        is NotebookBlock.Heading -> "heading"
+        is NotebookBlock.Paragraph -> "paragraph"
+        is NotebookBlock.BulletItem -> "bullet"
+        is NotebookBlock.OrderedItem -> "ordered"
+        is NotebookBlock.TaskItem -> "taskItem"
+        is NotebookBlock.Quote -> "quote"
+        is NotebookBlock.Code -> "code"
+        is NotebookBlock.Math -> "math"
+        is NotebookBlock.Table -> "table"
+        is NotebookBlock.ToolFence -> "toolFence"
+        NotebookBlock.Divider -> "divider"
+        is NotebookBlock.TaskBlock -> "task"
+        is NotebookBlock.Image -> "image"
+        is NotebookBlock.Drawing -> "drawing"
+    }
+
     // Block parsing (reading view)
 
     fun parseBlocks(contentMd: String): List<NotebookBlock> {
@@ -134,10 +163,10 @@ object NotebookMarkdown {
         val quote = mutableListOf<String>()
 
         fun flushParagraph() {
-            if (paragraph.isNotEmpty()) {
-                blocks.add(NotebookBlock.Paragraph(paragraph.joinToString("\n")))
-                paragraph.clear()
-            }
+            if (paragraph.isEmpty()) return
+            val text = paragraph.joinToString("\n")
+            paragraph.clear()
+            parseStandaloneMath(text)?.let { blocks.add(it) } ?: blocks.add(NotebookBlock.Paragraph(text))
         }
         fun flushQuote() {
             if (quote.isNotEmpty()) {
@@ -150,12 +179,20 @@ object NotebookMarkdown {
             flushQuote()
         }
 
-        val lines = contentMd.replace("\r\n", "\n").split("\n")
+        val lines = MarkdownTableLogic.normalizeMarkdownTables(contentMd.replace("\r\n", "\n")).split("\n")
         var i = 0
         var drawingIndex = 0
         while (i < lines.size) {
             val trimmed = lines[i].trim()
+            val depth = listDepth(lines[i]).coerceAtMost(3)
+            val table = MarkdownTableLogic.parseTable(lines, i)
             when {
+                table != null -> {
+                    flushAll()
+                    blocks.add(NotebookBlock.Table(align = table.align, header = table.header, rows = table.rows))
+                    i = table.end
+                    continue
+                }
                 trimmed.startsWith("```drawing") -> {
                     flushAll()
                     val inner = mutableListOf<String>()
@@ -179,13 +216,20 @@ object NotebookMarkdown {
                 }
                 trimmed.startsWith("```") -> {
                     flushAll()
+                    val language = fenceLanguage(trimmed)
                     val inner = mutableListOf<String>()
                     i++
                     while (i < lines.size && !lines[i].trim().startsWith("```")) {
                         inner.add(lines[i])
                         i++
                     }
-                    blocks.add(NotebookBlock.Code(inner.joinToString("\n")))
+                    val source = inner.joinToString("\n")
+                    val tool = if (language == "lex-tool") parseLexToolFence(source) else null
+                    if (tool != null) {
+                        blocks.add(tool)
+                    } else {
+                        blocks.add(NotebookBlock.Code(text = source, language = language))
+                    }
                 }
                 parseHeading(trimmed) != null -> {
                     flushAll()
@@ -200,14 +244,31 @@ object NotebookMarkdown {
                     val match = imageRegex.find(trimmed)!!
                     blocks.add(NotebookBlock.Image(alt = match.groupValues[1], url = match.groupValues[2]))
                 }
+                taskListRegex.matches(trimmed) -> {
+                    flushAll()
+                    val match = taskListRegex.find(trimmed)!!
+                    blocks.add(
+                        NotebookBlock.TaskItem(
+                            checked = match.groupValues[1].equals("x", ignoreCase = true),
+                            text = match.groupValues[2],
+                            depth = depth,
+                        ),
+                    )
+                }
                 trimmed.startsWith("- ") || trimmed.startsWith("* ") -> {
                     flushAll()
-                    blocks.add(NotebookBlock.BulletItem(trimmed.drop(2)))
+                    blocks.add(NotebookBlock.BulletItem(text = trimmed.drop(2), depth = depth))
                 }
                 orderedItemRegex.matches(trimmed) -> {
                     flushAll()
                     val match = orderedItemRegex.find(trimmed)!!
-                    blocks.add(NotebookBlock.OrderedItem(number = match.groupValues[1], text = match.groupValues[2]))
+                    blocks.add(
+                        NotebookBlock.OrderedItem(
+                            number = match.groupValues[1],
+                            text = match.groupValues[2],
+                            depth = depth,
+                        ),
+                    )
                 }
                 trimmed.startsWith(">") -> {
                     flushParagraph()
@@ -223,6 +284,46 @@ object NotebookMarkdown {
         }
         flushAll()
         return blocks
+    }
+
+    private fun fenceLanguage(opener: String): String? {
+        val rest = opener.removePrefix("```").trim()
+        if (rest.isEmpty()) return null
+        return rest.split(Regex("\\s+")).firstOrNull()?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun parseLexToolFence(source: String): NotebookBlock.ToolFence? {
+        val obj = runCatching {
+            json.parseToJsonElement(source.trim()) as? JsonObject
+        }.getOrNull() ?: return null
+        val instanceId = (obj["instanceId"] as? JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+        val toolId = (obj["toolId"] as? JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+        val version = when (val v = obj["v"]) {
+            is JsonPrimitive -> v.contentOrNull?.toIntOrNull() ?: v.content.toIntOrNull()
+            else -> null
+        }
+        if (instanceId.isEmpty() || toolId.isEmpty() || version != 1) return null
+        return NotebookBlock.ToolFence(instanceId = instanceId, toolId = toolId, version = 1)
+    }
+
+    private fun parseStandaloneMath(text: String): NotebookBlock.Math? {
+        val t = text.trim()
+        if (!t.startsWith("$$") || !t.endsWith("$$") || t.length < 4) return null
+        val inner = t.removePrefix("$$").removeSuffix("$$").trim()
+        if (inner.isEmpty() || inner.contains("$$")) return null
+        return NotebookBlock.Math(latex = inner, display = true)
+    }
+
+    private fun listDepth(line: String): Int {
+        var spaces = 0
+        for (ch in line) {
+            when (ch) {
+                ' ' -> spaces++
+                '\t' -> spaces += 2
+                else -> break
+            }
+        }
+        return (spaces / 2).coerceAtMost(3)
     }
 
     private fun parseHeading(line: String): NotebookBlock.Heading? {
@@ -250,12 +351,34 @@ object NotebookMarkdown {
                     out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Bullet, text = block.text))
                 is NotebookBlock.OrderedItem ->
                     out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Ordered, text = block.text))
+                is NotebookBlock.TaskItem -> {
+                    val mark = if (block.checked) "x" else " "
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Bullet, text = "[$mark] ${block.text}"))
+                }
                 is NotebookBlock.Quote ->
                     block.text.split("\n").forEach {
                         out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Quote, text = it))
                     }
                 is NotebookBlock.Code ->
                     out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Code, text = block.text))
+                is NotebookBlock.Math ->
+                    out.add(
+                        NotebookEditBlock(
+                            kind = NotebookEditBlock.Kind.Paragraph,
+                            text = if (block.display) "$$${block.latex}$$" else "$${block.latex}$",
+                        ),
+                    )
+                is NotebookBlock.Table ->
+                    MarkdownTableLogic.serialize(block.align, block.header, block.rows)
+                        .split("\n")
+                        .forEach { out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Paragraph, text = it)) }
+                is NotebookBlock.ToolFence ->
+                    out.add(
+                        NotebookEditBlock(
+                            kind = NotebookEditBlock.Kind.Code,
+                            text = """{"instanceId":"${block.instanceId}","toolId":"${block.toolId}","v":${block.version}}""",
+                        ),
+                    )
                 NotebookBlock.Divider ->
                     out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Divider))
                 is NotebookBlock.TaskBlock ->
@@ -381,8 +504,14 @@ object NotebookMarkdown {
                 is NotebookBlock.Paragraph -> block.text
                 is NotebookBlock.BulletItem -> block.text
                 is NotebookBlock.OrderedItem -> block.text
+                is NotebookBlock.TaskItem -> block.text
                 is NotebookBlock.Quote -> block.text
                 is NotebookBlock.Code -> block.text
+                is NotebookBlock.Math -> block.latex
+                is NotebookBlock.Table ->
+                    (listOf(block.header.joinToString(" ")) + block.rows.take(3).map { it.joinToString(" ") })
+                        .joinToString(" ")
+                is NotebookBlock.ToolFence -> block.toolId
                 is NotebookBlock.TaskBlock -> block.task.text
                 is NotebookBlock.Image -> block.alt
                 is NotebookBlock.Drawing -> "Drawing"

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/routing/ContentLinkRouter.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/routing/ContentLinkRouter.kt
@@ -1,0 +1,32 @@
+package com.lextures.android.core.routing
+
+/**
+ * In-app link allowlist + deep-link resolution for markdown hrefs (CT.M1 FR-9).
+ * Mirrors iOS `ContentLinkRouter` scheme policy: http, https, mailto, and in-app paths.
+ */
+object ContentLinkRouter {
+    fun isAllowedHref(href: String): Boolean {
+        val t = href.trim()
+        if (t.isEmpty()) return false
+        if (t.startsWith("/")) return true
+        val lower = t.lowercase()
+        return lower.startsWith("http://") ||
+            lower.startsWith("https://") ||
+            lower.startsWith("mailto:") ||
+            lower.startsWith("lextures://")
+    }
+
+    fun isExternalHref(href: String): Boolean {
+        val lower = href.trim().lowercase()
+        return lower.startsWith("http://") ||
+            lower.startsWith("https://") ||
+            lower.startsWith("mailto:")
+    }
+
+    /** Resolve markdown href into a deep-link destination when it is an in-app path/URL. */
+    fun resolveDeepLink(href: String): DeepLinkDestination? {
+        val t = href.trim()
+        if (!isAllowedHref(t) || t.lowercase().startsWith("mailto:")) return null
+        return DeepLinkRouter.resolve(t)
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/ItemDetailScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/ItemDetailScreen.kt
@@ -76,6 +76,7 @@ import com.lextures.android.core.lms.SubmissionGrade
 import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsCoverTile
 import com.lextures.android.features.home.LmsErrorBanner
+import com.lextures.android.features.notebooks.NotebookContentView
 
 /** Shared icon/label mapping for course structure item kinds. */
 object ItemKind {
@@ -407,98 +408,19 @@ private fun lateLabel(policy: String, penalty: Int?): String = when (policy) {
 private fun titlecase(raw: String): String =
     raw.replace('_', ' ').replaceFirstChar { it.uppercase() }
 
-/** Lightweight block-level markdown renderer (headings, bullets, paragraphs). */
+/**
+ * CT.M1 shim: legacy call sites keep `MarkdownText(...)` while the rich engine
+ * (`NotebookContentView`) renders tables/code/math/inline formatting.
+ * `stripInline` is deleted — formatting is no longer stripped (FR-8).
+ */
 @Composable
 fun MarkdownText(markdown: String, modifier: Modifier = Modifier) {
-    val lines = remember(markdown) { parseMarkdownBlocks(markdown) }
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        lines.forEach { block ->
-            when (block) {
-                is MdBlock.Heading -> Text(
-                    text = block.text,
-                    style = LexturesType.display(if (block.level == 1) 21 else if (block.level == 2) 18 else 16),
-                    color = textPrimary(),
-                    modifier = Modifier.padding(top = 4.dp),
-                )
-                is MdBlock.Bullet -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(
-                        modifier = Modifier
-                            .padding(top = 7.dp)
-                            .size(5.dp)
-                            .clip(CircleShape)
-                            .background(accentColor()),
-                    )
-                    Text(text = block.text, fontSize = 14.sp, color = textPrimary())
-                }
-                is MdBlock.Numbered -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
-                        text = block.index,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        color = accentColor(),
-                    )
-                    Text(text = block.text, fontSize = 14.sp, color = textPrimary())
-                }
-                is MdBlock.Paragraph -> Text(
-                    text = block.text,
-                    fontSize = 14.sp,
-                    lineHeight = 21.sp,
-                    color = textPrimary(),
-                )
-            }
-        }
-    }
-}
-
-private sealed interface MdBlock {
-    data class Heading(val level: Int, val text: String) : MdBlock
-    data class Bullet(val text: String) : MdBlock
-    data class Numbered(val index: String, val text: String) : MdBlock
-    data class Paragraph(val text: String) : MdBlock
-}
-
-private val numberedRegex = Regex("""^(\d+)\.\s+(.*)$""")
-
-private fun stripInline(text: String): String =
-    text.replace(Regex("""\*\*(.+?)\*\*"""), "$1")
-        .replace(Regex("""\*(.+?)\*"""), "$1")
-        .replace(Regex("""`(.+?)`"""), "$1")
-        .replace(Regex("""\[(.+?)]\(.+?\)"""), "$1")
-
-private fun parseMarkdownBlocks(markdown: String): List<MdBlock> {
-    val out = mutableListOf<MdBlock>()
-    val paragraph = mutableListOf<String>()
-
-    fun flush() {
-        if (paragraph.isNotEmpty()) {
-            out.add(MdBlock.Paragraph(stripInline(paragraph.joinToString(" "))))
-            paragraph.clear()
-        }
-    }
-
-    markdown.lineSequence().forEach { raw ->
-        val line = raw.trim()
-        when {
-            line.isEmpty() -> flush()
-            line.startsWith("#") -> {
-                flush()
-                val level = line.takeWhile { it == '#' }.length.coerceAtMost(3)
-                out.add(MdBlock.Heading(level, stripInline(line.dropWhile { it == '#' }.trim())))
-            }
-            line.startsWith("- ") || line.startsWith("* ") -> {
-                flush()
-                out.add(MdBlock.Bullet(stripInline(line.drop(2))))
-            }
-            numberedRegex.matches(line) -> {
-                flush()
-                val match = numberedRegex.find(line)!!
-                out.add(MdBlock.Numbered("${match.groupValues[1]}.", stripInline(match.groupValues[2])))
-            }
-            else -> paragraph.add(line)
-        }
-    }
-    flush()
-    return out
+    NotebookContentView(
+        markdown = markdown,
+        onToggleTask = {},
+        onEditTaskDue = {},
+        modifier = modifier,
+    )
 }
 
 /** Student view of their own submission status and released grade. */

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownCodeBlock.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownCodeBlock.kt
@@ -1,0 +1,121 @@
+package com.lextures.android.features.courses.markdown
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lextures.android.R
+import com.lextures.android.core.design.fieldBorder
+import com.lextures.android.core.design.isDarkTheme
+import com.lextures.android.core.design.sceneBackground
+import com.lextures.android.core.design.textPrimary
+import com.lextures.android.core.design.textSecondary
+import com.lextures.android.core.i18n.L
+import com.lextures.android.core.design.LexturesColors
+
+/** Fenced code block: language label, monospace, horizontal scroll, copy (CT.M1 FR-7). */
+@Composable
+fun MarkdownCodeBlock(
+    source: String,
+    language: String?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var copied by remember { mutableStateOf(false) }
+    val languageLabel = if (!language.isNullOrBlank()) {
+        L.format(R.string.mobile_markdown_code_language, language)
+    } else {
+        L.text(R.string.mobile_markdown_code_languageFallback)
+    }
+    val a11y = if (!language.isNullOrBlank()) {
+        "$language ${L.text(R.string.mobile_markdown_code_block)}"
+    } else {
+        L.text(R.string.mobile_markdown_code_block)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (isDarkTheme()) sceneBackground() else LexturesColors.SceneBackground)
+            .border(1.dp, fieldBorder(), RoundedCornerShape(10.dp))
+            .semantics { contentDescription = a11y },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = languageLabel,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = textSecondary(),
+                modifier = Modifier.padding(start = 4.dp),
+            )
+            TextButton(
+                onClick = {
+                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText("code", source))
+                    copied = true
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.mobile_markdown_code_copied),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                },
+            ) {
+                Text(
+                    text = if (copied) L.text(R.string.mobile_markdown_code_copied) else L.text(R.string.mobile_markdown_code_copy),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+        Row(
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = 12.dp)
+                .padding(bottom = 12.dp),
+        ) {
+            Text(
+                text = source.ifEmpty { " " },
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace,
+                color = textPrimary(),
+                softWrap = false,
+                overflow = TextOverflow.Visible,
+            )
+        }
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownMath.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownMath.kt
@@ -1,0 +1,54 @@
+package com.lextures.android.features.courses.markdown
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lextures.android.R
+import com.lextures.android.core.design.textPrimary
+import com.lextures.android.core.i18n.L
+
+/**
+ * Math rendering with a safe monospace fallback (CT.M1 FR-10 / open question #1).
+ * Unparseable LaTeX still shows source text — never blank or crash.
+ */
+@Composable
+fun MarkdownMath(
+    latex: String,
+    display: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val pretty = prettyLatex(latex)
+    val label = L.format(
+        if (display) R.string.mobile_markdown_math_display else R.string.mobile_markdown_math_inline,
+        latex,
+    )
+    Text(
+        text = pretty,
+        fontSize = if (display) 15.sp else 13.sp,
+        fontFamily = FontFamily.Monospace,
+        color = textPrimary(),
+        textAlign = if (display) TextAlign.Center else TextAlign.Start,
+        modifier = modifier
+            .then(if (display) Modifier.fillMaxWidth() else Modifier)
+            .padding(vertical = if (display) 4.dp else 0.dp)
+            .semantics { contentDescription = label },
+    )
+}
+
+internal fun prettyLatex(latex: String): String {
+    val trimmed = latex.trim()
+    if (trimmed.isEmpty()) return latex
+    return trimmed
+        .replace("\\frac{", "(")
+        .replace("}{", ")/(")
+        .replace("\\cdot", "·")
+        .replace("\\times", "×")
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownTable.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownTable.kt
@@ -1,0 +1,171 @@
+package com.lextures.android.features.courses.markdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.lextures.android.R
+import com.lextures.android.core.design.fieldBorder
+import com.lextures.android.core.design.isDarkTheme
+import com.lextures.android.core.design.sceneBackground
+import com.lextures.android.core.design.textPrimary
+import com.lextures.android.core.design.LexturesColors
+import com.lextures.android.core.i18n.L
+import com.lextures.android.core.notebook.MarkdownTableAlign
+import com.lextures.android.features.notebooks.inlineMarkdown
+
+/** Inline GFM table with horizontal scroll and full-screen expand (CT.M1 FR-5 / FR-6). */
+@Composable
+fun MarkdownTable(
+    align: List<MarkdownTableAlign>,
+    header: List<String>,
+    rows: List<List<String>>,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(modifier = Modifier.horizontalScroll(rememberScrollState())) {
+            TableGrid(align = align, header = header, rows = rows, minCellWidth = 96)
+        }
+        TextButton(onClick = { expanded = true }) {
+            Text(
+                text = L.text(R.string.mobile_markdown_table_expand),
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+
+    if (expanded) {
+        Dialog(
+            onDismissRequest = { expanded = false },
+            properties = DialogProperties(usePlatformDefaultWidth = false),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(if (isDarkTheme()) sceneBackground() else LexturesColors.SceneBackground)
+                    .padding(16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = L.text(R.string.mobile_markdown_table_expand),
+                        fontWeight = FontWeight.SemiBold,
+                        color = textPrimary(),
+                    )
+                    TextButton(onClick = { expanded = false }) {
+                        Text(L.text(R.string.mobile_markdown_table_close))
+                    }
+                }
+                Row(
+                    modifier = Modifier
+                        .horizontalScroll(rememberScrollState())
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    TableGrid(align = align, header = header, rows = rows, minCellWidth = 120)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableGrid(
+    align: List<MarkdownTableAlign>,
+    header: List<String>,
+    rows: List<List<String>>,
+    minCellWidth: Int,
+) {
+    Column(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .border(1.dp, fieldBorder(), RoundedCornerShape(8.dp)),
+    ) {
+        Row(modifier = Modifier.background(if (isDarkTheme()) sceneBackground() else LexturesColors.SceneBackground)) {
+            header.forEachIndexed { index, cell ->
+                TableCell(
+                    text = cell,
+                    align = align.getOrElse(index) { MarkdownTableAlign.Default },
+                    isHeader = true,
+                    a11y = cell,
+                    minCellWidth = minCellWidth,
+                )
+            }
+        }
+        rows.forEach { row ->
+            Row {
+                row.forEachIndexed { index, cell ->
+                    val column = header.getOrElse(index) { "" }
+                    val rowHeader = row.firstOrNull().orEmpty()
+                    val label = if (rowHeader.isNotEmpty() && rowHeader != cell) {
+                        "$column, $rowHeader: $cell"
+                    } else {
+                        "$column: $cell"
+                    }
+                    TableCell(
+                        text = cell,
+                        align = align.getOrElse(index) { MarkdownTableAlign.Default },
+                        isHeader = false,
+                        a11y = label,
+                        minCellWidth = minCellWidth,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableCell(
+    text: String,
+    align: MarkdownTableAlign,
+    isHeader: Boolean,
+    a11y: String,
+    minCellWidth: Int,
+) {
+    val textAlign = when (align) {
+        MarkdownTableAlign.Center -> TextAlign.Center
+        MarkdownTableAlign.Right -> TextAlign.End
+        MarkdownTableAlign.Left, MarkdownTableAlign.Default -> TextAlign.Start
+    }
+    Text(
+        text = inlineMarkdown(text),
+        fontSize = 12.sp,
+        fontWeight = if (isHeader) FontWeight.SemiBold else FontWeight.Normal,
+        color = textPrimary(),
+        textAlign = textAlign,
+        modifier = Modifier
+            .widthIn(min = minCellWidth.dp)
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+            .semantics { contentDescription = a11y },
+    )
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownToolPlaceholder.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownToolPlaceholder.kt
@@ -1,0 +1,43 @@
+package com.lextures.android.features.courses.markdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lextures.android.R
+import com.lextures.android.core.design.fieldBorder
+import com.lextures.android.core.design.isDarkTheme
+import com.lextures.android.core.design.sceneBackground
+import com.lextures.android.core.design.textSecondary
+import com.lextures.android.core.design.LexturesColors
+import com.lextures.android.core.i18n.L
+
+/** Neutral placeholder for ```lex-tool fences until CT.M3 hosts the live tool. */
+@Composable
+fun MarkdownToolPlaceholder(
+    toolId: String,
+    modifier: Modifier = Modifier,
+) {
+    val label = L.format(R.string.mobile_markdown_tool_placeholder, toolId)
+    Text(
+        text = label,
+        fontSize = 14.sp,
+        color = textSecondary(),
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (isDarkTheme()) sceneBackground() else LexturesColors.SceneBackground)
+            .border(1.dp, fieldBorder(), RoundedCornerShape(10.dp))
+            .padding(12.dp)
+            .semantics { contentDescription = label },
+    )
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookContentView.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookContentView.kt
@@ -34,12 +34,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lextures.android.core.design.LexturesColors
@@ -59,6 +61,11 @@ import com.lextures.android.core.notebook.NotebookBlock
 import com.lextures.android.core.notebook.NotebookDrawing
 import com.lextures.android.core.notebook.NotebookMarkdown
 import com.lextures.android.core.notebook.ParsedNotebookTask
+import com.lextures.android.core.routing.ContentLinkRouter
+import com.lextures.android.features.courses.markdown.MarkdownCodeBlock
+import com.lextures.android.features.courses.markdown.MarkdownMath
+import com.lextures.android.features.courses.markdown.MarkdownTable
+import com.lextures.android.features.courses.markdown.MarkdownToolPlaceholder
 import com.lextures.android.features.reader.CaptionedPlayer
 import com.lextures.android.features.reader.ContentVideoPlayer
 import com.lextures.android.features.reader.ReaderLogic
@@ -78,8 +85,10 @@ fun NotebookContentView(
     captionsEnabled: Boolean = false,
     onEditDrawing: ((index: Int, elementsJson: String) -> Unit)? = null,
 ) {
+    // Memoised once per markdown body (CT.M1 NFR).
+    val blocks = remember(markdown) { NotebookMarkdown.parseBlocks(markdown) }
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        NotebookMarkdown.parseBlocks(markdown).forEach { block ->
+        blocks.forEach { block ->
             when (block) {
                 is NotebookBlock.Heading -> Text(
                     text = inlineMarkdown(block.text),
@@ -95,26 +104,13 @@ fun NotebookContentView(
                             CaptionedPlayer(url = videoUrl, accessToken = accessToken)
                         videoUrl != null && accessToken != null ->
                             ContentVideoPlayer(url = videoUrl, accessToken = accessToken)
-                        videoUrl != null ->
-                            Text(
-                                text = inlineMarkdown(block.text),
-                                fontSize = 14.sp,
-                                lineHeight = 21.sp,
-                                color = textPrimary(),
-                            )
-                        else ->
-                            Text(
-                                text = inlineMarkdown(block.text),
-                                fontSize = 14.sp,
-                                lineHeight = 21.sp,
-                                color = textPrimary(),
-                            )
+                        else -> MathAwareParagraph(text = block.text)
                     }
                 }
 
                 is NotebookBlock.BulletItem -> Row(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    modifier = Modifier.padding(start = 4.dp),
+                    modifier = Modifier.padding(start = (4 + block.depth * 16).dp),
                 ) {
                     Box(
                         Modifier
@@ -123,12 +119,12 @@ fun NotebookContentView(
                             .clip(CircleShape)
                             .background(accentColor()),
                     )
-                    Text(text = inlineMarkdown(block.text), fontSize = 14.sp, color = textPrimary())
+                    MathAwareParagraph(text = block.text)
                 }
 
                 is NotebookBlock.OrderedItem -> Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier.padding(start = 4.dp),
+                    modifier = Modifier.padding(start = (4 + block.depth * 16).dp),
                 ) {
                     Text(
                         text = "${block.number}.",
@@ -136,7 +132,25 @@ fun NotebookContentView(
                         fontWeight = FontWeight.SemiBold,
                         color = accentColor(),
                     )
-                    Text(text = inlineMarkdown(block.text), fontSize = 14.sp, color = textPrimary())
+                    MathAwareParagraph(text = block.text)
+                }
+
+                is NotebookBlock.TaskItem -> Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(start = (4 + block.depth * 16).dp),
+                ) {
+                    Icon(
+                        imageVector = if (block.checked) Icons.Default.CheckBox else Icons.Default.CheckBoxOutlineBlank,
+                        contentDescription = if (block.checked) "Completed" else "Not completed",
+                        tint = if (block.checked) accentColor() else textSecondary(),
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Text(
+                        text = inlineMarkdown(block.text),
+                        fontSize = 14.sp,
+                        color = if (block.checked) textSecondary() else textPrimary(),
+                        textDecoration = if (block.checked) TextDecoration.LineThrough else TextDecoration.None,
+                    )
                 }
 
                 is NotebookBlock.Quote -> Row(
@@ -158,18 +172,17 @@ fun NotebookContentView(
                     )
                 }
 
-                is NotebookBlock.Code -> Text(
-                    text = block.text,
-                    fontSize = 12.sp,
-                    fontFamily = FontFamily.Monospace,
-                    color = textPrimary(),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(if (isDarkTheme()) sceneBackground() else LexturesColors.SceneBackground)
-                        .border(1.dp, fieldBorder(), RoundedCornerShape(10.dp))
-                        .padding(12.dp),
+                is NotebookBlock.Code -> MarkdownCodeBlock(source = block.text, language = block.language)
+
+                is NotebookBlock.Math -> MarkdownMath(latex = block.latex, display = block.display)
+
+                is NotebookBlock.Table -> MarkdownTable(
+                    align = block.align,
+                    header = block.header,
+                    rows = block.rows,
                 )
+
+                is NotebookBlock.ToolFence -> MarkdownToolPlaceholder(toolId = block.toolId)
 
                 NotebookBlock.Divider -> Box(
                     Modifier
@@ -198,6 +211,67 @@ fun NotebookContentView(
             }
         }
     }
+}
+
+@Composable
+private fun MathAwareParagraph(text: String) {
+    val segments = remember(text) { mathSegments(text) }
+    if (segments.size == 1 && segments[0] is MathSegment.Text) {
+        Text(
+            text = inlineMarkdown((segments[0] as MathSegment.Text).value),
+            fontSize = 14.sp,
+            lineHeight = 21.sp,
+            color = textPrimary(),
+        )
+        return
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        segments.forEach { segment ->
+            when (segment) {
+                is MathSegment.Text -> Text(
+                    text = inlineMarkdown(segment.value),
+                    fontSize = 14.sp,
+                    lineHeight = 21.sp,
+                    color = textPrimary(),
+                )
+                is MathSegment.Math -> MarkdownMath(latex = segment.latex, display = segment.display)
+            }
+        }
+    }
+}
+
+private sealed interface MathSegment {
+    data class Text(val value: String) : MathSegment
+    data class Math(val latex: String, val display: Boolean) : MathSegment
+}
+
+private fun mathSegments(text: String): List<MathSegment> {
+    if (!text.contains('$')) return listOf(MathSegment.Text(text))
+    val out = mutableListOf<MathSegment>()
+    var i = 0
+    var cursor = 0
+    while (i < text.length) {
+        if (text[i] != '$') {
+            i++
+            continue
+        }
+        val display = i + 1 < text.length && text[i + 1] == '$'
+        val openLen = if (display) 2 else 1
+        if (i > cursor) out.add(MathSegment.Text(text.substring(cursor, i)))
+        val openEnd = i + openLen
+        val closePat = if (display) "$$" else "$"
+        val close = text.indexOf(closePat, openEnd)
+        if (close < 0) {
+            out.add(MathSegment.Text(text.substring(i)))
+            return out
+        }
+        out.add(MathSegment.Math(latex = text.substring(openEnd, close), display = display))
+        i = close + closePat.length
+        cursor = i
+    }
+    if (cursor < text.length) out.add(MathSegment.Text(text.substring(cursor)))
+    if (out.isEmpty()) out.add(MathSegment.Text(text))
+    return out
 }
 
 /**
@@ -328,7 +402,9 @@ private fun NotebookTaskRow(
 private fun isPastDue(dueAt: String): Boolean =
     runCatching { Instant.parse(dueAt).isBefore(Instant.now()) }.getOrDefault(false)
 
-/** Minimal inline markdown: **bold**, *italic*, `code`. */
+private val linkRegex = Regex("""\[([^\]]+)]\(([^)]+)\)""")
+
+/** Inline markdown: **bold**, *italic*, ~~strike~~, `code`, [text](url). */
 fun inlineMarkdown(raw: String): AnnotatedString = buildAnnotatedString {
     var i = 0
     while (i < raw.length) {
@@ -337,6 +413,17 @@ fun inlineMarkdown(raw: String): AnnotatedString = buildAnnotatedString {
                 val end = raw.indexOf("**", i + 2)
                 if (end > i + 1) {
                     pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                    append(raw.substring(i + 2, end))
+                    pop()
+                    i = end + 2
+                } else {
+                    append(raw[i]); i++
+                }
+            }
+            raw.startsWith("~~", i) -> {
+                val end = raw.indexOf("~~", i + 2)
+                if (end > i + 1) {
+                    pushStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
                     append(raw.substring(i + 2, end))
                     pop()
                     i = end + 2
@@ -362,6 +449,31 @@ fun inlineMarkdown(raw: String): AnnotatedString = buildAnnotatedString {
                     append(raw.substring(i + 1, end))
                     pop()
                     i = end + 1
+                } else {
+                    append(raw[i]); i++
+                }
+            }
+            raw.startsWith("[", i) -> {
+                val match = linkRegex.matchAt(raw, i)
+                if (match != null && ContentLinkRouter.isAllowedHref(match.groupValues[2])) {
+                    val label = match.groupValues[1]
+                    val href = match.groupValues[2]
+                    val linkStyle = SpanStyle(
+                        color = LexturesColors.Primary,
+                        textDecoration = TextDecoration.Underline,
+                    )
+                    if (ContentLinkRouter.isExternalHref(href)) {
+                        withLink(LinkAnnotation.Url(href)) {
+                            pushStyle(linkStyle)
+                            append(label)
+                            pop()
+                        }
+                    } else {
+                        pushStyle(linkStyle)
+                        append(label)
+                        pop()
+                    }
+                    i = match.range.last + 1
                 } else {
                     append(raw[i]); i++
                 }

--- a/clients/android/app/src/main/res/values-ar/strings.xml
+++ b/clients/android/app/src/main/res/values-ar/strings.xml
@@ -2675,6 +2675,17 @@ I noticed %2$s in our course and wanted to check in. Let me know if you need hel
     <string name="mobile_liveQuiz_play_yourRank">You are #%1$d with %2$d points</string>
     <string name="mobile_liveQuiz_results_load">View my results</string>
     <string name="mobile_liveQuiz_results_summary">Rank #%1$d · %2$d points · %3$d/%4$d correct</string>
+    <string name="mobile_markdown_code_block">كتلة تعليمات برمجية</string>
+    <string name="mobile_markdown_code_copied">تم النسخ</string>
+    <string name="mobile_markdown_code_copy">نسخ</string>
+    <string name="mobile_markdown_code_language">%1$s</string>
+    <string name="mobile_markdown_code_languageFallback">رمز</string>
+    <string name="mobile_markdown_math_display">معادلة: %1$s</string>
+    <string name="mobile_markdown_math_inline">معادلة مضمنة: %1$s</string>
+    <string name="mobile_markdown_table_close">إغلاق</string>
+    <string name="mobile_markdown_table_expand">توسيع الجدول</string>
+    <string name="mobile_markdown_table_expandHint">يفتح الجدول بملء الشاشة</string>
+    <string name="mobile_markdown_tool_placeholder">أداة تفاعلية: %1$s</string>
     <string name="mobile_marketplace_aboutTitle">حول</string>
     <string name="mobile_marketplace_buy">شراء</string>
     <string name="mobile_marketplace_buyOnWeb">الشراء عبر الويب</string>

--- a/clients/android/app/src/main/res/values-en-rXA/strings.xml
+++ b/clients/android/app/src/main/res/values-en-rXA/strings.xml
@@ -2675,6 +2675,17 @@ I noticed %2$s in our course and wanted to check in. Let me know if you need hel
     <string name="mobile_liveQuiz_play_yourRank">You are #%1$d with %2$d points</string>
     <string name="mobile_liveQuiz_results_load">View my results</string>
     <string name="mobile_liveQuiz_results_summary">Rank #%1$d · %2$d points · %3$d/%4$d correct</string>
+    <string name="mobile_markdown_code_block">[code block]</string>
+    <string name="mobile_markdown_code_copied">[Copied]</string>
+    <string name="mobile_markdown_code_copy">[Copy]</string>
+    <string name="mobile_markdown_code_language">[%1$s]</string>
+    <string name="mobile_markdown_code_languageFallback">[Code]</string>
+    <string name="mobile_markdown_math_display">[Display equation: %1$s]</string>
+    <string name="mobile_markdown_math_inline">[Inline equation: %1$s]</string>
+    <string name="mobile_markdown_table_close">[Close]</string>
+    <string name="mobile_markdown_table_expand">[Expand table]</string>
+    <string name="mobile_markdown_table_expandHint">[Opens a full-screen table viewer]</string>
+    <string name="mobile_markdown_tool_placeholder">[Interactive tool: %1$s]</string>
     <string name="mobile_marketplace_aboutTitle">[About]</string>
     <string name="mobile_marketplace_buy">[Buy]</string>
     <string name="mobile_marketplace_buyOnWeb">[Buy on web]</string>

--- a/clients/android/app/src/main/res/values-es/strings.xml
+++ b/clients/android/app/src/main/res/values-es/strings.xml
@@ -2675,6 +2675,17 @@ I noticed %2$s in our course and wanted to check in. Let me know if you need hel
     <string name="mobile_liveQuiz_play_yourRank">You are #%1$d with %2$d points</string>
     <string name="mobile_liveQuiz_results_load">View my results</string>
     <string name="mobile_liveQuiz_results_summary">Rank #%1$d · %2$d points · %3$d/%4$d correct</string>
+    <string name="mobile_markdown_code_block">bloque de código</string>
+    <string name="mobile_markdown_code_copied">Copiado</string>
+    <string name="mobile_markdown_code_copy">Copiar</string>
+    <string name="mobile_markdown_code_language">%1$s</string>
+    <string name="mobile_markdown_code_languageFallback">Código</string>
+    <string name="mobile_markdown_math_display">Ecuación: %1$s</string>
+    <string name="mobile_markdown_math_inline">Ecuación en línea: %1$s</string>
+    <string name="mobile_markdown_table_close">Cerrar</string>
+    <string name="mobile_markdown_table_expand">Ampliar tabla</string>
+    <string name="mobile_markdown_table_expandHint">Abre la tabla a pantalla completa</string>
+    <string name="mobile_markdown_tool_placeholder">Herramienta interactiva: %1$s</string>
     <string name="mobile_marketplace_aboutTitle">Acerca de</string>
     <string name="mobile_marketplace_buy">Comprar</string>
     <string name="mobile_marketplace_buyOnWeb">Comprar en la web</string>

--- a/clients/android/app/src/main/res/values-fr/strings.xml
+++ b/clients/android/app/src/main/res/values-fr/strings.xml
@@ -2675,6 +2675,17 @@ I noticed %2$s in our course and wanted to check in. Let me know if you need hel
     <string name="mobile_liveQuiz_play_yourRank">You are #%1$d with %2$d points</string>
     <string name="mobile_liveQuiz_results_load">View my results</string>
     <string name="mobile_liveQuiz_results_summary">Rank #%1$d · %2$d points · %3$d/%4$d correct</string>
+    <string name="mobile_markdown_code_block">bloc de code</string>
+    <string name="mobile_markdown_code_copied">Copié</string>
+    <string name="mobile_markdown_code_copy">Copier</string>
+    <string name="mobile_markdown_code_language">%1$s</string>
+    <string name="mobile_markdown_code_languageFallback">Code</string>
+    <string name="mobile_markdown_math_display">Équation : %1$s</string>
+    <string name="mobile_markdown_math_inline">Équation en ligne : %1$s</string>
+    <string name="mobile_markdown_table_close">Fermer</string>
+    <string name="mobile_markdown_table_expand">Agrandir le tableau</string>
+    <string name="mobile_markdown_table_expandHint">Ouvre le tableau en plein écran</string>
+    <string name="mobile_markdown_tool_placeholder">Outil interactif : %1$s</string>
     <string name="mobile_marketplace_aboutTitle">À propos</string>
     <string name="mobile_marketplace_buy">Acheter</string>
     <string name="mobile_marketplace_buyOnWeb">Acheter sur le web</string>

--- a/clients/android/app/src/main/res/values/strings.xml
+++ b/clients/android/app/src/main/res/values/strings.xml
@@ -2675,6 +2675,17 @@ I noticed %2$s in our course and wanted to check in. Let me know if you need hel
     <string name="mobile_liveQuiz_play_yourRank">You are #%1$d with %2$d points</string>
     <string name="mobile_liveQuiz_results_load">View my results</string>
     <string name="mobile_liveQuiz_results_summary">Rank #%1$d · %2$d points · %3$d/%4$d correct</string>
+    <string name="mobile_markdown_code_block">code block</string>
+    <string name="mobile_markdown_code_copied">Copied</string>
+    <string name="mobile_markdown_code_copy">Copy</string>
+    <string name="mobile_markdown_code_language">%1$s</string>
+    <string name="mobile_markdown_code_languageFallback">Code</string>
+    <string name="mobile_markdown_math_display">Display equation: %1$s</string>
+    <string name="mobile_markdown_math_inline">Inline equation: %1$s</string>
+    <string name="mobile_markdown_table_close">Close</string>
+    <string name="mobile_markdown_table_expand">Expand table</string>
+    <string name="mobile_markdown_table_expandHint">Opens a full-screen table viewer</string>
+    <string name="mobile_markdown_tool_placeholder">Interactive tool: %1$s</string>
     <string name="mobile_marketplace_aboutTitle">About</string>
     <string name="mobile_marketplace_buy">Buy</string>
     <string name="mobile_marketplace_buyOnWeb">Buy on web</string>

--- a/clients/android/app/src/test/kotlin/com/lextures/android/core/notebook/MarkdownTableLogicTest.kt
+++ b/clients/android/app/src/test/kotlin/com/lextures/android/core/notebook/MarkdownTableLogicTest.kt
@@ -1,0 +1,49 @@
+package com.lextures.android.core.notebook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownTableLogicTest {
+    @Test
+    fun healsBlankLinesInsideTable() {
+        val input = """
+            | A | B |
+
+            | --- | --- |
+
+            | 1 | 2 |
+
+            After
+        """.trimIndent()
+        val healed = MarkdownTableLogic.normalizeMarkdownTables(input)
+        assertFalse(healed.contains("|\n\n|"))
+        assertTrue(healed.contains("| A | B |"))
+        assertTrue(healed.contains("| --- | --- |"))
+        assertTrue(healed.contains("| 1 | 2 |"))
+        assertTrue(healed.contains("After"))
+    }
+
+    @Test
+    fun leavesPipeProseAlone() {
+        val input = "Use | as OR in boolean logic."
+        assertEquals(input, MarkdownTableLogic.normalizeMarkdownTables(input))
+    }
+
+    @Test
+    fun parsesAlignment() {
+        val lines = listOf(
+            "| Left | Center | Right |",
+            "| :--- | :---: | ---: |",
+            "| a | b | c |",
+        )
+        val table = MarkdownTableLogic.parseTable(lines, 0)!!
+        assertEquals(listOf("Left", "Center", "Right"), table.header)
+        assertEquals(
+            listOf(MarkdownTableAlign.Left, MarkdownTableAlign.Center, MarkdownTableAlign.Right),
+            table.align,
+        )
+        assertEquals(listOf(listOf("a", "b", "c")), table.rows)
+    }
+}

--- a/clients/android/app/src/test/kotlin/com/lextures/android/core/notebook/NotebookMarkdownTest.kt
+++ b/clients/android/app/src/test/kotlin/com/lextures/android/core/notebook/NotebookMarkdownTest.kt
@@ -1,0 +1,94 @@
+package com.lextures.android.core.notebook
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class NotebookMarkdownTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun parsesCodeLanguageAndLexTool() {
+        val code = NotebookMarkdown.parseBlocks("```python\nprint(1)\n```")
+        val codeBlock = code.first() as NotebookBlock.Code
+        assertEquals("python", codeBlock.language)
+        assertEquals("print(1)", codeBlock.text)
+
+        val tool = NotebookMarkdown.parseBlocks(
+            """
+            ```lex-tool
+            {"instanceId":"abc-123","toolId":"inline_questions","v":1}
+            ```
+            """.trimIndent(),
+        )
+        val fence = tool.first() as NotebookBlock.ToolFence
+        assertEquals("abc-123", fence.instanceId)
+        assertEquals("inline_questions", fence.toolId)
+        assertEquals(1, fence.version)
+        assertTrue(tool.none { it is NotebookBlock.Code })
+    }
+
+    @Test
+    fun parsesMathAndTaskList() {
+        val math = NotebookMarkdown.parseBlocks("$$\\frac{a}{b}$$").first() as NotebookBlock.Math
+        assertEquals("\\frac{a}{b}", math.latex)
+        assertTrue(math.display)
+
+        val tasks = NotebookMarkdown.parseBlocks("- [ ] Todo\n- [x] Done")
+        assertEquals(2, tasks.size)
+        assertEquals(NotebookBlock.TaskItem(checked = false, text = "Todo", depth = 0), tasks[0])
+        assertEquals(NotebookBlock.TaskItem(checked = true, text = "Done", depth = 0), tasks[1])
+    }
+
+    @Test
+    fun previewHidesLexToolJson() {
+        val preview = NotebookMarkdown.previewText(
+            """
+            Hello
+
+            ```lex-tool
+            {"instanceId":"abc-123","toolId":"flashcards","v":1}
+            ```
+            """.trimIndent(),
+        )
+        assertFalse(preview.contains("abc-123"))
+        assertFalse(preview.contains("instanceId"))
+    }
+
+    @Test
+    fun sharedFixtureCorpusKindSequences() {
+        val corpus = resolveCorpus()
+        val root = json.decodeFromString(FixtureCorpus.serializer(), corpus.readText())
+        assertTrue(root.fixtures.isNotEmpty())
+        for (fixture in root.fixtures) {
+            val actual = NotebookMarkdown.parseBlocks(fixture.markdown).map(NotebookMarkdown::fixtureKindName)
+            assertEquals("fixture ${fixture.id}", fixture.kinds, actual)
+        }
+    }
+
+    @Serializable
+    private data class FixtureCorpus(val fixtures: List<Fixture>)
+
+    @Serializable
+    private data class Fixture(val id: String, val markdown: String, val kinds: List<String>)
+
+    private fun resolveCorpus(): File {
+        var dir: File? = File(System.getProperty("user.dir") ?: ".")
+        repeat(8) {
+            val current = dir ?: return@repeat
+            val candidates = listOf(
+                File(current, "clients/mobile/fixtures/markdown/corpus.json"),
+                File(current, "../mobile/fixtures/markdown/corpus.json"),
+                File(current, "../../mobile/fixtures/markdown/corpus.json"),
+                File(current, "mobile/fixtures/markdown/corpus.json"),
+            )
+            candidates.firstOrNull { it.isFile }?.let { return it.canonicalFile }
+            dir = current.parentFile
+        }
+        error("clients/mobile/fixtures/markdown/corpus.json not found from ${System.getProperty("user.dir")}")
+    }
+}

--- a/clients/ios/Lextures.xcodeproj/project.pbxproj
+++ b/clients/ios/Lextures.xcodeproj/project.pbxproj
@@ -3,2647 +3,2657 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0041FE5FA6BB46839C7C23EC /* LMSAPIWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E06DECBA6A543058452BA6D /* LMSAPIWallet.swift */; };
-		008DC40656C04572BF7B3DB2 /* GroupSpaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557C836ABA0F405BA0BA8274 /* GroupSpaceView.swift */; };
-		00DE2F91BB654728ADFF6E0A /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE968F8454A7464DBA2E7DCE /* CalendarView.swift */; };
-		01E9158AEBE6416BAA8A83D8 /* LMSAPIOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DBB0D86C7348E1BE18B3EC /* LMSAPIOutcomes.swift */; };
-		02459F671A994F438714916C /* InstructorInsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6FD13AFC9F41AE93B53166 /* InstructorInsightsLogic.swift */; };
-		02E84C176207435C97F45A2B /* LiveQuizHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4A233AE9004DF38E177479 /* LiveQuizHubView.swift */; };
-		03E7E70C3AA343B7A4B7A704 /* NotebookEditorSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155369C709104486B5CEF414 /* NotebookEditorSupportViews.swift */; };
-		0406ADE00F654602A624A7F0 /* IntegrationsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC9A2DB205E407EA3EE4C4A /* IntegrationsAdminEntryCard.swift */; };
-		04692B741C304CDA9A684869 /* ItemDetailRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49305A5741A448B873B01D0 /* ItemDetailRows.swift */; };
-		0511972636604627A87F2339 /* OrgStructureAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C82E80113694021ACA9D6D5 /* OrgStructureAdminLogic.swift */; };
-		055BFD1A7F664F52A1482A96 /* UnsavedChangesBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3768F85B792C4240B933C599 /* UnsavedChangesBanner.swift */; };
-		063E54D3CDDD40488EB8CF56 /* AssignmentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF60F0181744AD795AA80A6 /* AssignmentLogic.swift */; };
-		0783785EA4884A2CAC9E37BA /* OfficeHoursReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A30C3BE3E94FFA8D4579CF /* OfficeHoursReminderScheduler.swift */; };
-		0859F752E2E44CDE99BB3EC6 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 5FEFA96C5EB24052B0050712 /* Localizable.xcstrings */; };
-		091AC461C9D646F6AC1B8506 /* CourseLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62DF94E4C7246ABAA19151C /* CourseLibraryView.swift */; };
-		098D44D05D004C3BA8C100BB /* CanvasImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116CD8D82EB84CC5913B763F /* CanvasImportView.swift */; };
-		0AF60812256C4354A7B797B2 /* CourseArchivedContentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7891F7914C1F4E758EB25057 /* CourseArchivedContentLogicTests.swift */; };
-		0AFD410D254F4754AD2F322E /* CourseEvaluationsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48146640FF274D49B1CE65F3 /* CourseEvaluationsSection.swift */; };
-		0B1536152886452A8897C6D9 /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7890AD9B99F44F78915DF506 /* NotebookTree.swift */; };
-		0B5BC9E20E9A49BAAD6FEFA6 /* NotebookDrawingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7D2973CAE543D4874EBE06 /* NotebookDrawingViews.swift */; };
-		0C9BFA3B36E0462A9450735F /* PeopleAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC40644EAAB4420E81ECB0DC /* PeopleAdminLogic.swift */; };
-		0CEB505A9C73423E9EB7D46F /* AiAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE3F78583244C0A93866713 /* AiAdminEntryCard.swift */; };
-		0DA2B8FB6825458EB63265B0 /* MarketplaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E78A8DCB3D94B559F5A54F3 /* MarketplaceView.swift */; };
-		0E01CAF9578B4E70A3D01BAD /* ProfileSecurityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A51A7141A04A35853163AC /* ProfileSecurityCard.swift */; };
-		0EBF7149F3FF447794A33532 /* ShareFeedbackEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5882273D98498585C2F544 /* ShareFeedbackEntryCard.swift */; };
-		0F32C3FBBA54462191A025A7 /* TranscriptsAdvisingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8615D5FFDF4DF89B01879B /* TranscriptsAdvisingAdminLogic.swift */; };
-		0FCDF694BC1C4F1C913A9E10 /* PlannerSnapshotCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AC5AB4C0254A5DA652C1D7 /* PlannerSnapshotCoding.swift */; };
-		0FD9988E24D04968B1D2F705 /* IntroCourseEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109D480447DC4C5EA88DE50D /* IntroCourseEntryCard.swift */; };
-		0FF9D649AEEC4D50B096AEE6 /* ReadAloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6108A205AC48FEB57A2C55 /* ReadAloud.swift */; };
-		10543BC17F9243F5BAE1A492 /* EvaluationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA86C4C8DEE43549744766D /* EvaluationLogic.swift */; };
-		109D1E0CD38D4C2FBEBFF9D5 /* BoardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E39FC12B86C4A3E99379A39 /* BoardDetailView.swift */; };
-		10E80F150668454D882A4CE8 /* GamificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449E8BCF335C4BBA82508BBC /* GamificationView.swift */; };
-		1107800C47D74FD9862ECABC /* TakeAttendanceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA908ADC182496F9D55A70E /* TakeAttendanceLogic.swift */; };
-		11280210EE584BCEB52E0D65 /* AiModelsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5432BC7753842708D3C91B8 /* AiModelsAdminLogic.swift */; };
-		119AA9A0A2E24657813981E7 /* CourseFeedSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8506C9F6826D472A81CE4394 /* CourseFeedSection.swift */; };
-		11F8FBDE407A40D8A682F6BF /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0093B5FC2AE4D6C89B920C8 /* KeychainStore.swift */; };
-		1234040BAAF643D1BFC48E73 /* WhiteboardLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00E38E54FD44BE9006F19E /* WhiteboardLogic.swift */; };
-		128540713D8F44B3A8C17260 /* LMSAPIEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B096DDAC85418AA92EDA6F /* LMSAPIEportfolio.swift */; };
-		129D89573F524425AE2F41DB /* MasteryLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61078B95908641F0AE74BC4F /* MasteryLogic.swift */; };
-		12A86CE4267D47BDA20E665D /* PathsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAC489BE3F34CCCACE6AAEF /* PathsLogic.swift */; };
-		12BB2217AB3E40B9A82AE187 /* RealtimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55B25BC6CFB43AEA7AB087B /* RealtimeManager.swift */; };
-		12D8E3453B06466F8FAB1740 /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3D2D2779EA474EBEA0EF8C /* ComposeMessageView.swift */; };
-		1310FF7496424B90B8B83BEF /* CourseFeaturesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5973534E35CB4A26ABFD0B07 /* CourseFeaturesSettingsView.swift */; };
-		13FEC5FC6B4443B5A56A9708 /* DashboardHeroPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256C35FFC6634439A4CAB04C /* DashboardHeroPanel.swift */; };
-		140738F3D7924103861E9C4C /* PeopleAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618AC2137984A458564EC23 /* PeopleAdminLogicTests.swift */; };
-		152B51588C0844068C99EA7B /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7F372F388643E186403729 /* AuthFieldRepresentable.swift */; };
-		153281B8E32648E885845203 /* LMSFeatureModelsEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8BA50BE7B246D9A14E56C5 /* LMSFeatureModelsEportfolio.swift */; };
-		158B9F3437A646F48BF49449 /* LMSAPIAnnouncements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9982456D8DA5490FBF00392F /* LMSAPIAnnouncements.swift */; };
-		15941DA9DB624FEE9207726F /* NotificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E447C0DDD144B88568A961 /* NotificationLogic.swift */; };
-		15FC4425DCCF467BB295B342 /* MarketplaceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE3837997044C3CAF1F81E5 /* MarketplaceLogic.swift */; };
-		161E1A5C0A464881ABBD6F9C /* CatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D83CC2AB82D4112A681BF79 /* CatalogView.swift */; };
-		163FD7A39FEE4E59969E3D76 /* AtRiskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA88F6127DEA4B3298045809 /* AtRiskListView.swift */; };
-		165CCB3A2AD94B48B358F967 /* ProfileDepthLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16A062E54DF456CB2FF8087 /* ProfileDepthLogic.swift */; };
-		1680DEF5581A4058BDD95FAA /* LiveGameSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C18FF32FA146DB8FDDABCB /* LiveGameSocket.swift */; };
-		16ECA9917F444FA1A1918CEA /* LMSAPIAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD0733539D4466E9CC056C3 /* LMSAPIAccountIntegrations.swift */; };
-		17EDAAD651CC447698885CF4 /* MyPathsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA3A1F78B7C4590A20AD7D5 /* MyPathsView.swift */; };
-		1820FF2D48634943A1170F63 /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C867B43E2703464F877FC979 /* ArtifactDetailView.swift */; };
-		18C0E38F7C7D410BBA29BACE /* OfficeHoursView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13F5C2201A9439FB4B346EC /* OfficeHoursView.swift */; };
-		194E3E78461E4738B9BCA0C3 /* ReviewHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE69070781249E88461A5A6 /* ReviewHomeView.swift */; };
-		1A24A73E846F4746AB5A37D0 /* AiModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECAFA063878407F86C7AE46 /* AiModelsSettingsView.swift */; };
-		1A6E9681B15C4946BA49F402 /* PlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EC2F62124947CFA5753E97 /* PlannerView.swift */; };
-		1A9CCA400B374FBDB1F282C5 /* LMSAPIReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7BE364B12F4037819B6D7E /* LMSAPIReader.swift */; };
-		1AC9F9A2670742629BCAF122 /* LMSFeatureModelsLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6658747E5AE4132BE360D97 /* LMSFeatureModelsLive.swift */; };
-		1B26EF24172B4093BCC12644 /* CourseGroupsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B73CD6651445D8BA65B37A /* CourseGroupsSection.swift */; };
-		1BCAAB480A9649CAB28C70D2 /* BoardExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EEE24B337F47059EB78C3C /* BoardExportSheet.swift */; };
-		1C5BFD491EC3485D84E82AAE /* OrgStructureAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5F89E5B4424EB0BA488C06 /* OrgStructureAdminEntryCard.swift */; };
-		1E21D92794304E6E9529AF69 /* WalletLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89A96A62A294B11B053B1BF /* WalletLogicTests.swift */; };
-		1E46551F66494BDEB2A88D3E /* AuthCallbackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C42D131DBC6453CB932AEE1 /* AuthCallbackParser.swift */; };
-		1E5BFE03C54543E198D0A42D /* FeedbackLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF85BA6B55D24B0F9AB635D9 /* FeedbackLogic.swift */; };
-		1E63F70BA0DA47E5B48BCBCD /* MarketplaceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD0319136154E8D83B21269 /* MarketplaceLogicTests.swift */; };
-		1E6745D4204E45B39A469D71 /* CredentialsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56ACCFF75AEF4A9CAFECD03C /* CredentialsLogicTests.swift */; };
-		1E9E82FEBEBE490EB273A5E5 /* ReportDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7744DD60219447E28F115D42 /* ReportDialog.swift */; };
-		1EB946BBC07C4F0E91562AFA /* ParentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E53C28079A4E6C983463A8 /* ParentLogicTests.swift */; };
-		1EC08E8B5C39426D93A6936D /* CourseBlueprintLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A759FB2A25A544B09FA669EB /* CourseBlueprintLogicTests.swift */; };
-		1EF082CD18674F1F928B7FFF /* BoardSaveAsTemplateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D848E3CFF3564E8F8F3EF421 /* BoardSaveAsTemplateSheet.swift */; };
-		1EFBE40ACCF6448493B79835 /* LMSAPICourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C382B37AD7B41FDACBBF68A /* LMSAPICourseAccessibility.swift */; };
-		1F4F38E4463846D0A7DB99FE /* DeviceSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B9C62DD66C4A6BA003B1E1 /* DeviceSessionsView.swift */; };
-		1F980C19CAC7471AB1E8D74D /* OfficeHoursLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3302C2097D714588B442C1BE /* OfficeHoursLogicTests.swift */; };
-		1FFB778E822C4DBDB715A916 /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D524FD4C47D48D4B04D660A /* CoursesListView.swift */; };
-		208D01F988FD4F2CAA8D1860 /* QuizResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804D6FAE7F334402992FAD26 /* QuizResultsView.swift */; };
-		2163DE54E70F475FBC157C13 /* MobileDestinations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EA2F1D66A6499B8343CCE3 /* MobileDestinations.swift */; };
-		221C5AE6E9D94734A5ABDAF4 /* MasteryLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65989912D7B347D1AAC83331 /* MasteryLogicTests.swift */; };
-		2220CC5287354BADB428FAC8 /* WebItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F8E99D3FF94297B94B02D7 /* WebItemView.swift */; };
-		2458C373E24043C29532B285 /* CourseGradingAgentsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D99243ADB74AE28BAEA1FA /* CourseGradingAgentsLogic.swift */; };
-		245E9ED1537E44F59EB5B52A /* WhiteboardLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA2F9A7AD954C8B88AD6E9A /* WhiteboardLogicTests.swift */; };
-		247E109255614CD7975F7F90 /* LMSFeatureModelsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065C3BABC11144C79BFC5D7D /* LMSFeatureModelsCredentials.swift */; };
-		24CE6910263A41578FEA0F0F /* PurchaseFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3550FF35F84CD5BEC85D1C /* PurchaseFlow.swift */; };
-		25226443E8C5498E9C28A047 /* LMSFeatureModelsCourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FDA97D2744AB58F335445 /* LMSFeatureModelsCourseTranslations.swift */; };
-		255B2A9B0A7D46FDB8C9FA76 /* LMSAPICourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D516E4132064312ADC97EF2 /* LMSAPICourseReviews.swift */; };
-		257F3C5CB2634E30B3975B81 /* LMSFeatureModelsInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2857A249A7D44D8A35F0588 /* LMSFeatureModelsInsights.swift */; };
-		26262FED1F804D2AB50D384A /* PeopleAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7894ED56BEAE4FFA8F993DF6 /* PeopleAdminEntryCard.swift */; };
-		2683BEB70FC64E038D00AF14 /* LMSAPIAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449CD77DD2A04631B9B1513A /* LMSAPIAdvising.swift */; };
-		26FC2540641745239230A199 /* ModuleItemRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F2DB59FA2D4A86B9F6A2E6 /* ModuleItemRouteView.swift */; };
-		27760B53231046E2A5894CB3 /* VibeActivityLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208785AC35264E2F844BC2B0 /* VibeActivityLogicTests.swift */; };
-		27801420702A4194B69AA17A /* CredentialsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF14C133F894FDCA69C54A7 /* CredentialsLogic.swift */; };
-		27A8F5F29E9B4570B09D83DD /* ProfileDepthLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77A51CF0586468F99A3FD17 /* ProfileDepthLogicTests.swift */; };
-		27BD31BB7E6244DCBEEF50F7 /* PortfolioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21EC9AD051A47708EF12C64 /* PortfolioView.swift */; };
-		27D31B7E47704438A8E8A2BA /* CourseArchivedContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B059A1DA5B4AFC81AE8CD4 /* CourseArchivedContentView.swift */; };
-		28241AD74F904A5EA30F0639 /* SettingsAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644B81595D4A419AB600062F /* SettingsAdminHubView.swift */; };
-		28F63354CA3047B295664F71 /* MeetingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6537BE01A4D4E8B9ABD4AD9 /* MeetingListView.swift */; };
-		291C866A8BA34F9AA7432278 /* MyAccommodationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43743C8A7CD4D20AE020BE1 /* MyAccommodationsView.swift */; };
-		292A13FC17864E9EA4DFE416 /* BoardsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7573C7EAB3B14B0BA16D68D6 /* BoardsListView.swift */; };
-		295E887EBB29498D818FEFC9 /* LMSAPILiveQuiz.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EE7AE153204335AEBBBB6C /* LMSAPILiveQuiz.swift */; };
-		297D6F0367774B138A7B7DE2 /* FeedChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E16F188C46420487CB8AD0 /* FeedChannelsView.swift */; };
-		29A616DCD45648508FD20238 /* PortfolioDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6142AEC908E24BA28DC2FD5C /* PortfolioDetailView.swift */; };
-		2A64E06493784F7F93868D88 /* LexturesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E1D67CF59949ED8000FA8C /* LexturesType.swift */; };
-		2B2AF9E2736C4E8980FF32C0 /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED83CBC0CCA40219F4F2D41 /* DateFormatting.swift */; };
-		2B5F5B470EBE437788CCB53A /* DictationField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA6A21122004750A3F1AE37 /* DictationField.swift */; };
-		2B6CA9651A464E7899854C5E /* LMSFeatureModelsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BB8F7A48F4902A8AC0ACB /* LMSFeatureModelsReader.swift */; };
-		2BA96659F8894261B1CD5646 /* AiModelsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1607A9155C488EBDACD2AD /* AiModelsAdminLogicTests.swift */; };
-		2BC0ED5C27E14886BD6B39D8 /* MobileProfileDepthPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF4DDCB19714EE3920D1984 /* MobileProfileDepthPreferences.swift */; };
-		2BE42B7168E74AC9BB49AA37 /* ProfileSettingsCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = F187B38EA4C4471788C5E79A /* ProfileSettingsCards.swift */; };
-		2CB0D9BB9B8D4DBA86AE023F /* LMSAPIMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA6CF17C66741A7B273C184 /* LMSAPIMastery.swift */; };
-		2CBC37EBAA694A7F9B87A33D /* BoardsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EBFCEDAB574DD18062254A /* BoardsLogic.swift */; };
-		2D6401AEC1504603B1AE2401 /* LMSAPIBoardAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768BFDBA7AC042C189053972 /* LMSAPIBoardAccess.swift */; };
-		2D7172CF2B3B4C839652F631 /* ReviewSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF348B6075744E14A3B51A5E /* ReviewSessionView.swift */; };
-		2DDD559AB54B469182552EF2 /* CourseCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D0CBFA914409C9C34D400 /* CourseCreateView.swift */; };
-		2ED9D4A0907A45A593C5DC0F /* GradeFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD084088C724283AC56BFCD /* GradeFeedbackView.swift */; };
-		2EE42BB2867E42EAB056D0D6 /* ReaderToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64303C4AF6544D0CB0E892DB /* ReaderToolbar.swift */; };
-		2FBA4F6CEEAD4E5A80EDFCF1 /* RolesPermissionsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F64F258911C48999538A5B1 /* RolesPermissionsAdminLogic.swift */; };
-		2FCF2AE17D474A7DAA8B706C /* OrgBrandingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA6F2ABD004BB7A7F2DCF3 /* OrgBrandingAdminView.swift */; };
-		30A55546C8BF414EA6AB0B96 /* ReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A694B01E62B9474ABFEC7892 /* ReviewLogicTests.swift */; };
-		310AB9BA30434CABBF8B79CA /* CoursePlagiarismSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4578D962A54EDD87A1FB1C /* CoursePlagiarismSettingsView.swift */; };
-		31C2123B782547B3ACA82701 /* PortfolioLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7140D08ECB4DD8828FD4DC /* PortfolioLogicTests.swift */; };
-		31E7CD33FC6F469590F0DC38 /* LMSAPIDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AA4EFD58D94D15B395E243 /* LMSAPIDiscussions.swift */; };
-		32B897C4893F43F89995CCD7 /* TranscriptsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71FB03292EB479498E7C037 /* TranscriptsSettingsView.swift */; };
-		32CCFC36F06242FA9E84674F /* LMSAPICoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D6F3EF92B24D05B2B7779C /* LMSAPICoursePlagiarism.swift */; };
-		331DC6E1A2054E6DB46BAA22 /* CourseReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344E381A27B44C94816F4DC9 /* CourseReviewLogicTests.swift */; };
-		33991E4F08F5489890DC1D8A /* LMSAPIMobileWave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE5438B1B5A4AEDB8356E07 /* LMSAPIMobileWave.swift */; };
-		33F28A8B9D994F8E9F3AB4D8 /* LibraryBrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33CF3B2534542B097B35C1B /* LibraryBrowseView.swift */; };
-		3411C7861AB84C11A17B2781 /* LMSInteractiveModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235B2EBE17694F38AFF7765D /* LMSInteractiveModels.swift */; };
-		34233CB7D4294DAC88E3098F /* TutorChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FEF491388147718568247F /* TutorChatModel.swift */; };
-		354AC34CCC7245F88FCE0FE8 /* DiscussionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA80204536948B28987E9D2 /* DiscussionLogic.swift */; };
-		356934E3D5634817AE72D22D /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F894CB179FB2419991AC1D55 /* InsightsView.swift */; };
-		35E90F21E769441F818D9EB8 /* DashboardCoursesCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A640A9490874D41B2FE85CE /* DashboardCoursesCarousel.swift */; };
-		35E9126EBAEA4A61A95F8F81 /* I18nTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E39200EE6C94FF29BED5934 /* I18nTests.swift */; };
-		361251740E774FCAA7F2D1DE /* OfflineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299F11BDA0A444EBB3960E99 /* OfflineModels.swift */; };
-		367A30D7717C4098B90DD527 /* UIModeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D58D84855D54A859F14F9D3 /* UIModeLogicTests.swift */; };
-		372174549C0B424A9A21B394 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A66CC7AA25B4A5EB14CBA22 /* SyncStatusView.swift */; };
-		3745C6A65FA44A1EBB68DE4F /* ContentLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E19E2D4DAE44EE97DA583C /* ContentLinkRouter.swift */; };
-		37747D0BE8544ABB914D5AA8 /* LMSAPICourseBlueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D56D54A5114FC7AD4449A3 /* LMSAPICourseBlueprint.swift */; };
-		37922A070862498D854F5FC6 /* ReadingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBE28F0AD44768B60A3E99 /* ReadingLogicTests.swift */; };
-		37970C43701C4ADC9044BF83 /* AppleSignInLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765ABC1C76234576883D0A1D /* AppleSignInLogicTests.swift */; };
-		3823C380D04E4AF2A770AE6C /* LMSFeatureModelsGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D21A57EA87849F38CB40E33 /* LMSFeatureModelsGroups.swift */; };
-		38600437A0944CE59A03CB4C /* TimelineLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91374B24492642BCB4E88D1B /* TimelineLayout.swift */; };
-		38BFAC36FA7A40D388A87AC9 /* OrgStructureAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0F151D42A4B7BBBE595A4 /* OrgStructureAdminLogicTests.swift */; };
-		396E059A46FD4E69BEC89F4E /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5714502F0C4952B43A0969 /* DeepLinkRouter.swift */; };
-		3971550B4A6C4B43A275676C /* StudentProgressDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586AB25CB90C40D69E0DAE6D /* StudentProgressDetailView.swift */; };
-		397D4FEDEE754D49B2F21136 /* ReactionControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5038E5EB4FF249EFBC5C63FC /* ReactionControl.swift */; };
-		399915F355844D0F9F23FA14 /* CourseFeaturesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF5D397892B4D0183985779 /* CourseFeaturesLogicTests.swift */; };
-		39A25DA310FD4B8983EBFCE9 /* GradeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4209468B67084C02BC930593 /* GradeCalculatorTests.swift */; };
-		3AABCAF0D9F245F6B4750B52 /* DownloadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B156EC63DA0545DFA9886B4E /* DownloadStore.swift */; };
-		3B070D29D7B144DDB3ACE13D /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1FF550C55542478C92B16C /* WebSocketClient.swift */; };
-		3B490906D5444BF5BB87DF14 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76441B24A6450683771C3B /* CourseDetailView.swift */; };
-		3B5C9B7266CE49A68E8C4BB2 /* QuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C78F9BCAE5848B082A3E3BA /* QuizLogic.swift */; };
-		3B9EA2147C274086B2623EA0 /* LMSAPIReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C685DDE626FD43AE8E794DF9 /* LMSAPIReview.swift */; };
-		3C26EDC7951C4EA9A8F87280 /* LMSAPIFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EABAF87B38948CD96516C1B /* LMSAPIFeed.swift */; };
-		3C2B7EF9D8FC43AD99E0A7FA /* PathRunnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD75FD7E8C547E0AE275195 /* PathRunnerView.swift */; };
-		3C4437AEBF744DF084943225 /* NotebookPagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41405FFAA6E74123B7CD71F8 /* NotebookPagesView.swift */; };
-		3C457332F57045D2A151F797 /* RolesPermissionsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC54A0C4908441CA4EA494D /* RolesPermissionsAdminEntryCard.swift */; };
-		3D6137C08EDA4006944CB2CD /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F62442A38E64FFCBB19CDB7 /* LoginView.swift */; };
-		3D6F154A9E0042DEBCA6163A /* LMSAPIQuizCodeRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951CD3FD737C4BA195298FBB /* LMSAPIQuizCodeRun.swift */; };
-		3DD822D36CEF44358FA5B609 /* LMSFeatureModelsCourseOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CD6077FE5D40CC8319EE83 /* LMSFeatureModelsCourseOutcomes.swift */; };
-		3E733C4250324F8ABC2BA381 /* VibeActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D8486728CD49FB9B7E622C /* VibeActivityView.swift */; };
-		3EACCA5C1D4B4F90846510B7 /* CourseBlueprintSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B6A04F2AA847F2B0007D9D /* CourseBlueprintSettingsView.swift */; };
-		3F025BCC323E4D21BBE26743 /* CollabDocView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCADC30404644DCCB14F7CF5 /* CollabDocView.swift */; };
-		3F74682A50FE429EA4297D96 /* IntegrationsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770C736B28C0432396B68FFA /* IntegrationsAdminLogic.swift */; };
-		3FAE014984844B32AA2A4A09 /* LMSAPICredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02639B5CAA2949FEBA60BCA6 /* LMSAPICredentials.swift */; };
-		40A5CFCB2F5D4551BF1FB546 /* InteractiveLaunchLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79ADB99674041B1A81298EC /* InteractiveLaunchLogicTests.swift */; };
-		410A494F5DCF4E7FAA734EE4 /* ArtifactEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A49502E6AB94ABE82C6B9C5 /* ArtifactEditorView.swift */; };
-		41A794A270F3482F8D29FD17 /* CoursePeopleObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D3F6FF903E49CE90FB8282 /* CoursePeopleObservability.swift */; };
-		427867C6638644B7A5D65A77 /* PlatformSettingsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021982ACCF24416286E33E7F /* PlatformSettingsAdminLogicTests.swift */; };
-		434EEA1081F14774B6C15627 /* LMSAPIWhiteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC498FBB0BB41AD957F3E63 /* LMSAPIWhiteboard.swift */; };
-		4412D47BDD0A407D954FD936 /* LMSBoardModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F35B5D01D274083BC601865 /* LMSBoardModels.swift */; };
-		4474D014A704412E90E1E026 /* WhatsWorkingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3ECBF38B134BCBAFE1BECF /* WhatsWorkingView.swift */; };
-		45680A9D32DF41EB8F0D216A /* WalletOfficialTranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C9F5B4AB07403FBE7C47AF /* WalletOfficialTranscriptDetailView.swift */; };
-		456FBCCE4C5E41829C383E3D /* ModuleListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBE9B830C2C4543A4ED7B2F /* ModuleListView.swift */; };
-		45B4DE5DE02E4620BBD116BD /* MyPurchasesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12A8567D2FD4F96A46A78C9 /* MyPurchasesView.swift */; };
-		469CF13396A64D35AD52F151 /* LMSFeatureModelsCanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4188B26349243DDA32FD60F /* LMSFeatureModelsCanvasImport.swift */; };
-		46A16472B9CE4506AD378C1E /* BoardAnalyticsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96269A903D444BCB8403956F /* BoardAnalyticsSheet.swift */; };
-		474EF57FA52447A9AE7C0BF0 /* MobileDestinationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C5E4D851054C9F90CE7AD1 /* MobileDestinationsTests.swift */; };
-		4764BA623AA6458489258500 /* InsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95897DDA808D4572AA50C4D1 /* InsightsLogic.swift */; };
-		4800B6BD78CC47F6A256900F /* LMSAPIBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E678B5431544F439C1072C9 /* LMSAPIBilling.swift */; };
-		486652BD754D4CDAB7F6BF97 /* AiReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E0CE51BDA342C7B099E9A8 /* AiReportsView.swift */; };
-		48696B5FE1804FAD83864AFB /* CanvasImportObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF68DEFDB6F644F1B49AE7FC /* CanvasImportObservability.swift */; };
-		4870EA14D21F4ED3A5CEB5CE /* LMSAPIProctoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594CE084CFFA400D985A7E3E /* LMSAPIProctoring.swift */; };
-		4937DEA49B2F472BB2346E9C /* GetStartedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2271CD0EF66D45C0AFEEF21D /* GetStartedView.swift */; };
-		4941EBAB677E4EF1BA57291F /* CoursePlagiarismLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9468E3BCBC43738DFFE9C5 /* CoursePlagiarismLogic.swift */; };
-		4AE4429A16C447A89EC97BA9 /* AuthCallbackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E704138E9AFA40C68C28E541 /* AuthCallbackParserTests.swift */; };
-		4AFB47AF0D794E44B80BE4BD /* CourseSettingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCB109F4F14696B51C6CBF /* CourseSettingsLogic.swift */; };
-		4B4025DA85014201BAE6D0BF /* AssignmentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAD6803550D45479F900217 /* AssignmentLogicTests.swift */; };
-		4B7EB06DE842446380DC8B5A /* CourseSettingsHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A77838A5C244C1B33172C8 /* CourseSettingsHostView.swift */; };
-		4B985EBA95714ABFA51EE528 /* TutorFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE97C894473F4880BF6E4146 /* TutorFlowLayout.swift */; };
-		4BC3D5CEFE5548908076E216 /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04636FB552D74F78AE3481B3 /* NotebookMarkdown.swift */; };
-		4C088F6EA1B34C28A0C60EEA /* CourseAccessibilityReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46261D0C61D7422C825EBEF6 /* CourseAccessibilityReviewLogicTests.swift */; };
-		4C3BEBC752E0497C8B14AD2F /* LMSFeatureModelsTutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67E1F886BFA47138686710E /* LMSFeatureModelsTutor.swift */; };
-		4D19C536B8884E54BA534406 /* SettingsMenuLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966EEB61DF6A41CDA5A6C782 /* SettingsMenuLogic.swift */; };
-		4D68557B07644E6BA10DF57F /* CourseBlueprintLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CF1F6145E94FBDA9B42BCF /* CourseBlueprintLogic.swift */; };
-		4DC46457177E4D40AB442A4B /* CanvasImportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6736D5AB4D3C4D27B4D6F79D /* CanvasImportLogic.swift */; };
-		4E2FB52EBA3A4F89A6E4D640 /* ReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673BC88CC18C46119E3F0DD0 /* ReviewModels.swift */; };
-		4E9014A25F7E4942A0F8D69D /* OrgBrandingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F26CD37E0CC46E89928A002 /* OrgBrandingAdminLogic.swift */; };
-		4E9ED2F500CC489EB0217A92 /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C2429040EA4973B3CA5ABE /* SyncEngine.swift */; };
-		4EA26CA0154F45C39BF013D5 /* BillingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B69A18DEB4845679ACC432E /* BillingView.swift */; };
-		4F582EC491774E0CB6D3916F /* LMSFeatureModelsAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9CCBAC5A95489D952F732F /* LMSFeatureModelsAccountIntegrations.swift */; };
-		507D3C9F02F64883A5BAFB77 /* PortfolioLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BEE775C57A94F28B6998EF4 /* PortfolioLogic.swift */; };
-		50B50058AA824B3AAF879DF8 /* CalendarSubscribeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EABEF6DC594B13AB302015 /* CalendarSubscribeSheet.swift */; };
-		50D84A8CE65B498A90F0154A /* PlatformSettingsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31AE65FEEC54DDBB83A298F /* PlatformSettingsAdminLogic.swift */; };
-		515012AE71E84025AE4F1333 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1882D9B3000C4B87B0033111 /* Assets.xcassets */; };
-		5227F0973A5E4FC29A61FC44 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FEFBF6E80EE49B6954E7C68 /* AuthSession.swift */; };
-		524C2D5121224121959AB240 /* LMSFeatureModelsAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BCA8EBF7554564B0C4B34E /* LMSFeatureModelsAdvising.swift */; };
-		524EA0BC49FE44B1B1D9243F /* LMSAPIParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3219C169154315A1EABC2A /* LMSAPIParent.swift */; };
-		526275159DF64DD0AA38775B /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7284D67AEFA4B6B89CFABB4 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */; };
-		5319DF83F3254430A3E7F4E8 /* PlannerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7A122FBFBF44F68381972E /* PlannerLogic.swift */; };
-		5369BEC3ECC641139A1A206D /* GamificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46DCEFAEE87493A9E31AC43 /* GamificationLogic.swift */; };
-		53832ACC0D8140FB84A3037A /* TodosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CB6F1A4D534109BD3F78A5 /* TodosView.swift */; };
-		549AA37529FE4D44B120602C /* CourseCreateLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DE8DE61E0F493AA4729F3A /* CourseCreateLogicTests.swift */; };
-		5519921AD5AC4370A4A53280 /* LMSFeatureModelsAiAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF67DD138BFE4DD691D2B8E2 /* LMSFeatureModelsAiAdmin.swift */; };
-		552D04812A7F4D669B929277 /* CourseMasterySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FC4DBC336D4409B223A7F6 /* CourseMasterySection.swift */; };
-		55309946A5694048A3776B6C /* WhiteboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E370F1CBBF124190ACEA5B92 /* WhiteboardView.swift */; };
-		55862CD7195C4FCD9B727DA2 /* CourseLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FFEC5BD1A44C7D9086AFCF /* CourseLandingView.swift */; };
-		5634E0E8A20C43BA966DDA02 /* LMSFeatureModelsMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690BD68F0A574B6093EE8CA6 /* LMSFeatureModelsMarketplace.swift */; };
-		566F6E0C129248239B6B757F /* CourseOutcomesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F5044EA5764DB8B55673CF /* CourseOutcomesLogicTests.swift */; };
-		573D2C6B67AF45B29139D737 /* LMSFeatureModelsDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BE7B6F9FD24732B3294FD1 /* LMSFeatureModelsDiscussions.swift */; };
-		57441831B33A4FEBB6EF1DEC /* ProfileDepthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757045ECE48246F1A51BCB30 /* ProfileDepthModels.swift */; };
-		576B43B37B5A408EA923E0C9 /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CE45281D2C45AEB0062B4B /* NotebooksListView.swift */; };
-		576ED90154C9470EA4AD3DDF /* LMSFeatureModelsCourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B7198BC9464E688E63632D /* LMSFeatureModelsCourseGradingAgents.swift */; };
-		57C6DBA3DFCE486C8EE2496F /* LMSAPIInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52756647D9D34EB1B5B6DAAA /* LMSAPIInstructorInsights.swift */; };
-		580DF4E568C442BF8D09CD35 /* BoardShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632A81DB862E42068731DE45 /* BoardShareSheet.swift */; };
-		580FAF0A4DBE4AC19ED1CF9B /* CourseCollabDocsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F235B995F649415F8E39B499 /* CourseCollabDocsSection.swift */; };
-		58FEBB43733842C98EFCBADB /* ReadingPreferencesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65FBEB6E44745D48D2CBB62 /* ReadingPreferencesSheet.swift */; };
-		591F119EEF2E442DA605DAD4 /* LeveledLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E7205FF51040FCB72CBF82 /* LeveledLibraryView.swift */; };
-		596AA128B6654471A916A463 /* MyConferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE38EA90FA4B9A9F425D60 /* MyConferencesView.swift */; };
-		597DBA421E844192926BB697 /* ProfileViewSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723ADB534980465A86521896 /* ProfileViewSections.swift */; };
-		59A0EE6FC1AF4DF98D4A8114 /* NotificationPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9E51F3B6C244E5825F2FDC /* NotificationPreferencesView.swift */; };
-		59C74B928DD44749B179287E /* LiveQuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76D6B8EFF32425AB3F621A6 /* LiveQuizLogic.swift */; };
-		59D814C31C044B6FB0162D41 /* LMSFeatureModelsPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C479EBF1A114D379C503F12 /* LMSFeatureModelsPaths.swift */; };
-		5A8F0E83430A48BFB8D69806 /* AiProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A997C2E681E14B0E86E1FF00 /* AiProviderSettingsView.swift */; };
-		5AF3CA042B8E47CFA2D48C32 /* CourseFileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5512688359B4814B37EEE73 /* CourseFileLogic.swift */; };
-		5C27043D5C43469C953ED076 /* ParentGradesDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083115F582E34B1F8B9EC068 /* ParentGradesDetailView.swift */; };
-		5C3C84050A8A4B42823C0B15 /* Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6100991B98475EA6F3E955 /* Localized.swift */; };
-		5C7B03E9B1C742DCBE69369A /* MyBookingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15102891D765497683B09AF7 /* MyBookingsView.swift */; };
-		5D8AE7AC158248C7B143ABB8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC032FFE898494AAE5AD290 /* IntegrationsView.swift */; };
-		5DED8AF9AD2D4F9D93314DFD /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EDF93341CE47D0B74C0CC0 /* LMSAPI.swift */; };
-		5E04043E5E7C43238F5AE319 /* InteractiveLaunchLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527B4669637B4F1DB8F64BA3 /* InteractiveLaunchLogic.swift */; };
-		5E5748296D024B9DA11004B2 /* ReaderLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AF719197EF4E2890D94BFD /* ReaderLogic.swift */; };
-		5F2EAB1BC0DC4C91836F6058 /* EvaluationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29903FC1ACA442DBB5CA908C /* EvaluationFormView.swift */; };
-		60035C8CE27646DD87B88612 /* OutboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09E3B692B6B4DCDBADC1A24 /* OutboxStore.swift */; };
-		601BF591C4F04942B5061CEE /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296DA335A83B4D89A5E3627B /* Haptics.swift */; };
-		60449CE622584C98B5FAF9ED /* AnnouncementLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37018A24C2F34F659FA49BA9 /* AnnouncementLogicTests.swift */; };
-		60513E6280134638A5FA83DA /* DiscussionLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A2A1B1786447C9A1046778 /* DiscussionLogicTests.swift */; };
-		605E48EACCCA45C983B7EE5B /* LMSFeatureModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584D006BF6E14023B0544198 /* LMSFeatureModels.swift */; };
-		6097F22C2B83482D8362FE34 /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CEE4E31021C4DC598C25815 /* CommentSheet.swift */; };
-		609992B1A1834EC39CE7E208 /* MobileIaPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF4E68A7EFD4FE7A3E90097 /* MobileIaPreferences.swift */; };
-		60C2FAC9ECF540C7B51A1F4A /* LMSFeatureModelsCourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98363B34BAB64153B9744806 /* LMSFeatureModelsCourseGrading.swift */; };
-		60D36AB086624FA6A917BA6E /* CurrencyExponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D4CB337387490E9E66310D /* CurrencyExponent.swift */; };
-		6139DF3DE59A4A1EA4B45C4E /* PostComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1EFCDD4B1B414CAE377ADA /* PostComposerView.swift */; };
-		6176747AED8E456FB77751E6 /* BookingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B924B190901D424E95E8A674 /* BookingSheet.swift */; };
-		62306CC29174472B802EF4F9 /* CardArrangeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292955293ECD44C08E3482A0 /* CardArrangeMenu.swift */; };
-		62FDBE7FC0464006B5C44C6B /* MarkupOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE949E1B6E74D0F88D2EFB9 /* MarkupOverlayView.swift */; };
-		635A79E2C2EB4C2C9FE2D9A5 /* AdvisingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99FC059348942538237B214 /* AdvisingLogicTests.swift */; };
-		6413FAEE66EA48BDBBB249E9 /* VibeActivityLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A875C09B2EE4A7CB6000B43 /* VibeActivityLogic.swift */; };
-		6420BD61D1E740B183DAFD10 /* AccessibilitySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DFAFCB274D143E49E22EF3F /* AccessibilitySupportTests.swift */; };
-		642F072D628E41F9AFCEA6FA /* CourseCreateLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A99646D93646DAABE7B029 /* CourseCreateLogic.swift */; };
-		647F1978D5334FD3A73FE0DC /* ModuleLastVisited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0932C48BD6084509935F6B79 /* ModuleLastVisited.swift */; };
-		6504D2530A984BEBA5F3A89C /* ShareFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E31B7BEE5E4E86AF1E1C02 /* ShareFeedbackView.swift */; };
-		659584D8810544F991297122 /* CourseReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7BF5493ABE454C931A4633 /* CourseReviewLogic.swift */; };
-		65D059F874154C65A971BAEB /* CourseDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99582A786E0C487C9B97290C /* CourseDrawer.swift */; };
-		66554CA03B054EB7B8AADC75 /* GradeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522BA4E302B345C7B5F5D022 /* GradeCalculator.swift */; };
-		66D0F48F34544C2FB44434DA /* LMSAPIIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C305FCC30ECF400C98CA8785 /* LMSAPIIntroCourse.swift */; };
-		66FEF12457A947CFA3928C46 /* CourseGradingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB60E6F45C645AD83B3A357 /* CourseGradingLogic.swift */; };
-		676FDF2B65E642F19A0A2627 /* CourseArchivedContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB40ECDD371D46629FA4B0B9 /* CourseArchivedContentLogic.swift */; };
-		68B3FD62633745B19917CBF4 /* AccessibilitySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC704C864B14285BA2F8CF8 /* AccessibilitySupport.swift */; };
-		68D54D78AA3A4E2B8CD5979C /* ReviewReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045BD75FC50049ACB642089C /* ReviewReminderScheduler.swift */; };
-		692ECF1A1EB54EEDB701CA0E /* CanvasImportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6613F6EF4E9F48B990DE7564 /* CanvasImportLogicTests.swift */; };
-		693493C628D9452B8528B6A0 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71A55C4A7074EA98B82BDE4 /* APIError.swift */; };
-		6B0362DAAFE04A728FD8B85B /* IntegrationsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB248334F51E4753BD8F22EC /* IntegrationsAdminView.swift */; };
-		6B205032F85E4421AF1886AD /* LibraryResourceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5439138D5A6245AF937F5AE1 /* LibraryResourceLogic.swift */; };
-		6B208988F688450F91BF27AE /* FeedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D290C583E4A4DFAAE942E2D /* FeedLogicTests.swift */; };
-		6B5A6E7C1C58495491AF6D40 /* AssignmentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD8CDF78FE4E4597E38BA6 /* AssignmentDetailView.swift */; };
-		6BA592160CFA49FD8CA9EE80 /* TranscriptsAdvisingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6284CF037D04D2E8BA40A82 /* TranscriptsAdvisingAdminView.swift */; };
-		6BB2750A1155418585023080 /* LiveQuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A099A324C6434C8EEF58F6 /* LiveQuizLogicTests.swift */; };
-		6BB282A21DFD4A38911028B3 /* LMSFeatureModelsMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3BA1A6B9704FB5883A71F1 /* LMSFeatureModelsMastery.swift */; };
-		6BCCAB5D1C05434AB871CA24 /* RubricScorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87B9822FB747678C319A5C /* RubricScorerView.swift */; };
-		6BEC30E92FE54787B4898C97 /* ContentTranslationControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615EF6F7090B489EA056E254 /* ContentTranslationControls.swift */; };
-		6CFDBC0C1A644BC48BB42EC7 /* WalletLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5977781DE424B91B8554838 /* WalletLogic.swift */; };
-		6D2B87FCC7F743BA879421DC /* LMSFeatureModelsFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDA8AE824C84289A9FE74D8 /* LMSFeatureModelsFeedback.swift */; };
-		6D92F9DD68F94B528B680B08 /* LMSAPIBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AC45FE1DCB94FB796DCD2D2 /* LMSAPIBehavior.swift */; };
-		6D9C6A2E7707486294527846 /* LiveMeetingsRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E614255DE8BB4580933D77CA /* LiveMeetingsRail.swift */; };
-		6DE87F208E28448393E40E3B /* CourseCreateDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A90396389242E6AE275FBA /* CourseCreateDraftStore.swift */; };
-		6DFA5CEDE5F84448AAE9B24E /* BoardComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26384B47056D4A18B88BCD9C /* BoardComposerView.swift */; };
-		6EBCCA48836F457786310E63 /* ReadingDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795D3DC0AE54485C94EC51BE /* ReadingDashboardView.swift */; };
-		6F0C6280A791470EB163B49A /* QuizQuestionViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E28E12F37D5457B9235362A /* QuizQuestionViews.swift */; };
-		6F501F5B83B649C39170BE6E /* TakeAttendanceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF28D43D9F054B83A90FD9A1 /* TakeAttendanceLogicTests.swift */; };
-		6F5AB077A8DB43F38FAF5FF4 /* CheckoutReturnHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5046D83BAA2F43A2B50F3C01 /* CheckoutReturnHandler.swift */; };
-		6F6E3EBB771E42DDAC20F64C /* DashboardInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B40BD2EBAA6468D83358962 /* DashboardInsightsSection.swift */; };
-		6FA00E86E84E4E3BBB0A517D /* UniversalSearchPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8105C3C25FB4042BF1C0D5F /* UniversalSearchPlaceholder.swift */; };
-		7048A2ACDAA345FCA49CD79A /* IntroCelebrationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8509D815EB5A4DACB3D86D38 /* IntroCelebrationPresenter.swift */; };
-		71313E28BE5A45D4A88D1B66 /* LMSFeatureModelsCourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC61B89E581D4A3BB74AEFF3 /* LMSFeatureModelsCourseSettings.swift */; };
-		722C60492C1441E2B1F0FFAC /* WalletCCRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2E48B8E6094ACCB33C40E2 /* WalletCCRDetailView.swift */; };
-		727B3BDFAD1F40ABB93B9024 /* LMSAPIInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5A4318357444D5A1424EF0 /* LMSAPIInsights.swift */; };
-		7285275760BC45C6897E5B88 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC615D5EE204BECA3AF4DA5 /* SearchTests.swift */; };
-		72CC2EFD7E8E42659F71F51B /* SearchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9D7743E1014F0EBEA6C333 /* SearchModels.swift */; };
-		7306496064624237B8BD3849 /* LocalePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5CD5F306E14A0795C85D3F /* LocalePreferences.swift */; };
-		74180EB939174351A09B2FC9 /* AssignmentDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6488B616A5044FB4AA42FBC6 /* AssignmentDraftStore.swift */; };
-		743A5EAE7224446E9F39C0C5 /* OrgBrandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7258426C748C9A0963E97 /* OrgBrandingView.swift */; };
-		750C491D7D234795A0F271C6 /* DiscussionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757E4E8E95AD4AC5A8E4A56F /* DiscussionsListView.swift */; };
-		759C660E0B414925B7C9087A /* RequirementsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C23B8331634027B6EF19AB /* RequirementsLogicTests.swift */; };
-		75E28D2258C84C498D5A951B /* CacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4365834BD24B03815205C4 /* CacheStore.swift */; };
-		75FC1D426AAC43B2A13AF26C /* CourseDiscussionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF03CFAC83945FF948F2D9F /* CourseDiscussionsSection.swift */; };
-		7619C558C00844668589F149 /* FeedSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F467FA654D6E4F58A25DFCBB /* FeedSocket.swift */; };
-		76E759BFEC0A479598FD3523 /* AuditLogAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1886274024544B18C648429 /* AuditLogAdminLogicTests.swift */; };
-		787573EB0DD34C91BB1E38B3 /* FeedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39A6C065DBD48999414206D /* FeedLogic.swift */; };
-		78A071596C2D41D7BFA782EC /* CredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753E4D89CC4142DC8B5EA353 /* CredentialsView.swift */; };
-		794F748BFAB642C08B8E2D6C /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E55D7EA8B6844EF97A42FA9 /* APIClient.swift */; };
-		795FED7D1CD749E18284AA7C /* SchoolCodeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0F2E71D5D9404484B63E87 /* SchoolCodeLogicTests.swift */; };
-		79A5C647C7AA4F71AEDEC710 /* LMSFeatureModelsReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7195D6BC0113463F990C5A7B /* LMSFeatureModelsReading.swift */; };
-		7A76604B2B5645FCB6D07009 /* RolesPermissionsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1666B71154D94DEA9810E776 /* RolesPermissionsAdminView.swift */; };
-		7A9DEAD3BF094E5B92D46A85 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D394A203B748D98B1B875F /* ProfileView.swift */; };
-		7B07D6700B1D4D6EB54C262C /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D551415EA1FA4987A692152F /* MessageDetailView.swift */; };
-		7BB65235FC394C68A9AAC834 /* CourseGradingAgentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FFBD5BE01745E38AD2E525 /* CourseGradingAgentsView.swift */; };
-		7BE38577F5CA48439F03BC39 /* AdvisingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337A072C810F475DAB09B979 /* AdvisingLogic.swift */; };
-		7BF4836E3E2E4E0EA2E8758A /* LMSAPIPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7361328A9343E697C079EC /* LMSAPIPeerReview.swift */; };
-		7C87294D17684717BDF67ADD /* FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F14CDD80314E2496D1007F /* FilePreviewView.swift */; };
-		7E11880E31C3449793E33DFD /* CourseSectionsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B064CC9A4244A1597D63D68 /* CourseSectionsLogicTests.swift */; };
-		7E4812A8D58B45FEA782EEFD /* CourseAccessibilityReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2987419F9724F8BAE46DE7C /* CourseAccessibilityReviewLogic.swift */; };
-		7E666BF9EA5E44FB872C6A94 /* LexturesMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81BD291938946D2B18D20F9 /* LexturesMotion.swift */; };
-		7F5654D27B1C4FE3B689362F /* IntroCourseProgressRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7773C1A7F21548E789E11ABA /* IntroCourseProgressRail.swift */; };
-		8049C3444D6C491193106550 /* ColumnsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C744D517A0C43CC92157CEE /* ColumnsLayout.swift */; };
-		81267E68B4824E49A31C8C56 /* InsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E5D05AABFB4BA784539EEB /* InsightsLogicTests.swift */; };
-		8154BF2BBE6745FAA9CB652D /* NotebookSlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4903F7AD608C4E9094700387 /* NotebookSlashCommands.swift */; };
-		817B6C6161E24FA89B2A6BE4 /* OnboardingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B3270831A346DE871D0F76 /* OnboardingModels.swift */; };
-		819E8697D0E049FAA19E2001 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782888F21CBE4F09860D4AE5 /* InboxView.swift */; };
-		8229F77CB1934F048EF06DA9 /* BoardPublicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FDF50245D841AABC037498 /* BoardPublicView.swift */; };
-		822C5A8DA93F4267A997CCA9 /* CourseFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F6153ECD64C1EA66A5402 /* CourseFilesView.swift */; };
-		83DBFDAA0CBB4B2BA29320C7 /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5541BAAA56DC484EBDE23C5D /* LMSFeatureModelsPlatformSettingsAdmin.swift */; };
-		851F70CB0C8E4808A602384D /* DrawerScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCEA38143AB4CF89C166D39 /* DrawerScaffold.swift */; };
-		8559064BF9E24F80AC2B7FDB /* AiGovernanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71BDC82DDF14C3E8F5AD1BE /* AiGovernanceView.swift */; };
-		85BEC9615D3A4D51B5E11BEE /* DiagnosticView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CA850819B142608E94AFA4 /* DiagnosticView.swift */; };
-		8607C609107B4A8A91889CC2 /* AccountIntegrationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E1315641EA4B12952161FD /* AccountIntegrationsLogic.swift */; };
-		878B5AAA493B40A589D99AF3 /* WalletCETranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF8A0F2606F4936A8D63310 /* WalletCETranscriptDetailView.swift */; };
-		87D839F0C4A74FD98256B176 /* LaunchContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45098D4AA2AE48DBB30EEBA5 /* LaunchContainerView.swift */; };
-		88706E79220242D78EC8A779 /* ContentPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575351DD2E5D49499CE32173 /* ContentPageView.swift */; };
-		8875D5B55E1348EFBD056A23 /* BoardsGovernanceAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E4F8B061E74A2DA6074099 /* BoardsGovernanceAdminLogic.swift */; };
-		88865EAA088343F18C3DFA57 /* OnboardingModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA8CDE1474473E9595C951 /* OnboardingModelsTests.swift */; };
-		891D058966D8460491A1A4FF /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AB7C2F52454D92AD0A2C92 /* NotificationsView.swift */; };
-		8991DE6555DF4A7B890608C7 /* LMSAPICourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B1442FD4F64EBBABDA4E2A /* LMSAPICourseGradingAgents.swift */; };
-		89A7EC38C520488BA9761223 /* CourseHeroImageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22020B8EFBB44AB1893DE536 /* CourseHeroImageEditor.swift */; };
-		89E8D81B4C9A4C47AF4BDC13 /* CourseTranslationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C0CC13B9314D539C1DF7F0 /* CourseTranslationsSettingsView.swift */; };
-		8CECDE4CA48E46B68194DE68 /* BoardEngagementEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBC8AD22D194FB5866E18E7 /* BoardEngagementEnvironment.swift */; };
-		8D607FC0027B424B89FACB72 /* CourseCrossListingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88574A59D8B1410D805D6E5A /* CourseCrossListingView.swift */; };
-		8DF4FC36D0844CD7A279D8CD /* TeachHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCBB607EB6E46AFB189E9DB /* TeachHubView.swift */; };
-		8DFB3B8F33C845A2BD3C5A74 /* TutorChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FB7231D19640CBBFC5BF0C /* TutorChatView.swift */; };
-		8E09A5C7101F42FCA97FFDC9 /* LearnerProfileEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240D0977D3CB497F9CCE0202 /* LearnerProfileEntryCard.swift */; };
-		8E390168F0A24280B46A6D7A /* LexturesMotionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DCDD29E5BE4924BCAA2BAE /* LexturesMotionTests.swift */; };
-		8E3DFB4100A14025B5EF5B4E /* ImmersiveReaderCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5D9232E0D949B1AE165711 /* ImmersiveReaderCapabilities.swift */; };
-		8E5A7026DB48466D91B97274 /* CourseBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4ECFC2BCFB4C1D9488BC4F /* CourseBanner.swift */; };
-		8F3C8B7B258E4B7E89CFCF7A /* SearchRecentsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406DBB9303244C2E838EDC19 /* SearchRecentsStore.swift */; };
-		8FBCA5C6CFF64F42A4A5BF38 /* ParentNotificationPrefsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1EA664D9A84F93BFDD12A8 /* ParentNotificationPrefsView.swift */; };
-		8FD3844A4F6D447194A0FD9F /* EvaluationResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A85E757F674DDCAFB5FAE6 /* EvaluationResultsView.swift */; };
-		9012C4718113455798FBCE75 /* LiveMeetingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6FB26236674F82B674D4CD /* LiveMeetingsLogic.swift */; };
-		90D4320268704514890D85B7 /* WallLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D90C8248E34AC48BA0EDE8 /* WallLayout.swift */; };
-		912611A92A2041A9A8296D12 /* PeerReviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7AB62D36E9483EB9CC13E9 /* PeerReviewListView.swift */; };
-		91680EBC953B407498410AF0 /* MyHallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF7A75D2F5426A9F1E024F /* MyHallPassView.swift */; };
-		920E81216AA94D969E724F53 /* SearchActionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF79059A94514B73B029F985 /* SearchActionRegistry.swift */; };
-		933D49527AE1422A98DEA987 /* OnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8745232550FC42459DEC5E9D /* OnboardingFlowView.swift */; };
-		94189DBC6AC34E4BB3DE7F27 /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E9DFFAE1F4090888340AE /* NotebookDrawing.swift */; };
-		9528176BD8A94834852673A4 /* LMSBoardAdvancedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF3F1B270A24C95A700749A /* LMSBoardAdvancedModels.swift */; };
-		953ABDF98FEE4D8C85EE68F3 /* LMSAPICourseSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BCA544511647D2BFD0A74D /* LMSAPICourseSections.swift */; };
-		9557877184F043BAA7DFCAD5 /* LMSFeatureModelsLearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C509211B07064B4880574F26 /* LMSFeatureModelsLearnerProfile.swift */; };
-		95C256B92C994F73BD37211F /* LMSAPIBoardAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2815C9121014FFEBFF015F6 /* LMSAPIBoardAnalytics.swift */; };
-		95DE329B5E834CA2AD2AB423 /* IntroCourseLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F97983553124510BC455373 /* IntroCourseLogic.swift */; };
-		95FBD7141783422994CB342B /* GradeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEB663DFBA45DAA3D18684 /* GradeSheet.swift */; };
-		97288F004307499D820EA091 /* CourseGeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BCF61797854B9C836948B6 /* CourseGeneralSettingsView.swift */; };
-		972F35CF808C4FEAA9C04BA8 /* FileDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8028537BA35401A846CBE77 /* FileDownloadManager.swift */; };
-		983C270449494C999A874F30 /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183F16CF73A64A6CBF0F9517 /* NotebookEditorView.swift */; };
-		9861C3C32A19487F84BD7255 /* PlannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FF8D7F7E1742BF81FB0E02 /* PlannerModel.swift */; };
-		98C001A02FBC42D4AC15B4E1 /* CourseFilesSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297CEFFC74494B8595F618C1 /* CourseFilesSocket.swift */; };
-		990606FDE8B247DD949E7704 /* IntegrationsEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABBDFEA71D5348138DDD69DA /* IntegrationsEntryCard.swift */; };
-		991719A67D81438F9C8F25A1 /* LMSAPIGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6419C9F06DE54C3691051BFE /* LMSAPIGamification.swift */; };
-		99985465AED1482D95C45191 /* PlatformSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72AAB74BD74D449794D722DE /* PlatformSettingsView.swift */; };
-		99D64CAF336F41938B344B15 /* LMSFeatureModelsEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51738328C8246AB882B8626 /* LMSFeatureModelsEvaluations.swift */; };
-		9A0A50254C844A608B6D253D /* LiveQuizPlaySurfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DD77A6498641D8973F640C /* LiveQuizPlaySurfaces.swift */; };
-		9A230916D0B949F28B918F74 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAB1373F79548DFB5272E36 /* LMSFeatureModelsOrgBrandingAdmin.swift */; };
-		9A762A2C9AC2401BA56F698E /* LibraryResourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D6B748A1844AD086CFF7D5 /* LibraryResourceView.swift */; };
-		9ADD6D058085441AB9284F62 /* CourseInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48A86F51A83443090DAAD20 /* CourseInsightsSection.swift */; };
-		9B0C6FC09973444385C1852A /* CourseWorkspaceNav.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4C83568F874AAE8808D52D /* CourseWorkspaceNav.swift */; };
-		9B79351E323A481189C13F49 /* LMSFeatureModelsCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD996D1B848646BCB3808AC4 /* LMSFeatureModelsCatalog.swift */; };
-		9C87E7A7679D47F4A6E530D9 /* ConferenceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610E01F509854A408EC0210D /* ConferenceLogicTests.swift */; };
-		9CEB41E78B014578999FE1E7 /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251DF9545D842B18E522D83 /* LexturesApp.swift */; };
-		9E04EFC7D6594743B97742ED /* RequirementsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D1C10DF9A741DFA99D3799 /* RequirementsLogic.swift */; };
-		9E50A3A5CE2C4BAD857A4559 /* EnvironmentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A93B7496D0403F9F843B37 /* EnvironmentStore.swift */; };
-		9EA5FB66CC4A48998BA81C67 /* BehaviorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97A8E72069448ECA7AA73A8 /* BehaviorLogic.swift */; };
-		9EBFC64B85254654BD48655B /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854660018C6A49E286436E73 /* LMSFeatureModelsIntegrationsAdmin.swift */; };
-		9F1AAC1F6ACB4BE585C06C9E /* ReadingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02995DB88EE8419CA408DF6E /* ReadingLogic.swift */; };
-		A02910682A4C4B1AB72246E7 /* LMSFeatureModelsBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CE83F7AD58240F982BBBBE5 /* LMSFeatureModelsBilling.swift */; };
-		A02D365906FA47298A46828C /* GradeCalculator+MyGrades.swift in Sources */ = {isa = PBXBuildFile; fileRef = E837FD6AE64B48B89B9DFDB1 /* GradeCalculator+MyGrades.swift */; };
-		A072A5B86D3246518D8C2746 /* SettingsAccommodationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD48DE61916044ADBA57ED63 /* SettingsAccommodationsTests.swift */; };
-		A0ADEDE3F45A4A5199AF6613 /* TutorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5112DB5AF7744BB89E98CAE /* TutorLogic.swift */; };
-		A147E26E557B4E058E36D615 /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92102CDBB0764704BED6B9E4 /* LMSFeatureModelsRolesPermissionsAdmin.swift */; };
-		A14BDA044959488C8B91C7C5 /* LMSAPIBoardTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1420DA486C9F41B7B6B205CE /* LMSAPIBoardTemplates.swift */; };
-		A15836F484374FA993B3B0E5 /* LMSFeatureModelsIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD685807326846CF91C2CFCF /* LMSFeatureModelsIntroCourse.swift */; };
-		A18CE0C0CDB941F19A87EA34 /* LMSAPICourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86976AC5DBF94CE0B9E2A282 /* LMSAPICourseCreate.swift */; };
-		A1DC4A6E047E4995BEE9BA58 /* BroadcastComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465192747C534F43B060EC6B /* BroadcastComposerView.swift */; };
-		A240815877394C7E99D051FA /* BoardRealtimeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261ED70950AB4FF497C90164 /* BoardRealtimeLogic.swift */; };
-		A2E2866C0B334CAFB2C324B3 /* CatalogLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1465ECA6ED41A7A88945E1 /* CatalogLogicTests.swift */; };
-		A2E33B214B2B4592A5250C26 /* LMSAPICourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB46D38E74640FB9DF737ED /* LMSAPICourseTranslations.swift */; };
-		A38D622CC1C04C5399C07A35 /* BoardSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B03553DDF274E11BA2DED01 /* BoardSocket.swift */; };
-		A432FE3D812444A48D727D8D /* FeedbackLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8C2C87D8DC48378C6A5E31 /* FeedbackLogicTests.swift */; };
-		A45AA81CBC434A33B7A4C765 /* InstructorInsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4357F04E9A14427CA177B76D /* InstructorInsightsLogicTests.swift */; };
-		A5E21BECBD9A460B9E0E86FF /* LearnerProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4B319C0A3744029706BEB9 /* LearnerProfileView.swift */; };
-		A635E9A54F7A480B97EE4CB6 /* MFAChallengeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E40DCAB8ADF428C916AB163 /* MFAChallengeView.swift */; };
-		A651CF55A5A44D0E8787B832 /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB69423EE1D42BEBC5443D7 /* NotebookSync.swift */; };
-		A6C16B9917BE4C8293D40720 /* LMSAPIBoardExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8624F5F731494067A6E5226A /* LMSAPIBoardExport.swift */; };
-		A6D9165159F348E18D67E94F /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BDC37551114E39AA3542F2 /* ItemDetailView.swift */; };
-		A6EF6BFB82EE4E239C201717 /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892AD94103F8491FB5EB73D8 /* SignupView.swift */; };
-		A6F27E3FE6AF4F8882C16D17 /* NetworkAuthContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22647F342CB4244ACAE5B64 /* NetworkAuthContext.swift */; };
-		A71747CAB1B24A74B64877B6 /* BoardsAdvancedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BEE84922AA4F1FAE0FE787 /* BoardsAdvancedLogic.swift */; };
-		A800A691052949D6842829D5 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66435D97765F43E49613CCE8 /* TranscriptsAdvisingAdminLogicTests.swift */; };
-		A843B32C407142939A8EE54E /* ReaderLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F4926954A4E40BE6D0026 /* ReaderLogicTests.swift */; };
-		A8B3DA894B934F2FA0DF77E5 /* RequirementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BE19A504844A7C80D5C190 /* RequirementsView.swift */; };
-		A8F5431C58BA4182A46D7200 /* CourseSectionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AF8D8B29A346D78F4869DC /* CourseSectionsSettingsView.swift */; };
-		A936B5A7E89F494CA7638183 /* TutorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBFC1A8B3044BAE9F7CA51A /* TutorLogicTests.swift */; };
-		A9611AC4DDD64335821B7EC0 /* LMSFeatureModelsFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1787B1BC4C704921B47965ED /* LMSFeatureModelsFeed.swift */; };
-		A9EF899DEBA64BD6BEEBC2DE /* EvaluationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82102C0304A41AF8F9EE470 /* EvaluationLogicTests.swift */; };
-		AA239B3F83A746C7B77D500A /* TutorLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA87ABBDD9C04C21B75E1AB9 /* TutorLauncher.swift */; };
-		AA5786ADF9914096A04A2584 /* ResearchStudiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59A779E94104C6FB2954401 /* ResearchStudiesView.swift */; };
-		AA60FEC0522240959A5F3295 /* LMSAPICourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D03F374531E48A2A2D19B4B /* LMSAPICourseSettings.swift */; };
-		AA69E28B703142DB95EC39E1 /* CourseGradingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DC931CE51A495DAE55C450 /* CourseGradingSettingsView.swift */; };
-		AA81A482F50144E4A99DABD5 /* CourseImportExportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD5634B0DB5409A948EDF25 /* CourseImportExportLogicTests.swift */; };
-		AA9595DACD5F458788C054D6 /* PlannerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40154251D5324D6BAA158FF2 /* PlannerModelsTests.swift */; };
-		AAD47D38AA4D4C358A6467F6 /* PathsCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D0423652744C3FBF159CA4 /* PathsCatalogView.swift */; };
-		AADCEDE334814AF3B877F04D /* TranscriptsAdvisingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD0F17DDF344DF38730C3D6 /* TranscriptsAdvisingAdminEntryCard.swift */; };
-		AB233BEEBF544D92ABA91E94 /* LMSFeatureModelsCourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C5DA8502AC42DC8309F82B /* LMSFeatureModelsCourseReviews.swift */; };
-		AB6B5EF2EB6C4D75BDECC9CA /* BoardsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D07E28ABBB84F81A39AA430 /* BoardsLogicTests.swift */; };
-		ACC1FD10C6CF45E6AEDEE3C2 /* BoardSyncStatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4965994E3A406CB9E590BC /* BoardSyncStatusChip.swift */; };
-		ACCE80FA96CA40DD91B04FE3 /* TakeAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8409A897679140FBBAE8A1C6 /* TakeAttendanceView.swift */; };
-		AD749EEA1C2149FA9A37229E /* LiveMeetingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30078A0DFE254665B1DC7212 /* LiveMeetingsLogicTests.swift */; };
-		AD90C099CDD04360A7C08F12 /* CourseImportExportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD2BD7E08934ECF89E37976 /* CourseImportExportLogic.swift */; };
-		ADB2122E83B24A3791404387 /* ModerationQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE8CEA9C7BE482BA8631124 /* ModerationQueueView.swift */; };
-		AF0E06604C84491997B9EC96 /* CourseStructureSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E5F6DFCA5C437BA9E687FC /* CourseStructureSocket.swift */; };
-		AF54E52BC1C6470888809DC2 /* ArchivedCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA969D6F8EDD4E3E93C80B2B /* ArchivedCoursesAdminLogicTests.swift */; };
-		AF86C7809C9941BDAD77AB55 /* QuizIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC16A66FAA4EF59125ED21 /* QuizIntroView.swift */; };
-		B025112610394F9C8DCB9F2D /* LMSFeatureModelsParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABF3BEB66C6415D92AF68B4 /* LMSFeatureModelsParent.swift */; };
-		B0522468284A4DEB8844C558 /* LMSFeatureModelsPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D37E2CCEE04493954CCD08 /* LMSFeatureModelsPlatform.swift */; };
-		B16FD4BF444C4BBAA4F34B19 /* ConferenceBookingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E2BE4578F448E6A93627A1 /* ConferenceBookingView.swift */; };
-		B2153F40E84A45C58D908328 /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B98EFBE72814209BD850A7A /* LMSFeatureModelsOrgStructureAdmin.swift */; };
-		B2C2AFB0C35343BC8A3BAB35 /* LMSAPICourseImportExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BA849320AE4B2590B89819 /* LMSAPICourseImportExport.swift */; };
-		B2C44709C9B041A1AB99A6BD /* BillingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E04D370DCA4C4595C4A250 /* BillingLogicTests.swift */; };
-		B3320B8C932C4BB99864A678 /* LMSAPICourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155DA7CBBE5949828B3DFB89 /* LMSAPICourseGrading.swift */; };
-		B35512518F934CDB82F896EC /* SessionsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB237F0D62A433293C8F48B /* SessionsAPI.swift */; };
-		B36EC8CF5A284C509DDB1989 /* AiAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347F90498E3C41F9864483A5 /* AiAdminHubView.swift */; };
-		B3A185F449E843EEB3EAC82B /* AnnouncementComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E991BA3545AB4BC385CE6C61 /* AnnouncementComposerView.swift */; };
-		B3CF1349C7904FD4A72E2A59 /* PeerReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E69FE71D6B24F72878DD03A /* PeerReviewDetailView.swift */; };
-		B419FF488647475FA61F50EF /* OrgBrandingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EDEF702EFA243D189990239 /* OrgBrandingAdminLogicTests.swift */; };
-		B47F885782034415824A6D81 /* SettingsAdminHubEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E561164FBBA14C149AF35828 /* SettingsAdminHubEntryCard.swift */; };
-		B5208F0E41D24AC29B919F33 /* LMSFeatureModelsBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE959B3CFB24B54AC6FD2B9 /* LMSFeatureModelsBehavior.swift */; };
-		B566482BBE204054B150DBDD /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FF5714CDFC4F2297B585A4 /* AuthAPI.swift */; };
-		B63422443B8D4320AF5CCEA5 /* FeedChannelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F039D646CDE4631BA5F4F4F /* FeedChannelView.swift */; };
-		B6CEBCA1A4574809A241F8A2 /* BillingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B60F313BAA4EECB7EE8839 /* BillingLogic.swift */; };
-		B73D98CA5E7143FDAE4DB880 /* LearnerProfileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3144D60E9447C49C7D4F48 /* LearnerProfileLogic.swift */; };
-		B7843FBA8342426A82563859 /* DueReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4121BC5624904F929BFA590A /* DueReminderScheduler.swift */; };
-		B8AD3EF6548E4ACBAD1200B2 /* ReviewComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EB0008863344FBB6D12DD1 /* ReviewComposer.swift */; };
-		B8C0054D9158489391E87711 /* BoardsGovernanceAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A87EB3831A4D58834A404D /* BoardsGovernanceAdminView.swift */; };
-		B8D3B06811A446FF9E119A9C /* CoursePeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE4D23B8C9546599886D708 /* CoursePeopleView.swift */; };
-		B971CC8D53FF4223A926F0B4 /* CourseSyllabusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA38C62A4B543D68D3F8753 /* CourseSyllabusView.swift */; };
-		B986C054028344EBB72DA919 /* CourseMarketplaceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA15B2844A64677B6B8EED6 /* CourseMarketplaceSettingsView.swift */; };
-		B9D0B7E434E241E2B6BD4180 /* LMSFeatureModelsMobile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F5389E48194F8389E80AEB /* LMSFeatureModelsMobile.swift */; };
-		B9F19E82434F4B5CAEECA496 /* PeopleAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4560C89AB641FE9EAB8247 /* PeopleAdminView.swift */; };
-		BA1E91FD69E148888F72EA8D /* QuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE653D023FE4E3F90297048 /* QuizLogicTests.swift */; };
-		BA2BA693E4C647998B56C23A /* LMSAPICourseFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8F92237382472281728AF9 /* LMSAPICourseFeatures.swift */; };
-		BA84C45015DE496786BAB636 /* AdvisingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D350AD0B0A59450F897F8526 /* AdvisingSettingsView.swift */; };
-		BAE0A5E289CC4C0A89C3B4AB /* LMSAPIBoardEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBFE8589904567948142C6 /* LMSAPIBoardEngagement.swift */; };
-		BB84C992D90D48D5BED3A40C /* OrgStructureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25EBE6EBF35344B88F675AC3 /* OrgStructureView.swift */; };
-		BD54CED1BAB14879A22E37B9 /* PathLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B2AB155D494CB797E298B3 /* PathLandingView.swift */; };
-		BD6BE1F17ED54BDA80A82AE8 /* CourseHeroImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41F92002E874326A55667BD /* CourseHeroImage.swift */; };
-		BD73621956374867A01EC4BC /* LMSFeatureModelsGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A756F9E12E3420D93F19CE8 /* LMSFeatureModelsGamification.swift */; };
-		BD7FF3CD17854CD49E4B67F4 /* ProfileDepthCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A45DEFCF3A452B878ED663 /* ProfileDepthCards.swift */; };
-		BEF2ABCB07A24CAB84BC8469 /* AuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9812B27E05DF4E7FAFD2FCF2 /* AuthConstants.swift */; };
-		BFEC5D70F8EB4D378B27CE88 /* LMSAPIFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91894EFBAE034F79870527FD /* LMSAPIFeatures.swift */; };
-		C0A1B001ADM1NMETR1C001 /* AdminMetricCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1F001ADM1NMETR1C001 /* AdminMetricCards.swift */; };
-		C0A1B002C0URSESADM1N01 /* CoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1F002C0URSESADM1N01 /* CoursesAdminView.swift */; };
-		C0A1B003PLATCRSM0DEL01 /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1F003PLATCRSM0DEL01 /* LMSFeatureModelsPlatformCoursesAdmin.swift */; };
-		C0A1B004PLATCRSL0G1C01 /* PlatformCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1F004PLATCRSL0G1C01 /* PlatformCoursesAdminLogic.swift */; };
-		C0A1B005PLATCRSTEST001 /* PlatformCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1F005PLATCRSTEST001 /* PlatformCoursesAdminLogicTests.swift */; };
-		C0A1B006PE0PLEMETR1C01 /* PeopleAdminMetricsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1F006PE0PLEMETR1C01 /* PeopleAdminMetricsLogicTests.swift */; };
-		C1CC5F8E6EA44BCEA5A7E64B /* PeerReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAEE7BF812449FDB58A6F5A /* PeerReviewLogicTests.swift */; };
-		C1E46A52153A4B2FABE3E7FC /* BoardModerationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031BBD2CE9D144BDB505C1E8 /* BoardModerationSettings.swift */; };
-		C1E5B10A52344EF6B03E631A /* GroupsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C275EF4E0C8D4533A9029498 /* GroupsLogicTests.swift */; };
-		C220BB4C21C64514A3C662AA /* QuizTakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD0B3FACC5C4B82BA453CF5 /* QuizTakerView.swift */; };
-		C264B03AEBC4479196BBA7E6 /* IntegrationsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7ED12235D492B881A0413 /* IntegrationsAdminLogicTests.swift */; };
-		C2AC1B4DEEED4A299B09F2FA /* AuditLogAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E981A936247546DDAB493E9B /* AuditLogAdminView.swift */; };
-		C30188EF2EDC45FB8F0DFA14 /* LMSAPILearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4020BC9FB68D42DF8A8A9DE9 /* LMSAPILearnerProfile.swift */; };
-		C35E03710A2442D4BBF94057 /* CourseSectionsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3BE6AB5EEA4770B176F672 /* CourseSectionsLogic.swift */; };
-		C362C2969A9D4F49928AAA0B /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B942CB11F344BE2AB8E0022 /* LMSFeatureModelsArchivedCoursesAdmin.swift */; };
-		C3B92074B29C4EDE96BCB5FC /* MoreHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FF8C29DFDB4864A97108C4 /* MoreHubView.swift */; };
-		C3C9C20AF0B74AF1A5AD6C06 /* MarketplaceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEC8E71FF2547BB9A2A2115 /* MarketplaceDetailView.swift */; };
-		C3CC188EF9D849A1870DFB39 /* ShellHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637BB24D553749F082807972 /* ShellHeaderBar.swift */; };
-		C44FFEBEDCB84839A0DDEF54 /* LMSAPIAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051235EB53344CE182F9407C /* LMSAPIAuditLog.swift */; };
-		C46336EB5EB44D109CACF82C /* CoursePeopleLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E673943775FD47B9A98EE557 /* CoursePeopleLogic.swift */; };
-		C4ED048BD8BB42BE87CAD4D4 /* LMSFeatureModelsPeopleAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354CF5EEFB1F4B59B969EF86 /* LMSFeatureModelsPeopleAdmin.swift */; };
-		C4F67C5E531D4ECC94B62E1C /* MeetingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC452CCAFEE4E4291B522E8 /* MeetingDetailView.swift */; };
-		C5423EDB54A849D8A000FCFF /* CourseMarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B83DE1E8D134EE693DAF4D2 /* CourseMarkdownContentView.swift */; };
-		C55A4ADDE3AE482BB4EEC346 /* SchoolCodeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA34F0EAA343E1AE64BF5F /* SchoolCodeLogic.swift */; };
-		C56862C1F9404A1FA04CF5D8 /* ReadingPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E76CCF94A8004D79A1A51F20 /* ReadingPreferencesStore.swift */; };
-		C591DE04D7F74F1484BC6D41 /* LMSFeatureModelsAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC108680F91495A91524028 /* LMSFeatureModelsAuditLog.swift */; };
-		C5D5309EBCC6480690671859 /* UIMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3FB578E5284EC9A48F5A1E /* UIMode.swift */; };
-		C5E6FF0F69AD4632B081682C /* CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D928A1285449689FE64A0A /* CanvasLayout.swift */; };
-		C64789CA8B5244B5A3C989F8 /* IntroCourseObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469622045ED645C9875B5506 /* IntroCourseObservability.swift */; };
-		C73F30631A4F4D4CB340F5F2 /* ArchivedCoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAED5AF179C46369218ABFF /* ArchivedCoursesAdminView.swift */; };
-		C8493F93F95641B9971E021A /* BiometricGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713361602A46405A9A79A692 /* BiometricGateTests.swift */; };
-		C87C7F322D0A43B9B8C2290F /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AB4FFE358F4BFA92960BD5 /* AppConfiguration.swift */; };
-		C8F9053AE3C5456D9772702F /* LMSAPIMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76B7EDA320347C8BB92749F /* LMSAPIMarketplace.swift */; };
-		C90C9B199371472391DEF7E0 /* SSOAuthController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694B3CE6841D49A0A0534073 /* SSOAuthController.swift */; };
-		C94508C2EF92492F875C0646 /* CourseGradingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BDB5DFC156485BA2DF8135 /* CourseGradingLogicTests.swift */; };
-		C98FAC049F824C8C98829EA2 /* AuditLogAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E12F1F50BC4094A28B6222 /* AuditLogAdminLogic.swift */; };
-		CA56948D75944FC9B722340E /* LMSFeatureModelsCourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42C097F349F4294B8245A75 /* LMSFeatureModelsCourseAccessibility.swift */; };
-		CA7BA9E0E964449BB6722446 /* WhatIfController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5519F8BD0DD462CAE1644A4 /* WhatIfController.swift */; };
-		CAA8331B4EF74E0C84947274 /* BoardPresentModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC7A71C1FDD4B25A97267EB /* BoardPresentModeView.swift */; };
-		CB366B3DD19946AE90A11436 /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CD3105B0534368AEDBC4E5 /* AccessibilityPreferences.swift */; };
-		CBB27F7B883A4E3BA3B1F709 /* CourseGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E07BDA89F7B432F9D56D98E /* CourseGradesView.swift */; };
-		CC43F800E0EC4217A63E99CA /* LMSAPIBoardPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C394658B9549BF840C6BF0 /* LMSAPIBoardPosts.swift */; };
-		CC7499DCBED24814BEB2A59A /* CaptionedPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62644DCDC2764C268460E21A /* CaptionedPlayerView.swift */; };
-		CDF518E09F7846E1BDFBED53 /* DashboardStudySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D82BBCDF07940DDA04B4A68 /* DashboardStudySection.swift */; };
-		CE5643BA1BFE4434AF87E34C /* AnnouncementsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F0CC36B0D345C2A65A5BCB /* AnnouncementsViews.swift */; };
-		CE7BB247BFFC498A872814C1 /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD79463AC6B4EBBBD437217 /* NotebookStore.swift */; };
-		CF097B32F73C4183BF542E7E /* CourseImportExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E05AF8855940BB80BD7CD3 /* CourseImportExportView.swift */; };
-		D13E762EE5044E77B6902CBA /* CredentialDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841CBC287D8A49CEA4A0FDD8 /* CredentialDetailView.swift */; };
-		D19DDD2E2F584485B6411D75 /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3164BC03EC448AB8E97BFCC /* AttachmentUploader.swift */; };
-		D3772A45DD6B453EB920673F /* LMSAPICourseArchivedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103F7EB8AA2543D486ADD013 /* LMSAPICourseArchivedContent.swift */; };
-		D39CDD05A8254115A4756B70 /* UserDetailAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2E44F6E66F42A8A779A6F8 /* UserDetailAdminView.swift */; };
-		D41C88D9B069467AB7056B5A /* BiometricLockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6F89F9E8DE46B6A9B578C7 /* BiometricLockView.swift */; };
-		D41D277FA28640088FA00B73 /* SearchPathNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9773DCAC81940CEBCADCAD9 /* SearchPathNavigator.swift */; };
-		D4AB1717C654406A9E932690 /* BehaviorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F457C4A9A120463BBD81621A /* BehaviorLogicTests.swift */; };
-		D4E0FDBA645A463E8DBCCFBD /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD1261709BF44839AA1260B /* AuthFlowView.swift */; };
-		D4FE653951F7491A93236667 /* LMSAPIGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CCEF8D2D48C4BA8A47E49A3 /* LMSAPIGroups.swift */; };
-		D53D91119D9245968AE48A9C /* BoardSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB9B0BCE84B4831B9EF48BE /* BoardSurface.swift */; };
-		D5AE0A8DD0404E0296584135 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F1B79344C9455A9C5AAE37 /* DashboardView.swift */; };
-		D6F0905A26F24194A1353962 /* ParentAttendanceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED855614454B92A2BBC138 /* ParentAttendanceDetailView.swift */; };
-		D7ABC29F9F3A4FE8AFB7FE7A /* CodeEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B96E9CD4CA4F5886D935BB /* CodeEditor.swift */; };
-		D7C434F123F942FD80F15BB4 /* ArchivedCoursesAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED5945B8F2F4E24ABA319D9 /* ArchivedCoursesAdminEntryCard.swift */; };
-		D85D2090E85246F3A6505493 /* ReviewsReceivedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D2103B93B3402AA7D1EF93 /* ReviewsReceivedView.swift */; };
-		D8A5A1065E68428397BB2D5F /* CourseFileModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31218713E083457A8317C488 /* CourseFileModelsTests.swift */; };
-		DA579C13C6C6414CB3B8BA4F /* DiscussionThreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18ECF1EC4F824EFAA02F45F1 /* DiscussionThreadView.swift */; };
-		DB438FB7C27C48C398716228 /* LMSFeatureModelsCoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6BEA02246548DEAAA0FD65 /* LMSFeatureModelsCoursePlagiarism.swift */; };
-		DB9F1913047B4D559ED54CBC /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED2D76C465F4BD3A914E66F /* MainTabView.swift */; };
-		DBF150A642F0430589B8A399 /* LMSAPICanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA06F4519974FCA96FB76DB /* LMSAPICanvasImport.swift */; };
-		DBF280805E3546E29FCF6B60 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 070F6C739E7B45298D747A0F /* RootView.swift */; };
-		DC512FF97B8641538792E11F /* AnnouncementLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EBA7A16ACA4AAA9668C226 /* AnnouncementLogic.swift */; };
-		DCED5394ECDC43CABFE96B3F /* CourseTranslationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8A7858007741A4B4A579AC /* CourseTranslationsLogicTests.swift */; };
-		DD01F14F19C240E3966087C1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78059E120F4442BE99182CA5 /* AppDelegate.swift */; };
-		DD54C72E4CD54C31A9385D96 /* ParentDashboardSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF5525DC9214A36B17416A0 /* ParentDashboardSections.swift */; };
-		DDDFCC770E2749F08589BE80 /* LearnerProfileLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88B7EA19C784143BC7DB84C /* LearnerProfileLogicTests.swift */; };
-		DE99DCACAD624C59B98DB912 /* PeerReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336D69F1011A4C2195F49B24 /* PeerReviewLogic.swift */; };
-		DE9DEBCF0BAC4A07B9451383 /* ConferenceReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5555FB34667B4BB896B33481 /* ConferenceReminderScheduler.swift */; };
-		DF5D56D9893C4925BE14E0B3 /* ThemePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D487ABD3C434B2BAF2F4156 /* ThemePreference.swift */; };
-		DFC265F701554105BFF4BEFE /* CatalogLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C721A4D0AE2C4562AD5DD503 /* CatalogLogic.swift */; };
-		E028EB4D5B7D4EF69AFA1833 /* CourseDestinationPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2726DACD8D1D4766BB8F4362 /* CourseDestinationPlaceholder.swift */; };
-		E0853E7BD04E41E7AFFC4ED5 /* CourseFeaturesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEDAAA8C69F4E3A95F27EF9 /* CourseFeaturesLogic.swift */; };
-		E0BC6DAB406D450894E30308 /* DrawerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B972F34DA69F49E59B3D03BD /* DrawerToolbar.swift */; };
-		E16394C2194F4C52B99DBF90 /* ModuleContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F642FE17A2E047EEB5479210 /* ModuleContentLogic.swift */; };
-		E1D3DE4D48B148AC90BC77AE /* BoardTemplatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0A6784B8734FF38D6BD93C /* BoardTemplatePickerView.swift */; };
-		E1FE3D42398F4D4C9BD402E6 /* TermsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668F646A938C431F9B20C7C3 /* TermsAdminView.swift */; };
-		E2294CDD0B1244019A5C469A /* OrgStructureAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC78C8052ED4603B861F8F4 /* OrgStructureAdminView.swift */; };
-		E25179C92C1C41C6B8296680 /* CoursePeopleLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38BE72075F141C68C01C98A /* CoursePeopleLogicTests.swift */; };
-		E266A835E7DA46E99FFC81CA /* UniversalSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5744E69F63C645F1AD96AF32 /* UniversalSearchView.swift */; };
-		E2AFB406791A4921A0F75ADA /* RolesPermissionsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6824A619F9FF47138869EE22 /* RolesPermissionsAdminLogicTests.swift */; };
-		E2E7715996814C6C993BDA21 /* CourseGradingAgentsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD7F20E5292421A917DF686 /* CourseGradingAgentsLogicTests.swift */; };
-		E349ED31E28947629CE58754 /* LMSAPIBoardModeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DA237C4E1F4A17A205FC81 /* LMSAPIBoardModeration.swift */; };
-		E36DB36496D5439F8CB9AD1D /* CourseOutcomesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB4D5F9613E4B4995CEDA4D /* CourseOutcomesSettingsView.swift */; };
-		E3C3FF22577D486189E530CD /* IntroCourseLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4669164521A846B6B7E232AD /* IntroCourseLogicTests.swift */; };
-		E3DEEA2352E24C0893D51C4C /* LMSAPIPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76565B44E7040E494081414 /* LMSAPIPaths.swift */; };
-		E4315CBD0D0F46C7968EA63F /* WhiteboardRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF64DD759A2F4B9AA6EC6761 /* WhiteboardRenderer.swift */; };
-		E454F05444F64D7F8973BBC7 /* LockdownController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF6A6D215824225A7D9D6B8 /* LockdownController.swift */; };
-		E45A30BA2EC641FDB8A2C9EB /* LMSFeatureModelsCourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39505FFCCC24326BBC0C3EF /* LMSFeatureModelsCourseCreate.swift */; };
-		E4642D50AEDE412D9A2C05EE /* BiometricGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE376101F5F4402BABE066E3 /* BiometricGate.swift */; };
-		E4C618B17FBF4C78BBAAB056 /* CourseAccessibilityReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E436753DC586426DB8B8D712 /* CourseAccessibilityReviewView.swift */; };
-		E4D173DFB1EA4C40B42F4259 /* PushManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7C3074787D4757B344CBA0 /* PushManager.swift */; };
-		E4DD0AF80B6044DE907EDFAC /* CoursePlagiarismLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11D7E51AFDE402A9CB4C5F1 /* CoursePlagiarismLogicTests.swift */; };
-		E595ECAF8AB64A7094BFB118 /* CourseAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657FC23688AA48E4A477065F /* CourseAttendanceView.swift */; };
-		E5B1B4CC641A4592B39BA00E /* ProfilePersonalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC4CDCB033A463DA0A746E2 /* ProfilePersonalDetailsView.swift */; };
-		E6253EE8BBD04AFE979562E9 /* LibraryResourceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B7A922ACC43F2B1141439 /* LibraryResourceLogicTests.swift */; };
-		E634B36AFA6546CA8DB2F8B5 /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5654BC08D54F1399A7B456 /* LMSModels.swift */; };
-		E6AE8BA5F5C8457EA0B981EF /* LMSAPIReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20636E18011042CE8BC078EF /* LMSAPIReading.swift */; };
-		E6D0C83BDB0D471D93DA5D65 /* SettingsMenuLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FA30ED87A2472F9C9CA9F4 /* SettingsMenuLogicTests.swift */; };
-		E6F7BA4AB67A4195B80148C1 /* LMSAPITutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB23DB1F524420EB1691BFB /* LMSAPITutor.swift */; };
-		E6FC3898DB844C9380D8F183 /* LMSAPIBoards.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2DA51DD8EE4449921CEDE6 /* LMSAPIBoards.swift */; };
-		E705CA697ED4496F9C907066 /* NotificationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9C5B54B7744E1D889061AF /* NotificationModelsTests.swift */; };
-		E70F747DE25948609EBD9DEB /* LiveGameLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC55BD9D73F44EAAB068187 /* LiveGameLogic.swift */; };
-		E7292817B6D74199944410C1 /* ParentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002B42EDB8C1480AB39F9343 /* ParentLogic.swift */; };
-		E755406C7057458298AEC62C /* CourseOutcomesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C59803EB384ED2BD2E4FF4 /* CourseOutcomesLogic.swift */; };
-		E7CEBF08E70545698FE082B1 /* BoardPostCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04F85EB97CD424DAADB983F /* BoardPostCard.swift */; };
-		E898B6C0799B45E6ABD7EEA3 /* AdvisingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CAA8F0D0E4729A71B3AF6 /* AdvisingView.swift */; };
-		E906AB146A44454D852FD825 /* IntroCompletionCelebrationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9396F92336A244AC8D3467B3 /* IntroCompletionCelebrationSheet.swift */; };
-		E947D06ABECB4B61B11F88A2 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CC6E171D1E4F0B8835516F /* AppleSignInController.swift */; };
-		EAB177196F6D49E0AD5DD062 /* PlatformSettingsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313C6A1E76CE4919943436F5 /* PlatformSettingsAdminEntryCard.swift */; };
-		EB60030B24C04B33968AEAB3 /* HallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD19D41247C463A95E4F3F4 /* HallPassView.swift */; };
-		EB69BC34D6464A0EA3F83BCB /* SpeedGraderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46B0315581D446E95672C86 /* SpeedGraderView.swift */; };
-		EC101926F0BC469E84DD9FFE /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E200FDE72EBE45E695A23ABD /* LexturesTheme.swift */; };
-		EC94861422944F95A1428DD4 /* OrgBrandingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DFAF51AD274252905975DE /* OrgBrandingAdminEntryCard.swift */; };
-		ECC896B994C148D5BD7BFF89 /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC286797DB05465394303FE5 /* EditProfileView.swift */; };
-		ECF3AF3EC60F437A826A62A5 /* ProfileAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11BE50906624153A159A9F0 /* ProfileAvatarView.swift */; };
-		ED26D8D24D4F4D78A8AABE89 /* LMSAPIBoardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF38853657840A195A73F41 /* LMSAPIBoardLayout.swift */; };
-		ED95D3D339554D458903D81C /* TutorStreamClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D47730AC9BC474B8D83E60B /* TutorStreamClient.swift */; };
-		EDEBA37D69784BE28AEE5C43 /* CodeQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2824972F97472BB707A125 /* CodeQuestionView.swift */; };
-		EE351684AEA54BC3860A64DC /* GamificationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132267FD5B84E9CB733911B /* GamificationLogicTests.swift */; };
-		EF2ABACFDB8047E9877199E5 /* BehaviorRosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB52324C18734849B0964957 /* BehaviorRosterView.swift */; };
-		EF5559D223E24EB086B5B0AA /* LMSFeatureModelsWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A05827BFF2447A9E87D715 /* LMSFeatureModelsWallet.swift */; };
-		F0234D51F3E34E3AB05D0885 /* LMSAPIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2EBD3E2D3D4385A04B65EB /* LMSAPIFeedback.swift */; };
-		F043F1D16C2840E9B6BC72BD /* ParentDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED18B763EA41E4BF2F9905 /* ParentDashboardView.swift */; };
-		F0B7AFBBEFCC448C970FAB5B /* LMSAPIAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC33ACFE534B42289892ACD0 /* LMSAPIAdmin.swift */; };
-		F164235052EE4101A339407F /* ModuleContentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961A69EC01BB40BC82BE203E /* ModuleContentModelsTests.swift */; };
-		F1FD6FB304A3456BAF766F57 /* AccountAccommodationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65E08AAAF35435F91EC11E2 /* AccountAccommodationModels.swift */; };
-		F2241D95566E44E2BB850323 /* PathsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA8F0165E34D14AABAE818 /* PathsLogicTests.swift */; };
-		F2FB5B6F614D4BE7B7603084 /* MfaPasskeyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B233796BCC544B687DE6F83 /* MfaPasskeyController.swift */; };
-		F31F08EB76764695B403A9A9 /* LMSFeatureModelsPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5290AAD24C2D4FE1A55D21BC /* LMSFeatureModelsPeerReview.swift */; };
-		F4069A4A72F94E33AA8C3889 /* OfflineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD624932F9E643898448AF98 /* OfflineService.swift */; };
-		F429E05333FF47F19016DE5C /* LocaleAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F90EFE7623642A7A924062F /* LocaleAPI.swift */; };
-		F575310A5D1045F797CF0E79 /* GlobalDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9130A525300541639EDC6BF7 /* GlobalDrawer.swift */; };
-		F5D784051A4641D79D500CD7 /* CourseCreateObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD1CD8513FF46B4B9547A10 /* CourseCreateObservability.swift */; };
-		F64D2168D658458588B868EB /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0F185E5E3B4478B06AA959 /* BrandLogoView.swift */; };
-		F6B61D39B8A84528B42BE86C /* LMSAPICatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBB5CE865524C7E9FE8EFCE /* LMSAPICatalog.swift */; };
-		F719C280E9E34F8F831EE571 /* ReportCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BABCA4837CF46C386214596 /* ReportCardListView.swift */; };
-		F761DF8CE6444D838E713B66 /* OfficeHoursLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB42BCF7AD14051AF1410B1 /* OfficeHoursLogic.swift */; };
-		F76BB5BAC0484A378052D930 /* CanvasImportComingSoonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C37D5824D0F4AB4884B0646 /* CanvasImportComingSoonView.swift */; };
-		F7DF2D5D6DB341B48B48470A /* BoardsAdvancedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445772B2379849AEAED2E890 /* BoardsAdvancedLogicTests.swift */; };
-		F7E1C56837724308A8402DA2 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648A52DA434F46EA8E2C9636 /* SplashView.swift */; };
-		F90102CE23744A3391050289 /* AccountIntegrationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1A952B8DE848359F5BE2B7 /* AccountIntegrationsLogicTests.swift */; };
-		F907DA13E1E5489D8A2FC191 /* CourseTranslationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC1AC4481FC4833BF1B61A7 /* CourseTranslationsLogic.swift */; };
-		F947C01BFAAE4BC29C197A19 /* ArchivedCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072DD96ED19D4F2AB9F0B99E /* ArchivedCoursesAdminLogic.swift */; };
-		F959393EF196487DB536229A /* LMSFeatureModelsInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84310772875447D85E385CA /* LMSFeatureModelsInstructorInsights.swift */; };
-		F9D06D4B1D5E4609AF061941 /* LogReadingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63C8BCE65AE45F9A02332C7 /* LogReadingSheet.swift */; };
-		FA892EEB0AB543C18F77C530 /* ConferenceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6ED1EE5D0457B909BE417 /* ConferenceLogic.swift */; };
-		FB8406AD901D4394B37589E5 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B331630BBB724A7BB2500383 /* NetworkMonitor.swift */; };
-		FC8804F6A7204CEE924E6182 /* LiveQuizPlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F6726D741A41E98A42A7C1 /* LiveQuizPlayView.swift */; };
-		FC92EFBF854F4B7AA0074550 /* WalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BF4BA121A54F69A6B4B087 /* WalletView.swift */; };
-		FCD30F4144FB421D83445546 /* GradingBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D53CC2405F4082A1898623 /* GradingBacklogView.swift */; };
-		FD0F1770733F48D4B2DCE847 /* PortfolioArtifactUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9E74A13E01474490F478FB /* PortfolioArtifactUploader.swift */; };
-		FDC1E1234C6141499E94BEB6 /* LMSAPIEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632C23893BC2467DBF9316C1 /* LMSAPIEvaluations.swift */; };
-		FE302E99CF2F4D909E55DEEA /* MapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD21D146CC427BA8F4DB93 /* MapLayout.swift */; };
-		FECC0401D1544AD187F86779 /* GroupsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8970BD54EE4C13BCB58BE0 /* GroupsLogic.swift */; };
-		FF26EBE988684E61A6DCAE00 /* CourseSettingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AECEE1A5A6439D9F9DCF5D /* CourseSettingsLogicTests.swift */; };
-		FF364A4117834E9683396B41 /* NetworkBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314FC24136554488997DDFA3 /* NetworkBootstrap.swift */; };
-		FF594D97F2CF4F11B0F7A966 /* SystemPromptsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A299331660DE48E19E79E2EB /* SystemPromptsView.swift */; };
+		6ED369A7EE154CDCBE032887 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC21ED0D16140FA8E128181 /* AppDelegate.swift */; };
+		15E1F90879A9406FBBBA92F6 /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB3CC07877B4410A1AA5030 /* LexturesApp.swift */; };
+		20454A04869B4B678FA6157E /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F09135218740BEA6B986E5 /* RootView.swift */; };
+		F4F1D79C0F53493EBAF31CCA /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2391332DEEEF49AB92138DD9 /* AccessibilityPreferences.swift */; };
+		A3D8BE5BBE4E4EC6922FB9AE /* AccessibilitySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D877139FEBC4481391B5DD95 /* AccessibilitySupport.swift */; };
+		DC933262AF1C4EE78BDDD135 /* DictationField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9F43CFA29B464B8321DE60 /* DictationField.swift */; };
+		6A559EEE76EA40B0B5E919D7 /* ReadAloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C08405046034F249A8E4203 /* ReadAloud.swift */; };
+		1F84B57453EC443DBD850C7C /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236584CA08EB4D21A75CB359 /* AuthAPI.swift */; };
+		625DE845245045A9B259C8F2 /* AuthCallbackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A6C2CF29B94FD8ACF73AA1 /* AuthCallbackParser.swift */; };
+		751CB6CA908C42AAA8A799EA /* AuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB15491376F47848D44B281 /* AuthConstants.swift */; };
+		9B9E21406160409F8D81FB5F /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7BD34CEB384CB3B4A718A6 /* AuthSession.swift */; };
+		6123B63B7BBD44C0B9A5EEF9 /* BiometricGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7552797A53BB4FCE9FE53E6D /* BiometricGate.swift */; };
+		AC0EE35E21034BB5BAAD78AC /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C1ED70666464594D7B357 /* KeychainStore.swift */; };
+		BE6ED0BBA1EB4014BEA5B85C /* SessionsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0B98E8DFAD4FD4870B4B32 /* SessionsAPI.swift */; };
+		41A7DB60D97B43A5ACCDA312 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCECD071C74C40B592761510 /* AppConfiguration.swift */; };
+		7C05A81CDD024AF5B53CF947 /* EnvironmentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706824795CA64D6CA900F6FD /* EnvironmentStore.swift */; };
+		DBA2446EE0D343D08044259A /* SchoolCodeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72B5AE8D40842608ED2A93B /* SchoolCodeLogic.swift */; };
+		30F64C0A143A46F59F00F5A1 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9E89A08F9048A498A3C2C9 /* AuthFieldRepresentable.swift */; };
+		45145825BFEA43AC83DDBDD5 /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E602BC87C274EB8BF6D2F82 /* BrandLogoView.swift */; };
+		D7AA30F9E7B44FBF9D2327B8 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4411A8DB948DBBC52AB07 /* Haptics.swift */; };
+		62107BFEAA9B4D66973F2017 /* LexturesMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217B50509F7E4605A3AEA934 /* LexturesMotion.swift */; };
+		49400339D9134FFFA49CE52A /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C13D65F0331422587A7251A /* LexturesTheme.swift */; };
+		B22762E1FBD14F85A0D0C148 /* LexturesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39991ABDC8984C10936F533E /* LexturesType.swift */; };
+		5FAA6C38FD1C480DAEE2D729 /* ProfileAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788BE3FA0266441F8EE51DDA /* ProfileAvatarView.swift */; };
+		F3CDAC973F184CF48652D5D9 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118A196BFF72440985648417 /* SyncStatusView.swift */; };
+		38B668077E8B49F5ACB6FFE0 /* ThemePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F9FFA509F042BA997FB0AD /* ThemePreference.swift */; };
+		5A9724DB099341E79DA96A47 /* UIMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A831877A709428DACAE01AA /* UIMode.swift */; };
+		0E6CE5FAF63D463BAE988E9D /* UnsavedChangesBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31131F38DD8C4F71AB103C65 /* UnsavedChangesBanner.swift */; };
+		88CA2A3A7A47431DA028824C /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122671E8CAD442C99A656D34 /* DateFormatting.swift */; };
+		5286BF63D688419CB52D762D /* LocaleAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820F8FD64D9F4831BF993A8D /* LocaleAPI.swift */; };
+		AA7440F0963E49EABD664063 /* LocalePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CA37F7628145F8A5485536 /* LocalePreferences.swift */; };
+		5864916C8AA948DA91B23021 /* Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEABF3ECB7BD4EE28923328C /* Localized.swift */; };
+		A77698B1846F4D6E9EFA6BAC /* AccountAccommodationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876822D3381A4D0EB3AD2B13 /* AccountAccommodationModels.swift */; };
+		47C0179CEEAB4D6F999ECF72 /* AccountIntegrationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DC0271021341C49AEE4143 /* AccountIntegrationsLogic.swift */; };
+		DD92909F887D4008BD46B6FE /* AdvisingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E4F4CDA774754BBF2B46E /* AdvisingLogic.swift */; };
+		C81BC21475CA478EA4075B85 /* AiModelsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C94283167EE41B58D02C513 /* AiModelsAdminLogic.swift */; };
+		A6C6FCAC87AB4EE381972F02 /* AnnouncementLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26AB3D0F63B4B1484296E98 /* AnnouncementLogic.swift */; };
+		DD96F4097EF446199697B80D /* ArchivedCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9200E6719844BDFA2739BCD /* ArchivedCoursesAdminLogic.swift */; };
+		1A31F1D6D90C4955BD1F573A /* AssignmentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413FF3F2B574D8BA4A8641A /* AssignmentLogic.swift */; };
+		30E996A34E254F359D5524D5 /* AuditLogAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA16EC96F3B47B7BB83472D /* AuditLogAdminLogic.swift */; };
+		584C5965CF674DBABA550E10 /* BehaviorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8218A5DA074493A9E0C1A59 /* BehaviorLogic.swift */; };
+		80CC735067BD4E049A911122 /* BillingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE3BC019E0A410DA462E0C9 /* BillingLogic.swift */; };
+		D2DA16D6D49B4DD9BBC1742D /* BoardRealtimeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9483963ED37B434EAC4A7F8C /* BoardRealtimeLogic.swift */; };
+		F0BD139076674FDC9CBEB5EB /* BoardsAdvancedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1216ABCEF6C4A5092B7575B /* BoardsAdvancedLogic.swift */; };
+		EEC299626D5E41C8BE6863AA /* BoardsGovernanceAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425CCC3EE56D42899515B90B /* BoardsGovernanceAdminLogic.swift */; };
+		B1626F1EDB1940F6B09877D4 /* BoardsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654A68FBFF004593A6234FEA /* BoardsLogic.swift */; };
+		64577D94F29F41D69F3429FB /* CanvasImportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAD098C5D86467195AAEFB2 /* CanvasImportLogic.swift */; };
+		1F2F3185DD6743408FDD59E7 /* CanvasImportObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2BC38FEABA48CFBA00F250 /* CanvasImportObservability.swift */; };
+		AF97D393CA304376A3EBECFA /* CatalogLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1B4CAE70324A789B0B2A32 /* CatalogLogic.swift */; };
+		1CBD8E88A0E746268004C5A7 /* ConferenceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902B8828157D4900A862C29C /* ConferenceLogic.swift */; };
+		04B226DB102E4A8D8F8940D4 /* CourseAccessibilityReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30416340D9054E0B99CD6FC9 /* CourseAccessibilityReviewLogic.swift */; };
+		51951A19C75B49CFB079BAC2 /* CourseArchivedContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94EF43760CF14277B04B2E26 /* CourseArchivedContentLogic.swift */; };
+		2EE334A9DD8843D7B8FED259 /* CourseBlueprintLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F96BF5345940B29F034AE7 /* CourseBlueprintLogic.swift */; };
+		58251CFEB17E4330BC32050D /* CourseCreateDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82679475DB4F44808D9B2A80 /* CourseCreateDraftStore.swift */; };
+		E0BF1ACE45BE4777989D0FDC /* CourseCreateLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010D8A6487C848EA8815BE13 /* CourseCreateLogic.swift */; };
+		B25B4B8A5947421BBC083268 /* CourseCreateObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA41BD3596684A6B9A402E7E /* CourseCreateObservability.swift */; };
+		79F9D65C98C945F28936F111 /* CourseFeaturesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECCB1A1680B415D932DA179 /* CourseFeaturesLogic.swift */; };
+		9832E919FE9E433DB05F6712 /* CourseFileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F1D7AAFF3346ECAB215A9A /* CourseFileLogic.swift */; };
+		851C32BA90434973909B7C7C /* CourseGradingAgentsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA328ED019264948840DC527 /* CourseGradingAgentsLogic.swift */; };
+		2C7F8DB9A7C74FC09536B274 /* CourseGradingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D4CE8302454BA09CB5BC24 /* CourseGradingLogic.swift */; };
+		17B40FA2B7084F90BA44AA56 /* CourseHeroImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E508006F4842A58668DB57 /* CourseHeroImage.swift */; };
+		1BCCDB4F8B184F498D1BA398 /* CourseImportExportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC62A6B2B27441E5B7915806 /* CourseImportExportLogic.swift */; };
+		B6AC338EF20A481080AAEC66 /* CourseOutcomesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8EA99BDF0A4AF6ACD0C05B /* CourseOutcomesLogic.swift */; };
+		044E734121B04AD4AF133F21 /* CoursePeopleLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B286388C9EC40C887371ED5 /* CoursePeopleLogic.swift */; };
+		E0034CBC4A4A44AA9ACA8F84 /* CoursePeopleObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89062806BF744D468AA7DFD1 /* CoursePeopleObservability.swift */; };
+		5604F5CF805A4EACA96AD8E6 /* CoursePlagiarismLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8877458D0E44F6DB649AF12 /* CoursePlagiarismLogic.swift */; };
+		964A3784221D48699021420C /* CourseReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E7C1D0E02D41ADBF4D5464 /* CourseReviewLogic.swift */; };
+		34AE4236646B4DFA92E7EE27 /* CourseSectionsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA37BA46DFF4A6392FE691F /* CourseSectionsLogic.swift */; };
+		57A71865D4EE48F7946F95E9 /* CourseSettingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4323122721FF43A98CBA77DD /* CourseSettingsLogic.swift */; };
+		56A36D1DABC144AE8BA8EDC2 /* CourseTranslationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39DD7B13CC04A99B5EEF892 /* CourseTranslationsLogic.swift */; };
+		D13E48A8AE0A44568B32D385 /* CredentialsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3388A3D4894C97907F21A6 /* CredentialsLogic.swift */; };
+		31449678DAE74DD994F3444C /* CurrencyExponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19865D60BF49490CA83E3FC8 /* CurrencyExponent.swift */; };
+		98F5A359170E43508EBC1010 /* DiscussionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821E07F7B3BD4516933FD25F /* DiscussionLogic.swift */; };
+		5B293A532CB94B5C8CAC371D /* EvaluationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5F20597F4246188C41BC16 /* EvaluationLogic.swift */; };
+		D7E0841ECCFC4A3395EC04C0 /* FeedbackLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802E14FA9C1E486E8320D4C9 /* FeedbackLogic.swift */; };
+		7F239EB29E674FEF9874B4A7 /* FileDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB1D45B7CFF4C63AE669D1A /* FileDownloadManager.swift */; };
+		AFF61B9106234F7D83EBC362 /* GamificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88B6AF6F97C420CA3528020 /* GamificationLogic.swift */; };
+		4091BD957DE54482B0A0C8C4 /* GradeCalculator+MyGrades.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4EAB0E8322489395633B7F /* GradeCalculator+MyGrades.swift */; };
+		A408256D4D144E1B95481536 /* GradeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3A0A78C0E24855A2FC15B9 /* GradeCalculator.swift */; };
+		B7EF464315D54771870EB1A1 /* GroupsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D19836EB74186A1414C77 /* GroupsLogic.swift */; };
+		0369207C3D5E44EBA0BEB2C4 /* InsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21D78D26D264655AB76C425 /* InsightsLogic.swift */; };
+		002905AB12F64D788195ADD0 /* InstructorInsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A150CD947F4E56BFF48EAD /* InstructorInsightsLogic.swift */; };
+		FB2CC0967E66475D95256EBA /* IntegrationsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C016EA4D3A0B472CB5D1125D /* IntegrationsAdminLogic.swift */; };
+		B8320F5DF6B9400F8A47EE47 /* InteractiveLaunchLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A43C87E3984E9097D25841 /* InteractiveLaunchLogic.swift */; };
+		75511354CC734D89A7A9C046 /* IntroCourseLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919E594A7B8D4B6F98B0B1F7 /* IntroCourseLogic.swift */; };
+		9FE504583E704A828E3CBBDC /* IntroCourseObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6542DA2E77D24963B76CF7C2 /* IntroCourseObservability.swift */; };
+		DD52F82C382945D2988DB8E3 /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966CD203A95F4B3B819D5965 /* LMSAPI.swift */; };
+		FC08960D992547B69F6FB9EA /* LMSAPIAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CDA1E5F1194D00ACE24EB7 /* LMSAPIAccountIntegrations.swift */; };
+		2A82B52122014896A389E3CB /* LMSAPIAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97217C9DC56846FA9D63293B /* LMSAPIAdmin.swift */; };
+		D5EA0BE7DFD747188BC89A0D /* LMSAPIAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56A544993F04A8CBB03CEDD /* LMSAPIAdvising.swift */; };
+		FCA20985E69A47AB8768D75D /* LMSAPIAnnouncements.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150DCF9F7224315B7B30C60 /* LMSAPIAnnouncements.swift */; };
+		CD3E2665C37C4A2CBEB05C30 /* LMSAPIAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9127F532CB4C378571046A /* LMSAPIAuditLog.swift */; };
+		5FB0E4CE699F408D908CD65B /* LMSAPIBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B851C9FA0E4125AC76F48A /* LMSAPIBehavior.swift */; };
+		DE38858E481D4A97B0078961 /* LMSAPIBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A904A5B0DB4B3098645E2A /* LMSAPIBilling.swift */; };
+		9E8BDF3EE56A4D038A7EC6CA /* LMSAPIBoardAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994BBFFE141A485DA43BC060 /* LMSAPIBoardAccess.swift */; };
+		77BE2015AE5E4F1EADDE9A8B /* LMSAPIBoardAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71BA7EC2E36488D9549FC98 /* LMSAPIBoardAnalytics.swift */; };
+		BD3D62016549414B9854CC64 /* LMSAPIBoardEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801E18789F664D0DA7B9F036 /* LMSAPIBoardEngagement.swift */; };
+		9DFF1DA4BB314351964D9086 /* LMSAPIBoardExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A55EC392CA1443EB6FD698D /* LMSAPIBoardExport.swift */; };
+		2BE5A0593D3A48EBB96A507C /* LMSAPIBoardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF09D800BBA244ADB1F89793 /* LMSAPIBoardLayout.swift */; };
+		D47A6CCBA23D418F9A53E695 /* LMSAPIBoardModeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C464E7B7706B46A6A1EC6B2F /* LMSAPIBoardModeration.swift */; };
+		163081DACD874AFC9CEBB4CB /* LMSAPIBoardPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86242101E8CC4D4D9DB48D1E /* LMSAPIBoardPosts.swift */; };
+		3F3F700D8EBD494F860E258F /* LMSAPIBoardTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02AE223E87C46CA849E4F4A /* LMSAPIBoardTemplates.swift */; };
+		3CAF4BC52EE14E59AA9AA375 /* LMSAPIBoards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9B571E7F1E4C1D8B0B8EB3 /* LMSAPIBoards.swift */; };
+		1EC0B2C122144589AD10A89D /* LMSAPICanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8955E4A2CB0471DB37AB7E1 /* LMSAPICanvasImport.swift */; };
+		AAF254745FA145C4978E8767 /* LMSAPICatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A728634557104CC48E4FA9FA /* LMSAPICatalog.swift */; };
+		1074AE412E3D45479E3FC24B /* LMSAPICourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3060A84315140D48D885600 /* LMSAPICourseAccessibility.swift */; };
+		B402E25ADDA4412DA067751D /* LMSAPICourseArchivedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB86D9F3B774232B8B64374 /* LMSAPICourseArchivedContent.swift */; };
+		05224A5A9E0D4046809E2B0D /* LMSAPICourseBlueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7649122040475593E51536 /* LMSAPICourseBlueprint.swift */; };
+		1357C78D319D4F308D52A8F8 /* LMSAPICourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F838E38FD3314A86A61313B3 /* LMSAPICourseCreate.swift */; };
+		BC762DECD0C844329C7F10F9 /* LMSAPICourseFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02159D88D4604E099DC45F01 /* LMSAPICourseFeatures.swift */; };
+		67538CE802674998AE77B463 /* LMSAPICourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C84ED01FAFE4F6A866A68EF /* LMSAPICourseGrading.swift */; };
+		A2BF109AE8C949C6937E69CD /* LMSAPICourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38FAB25C7DD43B284D8EFCD /* LMSAPICourseGradingAgents.swift */; };
+		8B8F3F12483D438983936BB7 /* LMSAPICourseImportExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD72034B7394CDDB3C71596 /* LMSAPICourseImportExport.swift */; };
+		4E904AB3021B4420B0C06A3B /* LMSAPICoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B5DBDBE0EA4FD6811B8A9C /* LMSAPICoursePlagiarism.swift */; };
+		48823DAE80D24C32B3F4873D /* LMSAPICourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5ECA1E769A42E8AB9D07AC /* LMSAPICourseReviews.swift */; };
+		B2295608748A41B7AC205BCC /* LMSAPICourseSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668A5BEF50304DEEB227C929 /* LMSAPICourseSections.swift */; };
+		70BE875893DA41728EF11CF0 /* LMSAPICourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF1717F955345CEB67D4387 /* LMSAPICourseSettings.swift */; };
+		574940E35AB04C66B966557F /* LMSAPICourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E5D70AB65A4BD0842B8517 /* LMSAPICourseTranslations.swift */; };
+		031BF94EDA8941B58ED65CFB /* LMSAPICredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A29CB1E340146B2AB9FC2E4 /* LMSAPICredentials.swift */; };
+		80612637EAEF448CA0384CBC /* LMSAPIDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068520BD32F0465EBD006759 /* LMSAPIDiscussions.swift */; };
+		B6494DA38A7547888D36551B /* LMSAPIEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3131373FEB59466C8AB0AC7C /* LMSAPIEportfolio.swift */; };
+		9B69CCFEB0034CFEA7F815A6 /* LMSAPIEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306DA47EB9F146349ADE21A8 /* LMSAPIEvaluations.swift */; };
+		5D61EF685351448BA9E2CEE8 /* LMSAPIFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5CE9C20A164A57A2912047 /* LMSAPIFeatures.swift */; };
+		E9B249DC0717464180E51A62 /* LMSAPIFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2D7AF6A7E74E419C4E3E6D /* LMSAPIFeed.swift */; };
+		0CDB3FDC6C064673A5C9FADC /* LMSAPIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D110AD56244378A93E0E15 /* LMSAPIFeedback.swift */; };
+		59E4A13C071A48CAAE16D8E1 /* LMSAPIGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894E2AD904124DDDB1BD3CBF /* LMSAPIGamification.swift */; };
+		0F52C3C798F4427B81D6C8A6 /* LMSAPIGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF12B79BA4A4F999CA668DF /* LMSAPIGroups.swift */; };
+		E5C077722D6940F78A4293E7 /* LMSAPIInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA3D5D9FD24A8B9B2EFDDF /* LMSAPIInsights.swift */; };
+		7DD3C39B0D0D4D5CAB137BFE /* LMSAPIInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BDAE0779984913A3A462B8 /* LMSAPIInstructorInsights.swift */; };
+		99DB368B3BC14B77AED0EA42 /* LMSAPIIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A92F7A21E3452886DEB48E /* LMSAPIIntroCourse.swift */; };
+		983CDB5358764FD6989EE994 /* LMSAPILearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4A56A3B3B84A10991DAF47 /* LMSAPILearnerProfile.swift */; };
+		1F65E5A34F584D36BC87EF70 /* LMSAPILiveQuiz.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDD6A07DA3446248362F3D7 /* LMSAPILiveQuiz.swift */; };
+		6D88B5874E204CF3A2E31F39 /* LMSAPIMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4288167DEBBD4889AE882767 /* LMSAPIMarketplace.swift */; };
+		D6CC17B5DA7540AFB7D53BBD /* LMSAPIMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FE81C12C6F499187483CE8 /* LMSAPIMastery.swift */; };
+		25BED0BFCE244FDDB113467B /* LMSAPIMobileWave.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD07E78BFB04381B3637B0E /* LMSAPIMobileWave.swift */; };
+		0107441311A1498BA49C74AD /* LMSAPIOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C746D09F7AED46FC9EFF8F3A /* LMSAPIOutcomes.swift */; };
+		8A9259E216124941B7AAA60B /* LMSAPIParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813EBA9635704CB7AA3ED889 /* LMSAPIParent.swift */; };
+		B89E19B30F1A4B31A8FF9534 /* LMSAPIPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9675FBC57BC64C3F9111FD59 /* LMSAPIPaths.swift */; };
+		B9641A3904A14311B0ACECCD /* LMSAPIPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33223C7241234E22923DE250 /* LMSAPIPeerReview.swift */; };
+		F80F0668233D435AA9111D91 /* LMSAPIProctoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F5E609206F4CC4A2CF95E1 /* LMSAPIProctoring.swift */; };
+		4E0F55A6CE1947508C936550 /* LMSAPIQuizCodeRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FE06D846ED40A58DCE2230 /* LMSAPIQuizCodeRun.swift */; };
+		F658066BAB224F77B2EE617C /* LMSAPIReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8906D74CFF4701B255EAF4 /* LMSAPIReader.swift */; };
+		07D34EE7807A46B59DEBC009 /* LMSAPIReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A0B299B0D94ADC97F88528 /* LMSAPIReading.swift */; };
+		F4F7980EFE93464DA5512090 /* LMSAPIReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8FDE10B9B4CEC8A5C6F5E /* LMSAPIReview.swift */; };
+		4FC4D8989506445D8A22D96B /* LMSAPITutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86ED0FB8585D46868F83CB1F /* LMSAPITutor.swift */; };
+		07E475945B75494B86C0EDD3 /* LMSAPIWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207E7D9985164CD29E02D922 /* LMSAPIWallet.swift */; };
+		6BFE443C16D44678883081EF /* LMSAPIWhiteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D9DD802E174B83AE982827 /* LMSAPIWhiteboard.swift */; };
+		4D015EF64B97490DAB901F99 /* LMSBoardAdvancedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F968115560419084BFD1DA /* LMSBoardAdvancedModels.swift */; };
+		73A688D46E3E48FCA0EE3FBD /* LMSBoardModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904B49C91AD649B8ACE9FF53 /* LMSBoardModels.swift */; };
+		57B5A846FD164DA1854CD044 /* LMSFeatureModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F30BB03583A40CBACF8BAC7 /* LMSFeatureModels.swift */; };
+		955A8DFB29674447B8015D2A /* LMSFeatureModelsAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5AFDFFD4954154AA08B6F0 /* LMSFeatureModelsAccountIntegrations.swift */; };
+		EC4CFF3700DC422A8E2DFFD7 /* LMSFeatureModelsAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80B84481BE743C8815CE2A1 /* LMSFeatureModelsAdvising.swift */; };
+		13161AA1ADBC4A6685BE7F95 /* LMSFeatureModelsAiAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EEC8D940813443B82EF99FB /* LMSFeatureModelsAiAdmin.swift */; };
+		6975DE522A664A1EB37B7F4C /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A3ACCAF55B4CB3BC634A50 /* LMSFeatureModelsArchivedCoursesAdmin.swift */; };
+		BEA8298EE5BE471F8CF2C10B /* LMSFeatureModelsAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE63E84856084D178F811FA9 /* LMSFeatureModelsAuditLog.swift */; };
+		B8AAEFE9A7EF494AA858B3C7 /* LMSFeatureModelsBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C177FF51E7499F98FEB135 /* LMSFeatureModelsBehavior.swift */; };
+		18B2F850A925428E8F668D01 /* LMSFeatureModelsBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8F213D1EFE4B02BE3EA0DC /* LMSFeatureModelsBilling.swift */; };
+		65B52B889BD547BC9A4643DC /* LMSFeatureModelsCanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189CE9ECC48A43A2934C6332 /* LMSFeatureModelsCanvasImport.swift */; };
+		E042CA4A3D2F4EC6A718B836 /* LMSFeatureModelsCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60FFEEF85CA49868E48854D /* LMSFeatureModelsCatalog.swift */; };
+		11725BAAC0164B4F934DDEEE /* LMSFeatureModelsCourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D140A0009994251829A8550 /* LMSFeatureModelsCourseAccessibility.swift */; };
+		D6C37562AEBD4CEA8739A1DE /* LMSFeatureModelsCourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8FE4612AF54B47AFEA77FC /* LMSFeatureModelsCourseCreate.swift */; };
+		930D5585356C42E6B1E714D3 /* LMSFeatureModelsCourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024FE8FC67C4411EA992E641 /* LMSFeatureModelsCourseGrading.swift */; };
+		625835250AA44CAB8BD357AF /* LMSFeatureModelsCourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2290E19122C4493AE1EBD28 /* LMSFeatureModelsCourseGradingAgents.swift */; };
+		C0681F597D194C86A516158D /* LMSFeatureModelsCourseOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55830F753A0046C981B6A5A6 /* LMSFeatureModelsCourseOutcomes.swift */; };
+		E33E8694BA8747CF9DA48BD7 /* LMSFeatureModelsCoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293E953D73FB46039E06FEA4 /* LMSFeatureModelsCoursePlagiarism.swift */; };
+		76595C5CC6AA4AD09A6DCD57 /* LMSFeatureModelsCourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB7B6D7573A436D9EE6C0BD /* LMSFeatureModelsCourseReviews.swift */; };
+		95816DE8A5154BAAB8FC9CFA /* LMSFeatureModelsCourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C78CFD171E4C50B5AC21BB /* LMSFeatureModelsCourseSettings.swift */; };
+		8E74170077DB4DE9808236D9 /* LMSFeatureModelsCourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6602EEA446149C0BF76FD4F /* LMSFeatureModelsCourseTranslations.swift */; };
+		8944F1C9147041929F16AB50 /* LMSFeatureModelsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215E096BEF9B47F68FB552A7 /* LMSFeatureModelsCredentials.swift */; };
+		B39FDDFD04C94707ABD777F0 /* LMSFeatureModelsDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448F3041DA3349A4B85A5849 /* LMSFeatureModelsDiscussions.swift */; };
+		9F23BC5B6D4740F1B1A95C87 /* LMSFeatureModelsEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F09DF8AF0BD45B195F3B93C /* LMSFeatureModelsEportfolio.swift */; };
+		D3D780D070DF42ACAA1FFF82 /* LMSFeatureModelsEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1655E9A8D3C4BF089B81C17 /* LMSFeatureModelsEvaluations.swift */; };
+		4DB2AB512BDB4A53AEE8BB95 /* LMSFeatureModelsFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7D2B5DFB6D4597B12EC5CC /* LMSFeatureModelsFeed.swift */; };
+		742C8A710730478F9387553E /* LMSFeatureModelsFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750096FF04F847F08FA588EE /* LMSFeatureModelsFeedback.swift */; };
+		29886400FBD04A58B95CC0B2 /* LMSFeatureModelsGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888D7AF98DAE4275B6026F44 /* LMSFeatureModelsGamification.swift */; };
+		8385C939AD84420C94FF12E3 /* LMSFeatureModelsGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DB93BEB74C4BDBA17AC808 /* LMSFeatureModelsGroups.swift */; };
+		FD948DD685444BF9BCF318B5 /* LMSFeatureModelsInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BD6CA3F08E413693067FCE /* LMSFeatureModelsInsights.swift */; };
+		6D88CE52C986453A8BF5B0C6 /* LMSFeatureModelsInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03308D4ECF2B43DB882A33FF /* LMSFeatureModelsInstructorInsights.swift */; };
+		093D43FBB19545D2AC4E75BD /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023909062EED4A2B9B375E4A /* LMSFeatureModelsIntegrationsAdmin.swift */; };
+		6894134B17314822902FFAF9 /* LMSFeatureModelsIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE321A529D7B4A4DA1F2EDB3 /* LMSFeatureModelsIntroCourse.swift */; };
+		179BA98C79DC4A5E95C34E79 /* LMSFeatureModelsLearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734204250DE94773B2699164 /* LMSFeatureModelsLearnerProfile.swift */; };
+		AA25A097B4D54E04ADEC2434 /* LMSFeatureModelsLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B548F6309447C3A3FBFF17 /* LMSFeatureModelsLive.swift */; };
+		0C741C7AE32844099FB1FBB5 /* LMSFeatureModelsMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD04098A231494CA3F09F78 /* LMSFeatureModelsMarketplace.swift */; };
+		0BB69957873C40A780B86B3F /* LMSFeatureModelsMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DDFFC0D69A491D9DA742FA /* LMSFeatureModelsMastery.swift */; };
+		4A098125BC2C473F9073B74E /* LMSFeatureModelsMobile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAE21F884C8447AA61BF858 /* LMSFeatureModelsMobile.swift */; };
+		494414593D924216A78D4AD8 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E0AB224456451DBA4E7994 /* LMSFeatureModelsOrgBrandingAdmin.swift */; };
+		34EE6AF8F3554C1CAC6172B3 /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C43119FFBC54D04B7C27FD9 /* LMSFeatureModelsOrgStructureAdmin.swift */; };
+		6ACCA3B209314501B5AA46CD /* LMSFeatureModelsParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550DB0C297164ED9880A4FD7 /* LMSFeatureModelsParent.swift */; };
+		FA454F66A1264FBEA9C2B06A /* LMSFeatureModelsPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4790175587647C88099ADD4 /* LMSFeatureModelsPaths.swift */; };
+		4610A27CBA494A13930F773F /* LMSFeatureModelsPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F3143CD283049999A70EE00 /* LMSFeatureModelsPeerReview.swift */; };
+		6DF84F2D562042BE961B6EDD /* LMSFeatureModelsPeopleAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B0D6B8EA2C4B84993EA288 /* LMSFeatureModelsPeopleAdmin.swift */; };
+		93D366EE1FF142819422301B /* LMSFeatureModelsPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CCABD2171944B38CFFE643 /* LMSFeatureModelsPlatform.swift */; };
+		29396971F24F4367A238A82D /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DD0143BF514EB898AEEFAD /* LMSFeatureModelsPlatformCoursesAdmin.swift */; };
+		9A52A294619B4BA18EC8E197 /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F009617AFF417CABF397AE /* LMSFeatureModelsPlatformSettingsAdmin.swift */; };
+		7029802B224848E9A126865B /* LMSFeatureModelsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4643CE61530B4FD8971104A2 /* LMSFeatureModelsReader.swift */; };
+		44F05A1005114E37884E5375 /* LMSFeatureModelsReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F39CB0482F4A64913BB349 /* LMSFeatureModelsReading.swift */; };
+		2C5D91394CC1432A9C1C7AEB /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E609EA910A5A463B99D7C222 /* LMSFeatureModelsRolesPermissionsAdmin.swift */; };
+		61D3278D97E84FC39DF35584 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9F3F51E5A245A1A459EF71 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */; };
+		F50DD76D2D8A4868B51A8C3E /* LMSFeatureModelsTutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E589186B3024558AE276C41 /* LMSFeatureModelsTutor.swift */; };
+		C6F366B4969647F4AEFCC95E /* LMSFeatureModelsWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB025E305E73486AB634D170 /* LMSFeatureModelsWallet.swift */; };
+		B718690ECB8C4105B00637EF /* LMSInteractiveModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3AEDE2A3A24B1FB83AD8CD /* LMSInteractiveModels.swift */; };
+		628623E4AE6B4DA19322109F /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C17447C206F491F86B62429 /* LMSModels.swift */; };
+		82B05DA5BBF04F6CA95B08A3 /* LearnerProfileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2DA8F783004A75B61C861E /* LearnerProfileLogic.swift */; };
+		5A300C2DE1AB4D8BAB2ABA39 /* LibraryResourceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B520F7E9737D4C78B5511ADA /* LibraryResourceLogic.swift */; };
+		9DBAA00087EE44908764E3A5 /* LiveGameLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37D57FE7FD94B599A7462C4 /* LiveGameLogic.swift */; };
+		D507791B8EAB4DC28817850A /* LiveMeetingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1968A81A18024476BACDA0C8 /* LiveMeetingsLogic.swift */; };
+		A3584F94A1494D57BCCBD4CF /* LiveQuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2A21241F6A48D79A316B25 /* LiveQuizLogic.swift */; };
+		D7807865C9EA4116A413AE18 /* MarketplaceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B6B3C5A0A44CF0BE0695FC /* MarketplaceLogic.swift */; };
+		AD5D29047CA546C58B133BCC /* MasteryLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D94CAC8ADF4E77ADBCE34B /* MasteryLogic.swift */; };
+		3CD94916407742879D20E044 /* ModuleContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76986149DC3348B4AB702714 /* ModuleContentLogic.swift */; };
+		5D01EB754B7645A6A12F9E6A /* ModuleLastVisited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11775417D81E4E9BAE6C9E95 /* ModuleLastVisited.swift */; };
+		345219F117C0489D85F68966 /* NotificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EA30C7BA6041EF97247A7D /* NotificationLogic.swift */; };
+		C02086BBF39A4D788E013067 /* OfficeHoursLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6855BB77F7A14D1EB6FC6F9B /* OfficeHoursLogic.swift */; };
+		597F6B4BE5874F68868530FA /* OnboardingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F81340A6FCF4880BBBA4791 /* OnboardingModels.swift */; };
+		D73F09E1288A4DDF9D908386 /* OrgBrandingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86594C5CEF924F1DB75AEC45 /* OrgBrandingAdminLogic.swift */; };
+		0BB946A1AB534B6085F62EED /* OrgStructureAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF8F46759714555BDFE85ED /* OrgStructureAdminLogic.swift */; };
+		53E1827781ED439DAE9BF12A /* ParentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E007BE645CB04728BEFB4B4B /* ParentLogic.swift */; };
+		EFD3A6E385E44BF5977B429F /* PathsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07AEF18A77544789FA89FEA /* PathsLogic.swift */; };
+		E4CE1F7DE7F544EB823E2729 /* PeerReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFB99E8194E4D8D91176740 /* PeerReviewLogic.swift */; };
+		BE55CC8650BC46489079B9B4 /* PeopleAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26155397F5234AE695039840 /* PeopleAdminLogic.swift */; };
+		D7784F2CEA6F4CBC924DA81D /* PlannerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25AC1FC6EA5428E8B72D682 /* PlannerLogic.swift */; };
+		5D1D2935B55E48899286F045 /* PlannerSnapshotCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5790510331EE4827B84DE958 /* PlannerSnapshotCoding.swift */; };
+		7C17718ECC9E4DE98F4CF7E1 /* PlatformCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D87AB33B084FB29D7A6D57 /* PlatformCoursesAdminLogic.swift */; };
+		12A7174B46624AB19D10DEA1 /* PlatformSettingsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F21F0185187479A99043D89 /* PlatformSettingsAdminLogic.swift */; };
+		6E4BFD606DEF461492C0CC34 /* PortfolioLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56248BCF827943AC98A609E6 /* PortfolioLogic.swift */; };
+		A9348C0F85494A02A4D7CE38 /* ProfileDepthLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7979B9805F94AC3BA42C0A2 /* ProfileDepthLogic.swift */; };
+		31B51BA5175E4674B9955071 /* ProfileDepthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182B9799F5841BDA349CFB7 /* ProfileDepthModels.swift */; };
+		6F6A3A5298B6448F8C99A3E7 /* QuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9C4896A7134E4EBBB34EB7 /* QuizLogic.swift */; };
+		3D4B2B612A2C4206A769AACC /* ReadingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C014105AAF843E483AA944A /* ReadingLogic.swift */; };
+		FF885585D39642C0B45C160C /* RequirementsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F385DEC274498C97903AA4 /* RequirementsLogic.swift */; };
+		F9C7058850944E8F95807196 /* ReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92202601E40437985EDDDBD /* ReviewModels.swift */; };
+		D1EE55FB461F463DAB742BBC /* RolesPermissionsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1B974B7FBA4A0B829A0604 /* RolesPermissionsAdminLogic.swift */; };
+		A1FBE83DFE4149CEB92B8765 /* SettingsMenuLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B5ECA2A97A41E096C017B9 /* SettingsMenuLogic.swift */; };
+		B2E07FFB481C4A5BBE6EF8E0 /* TakeAttendanceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A6BA560C44113A46D4988 /* TakeAttendanceLogic.swift */; };
+		C7567ACBBD6F4EECACCE2E4E /* TranscriptsAdvisingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922C235D780B473CBC59D7F5 /* TranscriptsAdvisingAdminLogic.swift */; };
+		232E17A4D7494AE1B6B77E79 /* TutorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89473B285B5E49A0A79308DC /* TutorLogic.swift */; };
+		C044F6B123904CB2A77EB75A /* TutorStreamClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2751D8B98E43CD9F62F7AD /* TutorStreamClient.swift */; };
+		36B0A7F4F4B44BC2A74438AA /* VibeActivityLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25FA4F8614F4D7D9EEED7D3 /* VibeActivityLogic.swift */; };
+		F27F3356FE4F482D8BDBE836 /* WalletLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C019B8498C499AAE46FEF3 /* WalletLogic.swift */; };
+		768E9C7C01454C198C99336C /* WhiteboardLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A531E690F2CE4FEB86896985 /* WhiteboardLogic.swift */; };
+		A066A4DDEEE34F5495CD715F /* WhiteboardRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2B972D59944A22A14CD382 /* WhiteboardRenderer.swift */; };
+		81164CE867B049079A45A29D /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9539914B91EA4AC0A10CD744 /* APIClient.swift */; };
+		FF6ADB7EFBA647D89ACCDB96 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C60DD35D434947B391DCCB /* APIError.swift */; };
+		18883053C2CF44569CD0FF76 /* NetworkAuthContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F886051A547F6B9915B17 /* NetworkAuthContext.swift */; };
+		648C39D5C7FE43B8B1F16146 /* NetworkBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034243060A9D460D8829F84B /* NetworkBootstrap.swift */; };
+		10385B466EC84FDBA0825283 /* MarkdownTableLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D674B0C9ED146939FC329F3 /* MarkdownTableLogic.swift */; };
+		EC8703EC21534F22B998CF6D /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83042AE2827442483E3E27C /* NotebookDrawing.swift */; };
+		ACEE34B68C1745D38686B7EC /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB326385E92C4DA1B823A4F4 /* NotebookMarkdown.swift */; };
+		508C1E9687124A349438D5EE /* NotebookSlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0190BC6FDADE41CCB994CF1F /* NotebookSlashCommands.swift */; };
+		B4D601C0AC7741FAB409722A /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD6D10890F84565933F42DB /* NotebookStore.swift */; };
+		98EF53753BB04B84A456942D /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC8BA6757C24485B7248CA1 /* NotebookSync.swift */; };
+		3172F3227AF54990B74FB813 /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6CC2ED061F4414B31ABB71 /* NotebookTree.swift */; };
+		681E8B1C40D540969DF80B6F /* CacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D48D6ED18E84162ADDD9DFD /* CacheStore.swift */; };
+		E71CF5810718438B94805D18 /* DownloadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08584DB395634C77BC5D895C /* DownloadStore.swift */; };
+		5954DCD025F74B1DAB907502 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CF0C8E08904DE4BA967198 /* NetworkMonitor.swift */; };
+		64342B0D4ADB4EA7913D491D /* OfflineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1594BFF9A242A9A66BDC90 /* OfflineModels.swift */; };
+		6CE5D9B0001044E7A96C0C1C /* OfflineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5662A6252F164C63B7CDBA00 /* OfflineService.swift */; };
+		DE91392DAAF24F848649990B /* OutboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748936187DFB496C964B1168 /* OutboxStore.swift */; };
+		167A204A3A04495A94282ECB /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01174D0301DC49278345703C /* SyncEngine.swift */; };
+		D77CDD1A60F04BDA84A8AC2A /* PushManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2AD54DF35243D08D0884D7 /* PushManager.swift */; };
+		65C54D08FE8A45C7BB5AFF62 /* RealtimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F8C9E8AEC94C8CB4048E6F /* RealtimeManager.swift */; };
+		BADCC8AA27914AD39AD39E8D /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF143DA58EC349B88DE918D5 /* WebSocketClient.swift */; };
+		CF4AB5B897894BD1BE2F2648 /* ContentLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1E5E66145E42A1971D08A6 /* ContentLinkRouter.swift */; };
+		7BE976C048F842CE82F153A5 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD1758A01574A04BD37420F /* DeepLinkRouter.swift */; };
+		567EA4491007481BA5DF9EEE /* MobileDestinations.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3755F559B9448F87A2512D /* MobileDestinations.swift */; };
+		1ED73BFD03AD49F7966024C1 /* MobileIaPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CF4329D62D43529C92A419 /* MobileIaPreferences.swift */; };
+		D492EBF9575B43CCB7D00891 /* MobileProfileDepthPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129D441D1F9D47469C14936A /* MobileProfileDepthPreferences.swift */; };
+		583F78BCFE074771AFB8CA3A /* SearchActionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AB82BC37F649188244C769 /* SearchActionRegistry.swift */; };
+		406EC6322EBB4CA38E0EF6A1 /* SearchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB95D2CEDEF34154B27C0629 /* SearchModels.swift */; };
+		74B0E82EE4094B42B32DEB3A /* SearchPathNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10471B9CC0341E191FCC111 /* SearchPathNavigator.swift */; };
+		4BC8D3E45C984AEF8E9EA992 /* SearchRecentsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C50C881A26455F812729AB /* SearchRecentsStore.swift */; };
+		25C1DAC6628B40E4B7BB1764 /* CodeEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3EC0B819B54DD1A3035E15 /* CodeEditor.swift */; };
+		4F3D564DFDAA45D485DC08BC /* AdvisingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20692C98F7CF4C5E9E630940 /* AdvisingView.swift */; };
+		2B5AC6605D1C41C197E6144E /* AssignmentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E0B6EB1F464ADEABF0BBEE /* AssignmentDetailView.swift */; };
+		44288896B6304DC8833C55B1 /* AssignmentDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB370489A524C4494940128 /* AssignmentDraftStore.swift */; };
+		0C506D3676A448019F3501F8 /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0253694A82134E3AAEB30D97 /* AttachmentUploader.swift */; };
+		9E093827852844E099424DD5 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969DA09CDDFD40049CE615D0 /* AppleSignInController.swift */; };
+		E71DA52069B94A41A248DC44 /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9B1359A4404825AE15F3A3 /* AuthFlowView.swift */; };
+		3A41AC17DEE546AE8292162B /* GetStartedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42150EF643F4D7D9FFFFAE0 /* GetStartedView.swift */; };
+		9B69C172AE4C4CBB98B3D3AA /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10532DC1D669434B82A731A2 /* LoginView.swift */; };
+		0DDB95AAB94640099A401E97 /* MFAChallengeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FE0D2585394BF187ECA1B7 /* MFAChallengeView.swift */; };
+		7D119A5127964CCD8B9A239D /* MfaPasskeyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D04881B017D42D59271A7FF /* MfaPasskeyController.swift */; };
+		22DDAE6A06A24FDAAFE0A0D3 /* SSOAuthController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F813600B54249D3B9938C60 /* SSOAuthController.swift */; };
+		A6BDD382DFCB4C6CBFC6AEBD /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64116C457D144592923CE953 /* SignupView.swift */; };
+		CD9CF44DD51A41D4BB5EE71E /* BehaviorRosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6A680715844859B5AB1482 /* BehaviorRosterView.swift */; };
+		7ED3B55E2F194A148E68FB20 /* HallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F834E7C7E2B4F83977CD393 /* HallPassView.swift */; };
+		EAF60A9E783D4A6AA27B1BA4 /* MyHallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589449D3174C412290E4395C /* MyHallPassView.swift */; };
+		90DB3F5A985C452CA2BEFF3E /* BillingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D5E89F64034E519A897B39 /* BillingView.swift */; };
+		2CFDE3DCAFD943DFA374506A /* CheckoutReturnHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002621179B3240B88E42D3BE /* CheckoutReturnHandler.swift */; };
+		07AC8CA9D7B745DF959322CF /* PurchaseFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA28AFA45B4196BA532489 /* PurchaseFlow.swift */; };
+		7DFC6F1AB6804EB0B9AD139D /* BoardAnalyticsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA12F2E861645A1980CF97B /* BoardAnalyticsSheet.swift */; };
+		3087F31746B0445F88163E16 /* BoardComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8924613254124B5AA8FD0491 /* BoardComposerView.swift */; };
+		513201C8086B4D4ABAB2D2B6 /* BoardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03216D95DEEE443283E5957E /* BoardDetailView.swift */; };
+		112B5FC6A26A4C239DEA5E68 /* BoardEngagementEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337088D4F5644F398827A1F8 /* BoardEngagementEnvironment.swift */; };
+		B628B4D06766416D85DB280C /* BoardExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF51B8DD3EC1499B9B67BB98 /* BoardExportSheet.swift */; };
+		9350312EFD914AA18023A16A /* BoardModerationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83131615195A4ACC8EE64E7D /* BoardModerationSettings.swift */; };
+		E34650CFE1F245C7A1D446E0 /* BoardPostCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259DF311E035446E813AA4DB /* BoardPostCard.swift */; };
+		9CBB67B45CD6442AAF18BEA6 /* BoardPresentModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B34D6497C14CAC8663E762 /* BoardPresentModeView.swift */; };
+		462A976E735E43448BB18912 /* BoardSaveAsTemplateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B437E7FBB6B460F8178C628 /* BoardSaveAsTemplateSheet.swift */; };
+		4467D7B9B3724D79AE2541D8 /* BoardShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E9D9B7CC2408C88DC216F /* BoardShareSheet.swift */; };
+		F0DBF31E806B493FBE728A77 /* BoardSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B45A1B0F53148FEACFB6231 /* BoardSocket.swift */; };
+		CE9000050C4C46DD86BD15AD /* BoardSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51EF4DBC774C6DBD841565 /* BoardSurface.swift */; };
+		522B18E83695425299B42E93 /* BoardSyncStatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886E207B6264422F8B23AB06 /* BoardSyncStatusChip.swift */; };
+		55419C0568874D84A05F9222 /* BoardTemplatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3143CE3BEC4D3FB873211C /* BoardTemplatePickerView.swift */; };
+		DA3CB0D8439B43F9B04AAFC1 /* BoardsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490CFC138B7B46DDABD858C5 /* BoardsListView.swift */; };
+		B1C0367397C4440ABD4A3FF1 /* CardArrangeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D68ECFF7B644E71BC47AE87 /* CardArrangeMenu.swift */; };
+		E632825BF32E431EAB2DC308 /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC767DDD02B4309BF4ADDC0 /* CommentSheet.swift */; };
+		C33E125522F6463B8588D9DC /* GradeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED68C4F898B4AA492F84347 /* GradeSheet.swift */; };
+		E9500E279FD84474B49E2767 /* CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370BAE4B96A34903AB73ED0C /* CanvasLayout.swift */; };
+		F097D9E47BBD48E4B2995514 /* ColumnsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BA4EA8C1154A7EA1731CD8 /* ColumnsLayout.swift */; };
+		9D718AC9F4EA40A6B67DBBFC /* MapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780DA182FF4043B38696D36C /* MapLayout.swift */; };
+		35B8C5A588124A2495CEF149 /* TimelineLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CB8C1BE7504CD9B7CEEAC6 /* TimelineLayout.swift */; };
+		C4FB2773115A4272B35A725D /* WallLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDCF46AF3E4B0DA1A173DB /* WallLayout.swift */; };
+		B22FFB3070274427A9BA052C /* ModerationQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611830A137CA49C1959CDE8F /* ModerationQueueView.swift */; };
+		5DDFD0CD90AA4D949D3F81A6 /* BoardPublicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F852E57D2D14F8A95455DBE /* BoardPublicView.swift */; };
+		2CBEB5B6A97E4AD49B8E9B90 /* ReactionControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6055DB2C26AB4129A22E0F29 /* ReactionControl.swift */; };
+		7E6946757D0347E1A59361C3 /* ReportDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8288AA0576624915998DFB6D /* ReportDialog.swift */; };
+		ACDCFD35679449A495D39680 /* CatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133747F8014442AEB513EB08 /* CatalogView.swift */; };
+		CF786EBFF6C5411A86A78307 /* CourseLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DF8A394EE945B8B60D579F /* CourseLandingView.swift */; };
+		3762E2C6D0CA48B7A02CD6BA /* ReviewComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AB0F11CDF54868BE71CFF3 /* ReviewComposer.swift */; };
+		68FC92E933224C5AB8D3C8A7 /* ContentPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847219C1BF3A490581AAEF0D /* ContentPageView.swift */; };
+		086E2770AE5E4D4AA34E78AF /* CourseAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB770D3718FF4A90B5384778 /* CourseAttendanceView.swift */; };
+		C9E28C386F1E45C4980FBFBE /* CourseBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87682C9CFE11404282D85EDA /* CourseBanner.swift */; };
+		83260790D9E748C38AC0A640 /* CourseDestinationPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6439F689A7D84336B9539BD9 /* CourseDestinationPlaceholder.swift */; };
+		4DD69D0912AF47218F88D530 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0365B3EC4674A04B2BDFDFB /* CourseDetailView.swift */; };
+		853F5994106A4F3AB990ECC8 /* CourseGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8263EB4500D544EE8D550D89 /* CourseGradesView.swift */; };
+		24C3085C652641CD947EC5CC /* CourseLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCD2C6E51C24F738ED8C250 /* CourseLibraryView.swift */; };
+		49E8E80342304542BED428A5 /* CourseMarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A025369C914A4C87867124F5 /* CourseMarkdownContentView.swift */; };
+		800AC77153994AE1AB074F25 /* CoursePeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B6AC4FDA634026875BA2D4 /* CoursePeopleView.swift */; };
+		6460CCE4EDF641E9AB43BC36 /* CourseStructureSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DE8049A8EC481999C88093 /* CourseStructureSocket.swift */; };
+		43420264D4024516951C37A9 /* CourseSyllabusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7557B966F73F4899BC996BB4 /* CourseSyllabusView.swift */; };
+		6F2FA487AD9A474FBA27747A /* CourseWorkspaceNav.swift in Sources */ = {isa = PBXBuildFile; fileRef = A564BD3178B141A79D7DADA8 /* CourseWorkspaceNav.swift */; };
+		03AA2BD5DC0843E29F26566D /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40536B390EA3411BA49279F6 /* CoursesListView.swift */; };
+		16ACA5E324634EBD9F5D8FEC /* CanvasImportComingSoonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35EB05D53C374ABEB6EA3DD0 /* CanvasImportComingSoonView.swift */; };
+		E33361292D104B2FBC9EBD97 /* CanvasImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F823AB9D514792B470A794 /* CanvasImportView.swift */; };
+		9F2FF5D8602D49BB9EF3AAB4 /* CourseCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCB46E9122846B5904855D6 /* CourseCreateView.swift */; };
+		EF354F667A754B4CB3B2E808 /* ItemDetailRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F747815F954B388C7CD9D6 /* ItemDetailRows.swift */; };
+		59B70927C9A94595AF643F78 /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77028F77277348C399FE5293 /* ItemDetailView.swift */; };
+		DCEC40B738504791ACDF80AA /* LaunchContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6F3A0A6E144C2E9E1DA262 /* LaunchContainerView.swift */; };
+		3E6A765D21D14E129AB3740E /* LibraryResourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E68A635B7041AE8657D5F3 /* LibraryResourceView.swift */; };
+		068C3531D6A04E219A9A8DE0 /* MarkdownCodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CAC416D8494E778F4B9787 /* MarkdownCodeBlockView.swift */; };
+		916DEA86CCB2455EB02B79C2 /* MarkdownTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E00898CE0B5A4D8F832F234E /* MarkdownTableView.swift */; };
+		7E62025B1F4348478529176A /* ModuleItemRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659D85899B3942718E0FCEF8 /* ModuleItemRouteView.swift */; };
+		4BE9EB7CC590462388982E9D /* ModuleListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7F68903B0466686850D5D /* ModuleListView.swift */; };
+		69207C1393864BDCAE39E998 /* RequirementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0F193562AA48EA9D3B5751 /* RequirementsView.swift */; };
+		7821EF2DCC1D4F36A7BDDCF0 /* CourseAccessibilityReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E895804DE50A41ED8B232135 /* CourseAccessibilityReviewView.swift */; };
+		30464CEA6CC54B44A858A09C /* CourseArchivedContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267410C1A41D49FF99FBB5C7 /* CourseArchivedContentView.swift */; };
+		26EE54861D354BF990E116DF /* CourseBlueprintSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBAB76F491F4138AED91A60 /* CourseBlueprintSettingsView.swift */; };
+		5AA3C4A008D749E688257943 /* CourseCrossListingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84EB24717C41269F150D07 /* CourseCrossListingView.swift */; };
+		5AB361DED5A14AB09E19E088 /* CourseFeaturesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02BDC83DB8485CBCE81507 /* CourseFeaturesSettingsView.swift */; };
+		8B2102DFDD9C498D8547CBFB /* CourseGeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB6A4245D294042A00AA6A4 /* CourseGeneralSettingsView.swift */; };
+		E7025A24B32745AEA3557CC6 /* CourseGradingAgentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5349888EC0114570ACD831E4 /* CourseGradingAgentsView.swift */; };
+		6D313D94411C4894945CF1D9 /* CourseGradingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF72CCCF474E3AAA676528 /* CourseGradingSettingsView.swift */; };
+		509D8DAA646A45E284DCCC7B /* CourseHeroImageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA41E9040649456DB33BC162 /* CourseHeroImageEditor.swift */; };
+		E1BAD5B13167480E9754514E /* CourseImportExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA181A953E14C468095768C /* CourseImportExportView.swift */; };
+		C6B6CAB5BF834B7C87C57651 /* CourseMarketplaceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3AA0F3A6F4471AA1C6E35 /* CourseMarketplaceSettingsView.swift */; };
+		8A9ACCD6B4C54455887861BB /* CourseOutcomesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC1C07012AA400FB90CD1B1 /* CourseOutcomesSettingsView.swift */; };
+		5C6F24975F844463975AB0EF /* CoursePlagiarismSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2225D9D07D9C459196127219 /* CoursePlagiarismSettingsView.swift */; };
+		15846C31C0F34E3997155B24 /* CourseSectionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE94582729E48E39E56B2E9 /* CourseSectionsSettingsView.swift */; };
+		05DDF2F21D4247DA95411261 /* CourseSettingsHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713566F955A64593962A78CF /* CourseSettingsHostView.swift */; };
+		717C57DFB68848F9BDABD762 /* CourseTranslationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA5BBF44C9844CEA26C3C6A /* CourseTranslationsSettingsView.swift */; };
+		DE2BB701059B41B2B66D9BF9 /* TakeAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F287EF609D48A587AE804D /* TakeAttendanceView.swift */; };
+		7E0CB8C2CDAB46E79723EE12 /* VibeActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8937A1E1F8C542699D4EFCE3 /* VibeActivityView.swift */; };
+		09E2975018AA4483B41E86CA /* WebItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D25A64C53F44E8A3DCA18F /* WebItemView.swift */; };
+		402D0BB774624382981F9F26 /* CredentialDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FF896DFF2C4573B7293396 /* CredentialDetailView.swift */; };
+		78BA3A76893147B4A5737ABB /* CredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1B0BC5160C4FAF85C3E3A9 /* CredentialsView.swift */; };
+		3CF154ACD0AF4C26850C3895 /* DashboardCoursesCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFFCC5A901E49019C8EBA1D /* DashboardCoursesCarousel.swift */; };
+		078F8DA5217C45208D255A55 /* DashboardHeroPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DC62FD64AE4B6D8014259E /* DashboardHeroPanel.swift */; };
+		5C0F730A8CCC4506A5496BBC /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBAFCBF1764488498252FCB /* DashboardView.swift */; };
+		1D5E3116179641499E19A849 /* LiveMeetingsRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A1E7EAE66744EC93DF87FF /* LiveMeetingsRail.swift */; };
+		651F92E886654DF18ABF24B3 /* CourseDiscussionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F065BDB057427B997809FB /* CourseDiscussionsSection.swift */; };
+		8DC2AFB29CB44E3CB810C74D /* DiscussionThreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E79761A651C453CAD0276FA /* DiscussionThreadView.swift */; };
+		2F9DC1F6EE32484CBBABCC71 /* DiscussionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4292E5B6E44215941C86AE /* DiscussionsListView.swift */; };
+		566E104CBB1D406C922336C0 /* PostComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B640B95186493C897B723A /* PostComposerView.swift */; };
+		3298E94176FD4C4FBDF2852A /* CourseEvaluationsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1435004D17D84682BA71973A /* CourseEvaluationsSection.swift */; };
+		20D72CFD7A78479C8F207651 /* EvaluationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF3D50943E74F2FB0FA5844 /* EvaluationFormView.swift */; };
+		DE82C7D29D4741279DAA8153 /* EvaluationResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C00764961C47D08D3E81CA /* EvaluationResultsView.swift */; };
+		B100473493A545AC974176CD /* CourseFeedSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9C93B850C1470B8EDD80F4 /* CourseFeedSection.swift */; };
+		3FA12DC95AA74C2C9EC4BCAC /* FeedChannelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7EDA538039A4B58AFB7F963 /* FeedChannelView.swift */; };
+		F47EF201B61B48F7BACDBD03 /* FeedChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E2315E98DE4E0595C568E0 /* FeedChannelsView.swift */; };
+		DDEBC7E31C0045D68325CD41 /* FeedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767D634EA7C54421A5B762FC /* FeedLogic.swift */; };
+		DCB152BA4C474975930194DA /* FeedSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657339EC3D474DAAA0A66C9F /* FeedSocket.swift */; };
+		5F44382D41CB4D548EAB9004 /* ShareFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67E5F19F42C4743B164654A /* ShareFeedbackView.swift */; };
+		7426989562E9444DB451C246 /* CourseFilesSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C3F47E3007496C8003BA97 /* CourseFilesSocket.swift */; };
+		F61A96F44BC7447D9A85ACF5 /* CourseFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA60D42F624F89B59C7A13 /* CourseFilesView.swift */; };
+		27250EF2EC844ECFB41A423E /* FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12EC7DB66414805BFD47BEE /* FilePreviewView.swift */; };
+		22C990D73BB54604A866A4B6 /* MarkupOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50423B031C594FD081D8F3D3 /* MarkupOverlayView.swift */; };
+		426C6FBF61FE47208BF75BF1 /* GamificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2B964842AE422AB1F8FE31 /* GamificationView.swift */; };
+		66B9B406167D4F02B7E088F1 /* GradeFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58E798DDE14728B7048B49 /* GradeFeedbackView.swift */; };
+		03E52BCDB01948F1A6CD0C84 /* WhatIfController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98606023BD664072A84363A2 /* WhatIfController.swift */; };
+		F96BE9C647734EDAAF73934C /* GradingBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F830C796E96842FC902C5B4A /* GradingBacklogView.swift */; };
+		1350A36283514ED3AE5B98B6 /* SpeedGraderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3539CFC6934AD2BB2F4EAE /* SpeedGraderView.swift */; };
+		7A61CF28A0C5485EA1F34718 /* CollabDocView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC7E1DD087A4E1489ADF74E /* CollabDocView.swift */; };
+		0FCDDDBD482C46DDA0461CC1 /* CourseCollabDocsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2AC07D555534757A7A76999 /* CourseCollabDocsSection.swift */; };
+		15D8976AFB32451EB3D4CCDA /* CourseGroupsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A28AD16498A4136A77E5F6C /* CourseGroupsSection.swift */; };
+		B4EB528F99D34C3F83091138 /* GroupSpaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E086F925E3C94E3DBF6D5B8D /* GroupSpaceView.swift */; };
+		0ED62D425A4E451FBF6E7E0A /* AnnouncementComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C5179B7C504B4C9F06FE64 /* AnnouncementComposerView.swift */; };
+		A54A6D3D36D04795AD7F553D /* AnnouncementsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B357B269DD46DB9FB3C801 /* AnnouncementsViews.swift */; };
+		9AB309A4D92B488DA1EB2DAC /* BroadcastComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9961BE2DA57F4F4ABD8656AB /* BroadcastComposerView.swift */; };
+		283F45906F944EAE81A97E84 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DB00E3B5884F338081EA9C /* MainTabView.swift */; };
+		A169C2814F1A42D8A7284907 /* MoreHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903A8BB06DD34793B5FC272B /* MoreHubView.swift */; };
+		D64647424591472CB12CC11B /* ShellHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6A66930C9247509F766F7F /* ShellHeaderBar.swift */; };
+		1EFCE70315F94C0C92EEF4E4 /* TeachHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7ADBFE36AA24EB7B0908D7B /* TeachHubView.swift */; };
+		8DC73E8306284B74A24AB14A /* UniversalSearchPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4502383E9D304013A8EAB757 /* UniversalSearchPlaceholder.swift */; };
+		B97CB5F54C204F83A2274DA9 /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396EAFDB8CD498F95D9E93A /* ComposeMessageView.swift */; };
+		C4B4AFAF23E444D684C74E7F /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B52603AD774852A54614C5 /* InboxView.swift */; };
+		6BA3AA98591D46448467F24F /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8B2EA90F7F474F93CF162D /* MessageDetailView.swift */; };
+		7C69AE1F574F4047A3EF86DC /* DashboardInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06853E09C60842B0B32A7B61 /* DashboardInsightsSection.swift */; };
+		241714943727494EBFB5FF96 /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080ADF9D3C34BBC9A31EA9B /* InsightsView.swift */; };
+		740A06DFD62F4D29B36AFC9C /* AtRiskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8792C700AE49F4B0D8146F /* AtRiskListView.swift */; };
+		73C6E16C6E484470B9E7B784 /* CourseInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBD4F4A79CB4E4DBF2EE5F3 /* CourseInsightsSection.swift */; };
+		7A0C884A584B4D2FB584B571 /* StudentProgressDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE1EBB432794F2DA01BFC0D /* StudentProgressDetailView.swift */; };
+		606693184E4E4BA39AABB2BE /* WhatsWorkingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A903C2817C74B468239F028 /* WhatsWorkingView.swift */; };
+		5D2F4FB5C52F4FA595A14104 /* IntroCelebrationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E418402F1C0442649025F56A /* IntroCelebrationPresenter.swift */; };
+		EF16E79934FD4222BF0282C4 /* IntroCompletionCelebrationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E155C5C5BB47D28E97E754 /* IntroCompletionCelebrationSheet.swift */; };
+		B7F02A7A8E994A0F9731E277 /* IntroCourseEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE4282C6A94244BFF19D3C /* IntroCourseEntryCard.swift */; };
+		88956425ADC64D098DB484A6 /* IntroCourseProgressRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4180F25AFDF1407D98915D1C /* IntroCourseProgressRail.swift */; };
+		36D53233307941019D2C7BFC /* LearnerProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B80C1444C6A48B6A39E2FF2 /* LearnerProfileView.swift */; };
+		B3F5555053E046309DAEC51E /* LibraryBrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89023B353D84747859B117E /* LibraryBrowseView.swift */; };
+		E5BF3CA3C75442C0915A16B5 /* MeetingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9229467C210C4301B2D98D60 /* MeetingDetailView.swift */; };
+		24CEFEFAC27D484D8CA4488A /* MeetingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1302D78379A34ED49391CD74 /* MeetingListView.swift */; };
+		50524B78462E46138E798C76 /* WhiteboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EEEB959E8549A182B2DE40 /* WhiteboardView.swift */; };
+		31A43E223AE64CF7B317B52D /* LiveGameSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6C74B0C8A24ADFA92DCB62 /* LiveGameSocket.swift */; };
+		54A3749733E34452AABF49F0 /* LiveQuizHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9691EB7FB06A4E5DAF1ACA40 /* LiveQuizHubView.swift */; };
+		C3713CE5BCD84D13A708233F /* LiveQuizPlaySurfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65BBF0633EB45F0820C1161 /* LiveQuizPlaySurfaces.swift */; };
+		576FE9B632694797BF162106 /* LiveQuizPlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FBF86F867A46CCACACAEFB /* LiveQuizPlayView.swift */; };
+		013DB38E476047E5B10E42C4 /* MarketplaceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB840DC10A7340F085F9F10A /* MarketplaceDetailView.swift */; };
+		FD825CB92D9F4E53B6C36931 /* MarketplaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B11BF2897F4875B7A42317 /* MarketplaceView.swift */; };
+		0F0885C1A7A442658E9C26BB /* MyPurchasesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2B0D06CC104264A7571102 /* MyPurchasesView.swift */; };
+		8879708009664DF28200AABA /* CourseMasterySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E773ADF53394F77BEAFB505 /* CourseMasterySection.swift */; };
+		48BF5A9124F8434C87C1624B /* ReportCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2313BB40BCC74375989C45AC /* ReportCardListView.swift */; };
+		86BB5688245243B0BA1DE5E6 /* CourseDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62345060129B4913870E54C1 /* CourseDrawer.swift */; };
+		983B748754844B6F8577C6EB /* DrawerScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0688DB90454A19A18E8185 /* DrawerScaffold.swift */; };
+		B381D36A6BA443FAB2EF7852 /* DrawerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4638969A0A9A4BC3AFD33B5F /* DrawerToolbar.swift */; };
+		3A5938FDCD9243E9A370FB22 /* GlobalDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0276213236EA41DD87B05021 /* GlobalDrawer.swift */; };
+		6E60D3E912F14800A3BFDBEC /* NotebookDrawingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5685788C03E1478E8174A5CB /* NotebookDrawingViews.swift */; };
+		3C32289AF75C4E309711EA94 /* NotebookEditorSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E52B98F8D184587BFDA269B /* NotebookEditorSupportViews.swift */; };
+		FA31A98E26824E12877C62B9 /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5408DF2B2B44228B3BEC80B /* NotebookEditorView.swift */; };
+		C442C7E0CC254DD5975BAE3E /* NotebookPagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAFF705789F14DA1A6B7774C /* NotebookPagesView.swift */; };
+		2A0A014EBAF04CEA98BD74EE /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43F54B92C1F4A8FB207FE48 /* NotebooksListView.swift */; };
+		5DD96E804585487A93D22342 /* BookingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBBE5F676024C5A8546BD9E /* BookingSheet.swift */; };
+		23392DD7C8324AEBAA7FCBCA /* MyBookingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809FB33A0AD94818A168A9FA /* MyBookingsView.swift */; };
+		8BFEB92094DD4A6CAD797E5A /* OfficeHoursView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6402F22622804592B0BD16AF /* OfficeHoursView.swift */; };
+		7D513B71CE1D44A4B1949DF0 /* DiagnosticView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21416CD8DFA947858881FB67 /* DiagnosticView.swift */; };
+		260854A2B9AE45B0A1C9FC0C /* OnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B8423CB03A421DB125FA7E /* OnboardingFlowView.swift */; };
+		BCB3CC5EF20E4AAC9FF804CF /* ConferenceBookingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7495B658AA314BECB39FA0BC /* ConferenceBookingView.swift */; };
+		2F406664162147C2BD5E3C8E /* MyConferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D4BF14581E46E1877105A7 /* MyConferencesView.swift */; };
+		168A2E2592844CF78FEBB370 /* ParentAttendanceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1BEB9B7C19486C90AF60B6 /* ParentAttendanceDetailView.swift */; };
+		8826351567BC4109BDF7381B /* ParentDashboardSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E88D3509D4581AD3B0D49 /* ParentDashboardSections.swift */; };
+		AF30AF67DF5446A98623E2CB /* ParentDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E0738CB7DD4EDAAF0B898E /* ParentDashboardView.swift */; };
+		785871EE701340E2B507B3DF /* ParentGradesDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC689423511413EBBF6A2F0 /* ParentGradesDetailView.swift */; };
+		0BD013A4452946769F5F4A6F /* ParentNotificationPrefsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9913DD13854F259223B9CB /* ParentNotificationPrefsView.swift */; };
+		004B2E95410C4CE693140269 /* DashboardStudySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DDD4F6F0DF44B790377108 /* DashboardStudySection.swift */; };
+		5889497F36044AA98D79B813 /* MyPathsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519A867DDBC343C2BD999131 /* MyPathsView.swift */; };
+		3A24DF561FD049CE89E0824C /* PathLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFABD1859A945CFB9EE0177 /* PathLandingView.swift */; };
+		B9FCFF1F9A0F4A4B9557491E /* PathRunnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C84307E2BC94C6FA15D3BDE /* PathRunnerView.swift */; };
+		9A195E6758A34DDF8BA6D4EA /* PathsCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB94EA892F64D8D9B8737C2 /* PathsCatalogView.swift */; };
+		2464507F608B4D9F86E0A739 /* PeerReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2AD1BAB40F4D73A5DD2DBE /* PeerReviewDetailView.swift */; };
+		F62CC3ECE02147AF98727689 /* PeerReviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3BBE2A5AFB4B66ABFEA6C5 /* PeerReviewListView.swift */; };
+		FB2A2F3E3B674353B9C1ABAB /* ReviewsReceivedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144BCB7F170F41D9B763AE01 /* ReviewsReceivedView.swift */; };
+		110B95E7D06F41D98EEE593C /* RubricScorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62C5B28B5F148DAB9EAC51C /* RubricScorerView.swift */; };
+		93C936E6351E42909BEFFF64 /* CalendarSubscribeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60236CCDF7AA48738D0D49FB /* CalendarSubscribeSheet.swift */; };
+		271722C4C86E428FA661E784 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3F8A9FCD1249E79F8CC819 /* CalendarView.swift */; };
+		1629C666F31944FFAC72E301 /* ConferenceReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C606E34F9144B64A777B6FC /* ConferenceReminderScheduler.swift */; };
+		489FCA1B438644B3965E6729 /* DueReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD1CE39301A41058120A843 /* DueReminderScheduler.swift */; };
+		BBB85B31F17F444AA4F67A07 /* OfficeHoursReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427B5B7A544441FF83DAB84F /* OfficeHoursReminderScheduler.swift */; };
+		6FCF7610FB9B4724A89499D1 /* PlannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35482D532A2149B080CD6765 /* PlannerModel.swift */; };
+		38A42102E27A4C2483A4337C /* PlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADAEEFB6B414AA287062F8B /* PlannerView.swift */; };
+		B53D8D2674ED4316A7691858 /* TodosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C7B900B7ED4925A1869D55 /* TodosView.swift */; };
+		658C1E186EA74FAEAA965EE8 /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35BC5FD1AF146CBAF2065AB /* ArtifactDetailView.swift */; };
+		1CE32F92A4DD4B6797B7BB87 /* ArtifactEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E149F4B7DA48DD9F801DD0 /* ArtifactEditorView.swift */; };
+		912AC1F1D73A4DA3BFCE09C5 /* PortfolioArtifactUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5004097E1B874DDB93242DA0 /* PortfolioArtifactUploader.swift */; };
+		50C833577E5147D79BAFD02E /* PortfolioDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A30B10FF37F4C73B99B56B6 /* PortfolioDetailView.swift */; };
+		3F563D375D0842BC8CF659C8 /* PortfolioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1211C341964513B98889F4 /* PortfolioView.swift */; };
+		988D1AE76D7449ABBE80B402 /* AiAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849FD0BE416241E8A1617D59 /* AiAdminEntryCard.swift */; };
+		D5B2C7631A3C41D2B3CE4699 /* ArchivedCoursesAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F339E576E4464982A315D3 /* ArchivedCoursesAdminEntryCard.swift */; };
+		18E7D3CBDC874492BE473861 /* BiometricLockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269BBDA8E3F84DEA9DEA260D /* BiometricLockView.swift */; };
+		65BA9A19ECD34E46B75F0388 /* DeviceSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72BD8DB3522843548EDB368A /* DeviceSessionsView.swift */; };
+		A461B3DDA25A400B8E47CF0A /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D7198549954D4CA1AC7026 /* EditProfileView.swift */; };
+		EE46711E174C4CF8A90DAD74 /* IntegrationsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF071116BC2F446789DB95AC /* IntegrationsAdminEntryCard.swift */; };
+		A058ED27325C4EDF80191061 /* IntegrationsEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF54036E6B3426390D72262 /* IntegrationsEntryCard.swift */; };
+		232A98A3944642D0B5191DDF /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E6FEAC28BF4ECBB2548552 /* IntegrationsView.swift */; };
+		AE8F3E64ECA24E65A0F62C42 /* LearnerProfileEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292E60D74B50449DBF81B8D6 /* LearnerProfileEntryCard.swift */; };
+		DD2BB5D7D51B43E1AD072233 /* MyAccommodationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612542398DB34253A6686424 /* MyAccommodationsView.swift */; };
+		5C31A7F145FC463D9F6F5200 /* NotificationPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BBC380C7B14E1C97904F62 /* NotificationPreferencesView.swift */; };
+		6490751995BB44478A5830CC /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366826087F904BB7BC321C08 /* NotificationsView.swift */; };
+		D7521F8FD5314D019530DEC1 /* OrgBrandingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CEB80575D4484FBEFD5CC5 /* OrgBrandingAdminEntryCard.swift */; };
+		43BDD65562BA4828A30FDE61 /* OrgStructureAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283D9CE400334AC49AFD50AC /* OrgStructureAdminEntryCard.swift */; };
+		C1DA398745A3417792CDA221 /* PeopleAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE73F8C7ED4996B392B117 /* PeopleAdminEntryCard.swift */; };
+		51A96095D86A48D99E716480 /* PlatformSettingsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918C26A90C7045FD93FF96C1 /* PlatformSettingsAdminEntryCard.swift */; };
+		1B5CD9DECC884CD2AFFF2EA5 /* ProfileDepthCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E99FC07CB54E0C96EA10BD /* ProfileDepthCards.swift */; };
+		DBD0B30AA580420AA2E283B0 /* ProfilePersonalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCFBF1C1FCF47BB84AEAF38 /* ProfilePersonalDetailsView.swift */; };
+		5698DCD9EA9B44068CDDB85D /* ProfileSecurityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12BAF195789448DB078C7CF /* ProfileSecurityCard.swift */; };
+		981C208401B74B6C9998AB92 /* ProfileSettingsCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = E057149B676F46098DDDBD1A /* ProfileSettingsCards.swift */; };
+		81DEECEC9D914F06AE2B5B2F /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F1FD9E84874180BAD8D5DC /* ProfileView.swift */; };
+		8206C4C37F2949B4B3302494 /* ProfileViewSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BF6067904E4A2087EC27CE /* ProfileViewSections.swift */; };
+		209D699F24D347E39DA62895 /* ResearchStudiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53305DC75B204D9C81F3585B /* ResearchStudiesView.swift */; };
+		63622B33B9F34BF7973C9FF7 /* RolesPermissionsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4320E0C0E24EB9BE1B7F58 /* RolesPermissionsAdminEntryCard.swift */; };
+		F2F2C8589D5C4364A43B4E4E /* SettingsAdminHubEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E6AEEF26D44D3EA65A25A0 /* SettingsAdminHubEntryCard.swift */; };
+		5AED2A42200C417D901A3AAA /* ShareFeedbackEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67308866EF5479FA01FC732 /* ShareFeedbackEntryCard.swift */; };
+		B5CCD9D022344044B331EA01 /* TranscriptsAdvisingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD739C270344ADEB1A3142D /* TranscriptsAdvisingAdminEntryCard.swift */; };
+		1A87D70734574A048A8DC349 /* CodeQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BCD90D8A8E4EF4AFB9D583 /* CodeQuestionView.swift */; };
+		E17908C4CA6446149BE0EC97 /* LockdownController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633C85BCCB7941E5BD24D270 /* LockdownController.swift */; };
+		E04539B73C8E44DE96E3C469 /* QuizIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC57DD00547498A8F4FB307 /* QuizIntroView.swift */; };
+		FA7CC2716D954890A3F5890C /* QuizQuestionViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9DCCE9B89246218C4CE8EF /* QuizQuestionViews.swift */; };
+		1FD2CDA0ADAB418B997BA63D /* QuizResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34504285543C4C9A8CD6F5EA /* QuizResultsView.swift */; };
+		A6ED01A672094CE3B09AA985 /* QuizTakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B81ADC20ABF47A3AD5C31F4 /* QuizTakerView.swift */; };
+		0BA36578549C4277A43ECCCD /* CaptionedPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EC5757A7B946098AC5B893 /* CaptionedPlayerView.swift */; };
+		E1F0BF5110DB4C24A97D4986 /* ContentTranslationControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAACDFB103B9456BBC73750E /* ContentTranslationControls.swift */; };
+		6747A8A5EFF84C2D9C98F46D /* ImmersiveReaderCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49467C0BBC9C415780029214 /* ImmersiveReaderCapabilities.swift */; };
+		8CD1372F58304586963CF984 /* ReaderLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990F430024144399B37A91A2 /* ReaderLogic.swift */; };
+		588A85CFE0F0414794AFB234 /* ReaderToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F495ED7A44B4C73968DA21E /* ReaderToolbar.swift */; };
+		42A1556AAD4B4AD1BC0042AB /* ReadingPreferencesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDA47FBE9DE454C9CD75E5D /* ReadingPreferencesSheet.swift */; };
+		D288A4AEBF374F039E752C9A /* ReadingPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AB029FB1A444B3BEA5D695 /* ReadingPreferencesStore.swift */; };
+		FB5C34E084D24E9594C76212 /* LeveledLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56111FF37D29429987AB0096 /* LeveledLibraryView.swift */; };
+		8D420F0E8EED450E856C6A86 /* LogReadingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A83C44B84487CB01EFF3C /* LogReadingSheet.swift */; };
+		775B51A27C5345ABBB0D23EF /* ReadingDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5A6D6A50874B1FAB312EE8 /* ReadingDashboardView.swift */; };
+		1ED91D14ABB64871BA5D370B /* ReviewHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBB673CA4DB420BA37B9208 /* ReviewHomeView.swift */; };
+		11AC31C299564C5FBE87051E /* ReviewReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6440ADA1E9544ECBF69F85E /* ReviewReminderScheduler.swift */; };
+		FA96F45D033F489AB83FDE81 /* ReviewSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31DE89C777B4A51887F141C /* ReviewSessionView.swift */; };
+		F709C02F211E476BB1FF7DDA /* UniversalSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A178AEF05541188021889B /* UniversalSearchView.swift */; };
+		A89A4C91638E4106A0EE487A /* AdminMetricCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97B6F26B6DC4092BAB78F26 /* AdminMetricCards.swift */; };
+		5FAB919A843A440E82EE8D04 /* AdvisingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36A44F66604F3C843C50D9 /* AdvisingSettingsView.swift */; };
+		F2214A1D92FC45BB9CE2ADD2 /* AiAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9843014D154611A7BFD0C9 /* AiAdminHubView.swift */; };
+		50367A9E1471406B80ABF2A1 /* AiGovernanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A56979663249C4AFE83221 /* AiGovernanceView.swift */; };
+		FB796A715F674440A6409779 /* AiModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889FAFAF774142C2BA86329C /* AiModelsSettingsView.swift */; };
+		1019816343624011A7B557D1 /* AiProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C29C92B3B24E5C86725EE7 /* AiProviderSettingsView.swift */; };
+		9546906023EA4DD0BDBCA7B2 /* AiReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA28E77314484396AB0AE64A /* AiReportsView.swift */; };
+		65E89AD1ED204EC5B795CCA6 /* ArchivedCoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4355CA566304FBAAB98D098 /* ArchivedCoursesAdminView.swift */; };
+		65F73CED45624E1BB1713440 /* AuditLogAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942584F491914827B95F3282 /* AuditLogAdminView.swift */; };
+		0D91AF2DB19F485B93D7CD46 /* BoardsGovernanceAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88724DBA10A14C4BB795E26F /* BoardsGovernanceAdminView.swift */; };
+		D64E4E13C99E4D77B6F6F3F8 /* CoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914CCB5EAAF34214B8885432 /* CoursesAdminView.swift */; };
+		E4750E6368AF4758A9BB3FCB /* IntegrationsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BFDD3B36BC48A8B13DE360 /* IntegrationsAdminView.swift */; };
+		38487F2277664659A792B427 /* OrgBrandingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E256FCB9F14A47B25202B5 /* OrgBrandingAdminView.swift */; };
+		59AF1E78E14446BDA1C520AB /* OrgBrandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B6653C12AF4B4395D2650A /* OrgBrandingView.swift */; };
+		D7FD88DB8E924B1BA0FEF265 /* OrgStructureAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3124434EF14E0F9A93AF28 /* OrgStructureAdminView.swift */; };
+		2CA9B5373A0B4233A0A64771 /* OrgStructureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12EEAD3B385B4D19A7EE0841 /* OrgStructureView.swift */; };
+		00FD0ED59A7C49D393DA15A3 /* PeopleAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EF610BF1484F9AADE2AA95 /* PeopleAdminView.swift */; };
+		28B4BF03E7E34F9DAB34FE6A /* PlatformSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A03C39AFE47918DBCC377 /* PlatformSettingsView.swift */; };
+		5E588B67C7274185841CDBFC /* RolesPermissionsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67E4C60CD8D4042A5591FEE /* RolesPermissionsAdminView.swift */; };
+		880FB92F7CFC41E992B52F78 /* SystemPromptsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2FA99DD121458D8201C26C /* SystemPromptsView.swift */; };
+		0248213F393049E8B93709D2 /* TermsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AF5D02D2464887B58449B2 /* TermsAdminView.swift */; };
+		C27059C4026742968DB0FDCA /* TranscriptsAdvisingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5AD5CA80204A4D9F4EDB14 /* TranscriptsAdvisingAdminView.swift */; };
+		78C7EE57272F4082B42983A2 /* TranscriptsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B3CD2CBADB4D5CB7B5CD36 /* TranscriptsSettingsView.swift */; };
+		EB7EAB8B4A6B4BC6BF148FE1 /* UserDetailAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9240550142D1439DB32F9DDA /* UserDetailAdminView.swift */; };
+		A4F1C583F9C24D03A36D3CFC /* SettingsAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC90322BE577468290B4551A /* SettingsAdminHubView.swift */; };
+		20F7EAEFC0B14F1BAD3F7C3A /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C311030F725471CBF67D6F8 /* SplashView.swift */; };
+		22A3489D687C412B90F92BEC /* TutorChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871BFA5C95E049CBAFEC0731 /* TutorChatModel.swift */; };
+		8D963B4A899B4A9AB2B8B7E3 /* TutorChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9452C8D2829F4FB6B21CAB26 /* TutorChatView.swift */; };
+		A1287F5A19914A9EB261277C /* TutorFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAB6ED9091E4B3E94718267 /* TutorFlowLayout.swift */; };
+		ED9D1E5CFE484120B3D251C4 /* TutorLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66A524C7AAC4FB2B017F128 /* TutorLauncher.swift */; };
+		B517A0B3458F4E1A90327F51 /* WalletCCRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F9005EEE2744EBB7D096EC /* WalletCCRDetailView.swift */; };
+		AFF47FE7B05642EDBB6C2886 /* WalletCETranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF4CF0A377A4ED5B3DC1AA0 /* WalletCETranscriptDetailView.swift */; };
+		990C0994B030462C859A17BF /* WalletOfficialTranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AACA18723DA4543805BE85B /* WalletOfficialTranscriptDetailView.swift */; };
+		CEE26666B51048248A0CB7C0 /* WalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F06C20D3B941B69051DDA0 /* WalletView.swift */; };
+		A23C0799C9D5426B91951786 /* AccessibilitySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373523C32EB949A5B9CAA82A /* AccessibilitySupportTests.swift */; };
+		1994EFB9430B407BB04A3A7A /* AccountIntegrationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A13B3495F1F4A4F819B53AF /* AccountIntegrationsLogicTests.swift */; };
+		F2DCFE74B99E4C36AF1CDFE4 /* AdvisingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865591C44DA943BAAF006BA8 /* AdvisingLogicTests.swift */; };
+		3F6D6C71ECC34DD89E5D8DB0 /* AiModelsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCE179E631F4F1587E17C1A /* AiModelsAdminLogicTests.swift */; };
+		8EF49AF757964F3FA83DC6D5 /* AnnouncementLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FF81B2344C47318DA46DEA /* AnnouncementLogicTests.swift */; };
+		D26D2A6793B043DAB9A426AD /* AppleSignInLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B763FBAF0F348CEA7B7F700 /* AppleSignInLogicTests.swift */; };
+		9A97E0D3542C4B7EA5F79622 /* ArchivedCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B046C3491242F78AFC62B5 /* ArchivedCoursesAdminLogicTests.swift */; };
+		B52A437D41414FF4BC756B89 /* AssignmentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBA7D88E4324BAA8C417F29 /* AssignmentLogicTests.swift */; };
+		08789C3FDA64436EAF36AD7C /* AuditLogAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D03F861BB2F42CFA59E0822 /* AuditLogAdminLogicTests.swift */; };
+		82A951442D6E4BFBA1171B21 /* AuthCallbackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBC569F456A4BD3B900F0B4 /* AuthCallbackParserTests.swift */; };
+		61198ECE5E1041468DE0B80A /* BehaviorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F482AACC614C47BB93AC3A /* BehaviorLogicTests.swift */; };
+		9BEC92F81DA44E92B5D7C768 /* BillingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFB9831EC6A4D94810B09A2 /* BillingLogicTests.swift */; };
+		24567DB9CFE541B9A11D661B /* BiometricGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E50B8DE72E4B06BF467B31 /* BiometricGateTests.swift */; };
+		52BD152816234B4BB35A5E79 /* BoardsAdvancedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF89736CCA439C94F43B27 /* BoardsAdvancedLogicTests.swift */; };
+		B0B3BC864AA54AC095F4CBCA /* BoardsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F97E50BCA747C9BD1D9FA2 /* BoardsLogicTests.swift */; };
+		22CB296FDC75473EB06C7704 /* CanvasImportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FC3FBB11F247FBA7765A55 /* CanvasImportLogicTests.swift */; };
+		BBE628DF72F94D6D8F4FAC85 /* CatalogLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805240352A4542E6B904D4AC /* CatalogLogicTests.swift */; };
+		5686955245F34B759BD4C41B /* ConferenceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E480CDFCB0E5428393B4648B /* ConferenceLogicTests.swift */; };
+		E08A73F841714561BA2FF8EF /* CourseAccessibilityReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21EB256086B4484BE067D42 /* CourseAccessibilityReviewLogicTests.swift */; };
+		9237F4A866D74B20B3000265 /* CourseArchivedContentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550DA196AE6B43B6B903B0FA /* CourseArchivedContentLogicTests.swift */; };
+		37B9948867FB4B779B88D0FF /* CourseBlueprintLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86F2841498A4C32AA7093AA /* CourseBlueprintLogicTests.swift */; };
+		5CE78B0F31214C66A526476D /* CourseCreateLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1F7E879D54243A4DA10E1 /* CourseCreateLogicTests.swift */; };
+		A76CB6FC18E64768A79D0D8E /* CourseFeaturesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E7A2D79A0A47F1ABD4C3AC /* CourseFeaturesLogicTests.swift */; };
+		35FE576C56B342CF9FBA9E24 /* CourseFileModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16533B0965BB4F4DA160F03E /* CourseFileModelsTests.swift */; };
+		CEAE609950C8411FB1582E11 /* CourseGradingAgentsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 566A8F4AA7BB49848E5D5552 /* CourseGradingAgentsLogicTests.swift */; };
+		F795215E985444169BB9F10F /* CourseGradingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF4C3297E884354ADDEDFC6 /* CourseGradingLogicTests.swift */; };
+		96F2D3104820409688B27A99 /* CourseImportExportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A6BF2D82C24B07A02D4F16 /* CourseImportExportLogicTests.swift */; };
+		40A952AFC87949D89BDFDEF2 /* CourseOutcomesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FD447ED651463297DB49D6 /* CourseOutcomesLogicTests.swift */; };
+		A5E9605AA60241558C833BE9 /* CoursePeopleLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19A901DA16C44A98BCFC878 /* CoursePeopleLogicTests.swift */; };
+		32FBA9724D734FBEB97F3B1A /* CoursePlagiarismLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E96F164ACF476A90625A44 /* CoursePlagiarismLogicTests.swift */; };
+		E98EF898FC3B4BEE94D33E12 /* CourseReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FC803557FA400798E517D6 /* CourseReviewLogicTests.swift */; };
+		64482DC9BB234AD586064698 /* CourseSectionsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DCDA7BE5F4D968FD8C654 /* CourseSectionsLogicTests.swift */; };
+		024E9164F7D046E99E396E7C /* CourseSettingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDD54F128A34514B52E92C3 /* CourseSettingsLogicTests.swift */; };
+		AF4F359F681742A6B319F4D4 /* CourseTranslationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9DE4A71F4B41C1A155FAA9 /* CourseTranslationsLogicTests.swift */; };
+		97E2A381F45543519879F02D /* CredentialsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C40E4D7ACF46108CCE6999 /* CredentialsLogicTests.swift */; };
+		B84920E40A0C49FEBBF062DF /* DiscussionLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0EF8D14F18747E4B15D7672 /* DiscussionLogicTests.swift */; };
+		EB3A9F3EA1454D34B09EAD5C /* EvaluationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B5F96B46D4D66AB310255 /* EvaluationLogicTests.swift */; };
+		CA23903478C24FF19420A3DA /* FeedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43ECD1F3A5847A08AA8D7AE /* FeedLogicTests.swift */; };
+		1E50EEC9131644CA94A9BC1A /* FeedbackLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EDCFA8D4C441EC8D01E20E /* FeedbackLogicTests.swift */; };
+		79975C08D6A94A9E9257F513 /* GamificationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB4F84C218644FC898D5E1A5 /* GamificationLogicTests.swift */; };
+		507450EE9B44461F987791F3 /* GradeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A73FC830CB4D27A8DD4B25 /* GradeCalculatorTests.swift */; };
+		A9F1798F9AEF41A9A9DD4C07 /* GroupsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70912832963940B79AFA8373 /* GroupsLogicTests.swift */; };
+		F6A478037DE143208F54EE24 /* I18nTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DF14D128D64FE3913D78F3 /* I18nTests.swift */; };
+		4218315B4F5D411EA5FED6AB /* InsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0686994B5D846CF87F347DF /* InsightsLogicTests.swift */; };
+		205AA6319E3A4CABBA071659 /* InstructorInsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF2B2D6C6B44BC2866C2D93 /* InstructorInsightsLogicTests.swift */; };
+		F9429E0163E0422BA909AADF /* IntegrationsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF38019511514A39A5938F26 /* IntegrationsAdminLogicTests.swift */; };
+		27048DD189624218A3D9EA63 /* InteractiveLaunchLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD8FA95ACA24505AAD62EE7 /* InteractiveLaunchLogicTests.swift */; };
+		8F0235BD407A4F6FB044E84C /* IntroCourseLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F44242ADD2F4D4384FB8217 /* IntroCourseLogicTests.swift */; };
+		62C6355F8D3947F4A6BBDC7B /* LearnerProfileLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74498D27D0A423F9F710088 /* LearnerProfileLogicTests.swift */; };
+		606E7F5B576145F183AE8773 /* LexturesMotionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D31802C470C412595FA718E /* LexturesMotionTests.swift */; };
+		851D35021CA3471E82CE76F8 /* LibraryResourceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF702B17A3744F4AE9A21DB /* LibraryResourceLogicTests.swift */; };
+		6982609AD79E4AC4A422425F /* LiveMeetingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14872F45A72248E591C80A5C /* LiveMeetingsLogicTests.swift */; };
+		E242AD182E624AF48AE00B19 /* LiveQuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B152116F1844EA939CD2B0 /* LiveQuizLogicTests.swift */; };
+		AB6E3BB8C19646CD8F65649E /* MarketplaceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAEFB24E3C34525BC2F040B /* MarketplaceLogicTests.swift */; };
+		25AED480499D437B8DC4CE95 /* MasteryLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E6ECF6C15C455F86415C69 /* MasteryLogicTests.swift */; };
+		602715CA35FD410A82DE5CD5 /* MobileDestinationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D65C9AD65F4155AC1B2C74 /* MobileDestinationsTests.swift */; };
+		A7693FDB85E9410B9A5041AF /* ModuleContentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D553BFCCA75D4ADDB8E03FDA /* ModuleContentModelsTests.swift */; };
+		FC55C1D14A454B0FA30F13DF /* NotificationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8A5CE055EE4CBB875FFC50 /* NotificationModelsTests.swift */; };
+		6A8E25277A364360BB65ACF6 /* OfficeHoursLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6453702A8CC84167A99D06FC /* OfficeHoursLogicTests.swift */; };
+		BF0564D785B241C68D466A0A /* OnboardingModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A17E2E10AB14AF1A4BC0A20 /* OnboardingModelsTests.swift */; };
+		0C52FC70DBAD4D86AA0543FA /* OrgBrandingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C6AF633234B11B05AC8B3 /* OrgBrandingAdminLogicTests.swift */; };
+		4E9184D5D15D432F8D01B21C /* OrgStructureAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3030AF2E57974257827BCD97 /* OrgStructureAdminLogicTests.swift */; };
+		5E1F943D21FF466FAB849AB9 /* ParentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114DE315F90F46428790C499 /* ParentLogicTests.swift */; };
+		894A900460EE4AC1A6F32B83 /* PathsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B278631504942649E2B10A7 /* PathsLogicTests.swift */; };
+		B6C5C79CDC00441DB2E96564 /* PeerReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE0AAD7BE7F4DE4A0E2E97E /* PeerReviewLogicTests.swift */; };
+		5D8FB83EE1784AA9834AF116 /* PeopleAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E780269A3774488C96081F4D /* PeopleAdminLogicTests.swift */; };
+		28A35BBFB4FD4A7B90D31F79 /* PeopleAdminMetricsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1122C950BA74EC3B0F4C4BA /* PeopleAdminMetricsLogicTests.swift */; };
+		A70BDCB9398842E78C2B9DE1 /* PlannerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201E3DED9B6B4C7D9E3CDBA1 /* PlannerModelsTests.swift */; };
+		75F57C4C09F449DF9CA31233 /* PlatformCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADE113A4F7D4363B71AAB5D /* PlatformCoursesAdminLogicTests.swift */; };
+		A10E5A2734A24CD9B3D1C6EB /* PlatformSettingsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E20A89C03B34AE681FE9B7C /* PlatformSettingsAdminLogicTests.swift */; };
+		17A60B25F39A46F79C695BFC /* PortfolioLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFD385E20E4874B208B6E8 /* PortfolioLogicTests.swift */; };
+		D1C85862113641E3ABEA0EE8 /* ProfileDepthLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED465D36A86D429D8D927E4D /* ProfileDepthLogicTests.swift */; };
+		3DD7B3543EE44F449E16C4A3 /* QuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF03A123F79457888EEB315 /* QuizLogicTests.swift */; };
+		B12D7287F1B5479481CEFC9F /* ReaderLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CEBA182BF44B2BE3FCADD /* ReaderLogicTests.swift */; };
+		F559AC6173C54430ADC4CF98 /* ReadingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82D214349F34003A916A5BD /* ReadingLogicTests.swift */; };
+		3E747E0812D94FD4B3A68293 /* RequirementsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583B845B981A489A80BD757D /* RequirementsLogicTests.swift */; };
+		CA27E0A6B66846B78ABDB0E6 /* ReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164416E4C983431883516796 /* ReviewLogicTests.swift */; };
+		0D177076EAB349BA880EB4FD /* RolesPermissionsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C08E0BEB834A3EB334C08A /* RolesPermissionsAdminLogicTests.swift */; };
+		5741663D14FD43D7B577FFA3 /* SchoolCodeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232FFCED0306441FA66F4EB3 /* SchoolCodeLogicTests.swift */; };
+		0F9BB204DA8B4F88856BF2CC /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B291A3D998D4494EB5BF4F69 /* SearchTests.swift */; };
+		383DA9C55A7740BDAB59BA67 /* SettingsAccommodationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB038F7ADFA40A0958FCA12 /* SettingsAccommodationsTests.swift */; };
+		0BBABC3CD8E54355BB464CE0 /* SettingsMenuLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C23C8D85854FB8A73C1AE1 /* SettingsMenuLogicTests.swift */; };
+		C9FE307022A24D8EB0AF2915 /* TakeAttendanceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D33288F5C5A4CC4967D0503 /* TakeAttendanceLogicTests.swift */; };
+		825A451207EC4A378798D7F1 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1410FB35F44CC4B312DD2A /* TranscriptsAdvisingAdminLogicTests.swift */; };
+		3944357D2583408395A57ED8 /* TutorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BC8DA818EC4DBEB21CB6A3 /* TutorLogicTests.swift */; };
+		A7EB2920495A4EE4AD2481E4 /* UIModeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D38DC81AAE47D78174340E /* UIModeLogicTests.swift */; };
+		D6224B6580C04B12A4C74A73 /* VibeActivityLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DECA44A9D514EB9B68544FB /* VibeActivityLogicTests.swift */; };
+		08CD949DE86247FBB8107C76 /* WalletLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04481C8E09DD46DB93EA9D47 /* WalletLogicTests.swift */; };
+		978593606D454E40B811DDC5 /* WhiteboardLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2F1DCD549844B092CD0466 /* WhiteboardLogicTests.swift */; };
+		40E58270E8384B91A6D7D8D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F1D492B110A3479A86B62F45 /* Assets.xcassets */; };
+		86440F50A4684F768EF22A0B /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 6678AEC9159340A695FD20AD /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		A5ACD157202A4876B6856FE4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1EB58D3E83FF4D9A87F5844C /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A1DE4D1C828A4CC1860443E6;
-			remoteInfo = Lextures;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
-		002B42EDB8C1480AB39F9343 /* ParentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogic.swift; sourceTree = "<group>"; };
-		01AA4EFD58D94D15B395E243 /* LMSAPIDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIDiscussions.swift; sourceTree = "<group>"; };
-		01C2429040EA4973B3CA5ABE /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
-		01ED855614454B92A2BBC138 /* ParentAttendanceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentAttendanceDetailView.swift; sourceTree = "<group>"; };
-		020F6153ECD64C1EA66A5402 /* CourseFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesView.swift; sourceTree = "<group>"; };
-		021982ACCF24416286E33E7F /* PlatformSettingsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogicTests.swift; sourceTree = "<group>"; };
-		02639B5CAA2949FEBA60BCA6 /* LMSAPICredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICredentials.swift; sourceTree = "<group>"; };
-		02995DB88EE8419CA408DF6E /* ReadingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogic.swift; sourceTree = "<group>"; };
-		02B059A1DA5B4AFC81AE8CD4 /* CourseArchivedContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentView.swift; sourceTree = "<group>"; };
-		02FCB109F4F14696B51C6CBF /* CourseSettingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogic.swift; sourceTree = "<group>"; };
-		031BBD2CE9D144BDB505C1E8 /* BoardModerationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardModerationSettings.swift; sourceTree = "<group>"; };
-		03E5D05AABFB4BA784539EEB /* InsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogicTests.swift; sourceTree = "<group>"; };
-		03FEF491388147718568247F /* TutorChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatModel.swift; sourceTree = "<group>"; };
-		045BD75FC50049ACB642089C /* ReviewReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReminderScheduler.swift; sourceTree = "<group>"; };
-		04636FB552D74F78AE3481B3 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
-		04E04D370DCA4C4595C4A250 /* BillingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogicTests.swift; sourceTree = "<group>"; };
-		04E31B7BEE5E4E86AF1E1C02 /* ShareFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackView.swift; sourceTree = "<group>"; };
-		04F5044EA5764DB8B55673CF /* CourseOutcomesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogicTests.swift; sourceTree = "<group>"; };
-		04F8E99D3FF94297B94B02D7 /* WebItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebItemView.swift; sourceTree = "<group>"; };
-		04FF8C29DFDB4864A97108C4 /* MoreHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreHubView.swift; sourceTree = "<group>"; };
-		051235EB53344CE182F9407C /* LMSAPIAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAuditLog.swift; sourceTree = "<group>"; };
-		065C3BABC11144C79BFC5D7D /* LMSFeatureModelsCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCredentials.swift; sourceTree = "<group>"; };
-		06C23B8331634027B6EF19AB /* RequirementsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogicTests.swift; sourceTree = "<group>"; };
-		06E1315641EA4B12952161FD /* AccountIntegrationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogic.swift; sourceTree = "<group>"; };
-		070F6C739E7B45298D747A0F /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		072DD96ED19D4F2AB9F0B99E /* ArchivedCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogic.swift; sourceTree = "<group>"; };
-		083115F582E34B1F8B9EC068 /* ParentGradesDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGradesDetailView.swift; sourceTree = "<group>"; };
-		08C5DA8502AC42DC8309F82B /* LMSFeatureModelsCourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseReviews.swift; sourceTree = "<group>"; };
-		08D4CB337387490E9E66310D /* CurrencyExponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExponent.swift; sourceTree = "<group>"; };
-		0932C48BD6084509935F6B79 /* ModuleLastVisited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleLastVisited.swift; sourceTree = "<group>"; };
-		09BCF61797854B9C836948B6 /* CourseGeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGeneralSettingsView.swift; sourceTree = "<group>"; };
-		0A7D2973CAE543D4874EBE06 /* NotebookDrawingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawingViews.swift; sourceTree = "<group>"; };
-		0A875C09B2EE4A7CB6000B43 /* VibeActivityLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogic.swift; sourceTree = "<group>"; };
-		0AB237F0D62A433293C8F48B /* SessionsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsAPI.swift; sourceTree = "<group>"; };
-		0B064CC9A4244A1597D63D68 /* CourseSectionsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogicTests.swift; sourceTree = "<group>"; };
-		0B0A6784B8734FF38D6BD93C /* BoardTemplatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTemplatePickerView.swift; sourceTree = "<group>"; };
-		0C78F9BCAE5848B082A3E3BA /* QuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogic.swift; sourceTree = "<group>"; };
-		0CB42BCF7AD14051AF1410B1 /* OfficeHoursLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogic.swift; sourceTree = "<group>"; };
-		0D21A57EA87849F38CB40E33 /* LMSFeatureModelsGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGroups.swift; sourceTree = "<group>"; };
-		0D290C583E4A4DFAAE942E2D /* FeedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogicTests.swift; sourceTree = "<group>"; };
-		0D4560C89AB641FE9EAB8247 /* PeopleAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminView.swift; sourceTree = "<group>"; };
-		0D5F89E5B4424EB0BA488C06 /* OrgStructureAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminEntryCard.swift; sourceTree = "<group>"; };
-		0DF03CFAC83945FF948F2D9F /* CourseDiscussionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDiscussionsSection.swift; sourceTree = "<group>"; };
-		0E6FD13AFC9F41AE93B53166 /* InstructorInsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogic.swift; sourceTree = "<group>"; };
-		0EF5D397892B4D0183985779 /* CourseFeaturesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogicTests.swift; sourceTree = "<group>"; };
-		0FD0B3FACC5C4B82BA453CF5 /* QuizTakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizTakerView.swift; sourceTree = "<group>"; };
-		103F7EB8AA2543D486ADD013 /* LMSAPICourseArchivedContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseArchivedContent.swift; sourceTree = "<group>"; };
-		109D480447DC4C5EA88DE50D /* IntroCourseEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseEntryCard.swift; sourceTree = "<group>"; };
-		10EDF93341CE47D0B74C0CC0 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
-		10F6ED1EE5D0457B909BE417 /* ConferenceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogic.swift; sourceTree = "<group>"; };
-		116CD8D82EB84CC5913B763F /* CanvasImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportView.swift; sourceTree = "<group>"; };
-		11B7258426C748C9A0963E97 /* OrgBrandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingView.swift; sourceTree = "<group>"; };
-		11E19E2D4DAE44EE97DA583C /* ContentLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLinkRouter.swift; sourceTree = "<group>"; };
-		12DBB0D86C7348E1BE18B3EC /* LMSAPIOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIOutcomes.swift; sourceTree = "<group>"; };
-		1420DA486C9F41B7B6B205CE /* LMSAPIBoardTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardTemplates.swift; sourceTree = "<group>"; };
-		14D53CC2405F4082A1898623 /* GradingBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradingBacklogView.swift; sourceTree = "<group>"; };
-		15102891D765497683B09AF7 /* MyBookingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBookingsView.swift; sourceTree = "<group>"; };
-		155369C709104486B5CEF414 /* NotebookEditorSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorSupportViews.swift; sourceTree = "<group>"; };
-		155DA7CBBE5949828B3DFB89 /* LMSAPICourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGrading.swift; sourceTree = "<group>"; };
-		1666B71154D94DEA9810E776 /* RolesPermissionsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminView.swift; sourceTree = "<group>"; };
-		1787B1BC4C704921B47965ED /* LMSFeatureModelsFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeed.swift; sourceTree = "<group>"; };
-		183F16CF73A64A6CBF0F9517 /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
-		1882D9B3000C4B87B0033111 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		18E53C28079A4E6C983463A8 /* ParentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogicTests.swift; sourceTree = "<group>"; };
-		18ECF1EC4F824EFAA02F45F1 /* DiscussionThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionThreadView.swift; sourceTree = "<group>"; };
-		19FF8D7F7E1742BF81FB0E02 /* PlannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModel.swift; sourceTree = "<group>"; };
-		1A8A7858007741A4B4A579AC /* CourseTranslationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogicTests.swift; sourceTree = "<group>"; };
-		1AC54A0C4908441CA4EA494D /* RolesPermissionsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminEntryCard.swift; sourceTree = "<group>"; };
-		1B0F185E5E3B4478B06AA959 /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
-		1B98EFBE72814209BD850A7A /* LMSFeatureModelsOrgStructureAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgStructureAdmin.swift; sourceTree = "<group>"; };
-		1BAB1373F79548DFB5272E36 /* LMSFeatureModelsOrgBrandingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgBrandingAdmin.swift; sourceTree = "<group>"; };
-		1BC704C864B14285BA2F8CF8 /* AccessibilitySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupport.swift; sourceTree = "<group>"; };
-		1BEE775C57A94F28B6998EF4 /* PortfolioLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogic.swift; sourceTree = "<group>"; };
-		1C82E80113694021ACA9D6D5 /* OrgStructureAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogic.swift; sourceTree = "<group>"; };
-		1C9C5B54B7744E1D889061AF /* NotificationModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModelsTests.swift; sourceTree = "<group>"; };
-		1CEE4E31021C4DC598C25815 /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
-		1D3144D60E9447C49C7D4F48 /* LearnerProfileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogic.swift; sourceTree = "<group>"; };
-		1DFE38EA90FA4B9A9F425D60 /* MyConferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyConferencesView.swift; sourceTree = "<group>"; };
-		1E7C3074787D4757B344CBA0 /* PushManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushManager.swift; sourceTree = "<group>"; };
-		1F4C83568F874AAE8808D52D /* CourseWorkspaceNav.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseWorkspaceNav.swift; sourceTree = "<group>"; };
-		1F7A122FBFBF44F68381972E /* PlannerLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerLogic.swift; sourceTree = "<group>"; };
-		1F97983553124510BC455373 /* IntroCourseLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogic.swift; sourceTree = "<group>"; };
-		204CAA8F0D0E4729A71B3AF6 /* AdvisingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingView.swift; sourceTree = "<group>"; };
-		20636E18011042CE8BC078EF /* LMSAPIReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReading.swift; sourceTree = "<group>"; };
-		208785AC35264E2F844BC2B0 /* VibeActivityLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogicTests.swift; sourceTree = "<group>"; };
-		2132267FD5B84E9CB733911B /* GamificationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogicTests.swift; sourceTree = "<group>"; };
-		21E5F6DFCA5C437BA9E687FC /* CourseStructureSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseStructureSocket.swift; sourceTree = "<group>"; };
-		22020B8EFBB44AB1893DE536 /* CourseHeroImageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImageEditor.swift; sourceTree = "<group>"; };
-		2271CD0EF66D45C0AFEEF21D /* GetStartedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStartedView.swift; sourceTree = "<group>"; };
-		22DEB663DFBA45DAA3D18684 /* GradeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSheet.swift; sourceTree = "<group>"; };
-		22F14CDD80314E2496D1007F /* FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.swift; sourceTree = "<group>"; };
-		235B2EBE17694F38AFF7765D /* LMSInteractiveModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSInteractiveModels.swift; sourceTree = "<group>"; };
-		23A99646D93646DAABE7B029 /* CourseCreateLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogic.swift; sourceTree = "<group>"; };
-		240D0977D3CB497F9CCE0202 /* LearnerProfileEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileEntryCard.swift; sourceTree = "<group>"; };
-		24A93B7496D0403F9F843B37 /* EnvironmentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentStore.swift; sourceTree = "<group>"; };
-		24D56D54A5114FC7AD4449A3 /* LMSAPICourseBlueprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseBlueprint.swift; sourceTree = "<group>"; };
-		256C35FFC6634439A4CAB04C /* DashboardHeroPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardHeroPanel.swift; sourceTree = "<group>"; };
-		25CA850819B142608E94AFA4 /* DiagnosticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticView.swift; sourceTree = "<group>"; };
-		25EBE6EBF35344B88F675AC3 /* OrgStructureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureView.swift; sourceTree = "<group>"; };
-		2618AC2137984A458564EC23 /* PeopleAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogicTests.swift; sourceTree = "<group>"; };
-		261ED70950AB4FF497C90164 /* BoardRealtimeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardRealtimeLogic.swift; sourceTree = "<group>"; };
-		26384B47056D4A18B88BCD9C /* BoardComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardComposerView.swift; sourceTree = "<group>"; };
-		2726DACD8D1D4766BB8F4362 /* CourseDestinationPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDestinationPlaceholder.swift; sourceTree = "<group>"; };
-		28BEE84922AA4F1FAE0FE787 /* BoardsAdvancedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogic.swift; sourceTree = "<group>"; };
-		28C5E4D851054C9F90CE7AD1 /* MobileDestinationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinationsTests.swift; sourceTree = "<group>"; };
-		28FFBD5BE01745E38AD2E525 /* CourseGradingAgentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsView.swift; sourceTree = "<group>"; };
-		292955293ECD44C08E3482A0 /* CardArrangeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardArrangeMenu.swift; sourceTree = "<group>"; };
-		296DA335A83B4D89A5E3627B /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
-		297CEFFC74494B8595F618C1 /* CourseFilesSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesSocket.swift; sourceTree = "<group>"; };
-		29903FC1ACA442DBB5CA908C /* EvaluationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationFormView.swift; sourceTree = "<group>"; };
-		299F11BDA0A444EBB3960E99 /* OfflineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModels.swift; sourceTree = "<group>"; };
-		29CB6F1A4D534109BD3F78A5 /* TodosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodosView.swift; sourceTree = "<group>"; };
-		2A66CC7AA25B4A5EB14CBA22 /* SyncStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusView.swift; sourceTree = "<group>"; };
-		2AB69423EE1D42BEBC5443D7 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
-		2AC45FE1DCB94FB796DCD2D2 /* LMSAPIBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBehavior.swift; sourceTree = "<group>"; };
-		2B3550FF35F84CD5BEC85D1C /* PurchaseFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseFlow.swift; sourceTree = "<group>"; };
-		2B69A18DEB4845679ACC432E /* BillingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingView.swift; sourceTree = "<group>"; };
-		2C382B37AD7B41FDACBBF68A /* LMSAPICourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseAccessibility.swift; sourceTree = "<group>"; };
-		2C42D131DBC6453CB932AEE1 /* AuthCallbackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParser.swift; sourceTree = "<group>"; };
-		2C4965994E3A406CB9E590BC /* BoardSyncStatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSyncStatusChip.swift; sourceTree = "<group>"; };
-		2C4ECFC2BCFB4C1D9488BC4F /* CourseBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBanner.swift; sourceTree = "<group>"; };
-		2C9E74A13E01474490F478FB /* PortfolioArtifactUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioArtifactUploader.swift; sourceTree = "<group>"; };
-		2D03F374531E48A2A2D19B4B /* LMSAPICourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSettings.swift; sourceTree = "<group>"; };
-		2E28E12F37D5457B9235362A /* QuizQuestionViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizQuestionViews.swift; sourceTree = "<group>"; };
-		2E39FC12B86C4A3E99379A39 /* BoardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailView.swift; sourceTree = "<group>"; };
-		2E55D7EA8B6844EF97A42FA9 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		2E6FB26236674F82B674D4CD /* LiveMeetingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogic.swift; sourceTree = "<group>"; };
-		2E78A8DCB3D94B559F5A54F3 /* MarketplaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceView.swift; sourceTree = "<group>"; };
-		2EB4D5F9613E4B4995CEDA4D /* CourseOutcomesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesSettingsView.swift; sourceTree = "<group>"; };
-		2F90EFE7623642A7A924062F /* LocaleAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleAPI.swift; sourceTree = "<group>"; };
-		2FEFBF6E80EE49B6954E7C68 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
-		30078A0DFE254665B1DC7212 /* LiveMeetingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogicTests.swift; sourceTree = "<group>"; };
-		30A51A7141A04A35853163AC /* ProfileSecurityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSecurityCard.swift; sourceTree = "<group>"; };
-		31218713E083457A8317C488 /* CourseFileModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileModelsTests.swift; sourceTree = "<group>"; };
-		313C6A1E76CE4919943436F5 /* PlatformSettingsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminEntryCard.swift; sourceTree = "<group>"; };
-		314FC24136554488997DDFA3 /* NetworkBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBootstrap.swift; sourceTree = "<group>"; };
-		32B9C62DD66C4A6BA003B1E1 /* DeviceSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceSessionsView.swift; sourceTree = "<group>"; };
-		3302C2097D714588B442C1BE /* OfficeHoursLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogicTests.swift; sourceTree = "<group>"; };
-		336D69F1011A4C2195F49B24 /* PeerReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogic.swift; sourceTree = "<group>"; };
-		337A072C810F475DAB09B979 /* AdvisingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogic.swift; sourceTree = "<group>"; };
-		33BE7B6F9FD24732B3294FD1 /* LMSFeatureModelsDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsDiscussions.swift; sourceTree = "<group>"; };
-		33C59803EB384ED2BD2E4FF4 /* CourseOutcomesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogic.swift; sourceTree = "<group>"; };
-		344E381A27B44C94816F4DC9 /* CourseReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogicTests.swift; sourceTree = "<group>"; };
-		347F90498E3C41F9864483A5 /* AiAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminHubView.swift; sourceTree = "<group>"; };
-		354CF5EEFB1F4B59B969EF86 /* LMSFeatureModelsPeopleAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeopleAdmin.swift; sourceTree = "<group>"; };
-		37018A24C2F34F659FA49BA9 /* AnnouncementLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogicTests.swift; sourceTree = "<group>"; };
-		3768F85B792C4240B933C599 /* UnsavedChangesBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsavedChangesBanner.swift; sourceTree = "<group>"; };
-		3A1EA664D9A84F93BFDD12A8 /* ParentNotificationPrefsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentNotificationPrefsView.swift; sourceTree = "<group>"; };
-		3A756F9E12E3420D93F19CE8 /* LMSFeatureModelsGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGamification.swift; sourceTree = "<group>"; };
-		3A9D7743E1014F0EBEA6C333 /* SearchModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModels.swift; sourceTree = "<group>"; };
-		3AD2BD7E08934ECF89E37976 /* CourseImportExportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogic.swift; sourceTree = "<group>"; };
-		3AD75FD7E8C547E0AE275195 /* PathRunnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathRunnerView.swift; sourceTree = "<group>"; };
-		3B6100991B98475EA6F3E955 /* Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localized.swift; sourceTree = "<group>"; };
-		3BA2F9A7AD954C8B88AD6E9A /* WhiteboardLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogicTests.swift; sourceTree = "<group>"; };
-		3CCBB607EB6E46AFB189E9DB /* TeachHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeachHubView.swift; sourceTree = "<group>"; };
-		3CD0319136154E8D83B21269 /* MarketplaceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogicTests.swift; sourceTree = "<group>"; };
-		3CE5438B1B5A4AEDB8356E07 /* LMSAPIMobileWave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMobileWave.swift; sourceTree = "<group>"; };
-		3D487ABD3C434B2BAF2F4156 /* ThemePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePreference.swift; sourceTree = "<group>"; };
-		3D524FD4C47D48D4B04D660A /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
-		3F35B5D01D274083BC601865 /* LMSBoardModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardModels.swift; sourceTree = "<group>"; };
-		3F3BA1A6B9704FB5883A71F1 /* LMSFeatureModelsMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMastery.swift; sourceTree = "<group>"; };
-		3FE653D023FE4E3F90297048 /* QuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogicTests.swift; sourceTree = "<group>"; };
-		40154251D5324D6BAA158FF2 /* PlannerModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModelsTests.swift; sourceTree = "<group>"; };
-		4020BC9FB68D42DF8A8A9DE9 /* LMSAPILearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILearnerProfile.swift; sourceTree = "<group>"; };
-		406DBB9303244C2E838EDC19 /* SearchRecentsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRecentsStore.swift; sourceTree = "<group>"; };
-		40AF719197EF4E2890D94BFD /* ReaderLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogic.swift; sourceTree = "<group>"; };
-		40B096DDAC85418AA92EDA6F /* LMSAPIEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEportfolio.swift; sourceTree = "<group>"; };
-		40B60F313BAA4EECB7EE8839 /* BillingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogic.swift; sourceTree = "<group>"; };
-		40B6A04F2AA847F2B0007D9D /* CourseBlueprintSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintSettingsView.swift; sourceTree = "<group>"; };
-		40C0CC13B9314D539C1DF7F0 /* CourseTranslationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsSettingsView.swift; sourceTree = "<group>"; };
-		40D90C8248E34AC48BA0EDE8 /* WallLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallLayout.swift; sourceTree = "<group>"; };
-		40D928A1285449689FE64A0A /* CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasLayout.swift; sourceTree = "<group>"; };
-		4121BC5624904F929BFA590A /* DueReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DueReminderScheduler.swift; sourceTree = "<group>"; };
-		41405FFAA6E74123B7CD71F8 /* NotebookPagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPagesView.swift; sourceTree = "<group>"; };
-		41A099A324C6434C8EEF58F6 /* LiveQuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogicTests.swift; sourceTree = "<group>"; };
-		4209468B67084C02BC930593 /* GradeCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculatorTests.swift; sourceTree = "<group>"; };
-		42A2A1B1786447C9A1046778 /* DiscussionLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogicTests.swift; sourceTree = "<group>"; };
-		4357F04E9A14427CA177B76D /* InstructorInsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogicTests.swift; sourceTree = "<group>"; };
-		43A30C3BE3E94FFA8D4579CF /* OfficeHoursReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursReminderScheduler.swift; sourceTree = "<group>"; };
-		43DF7A75D2F5426A9F1E024F /* MyHallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHallPassView.swift; sourceTree = "<group>"; };
-		445772B2379849AEAED2E890 /* BoardsAdvancedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogicTests.swift; sourceTree = "<group>"; };
-		449CD77DD2A04631B9B1513A /* LMSAPIAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdvising.swift; sourceTree = "<group>"; };
-		449E8BCF335C4BBA82508BBC /* GamificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationView.swift; sourceTree = "<group>"; };
-		45098D4AA2AE48DBB30EEBA5 /* LaunchContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContainerView.swift; sourceTree = "<group>"; };
-		45A87EB3831A4D58834A404D /* BoardsGovernanceAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminView.swift; sourceTree = "<group>"; };
-		45DC16A66FAA4EF59125ED21 /* QuizIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizIntroView.swift; sourceTree = "<group>"; };
-		46261D0C61D7422C825EBEF6 /* CourseAccessibilityReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogicTests.swift; sourceTree = "<group>"; };
-		465192747C534F43B060EC6B /* BroadcastComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastComposerView.swift; sourceTree = "<group>"; };
-		4669164521A846B6B7E232AD /* IntroCourseLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogicTests.swift; sourceTree = "<group>"; };
-		469622045ED645C9875B5506 /* IntroCourseObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseObservability.swift; sourceTree = "<group>"; };
-		46CF1F6145E94FBDA9B42BCF /* CourseBlueprintLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogic.swift; sourceTree = "<group>"; };
-		47BF4BA121A54F69A6B4B087 /* WalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletView.swift; sourceTree = "<group>"; };
-		47C9F5B4AB07403FBE7C47AF /* WalletOfficialTranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletOfficialTranscriptDetailView.swift; sourceTree = "<group>"; };
-		48146640FF274D49B1CE65F3 /* CourseEvaluationsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseEvaluationsSection.swift; sourceTree = "<group>"; };
-		4903F7AD608C4E9094700387 /* NotebookSlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSlashCommands.swift; sourceTree = "<group>"; };
-		49CD21D146CC427BA8F4DB93 /* MapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLayout.swift; sourceTree = "<group>"; };
-		49DFAF51AD274252905975DE /* OrgBrandingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminEntryCard.swift; sourceTree = "<group>"; };
-		4A76441B24A6450683771C3B /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
-		4AAED5AF179C46369218ABFF /* ArchivedCoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminView.swift; sourceTree = "<group>"; };
-		4AF4DDCB19714EE3920D1984 /* MobileProfileDepthPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileProfileDepthPreferences.swift; sourceTree = "<group>"; };
-		4B233796BCC544B687DE6F83 /* MfaPasskeyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MfaPasskeyController.swift; sourceTree = "<group>"; };
-		4B5882273D98498585C2F544 /* ShareFeedbackEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackEntryCard.swift; sourceTree = "<group>"; };
-		4B6BEA02246548DEAAA0FD65 /* LMSFeatureModelsCoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCoursePlagiarism.swift; sourceTree = "<group>"; };
-		4B6F4926954A4E40BE6D0026 /* ReaderLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogicTests.swift; sourceTree = "<group>"; };
-		4B8BA50BE7B246D9A14E56C5 /* LMSFeatureModelsEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEportfolio.swift; sourceTree = "<group>"; };
-		4BA15B2844A64677B6B8EED6 /* CourseMarketplaceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarketplaceSettingsView.swift; sourceTree = "<group>"; };
-		4BC55BD9D73F44EAAB068187 /* LiveGameLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameLogic.swift; sourceTree = "<group>"; };
-		4BC615D5EE204BECA3AF4DA5 /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
-		4BD084088C724283AC56BFCD /* GradeFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeFeedbackView.swift; sourceTree = "<group>"; };
-		4C8615D5FFDF4DF89B01879B /* TranscriptsAdvisingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogic.swift; sourceTree = "<group>"; };
-		4C9CCBAC5A95489D952F732F /* LMSFeatureModelsAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAccountIntegrations.swift; sourceTree = "<group>"; };
-		4CE3837997044C3CAF1F81E5 /* MarketplaceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogic.swift; sourceTree = "<group>"; };
-		4CE3F78583244C0A93866713 /* AiAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminEntryCard.swift; sourceTree = "<group>"; };
-		4DD1261709BF44839AA1260B /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
-		4DE69070781249E88461A5A6 /* ReviewHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHomeView.swift; sourceTree = "<group>"; };
-		4DFAFCB274D143E49E22EF3F /* AccessibilitySupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupportTests.swift; sourceTree = "<group>"; };
-		4F805878F1A84A8EB6882D47 /* LexturesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LexturesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		5038E5EB4FF249EFBC5C63FC /* ReactionControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionControl.swift; sourceTree = "<group>"; };
-		5046D83BAA2F43A2B50F3C01 /* CheckoutReturnHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutReturnHandler.swift; sourceTree = "<group>"; };
-		50B73CD6651445D8BA65B37A /* CourseGroupsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGroupsSection.swift; sourceTree = "<group>"; };
-		51DA237C4E1F4A17A205FC81 /* LMSAPIBoardModeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardModeration.swift; sourceTree = "<group>"; };
-		51FB7231D19640CBBFC5BF0C /* TutorChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatView.swift; sourceTree = "<group>"; };
-		522BA4E302B345C7B5F5D022 /* GradeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculator.swift; sourceTree = "<group>"; };
-		52756647D9D34EB1B5B6DAAA /* LMSAPIInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInstructorInsights.swift; sourceTree = "<group>"; };
-		527B4669637B4F1DB8F64BA3 /* InteractiveLaunchLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogic.swift; sourceTree = "<group>"; };
-		5290AAD24C2D4FE1A55D21BC /* LMSFeatureModelsPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeerReview.swift; sourceTree = "<group>"; };
-		53D6F3EF92B24D05B2B7779C /* LMSAPICoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICoursePlagiarism.swift; sourceTree = "<group>"; };
-		5439138D5A6245AF937F5AE1 /* LibraryResourceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogic.swift; sourceTree = "<group>"; };
-		5541BAAA56DC484EBDE23C5D /* LMSFeatureModelsPlatformSettingsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformSettingsAdmin.swift; sourceTree = "<group>"; };
-		5555FB34667B4BB896B33481 /* ConferenceReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceReminderScheduler.swift; sourceTree = "<group>"; };
-		557C836ABA0F405BA0BA8274 /* GroupSpaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSpaceView.swift; sourceTree = "<group>"; };
-		55EE7AE153204335AEBBBB6C /* LMSAPILiveQuiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILiveQuiz.swift; sourceTree = "<group>"; };
-		55FBFE8589904567948142C6 /* LMSAPIBoardEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardEngagement.swift; sourceTree = "<group>"; };
-		56ACCFF75AEF4A9CAFECD03C /* CredentialsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogicTests.swift; sourceTree = "<group>"; };
-		5744E69F63C645F1AD96AF32 /* UniversalSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchView.swift; sourceTree = "<group>"; };
-		575351DD2E5D49499CE32173 /* ContentPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentPageView.swift; sourceTree = "<group>"; };
-		584D006BF6E14023B0544198 /* LMSFeatureModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModels.swift; sourceTree = "<group>"; };
-		586AB25CB90C40D69E0DAE6D /* StudentProgressDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentProgressDetailView.swift; sourceTree = "<group>"; };
-		594CE084CFFA400D985A7E3E /* LMSAPIProctoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIProctoring.swift; sourceTree = "<group>"; };
-		5973534E35CB4A26ABFD0B07 /* CourseFeaturesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesSettingsView.swift; sourceTree = "<group>"; };
-		59A05827BFF2447A9E87D715 /* LMSFeatureModelsWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsWallet.swift; sourceTree = "<group>"; };
-		5A5654BC08D54F1399A7B456 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
-		5CE4D23B8C9546599886D708 /* CoursePeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleView.swift; sourceTree = "<group>"; };
-		5D07E28ABBB84F81A39AA430 /* BoardsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogicTests.swift; sourceTree = "<group>"; };
-		5D58D84855D54A859F14F9D3 /* UIModeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIModeLogicTests.swift; sourceTree = "<group>"; };
-		5D83CC2AB82D4112A681BF79 /* CatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogView.swift; sourceTree = "<group>"; };
-		5E06DECBA6A543058452BA6D /* LMSAPIWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWallet.swift; sourceTree = "<group>"; };
-		5E7361328A9343E697C079EC /* LMSAPIPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPeerReview.swift; sourceTree = "<group>"; };
-		5EBE9B830C2C4543A4ED7B2F /* ModuleListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleListView.swift; sourceTree = "<group>"; };
-		5F26CD37E0CC46E89928A002 /* OrgBrandingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogic.swift; sourceTree = "<group>"; };
-		5F2E48B8E6094ACCB33C40E2 /* WalletCCRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCCRDetailView.swift; sourceTree = "<group>"; };
-		5F64F258911C48999538A5B1 /* RolesPermissionsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogic.swift; sourceTree = "<group>"; };
-		5FD5634B0DB5409A948EDF25 /* CourseImportExportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogicTests.swift; sourceTree = "<group>"; };
-		5FDA8AE824C84289A9FE74D8 /* LMSFeatureModelsFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeedback.swift; sourceTree = "<group>"; };
-		5FEFA96C5EB24052B0050712 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
-		61078B95908641F0AE74BC4F /* MasteryLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogic.swift; sourceTree = "<group>"; };
-		610E01F509854A408EC0210D /* ConferenceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogicTests.swift; sourceTree = "<group>"; };
-		6142AEC908E24BA28DC2FD5C /* PortfolioDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioDetailView.swift; sourceTree = "<group>"; };
-		615EF6F7090B489EA056E254 /* ContentTranslationControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTranslationControls.swift; sourceTree = "<group>"; };
-		62432DC303004EB1A855EFAB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		62644DCDC2764C268460E21A /* CaptionedPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionedPlayerView.swift; sourceTree = "<group>"; };
-		632A81DB862E42068731DE45 /* BoardShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardShareSheet.swift; sourceTree = "<group>"; };
-		632C23893BC2467DBF9316C1 /* LMSAPIEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEvaluations.swift; sourceTree = "<group>"; };
-		637BB24D553749F082807972 /* ShellHeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHeaderBar.swift; sourceTree = "<group>"; };
-		63AB4FFE358F4BFA92960BD5 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
-		6419C9F06DE54C3691051BFE /* LMSAPIGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGamification.swift; sourceTree = "<group>"; };
-		64303C4AF6544D0CB0E892DB /* ReaderToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderToolbar.swift; sourceTree = "<group>"; };
-		644B81595D4A419AB600062F /* SettingsAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubView.swift; sourceTree = "<group>"; };
-		6488B616A5044FB4AA42FBC6 /* AssignmentDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDraftStore.swift; sourceTree = "<group>"; };
-		648A52DA434F46EA8E2C9636 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
-		64AB7C2F52454D92AD0A2C92 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
-		64AC5AB4C0254A5DA652C1D7 /* PlannerSnapshotCoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerSnapshotCoding.swift; sourceTree = "<group>"; };
-		657FC23688AA48E4A477065F /* CourseAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAttendanceView.swift; sourceTree = "<group>"; };
-		65989912D7B347D1AAC83331 /* MasteryLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogicTests.swift; sourceTree = "<group>"; };
-		65E12F1F50BC4094A28B6222 /* AuditLogAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogic.swift; sourceTree = "<group>"; };
-		65ED18B763EA41E4BF2F9905 /* ParentDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardView.swift; sourceTree = "<group>"; };
-		6613F6EF4E9F48B990DE7564 /* CanvasImportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogicTests.swift; sourceTree = "<group>"; };
-		66435D97765F43E49613CCE8 /* TranscriptsAdvisingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogicTests.swift; sourceTree = "<group>"; };
-		668F646A938C431F9B20C7C3 /* TermsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAdminView.swift; sourceTree = "<group>"; };
-		6736D5AB4D3C4D27B4D6F79D /* CanvasImportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogic.swift; sourceTree = "<group>"; };
-		673BC88CC18C46119E3F0DD0 /* ReviewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewModels.swift; sourceTree = "<group>"; };
-		6824A619F9FF47138869EE22 /* RolesPermissionsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogicTests.swift; sourceTree = "<group>"; };
-		68A90396389242E6AE275FBA /* CourseCreateDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateDraftStore.swift; sourceTree = "<group>"; };
-		68B7198BC9464E688E63632D /* LMSFeatureModelsCourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGradingAgents.swift; sourceTree = "<group>"; };
-		68CC6E171D1E4F0B8835516F /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
-		690BD68F0A574B6093EE8CA6 /* LMSFeatureModelsMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMarketplace.swift; sourceTree = "<group>"; };
-		690FDA97D2744AB58F335445 /* LMSFeatureModelsCourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseTranslations.swift; sourceTree = "<group>"; };
-		694B3CE6841D49A0A0534073 /* SSOAuthController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOAuthController.swift; sourceTree = "<group>"; };
-		6A1EFCDD4B1B414CAE377ADA /* PostComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostComposerView.swift; sourceTree = "<group>"; };
-		6A640A9490874D41B2FE85CE /* DashboardCoursesCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCoursesCarousel.swift; sourceTree = "<group>"; };
-		6AE959B3CFB24B54AC6FD2B9 /* LMSFeatureModelsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBehavior.swift; sourceTree = "<group>"; };
-		6B3D2D2779EA474EBEA0EF8C /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
-		6B7BF5493ABE454C931A4633 /* CourseReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogic.swift; sourceTree = "<group>"; };
-		6BCEA38143AB4CF89C166D39 /* DrawerScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScaffold.swift; sourceTree = "<group>"; };
-		6C1A952B8DE848359F5BE2B7 /* AccountIntegrationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogicTests.swift; sourceTree = "<group>"; };
-		6C744D517A0C43CC92157CEE /* ColumnsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnsLayout.swift; sourceTree = "<group>"; };
-		6CA6A21122004750A3F1AE37 /* DictationField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationField.swift; sourceTree = "<group>"; };
-		6CE83F7AD58240F982BBBBE5 /* LMSFeatureModelsBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBilling.swift; sourceTree = "<group>"; };
-		6D516E4132064312ADC97EF2 /* LMSAPICourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseReviews.swift; sourceTree = "<group>"; };
-		6DAA8CDE1474473E9595C951 /* OnboardingModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModelsTests.swift; sourceTree = "<group>"; };
-		6DAD6803550D45479F900217 /* AssignmentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogicTests.swift; sourceTree = "<group>"; };
-		6DE8CEA9C7BE482BA8631124 /* ModerationQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationQueueView.swift; sourceTree = "<group>"; };
-		6E07BDA89F7B432F9D56D98E /* CourseGradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradesView.swift; sourceTree = "<group>"; };
-		6E8C2C87D8DC48378C6A5E31 /* FeedbackLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogicTests.swift; sourceTree = "<group>"; };
-		6EABAF87B38948CD96516C1B /* LMSAPIFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeed.swift; sourceTree = "<group>"; };
-		6EB60E6F45C645AD83B3A357 /* CourseGradingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogic.swift; sourceTree = "<group>"; };
-		6F039D646CDE4631BA5F4F4F /* FeedChannelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelView.swift; sourceTree = "<group>"; };
-		6F1607A9155C488EBDACD2AD /* AiModelsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogicTests.swift; sourceTree = "<group>"; };
-		6F7AB62D36E9483EB9CC13E9 /* PeerReviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewListView.swift; sourceTree = "<group>"; };
-		713361602A46405A9A79A692 /* BiometricGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGateTests.swift; sourceTree = "<group>"; };
-		7195D6BC0113463F990C5A7B /* LMSFeatureModelsReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReading.swift; sourceTree = "<group>"; };
-		71E16F188C46420487CB8AD0 /* FeedChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelsView.swift; sourceTree = "<group>"; };
-		71EBFCEDAB574DD18062254A /* BoardsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogic.swift; sourceTree = "<group>"; };
-		723ADB534980465A86521896 /* ProfileViewSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewSections.swift; sourceTree = "<group>"; };
-		72AAB74BD74D449794D722DE /* PlatformSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsView.swift; sourceTree = "<group>"; };
-		73DC931CE51A495DAE55C450 /* CourseGradingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingSettingsView.swift; sourceTree = "<group>"; };
-		753E4D89CC4142DC8B5EA353 /* CredentialsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsView.swift; sourceTree = "<group>"; };
-		757045ECE48246F1A51BCB30 /* ProfileDepthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthModels.swift; sourceTree = "<group>"; };
-		7573C7EAB3B14B0BA16D68D6 /* BoardsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsListView.swift; sourceTree = "<group>"; };
-		757E4E8E95AD4AC5A8E4A56F /* DiscussionsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionsListView.swift; sourceTree = "<group>"; };
-		75B96E9CD4CA4F5886D935BB /* CodeEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditor.swift; sourceTree = "<group>"; };
-		765ABC1C76234576883D0A1D /* AppleSignInLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInLogicTests.swift; sourceTree = "<group>"; };
-		768BFDBA7AC042C189053972 /* LMSAPIBoardAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAccess.swift; sourceTree = "<group>"; };
-		770C736B28C0432396B68FFA /* IntegrationsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogic.swift; sourceTree = "<group>"; };
-		7744DD60219447E28F115D42 /* ReportDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDialog.swift; sourceTree = "<group>"; };
-		7773C1A7F21548E789E11ABA /* IntroCourseProgressRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseProgressRail.swift; sourceTree = "<group>"; };
-		77AECEE1A5A6439D9F9DCF5D /* CourseSettingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogicTests.swift; sourceTree = "<group>"; };
-		78059E120F4442BE99182CA5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		782888F21CBE4F09860D4AE5 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
-		7890AD9B99F44F78915DF506 /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
-		7891F7914C1F4E758EB25057 /* CourseArchivedContentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogicTests.swift; sourceTree = "<group>"; };
-		7894ED56BEAE4FFA8F993DF6 /* PeopleAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminEntryCard.swift; sourceTree = "<group>"; };
-		795D3DC0AE54485C94EC51BE /* ReadingDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardView.swift; sourceTree = "<group>"; };
-		7B4365834BD24B03815205C4 /* CacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStore.swift; sourceTree = "<group>"; };
-		7B83DE1E8D134EE693DAF4D2 /* CourseMarkdownContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarkdownContentView.swift; sourceTree = "<group>"; };
-		7C479EBF1A114D379C503F12 /* LMSFeatureModelsPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPaths.swift; sourceTree = "<group>"; };
-		7CD7F20E5292421A917DF686 /* CourseGradingAgentsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogicTests.swift; sourceTree = "<group>"; };
-		7D82BBCDF07940DDA04B4A68 /* DashboardStudySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStudySection.swift; sourceTree = "<group>"; };
-		7E4A233AE9004DF38E177479 /* LiveQuizHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizHubView.swift; sourceTree = "<group>"; };
-		7E678B5431544F439C1072C9 /* LMSAPIBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBilling.swift; sourceTree = "<group>"; };
-		7EA86C4C8DEE43549744766D /* EvaluationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogic.swift; sourceTree = "<group>"; };
-		7EBC8AD22D194FB5866E18E7 /* BoardEngagementEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEngagementEnvironment.swift; sourceTree = "<group>"; };
-		7ECD8CDF78FE4E4597E38BA6 /* AssignmentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDetailView.swift; sourceTree = "<group>"; };
-		804D6FAE7F334402992FAD26 /* QuizResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResultsView.swift; sourceTree = "<group>"; };
-		80B1442FD4F64EBBABDA4E2A /* LMSAPICourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGradingAgents.swift; sourceTree = "<group>"; };
-		80D6B748A1844AD086CFF7D5 /* LibraryResourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceView.swift; sourceTree = "<group>"; };
-		81EA2F1D66A6499B8343CCE3 /* MobileDestinations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinations.swift; sourceTree = "<group>"; };
-		8251DF9545D842B18E522D83 /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
-		82D1C10DF9A741DFA99D3799 /* RequirementsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogic.swift; sourceTree = "<group>"; };
-		8409A897679140FBBAE8A1C6 /* TakeAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceView.swift; sourceTree = "<group>"; };
-		841CBC287D8A49CEA4A0FDD8 /* CredentialDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDetailView.swift; sourceTree = "<group>"; };
-		84BDC37551114E39AA3542F2 /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
-		8506C9F6826D472A81CE4394 /* CourseFeedSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeedSection.swift; sourceTree = "<group>"; };
-		8509D815EB5A4DACB3D86D38 /* IntroCelebrationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCelebrationPresenter.swift; sourceTree = "<group>"; };
-		854660018C6A49E286436E73 /* LMSFeatureModelsIntegrationsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntegrationsAdmin.swift; sourceTree = "<group>"; };
-		8624F5F731494067A6E5226A /* LMSAPIBoardExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardExport.swift; sourceTree = "<group>"; };
-		86976AC5DBF94CE0B9E2A282 /* LMSAPICourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseCreate.swift; sourceTree = "<group>"; };
-		86AF8D8B29A346D78F4869DC /* CourseSectionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsSettingsView.swift; sourceTree = "<group>"; };
-		8745232550FC42459DEC5E9D /* OnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowView.swift; sourceTree = "<group>"; };
-		87B0F151D42A4B7BBBE595A4 /* OrgStructureAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogicTests.swift; sourceTree = "<group>"; };
-		88574A59D8B1410D805D6E5A /* CourseCrossListingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCrossListingView.swift; sourceTree = "<group>"; };
-		892AD94103F8491FB5EB73D8 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
-		8AC78C8052ED4603B861F8F4 /* OrgStructureAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminView.swift; sourceTree = "<group>"; };
-		8B03553DDF274E11BA2DED01 /* BoardSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSocket.swift; sourceTree = "<group>"; };
-		8B1465ECA6ED41A7A88945E1 /* CatalogLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogicTests.swift; sourceTree = "<group>"; };
-		8B40BD2EBAA6468D83358962 /* DashboardInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardInsightsSection.swift; sourceTree = "<group>"; };
-		8B5D9232E0D949B1AE165711 /* ImmersiveReaderCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersiveReaderCapabilities.swift; sourceTree = "<group>"; };
-		8BA38C62A4B543D68D3F8753 /* CourseSyllabusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyllabusView.swift; sourceTree = "<group>"; };
-		8C37D5824D0F4AB4884B0646 /* CanvasImportComingSoonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportComingSoonView.swift; sourceTree = "<group>"; };
-		8CCEF8D2D48C4BA8A47E49A3 /* LMSAPIGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGroups.swift; sourceTree = "<group>"; };
-		8DBFC1A8B3044BAE9F7CA51A /* TutorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogicTests.swift; sourceTree = "<group>"; };
-		8E39200EE6C94FF29BED5934 /* I18nTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18nTests.swift; sourceTree = "<group>"; };
-		8E40DCAB8ADF428C916AB163 /* MFAChallengeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAChallengeView.swift; sourceTree = "<group>"; };
-		8E5714502F0C4952B43A0969 /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
-		8E69FE71D6B24F72878DD03A /* PeerReviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewDetailView.swift; sourceTree = "<group>"; };
-		8EA3A1F78B7C4590A20AD7D5 /* MyPathsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPathsView.swift; sourceTree = "<group>"; };
-		8FEC8E71FF2547BB9A2A2115 /* MarketplaceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceDetailView.swift; sourceTree = "<group>"; };
-		90BE19A504844A7C80D5C190 /* RequirementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsView.swift; sourceTree = "<group>"; };
-		90F1B79344C9455A9C5AAE37 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
-		9130A525300541639EDC6BF7 /* GlobalDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalDrawer.swift; sourceTree = "<group>"; };
-		91374B24492642BCB4E88D1B /* TimelineLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLayout.swift; sourceTree = "<group>"; };
-		91894EFBAE034F79870527FD /* LMSAPIFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeatures.swift; sourceTree = "<group>"; };
-		92102CDBB0764704BED6B9E4 /* LMSFeatureModelsRolesPermissionsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsRolesPermissionsAdmin.swift; sourceTree = "<group>"; };
-		92CA6F2ABD004BB7A7F2DCF3 /* OrgBrandingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminView.swift; sourceTree = "<group>"; };
-		92EC2F62124947CFA5753E97 /* PlannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerView.swift; sourceTree = "<group>"; };
-		9396F92336A244AC8D3467B3 /* IntroCompletionCelebrationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCompletionCelebrationSheet.swift; sourceTree = "<group>"; };
-		93D3F6FF903E49CE90FB8282 /* CoursePeopleObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleObservability.swift; sourceTree = "<group>"; };
-		951CD3FD737C4BA195298FBB /* LMSAPIQuizCodeRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIQuizCodeRun.swift; sourceTree = "<group>"; };
-		95897DDA808D4572AA50C4D1 /* InsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogic.swift; sourceTree = "<group>"; };
-		961A69EC01BB40BC82BE203E /* ModuleContentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentModelsTests.swift; sourceTree = "<group>"; };
-		96269A903D444BCB8403956F /* BoardAnalyticsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAnalyticsSheet.swift; sourceTree = "<group>"; };
-		966EEB61DF6A41CDA5A6C782 /* SettingsMenuLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogic.swift; sourceTree = "<group>"; };
-		96DD77A6498641D8973F640C /* LiveQuizPlaySurfaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlaySurfaces.swift; sourceTree = "<group>"; };
-		97A77838A5C244C1B33172C8 /* CourseSettingsHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsHostView.swift; sourceTree = "<group>"; };
-		97E0CE51BDA342C7B099E9A8 /* AiReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiReportsView.swift; sourceTree = "<group>"; };
-		9812B27E05DF4E7FAFD2FCF2 /* AuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConstants.swift; sourceTree = "<group>"; };
-		98363B34BAB64153B9744806 /* LMSFeatureModelsCourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGrading.swift; sourceTree = "<group>"; };
-		99582A786E0C487C9B97290C /* CourseDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDrawer.swift; sourceTree = "<group>"; };
-		9982456D8DA5490FBF00392F /* LMSAPIAnnouncements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAnnouncements.swift; sourceTree = "<group>"; };
-		99BCA544511647D2BFD0A74D /* LMSAPICourseSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSections.swift; sourceTree = "<group>"; };
-		9A49502E6AB94ABE82C6B9C5 /* ArtifactEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactEditorView.swift; sourceTree = "<group>"; };
-		9A6108A205AC48FEB57A2C55 /* ReadAloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAloud.swift; sourceTree = "<group>"; };
-		9AF14C133F894FDCA69C54A7 /* CredentialsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogic.swift; sourceTree = "<group>"; };
-		9B6F89F9E8DE46B6A9B578C7 /* BiometricLockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricLockView.swift; sourceTree = "<group>"; };
-		9B942CB11F344BE2AB8E0022 /* LMSFeatureModelsArchivedCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsArchivedCoursesAdmin.swift; sourceTree = "<group>"; };
-		9BABCA4837CF46C386214596 /* ReportCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCardListView.swift; sourceTree = "<group>"; };
-		9BD0733539D4466E9CC056C3 /* LMSAPIAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAccountIntegrations.swift; sourceTree = "<group>"; };
-		9C4578D962A54EDD87A1FB1C /* CoursePlagiarismSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismSettingsView.swift; sourceTree = "<group>"; };
-		9CF5525DC9214A36B17416A0 /* ParentDashboardSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardSections.swift; sourceTree = "<group>"; };
-		9D47730AC9BC474B8D83E60B /* TutorStreamClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorStreamClient.swift; sourceTree = "<group>"; };
-		9E8970BD54EE4C13BCB58BE0 /* GroupsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogic.swift; sourceTree = "<group>"; };
-		9EDEF702EFA243D189990239 /* OrgBrandingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogicTests.swift; sourceTree = "<group>"; };
-		9EEBE28F0AD44768B60A3E99 /* ReadingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogicTests.swift; sourceTree = "<group>"; };
-		9F3FB578E5284EC9A48F5A1E /* UIMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIMode.swift; sourceTree = "<group>"; };
-		9F62442A38E64FFCBB19CDB7 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
-		9FA6CF17C66741A7B273C184 /* LMSAPIMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMastery.swift; sourceTree = "<group>"; };
-		9FE949E1B6E74D0F88D2EFB9 /* MarkupOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkupOverlayView.swift; sourceTree = "<group>"; };
-		A0E2BE4578F448E6A93627A1 /* ConferenceBookingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceBookingView.swift; sourceTree = "<group>"; };
-		A11E9DFFAE1F4090888340AE /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
-		A21EC9AD051A47708EF12C64 /* PortfolioView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioView.swift; sourceTree = "<group>"; };
-		A299331660DE48E19E79E2EB /* SystemPromptsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptsView.swift; sourceTree = "<group>"; };
-		A31AE65FEEC54DDBB83A298F /* PlatformSettingsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogic.swift; sourceTree = "<group>"; };
-		A3D0423652744C3FBF159CA4 /* PathsCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsCatalogView.swift; sourceTree = "<group>"; };
-		A6284CF037D04D2E8BA40A82 /* TranscriptsAdvisingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminView.swift; sourceTree = "<group>"; };
-		A65FBEB6E44745D48D2CBB62 /* ReadingPreferencesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesSheet.swift; sourceTree = "<group>"; };
-		A6658747E5AE4132BE360D97 /* LMSFeatureModelsLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLive.swift; sourceTree = "<group>"; };
-		A694B01E62B9474ABFEC7892 /* ReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLogicTests.swift; sourceTree = "<group>"; };
-		A6A85E757F674DDCAFB5FAE6 /* EvaluationResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationResultsView.swift; sourceTree = "<group>"; };
-		A759FB2A25A544B09FA669EB /* CourseBlueprintLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogicTests.swift; sourceTree = "<group>"; };
-		A764804AD4B4428D98B9BBBE /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
-		A8D8486728CD49FB9B7E622C /* VibeActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityView.swift; sourceTree = "<group>"; };
-		A8E4F8B061E74A2DA6074099 /* BoardsGovernanceAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminLogic.swift; sourceTree = "<group>"; };
-		A97A8E72069448ECA7AA73A8 /* BehaviorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogic.swift; sourceTree = "<group>"; };
-		A997C2E681E14B0E86E1FF00 /* AiProviderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiProviderSettingsView.swift; sourceTree = "<group>"; };
-		A99FC059348942538237B214 /* AdvisingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogicTests.swift; sourceTree = "<group>"; };
-		A9E7ED12235D492B881A0413 /* IntegrationsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogicTests.swift; sourceTree = "<group>"; };
-		A9EBA7A16ACA4AAA9668C226 /* AnnouncementLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogic.swift; sourceTree = "<group>"; };
-		A9EEE24B337F47059EB78C3C /* BoardExportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardExportSheet.swift; sourceTree = "<group>"; };
-		AAC108680F91495A91524028 /* LMSFeatureModelsAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAuditLog.swift; sourceTree = "<group>"; };
-		AB1FF550C55542478C92B16C /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
-		AB7140D08ECB4DD8828FD4DC /* PortfolioLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogicTests.swift; sourceTree = "<group>"; };
-		ABBDFEA71D5348138DDD69DA /* IntegrationsEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsEntryCard.swift; sourceTree = "<group>"; };
-		AC2EBD3E2D3D4385A04B65EB /* LMSAPIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeedback.swift; sourceTree = "<group>"; };
-		AC33ACFE534B42289892ACD0 /* LMSAPIAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdmin.swift; sourceTree = "<group>"; };
-		AC61B89E581D4A3BB74AEFF3 /* LMSFeatureModelsCourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseSettings.swift; sourceTree = "<group>"; };
-		ACB23DB1F524420EB1691BFB /* LMSAPITutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPITutor.swift; sourceTree = "<group>"; };
-		ACC452CCAFEE4E4291B522E8 /* MeetingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailView.swift; sourceTree = "<group>"; };
-		ACF60F0181744AD795AA80A6 /* AssignmentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogic.swift; sourceTree = "<group>"; };
-		AD48DE61916044ADBA57ED63 /* SettingsAccommodationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccommodationsTests.swift; sourceTree = "<group>"; };
-		AE3ECBF38B134BCBAFE1BECF /* WhatsWorkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsWorkingView.swift; sourceTree = "<group>"; };
-		AE7BE364B12F4037819B6D7E /* LMSAPIReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReader.swift; sourceTree = "<group>"; };
-		AECAFA063878407F86C7AE46 /* AiModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsSettingsView.swift; sourceTree = "<group>"; };
-		AF64DD759A2F4B9AA6EC6761 /* WhiteboardRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardRenderer.swift; sourceTree = "<group>"; };
-		AF67DD138BFE4DD691D2B8E2 /* LMSFeatureModelsAiAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAiAdmin.swift; sourceTree = "<group>"; };
-		AF68DEFDB6F644F1B49AE7FC /* CanvasImportObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportObservability.swift; sourceTree = "<group>"; };
-		AFA06F4519974FCA96FB76DB /* LMSAPICanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICanvasImport.swift; sourceTree = "<group>"; };
-		AFD0F17DDF344DF38730C3D6 /* TranscriptsAdvisingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminEntryCard.swift; sourceTree = "<group>"; };
-		B12A8567D2FD4F96A46A78C9 /* MyPurchasesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPurchasesView.swift; sourceTree = "<group>"; };
-		B156EC63DA0545DFA9886B4E /* DownloadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadStore.swift; sourceTree = "<group>"; };
-		B16A062E54DF456CB2FF8087 /* ProfileDepthLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogic.swift; sourceTree = "<group>"; };
-		B2987419F9724F8BAE46DE7C /* CourseAccessibilityReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogic.swift; sourceTree = "<group>"; };
-		B331630BBB724A7BB2500383 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
-		B38BE72075F141C68C01C98A /* CoursePeopleLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogicTests.swift; sourceTree = "<group>"; };
-		B39A6C065DBD48999414206D /* FeedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogic.swift; sourceTree = "<group>"; };
-		B41F92002E874326A55667BD /* CourseHeroImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImage.swift; sourceTree = "<group>"; };
-		B42C097F349F4294B8245A75 /* LMSFeatureModelsCourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseAccessibility.swift; sourceTree = "<group>"; };
-		B43743C8A7CD4D20AE020BE1 /* MyAccommodationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccommodationsView.swift; sourceTree = "<group>"; };
-		B4EB0008863344FBB6D12DD1 /* ReviewComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewComposer.swift; sourceTree = "<group>"; };
-		B55B25BC6CFB43AEA7AB087B /* RealtimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeManager.swift; sourceTree = "<group>"; };
-		B5BA849320AE4B2590B89819 /* LMSAPICourseImportExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseImportExport.swift; sourceTree = "<group>"; };
-		B67E1F886BFA47138686710E /* LMSFeatureModelsTutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTutor.swift; sourceTree = "<group>"; };
-		B6C18FF32FA146DB8FDDABCB /* LiveGameSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameSocket.swift; sourceTree = "<group>"; };
-		B7284D67AEFA4B6B89CFABB4 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTranscriptsAdvisingAdmin.swift; sourceTree = "<group>"; };
-		B76565B44E7040E494081414 /* LMSAPIPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPaths.swift; sourceTree = "<group>"; };
-		B76D6B8EFF32425AB3F621A6 /* LiveQuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogic.swift; sourceTree = "<group>"; };
-		B88B7EA19C784143BC7DB84C /* LearnerProfileLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogicTests.swift; sourceTree = "<group>"; };
-		B924B190901D424E95E8A674 /* BookingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingSheet.swift; sourceTree = "<group>"; };
-		B972F34DA69F49E59B3D03BD /* DrawerToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerToolbar.swift; sourceTree = "<group>"; };
-		BA8F92237382472281728AF9 /* LMSAPICourseFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseFeatures.swift; sourceTree = "<group>"; };
-		BABF3BEB66C6415D92AF68B4 /* LMSFeatureModelsParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsParent.swift; sourceTree = "<group>"; };
-		BB40ECDD371D46629FA4B0B9 /* CourseArchivedContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogic.swift; sourceTree = "<group>"; };
-		BC3BE6AB5EEA4770B176F672 /* CourseSectionsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogic.swift; sourceTree = "<group>"; };
-		BC5A4318357444D5A1424EF0 /* LMSAPIInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInsights.swift; sourceTree = "<group>"; };
-		BCD19D41247C463A95E4F3F4 /* HallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HallPassView.swift; sourceTree = "<group>"; };
-		BCF38853657840A195A73F41 /* LMSAPIBoardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardLayout.swift; sourceTree = "<group>"; };
-		BD00E38E54FD44BE9006F19E /* WhiteboardLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogic.swift; sourceTree = "<group>"; };
-		BDDA8F0165E34D14AABAE818 /* PathsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogicTests.swift; sourceTree = "<group>"; };
-		BE376101F5F4402BABE066E3 /* BiometricGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGate.swift; sourceTree = "<group>"; };
-		BEB9B0BCE84B4831B9EF48BE /* BoardSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSurface.swift; sourceTree = "<group>"; };
-		C09E3B692B6B4DCDBADC1A24 /* OutboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxStore.swift; sourceTree = "<group>"; };
-		C0A1F001ADM1NMETR1C001 /* AdminMetricCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminMetricCards.swift; sourceTree = "<group>"; };
-		C0A1F002C0URSESADM1N01 /* CoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesAdminView.swift; sourceTree = "<group>"; };
-		C0A1F003PLATCRSM0DEL01 /* LMSFeatureModelsPlatformCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformCoursesAdmin.swift; sourceTree = "<group>"; };
-		C0A1F004PLATCRSL0G1C01 /* PlatformCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogic.swift; sourceTree = "<group>"; };
-		C0A1F005PLATCRSTEST001 /* PlatformCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
-		C0A1F006PE0PLEMETR1C01 /* PeopleAdminMetricsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminMetricsLogicTests.swift; sourceTree = "<group>"; };
-		C0CD6077FE5D40CC8319EE83 /* LMSFeatureModelsCourseOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseOutcomes.swift; sourceTree = "<group>"; };
-		C22647F342CB4244ACAE5B64 /* NetworkAuthContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAuthContext.swift; sourceTree = "<group>"; };
-		C275EF4E0C8D4533A9029498 /* GroupsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogicTests.swift; sourceTree = "<group>"; };
-		C2815C9121014FFEBFF015F6 /* LMSAPIBoardAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAnalytics.swift; sourceTree = "<group>"; };
-		C2857A249A7D44D8A35F0588 /* LMSFeatureModelsInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInsights.swift; sourceTree = "<group>"; };
-		C2BDB5DFC156485BA2DF8135 /* CourseGradingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogicTests.swift; sourceTree = "<group>"; };
-		C305FCC30ECF400C98CA8785 /* LMSAPIIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIIntroCourse.swift; sourceTree = "<group>"; };
-		C4188B26349243DDA32FD60F /* LMSFeatureModelsCanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCanvasImport.swift; sourceTree = "<group>"; };
-		C46B0315581D446E95672C86 /* SpeedGraderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderView.swift; sourceTree = "<group>"; };
-		C48A86F51A83443090DAAD20 /* CourseInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseInsightsSection.swift; sourceTree = "<group>"; };
-		C4E1D67CF59949ED8000FA8C /* LexturesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesType.swift; sourceTree = "<group>"; };
-		C509211B07064B4880574F26 /* LMSFeatureModelsLearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLearnerProfile.swift; sourceTree = "<group>"; };
-		C5112DB5AF7744BB89E98CAE /* TutorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogic.swift; sourceTree = "<group>"; };
-		C5432BC7753842708D3C91B8 /* AiModelsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogic.swift; sourceTree = "<group>"; };
-		C5519F8BD0DD462CAE1644A4 /* WhatIfController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIfController.swift; sourceTree = "<group>"; };
-		C5D2103B93B3402AA7D1EF93 /* ReviewsReceivedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsReceivedView.swift; sourceTree = "<group>"; };
-		C685DDE626FD43AE8E794DF9 /* LMSAPIReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReview.swift; sourceTree = "<group>"; };
-		C721A4D0AE2C4562AD5DD503 /* CatalogLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogic.swift; sourceTree = "<group>"; };
-		C79ADB99674041B1A81298EC /* InteractiveLaunchLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogicTests.swift; sourceTree = "<group>"; };
-		C7F6726D741A41E98A42A7C1 /* LiveQuizPlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlayView.swift; sourceTree = "<group>"; };
-		C82102C0304A41AF8F9EE470 /* EvaluationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogicTests.swift; sourceTree = "<group>"; };
-		C84310772875447D85E385CA /* LMSFeatureModelsInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInstructorInsights.swift; sourceTree = "<group>"; };
-		C867B43E2703464F877FC979 /* ArtifactDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailView.swift; sourceTree = "<group>"; };
-		C8B2AB155D494CB797E298B3 /* PathLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathLandingView.swift; sourceTree = "<group>"; };
-		C9F5389E48194F8389E80AEB /* LMSFeatureModelsMobile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMobile.swift; sourceTree = "<group>"; };
-		C9FC4DBC336D4409B223A7F6 /* CourseMasterySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMasterySection.swift; sourceTree = "<group>"; };
-		CA2E44F6E66F42A8A779A6F8 /* UserDetailAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailAdminView.swift; sourceTree = "<group>"; };
-		CA87ABBDD9C04C21B75E1AB9 /* TutorLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLauncher.swift; sourceTree = "<group>"; };
-		CA88F6127DEA4B3298045809 /* AtRiskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtRiskListView.swift; sourceTree = "<group>"; };
-		CAD79463AC6B4EBBBD437217 /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
-		CB248334F51E4753BD8F22EC /* IntegrationsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminView.swift; sourceTree = "<group>"; };
-		CC9E51F3B6C244E5825F2FDC /* NotificationPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesView.swift; sourceTree = "<group>"; };
-		CCADC30404644DCCB14F7CF5 /* CollabDocView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollabDocView.swift; sourceTree = "<group>"; };
-		CCC7A71C1FDD4B25A97267EB /* BoardPresentModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPresentModeView.swift; sourceTree = "<group>"; };
-		CEAC489BE3F34CCCACE6AAEF /* PathsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogic.swift; sourceTree = "<group>"; };
-		CED83CBC0CCA40219F4F2D41 /* DateFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
-		CEEDAAA8C69F4E3A95F27EF9 /* CourseFeaturesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogic.swift; sourceTree = "<group>"; };
-		CF348B6075744E14A3B51A5E /* ReviewSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionView.swift; sourceTree = "<group>"; };
-		CF79059A94514B73B029F985 /* SearchActionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchActionRegistry.swift; sourceTree = "<group>"; };
-		D0A45DEFCF3A452B878ED663 /* ProfileDepthCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthCards.swift; sourceTree = "<group>"; };
-		D1886274024544B18C648429 /* AuditLogAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogicTests.swift; sourceTree = "<group>"; };
-		D2D394A203B748D98B1B875F /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
-		D3164BC03EC448AB8E97BFCC /* AttachmentUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploader.swift; sourceTree = "<group>"; };
-		D33CF3B2534542B097B35C1B /* LibraryBrowseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBrowseView.swift; sourceTree = "<group>"; };
-		D350AD0B0A59450F897F8526 /* AdvisingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingSettingsView.swift; sourceTree = "<group>"; };
-		D51738328C8246AB882B8626 /* LMSFeatureModelsEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEvaluations.swift; sourceTree = "<group>"; };
-		D5512688359B4814B37EEE73 /* CourseFileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileLogic.swift; sourceTree = "<group>"; };
-		D551415EA1FA4987A692152F /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
-		D5D37E2CCEE04493954CCD08 /* LMSFeatureModelsPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatform.swift; sourceTree = "<group>"; };
-		D5DCDD29E5BE4924BCAA2BAE /* LexturesMotionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotionTests.swift; sourceTree = "<group>"; };
-		D63C8BCE65AE45F9A02332C7 /* LogReadingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReadingSheet.swift; sourceTree = "<group>"; };
-		D76B7EDA320347C8BB92749F /* LMSAPIMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMarketplace.swift; sourceTree = "<group>"; };
-		D7C394658B9549BF840C6BF0 /* LMSAPIBoardPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardPosts.swift; sourceTree = "<group>"; };
-		D7FDF50245D841AABC037498 /* BoardPublicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPublicView.swift; sourceTree = "<group>"; };
-		D8028537BA35401A846CBE77 /* FileDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadManager.swift; sourceTree = "<group>"; };
-		D81BD291938946D2B18D20F9 /* LexturesMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotion.swift; sourceTree = "<group>"; };
-		D82BB8F7A48F4902A8AC0ACB /* LMSFeatureModelsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReader.swift; sourceTree = "<group>"; };
-		D848E3CFF3564E8F8F3EF421 /* BoardSaveAsTemplateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSaveAsTemplateSheet.swift; sourceTree = "<group>"; };
-		DAAEE7BF812449FDB58A6F5A /* PeerReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogicTests.swift; sourceTree = "<group>"; };
-		DB52324C18734849B0964957 /* BehaviorRosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorRosterView.swift; sourceTree = "<group>"; };
-		DBC9A2DB205E407EA3EE4C4A /* IntegrationsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminEntryCard.swift; sourceTree = "<group>"; };
-		DBF4E68A7EFD4FE7A3E90097 /* MobileIaPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileIaPreferences.swift; sourceTree = "<group>"; };
-		DD0F2E71D5D9404484B63E87 /* SchoolCodeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogicTests.swift; sourceTree = "<group>"; };
-		DD3219C169154315A1EABC2A /* LMSAPIParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIParent.swift; sourceTree = "<group>"; };
-		DD685807326846CF91C2CFCF /* LMSFeatureModelsIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntroCourse.swift; sourceTree = "<group>"; };
-		DD996D1B848646BCB3808AC4 /* LMSFeatureModelsCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCatalog.swift; sourceTree = "<group>"; };
-		DDA80204536948B28987E9D2 /* DiscussionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogic.swift; sourceTree = "<group>"; };
-		DDBB5CE865524C7E9FE8EFCE /* LMSAPICatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICatalog.swift; sourceTree = "<group>"; };
-		DDD1CD8513FF46B4B9547A10 /* CourseCreateObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateObservability.swift; sourceTree = "<group>"; };
-		DDF3F1B270A24C95A700749A /* LMSBoardAdvancedModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardAdvancedModels.swift; sourceTree = "<group>"; };
-		DDF6A6D215824225A7D9D6B8 /* LockdownController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockdownController.swift; sourceTree = "<group>"; };
-		DE7B7A922ACC43F2B1141439 /* LibraryResourceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogicTests.swift; sourceTree = "<group>"; };
-		DE97C894473F4880BF6E4146 /* TutorFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorFlowLayout.swift; sourceTree = "<group>"; };
-		DED2D76C465F4BD3A914E66F /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
-		DED5945B8F2F4E24ABA319D9 /* ArchivedCoursesAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminEntryCard.swift; sourceTree = "<group>"; };
-		DF85BA6B55D24B0F9AB635D9 /* FeedbackLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogic.swift; sourceTree = "<group>"; };
-		E0093B5FC2AE4D6C89B920C8 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
-		E0E7205FF51040FCB72CBF82 /* LeveledLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeveledLibraryView.swift; sourceTree = "<group>"; };
-		E11BE50906624153A159A9F0 /* ProfileAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAvatarView.swift; sourceTree = "<group>"; };
-		E1EABEF6DC594B13AB302015 /* CalendarSubscribeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSubscribeSheet.swift; sourceTree = "<group>"; };
-		E200FDE72EBE45E695A23ABD /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
-		E2DE8DE61E0F493AA4729F3A /* CourseCreateLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogicTests.swift; sourceTree = "<group>"; };
-		E2FFEC5BD1A44C7D9086AFCF /* CourseLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLandingView.swift; sourceTree = "<group>"; };
-		E30D0CBFA914409C9C34D400 /* CourseCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateView.swift; sourceTree = "<group>"; };
-		E370F1CBBF124190ACEA5B92 /* WhiteboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardView.swift; sourceTree = "<group>"; };
-		E436753DC586426DB8B8D712 /* CourseAccessibilityReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewView.swift; sourceTree = "<group>"; };
-		E46DCEFAEE87493A9E31AC43 /* GamificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogic.swift; sourceTree = "<group>"; };
-		E49305A5741A448B873B01D0 /* ItemDetailRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailRows.swift; sourceTree = "<group>"; };
-		E561164FBBA14C149AF35828 /* SettingsAdminHubEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubEntryCard.swift; sourceTree = "<group>"; };
-		E5977781DE424B91B8554838 /* WalletLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogic.swift; sourceTree = "<group>"; };
-		E5D99243ADB74AE28BAEA1FA /* CourseGradingAgentsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogic.swift; sourceTree = "<group>"; };
-		E614255DE8BB4580933D77CA /* LiveMeetingsRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsRail.swift; sourceTree = "<group>"; };
-		E6537BE01A4D4E8B9ABD4AD9 /* MeetingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListView.swift; sourceTree = "<group>"; };
-		E65E08AAAF35435F91EC11E2 /* AccountAccommodationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAccommodationModels.swift; sourceTree = "<group>"; };
-		E673943775FD47B9A98EE557 /* CoursePeopleLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogic.swift; sourceTree = "<group>"; };
-		E704138E9AFA40C68C28E541 /* AuthCallbackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParserTests.swift; sourceTree = "<group>"; };
-		E71A55C4A7074EA98B82BDE4 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
-		E76CCF94A8004D79A1A51F20 /* ReadingPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesStore.swift; sourceTree = "<group>"; };
-		E77A51CF0586468F99A3FD17 /* ProfileDepthLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogicTests.swift; sourceTree = "<group>"; };
-		E7E447C0DDD144B88568A961 /* NotificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLogic.swift; sourceTree = "<group>"; };
-		E837FD6AE64B48B89B9DFDB1 /* GradeCalculator+MyGrades.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GradeCalculator+MyGrades.swift"; sourceTree = "<group>"; };
-		E89A96A62A294B11B053B1BF /* WalletLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogicTests.swift; sourceTree = "<group>"; };
-		E9773DCAC81940CEBCADCAD9 /* SearchPathNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPathNavigator.swift; sourceTree = "<group>"; };
-		E981A936247546DDAB493E9B /* AuditLogAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminView.swift; sourceTree = "<group>"; };
-		E991BA3545AB4BC385CE6C61 /* AnnouncementComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementComposerView.swift; sourceTree = "<group>"; };
-		E9F2DB59FA2D4A86B9F6A2E6 /* ModuleItemRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleItemRouteView.swift; sourceTree = "<group>"; };
-		E9FA30ED87A2472F9C9CA9F4 /* SettingsMenuLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogicTests.swift; sourceTree = "<group>"; };
-		EAC4CDCB033A463DA0A746E2 /* ProfilePersonalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePersonalDetailsView.swift; sourceTree = "<group>"; };
-		EB2824972F97472BB707A125 /* CodeQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeQuestionView.swift; sourceTree = "<group>"; };
-		EC286797DB05465394303FE5 /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
-		EC4B319C0A3744029706BEB9 /* LearnerProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileView.swift; sourceTree = "<group>"; };
-		ECF8A0F2606F4936A8D63310 /* WalletCETranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCETranscriptDetailView.swift; sourceTree = "<group>"; };
-		EDA908ADC182496F9D55A70E /* TakeAttendanceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogic.swift; sourceTree = "<group>"; };
-		EF28D43D9F054B83A90FD9A1 /* TakeAttendanceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogicTests.swift; sourceTree = "<group>"; };
-		EF5CD5F306E14A0795C85D3F /* LocalePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalePreferences.swift; sourceTree = "<group>"; };
-		F04F85EB97CD424DAADB983F /* BoardPostCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPostCard.swift; sourceTree = "<group>"; };
-		F0FF5714CDFC4F2297B585A4 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
-		F11D7E51AFDE402A9CB4C5F1 /* CoursePlagiarismLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogicTests.swift; sourceTree = "<group>"; };
-		F13F5C2201A9439FB4B346EC /* OfficeHoursView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursView.swift; sourceTree = "<group>"; };
-		F187B38EA4C4471788C5E79A /* ProfileSettingsCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsCards.swift; sourceTree = "<group>"; };
-		F1B3270831A346DE871D0F76 /* OnboardingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModels.swift; sourceTree = "<group>"; };
-		F235B995F649415F8E39B499 /* CourseCollabDocsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCollabDocsSection.swift; sourceTree = "<group>"; };
-		F2CE45281D2C45AEB0062B4B /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
-		F2E05AF8855940BB80BD7CD3 /* CourseImportExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportView.swift; sourceTree = "<group>"; };
-		F39505FFCCC24326BBC0C3EF /* LMSFeatureModelsCourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseCreate.swift; sourceTree = "<group>"; };
-		F457C4A9A120463BBD81621A /* BehaviorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogicTests.swift; sourceTree = "<group>"; };
-		F467FA654D6E4F58A25DFCBB /* FeedSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSocket.swift; sourceTree = "<group>"; };
-		F59A779E94104C6FB2954401 /* ResearchStudiesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResearchStudiesView.swift; sourceTree = "<group>"; };
-		F62DF94E4C7246ABAA19151C /* CourseLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLibraryView.swift; sourceTree = "<group>"; };
-		F642FE17A2E047EEB5479210 /* ModuleContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentLogic.swift; sourceTree = "<group>"; };
-		F6BCA8EBF7554564B0C4B34E /* LMSFeatureModelsAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAdvising.swift; sourceTree = "<group>"; };
-		F6F0CC36B0D345C2A65A5BCB /* AnnouncementsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsViews.swift; sourceTree = "<group>"; };
-		F71BDC82DDF14C3E8F5AD1BE /* AiGovernanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiGovernanceView.swift; sourceTree = "<group>"; };
-		F71FB03292EB479498E7C037 /* TranscriptsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsSettingsView.swift; sourceTree = "<group>"; };
-		F7CD3105B0534368AEDBC4E5 /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
-		F8105C3C25FB4042BF1C0D5F /* UniversalSearchPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchPlaceholder.swift; sourceTree = "<group>"; };
-		F894CB179FB2419991AC1D55 /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
-		F9CA34F0EAA343E1AE64BF5F /* SchoolCodeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogic.swift; sourceTree = "<group>"; };
-		FA7F372F388643E186403729 /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
-		FA969D6F8EDD4E3E93C80B2B /* ArchivedCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
-		FAC032FFE898494AAE5AD290 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
-		FBB46D38E74640FB9DF737ED /* LMSAPICourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseTranslations.swift; sourceTree = "<group>"; };
-		FC2DA51DD8EE4449921CEDE6 /* LMSAPIBoards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoards.swift; sourceTree = "<group>"; };
-		FC40644EAAB4420E81ECB0DC /* PeopleAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogic.swift; sourceTree = "<group>"; };
-		FC9468E3BCBC43738DFFE9C5 /* CoursePlagiarismLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogic.swift; sourceTree = "<group>"; };
-		FD624932F9E643898448AF98 /* OfflineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineService.swift; sourceTree = "<group>"; };
-		FD87B9822FB747678C319A5C /* RubricScorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricScorerView.swift; sourceTree = "<group>"; };
-		FDC0C405F08447CA83B590F7 /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		FDC498FBB0BB41AD957F3E63 /* LMSAPIWhiteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWhiteboard.swift; sourceTree = "<group>"; };
-		FE968F8454A7464DBA2E7DCE /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
-		FFC1AC4481FC4833BF1B61A7 /* CourseTranslationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogic.swift; sourceTree = "<group>"; };
+		45A94E45545C4385825A8FAB /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		15F81775D0274CCC924659BA /* LexturesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LexturesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCC21ED0D16140FA8E128181 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		2DB3CC07877B4410A1AA5030 /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
+		46F09135218740BEA6B986E5 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		2391332DEEEF49AB92138DD9 /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
+		D877139FEBC4481391B5DD95 /* AccessibilitySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupport.swift; sourceTree = "<group>"; };
+		7F9F43CFA29B464B8321DE60 /* DictationField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationField.swift; sourceTree = "<group>"; };
+		0C08405046034F249A8E4203 /* ReadAloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAloud.swift; sourceTree = "<group>"; };
+		236584CA08EB4D21A75CB359 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		42A6C2CF29B94FD8ACF73AA1 /* AuthCallbackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParser.swift; sourceTree = "<group>"; };
+		7CB15491376F47848D44B281 /* AuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConstants.swift; sourceTree = "<group>"; };
+		2B7BD34CEB384CB3B4A718A6 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
+		7552797A53BB4FCE9FE53E6D /* BiometricGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGate.swift; sourceTree = "<group>"; };
+		0E8C1ED70666464594D7B357 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
+		EC0B98E8DFAD4FD4870B4B32 /* SessionsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsAPI.swift; sourceTree = "<group>"; };
+		DCECD071C74C40B592761510 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+		706824795CA64D6CA900F6FD /* EnvironmentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentStore.swift; sourceTree = "<group>"; };
+		A72B5AE8D40842608ED2A93B /* SchoolCodeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogic.swift; sourceTree = "<group>"; };
+		3D9E89A08F9048A498A3C2C9 /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
+		1E602BC87C274EB8BF6D2F82 /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
+		94A4411A8DB948DBBC52AB07 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		217B50509F7E4605A3AEA934 /* LexturesMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotion.swift; sourceTree = "<group>"; };
+		8C13D65F0331422587A7251A /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
+		39991ABDC8984C10936F533E /* LexturesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesType.swift; sourceTree = "<group>"; };
+		788BE3FA0266441F8EE51DDA /* ProfileAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAvatarView.swift; sourceTree = "<group>"; };
+		118A196BFF72440985648417 /* SyncStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusView.swift; sourceTree = "<group>"; };
+		C3F9FFA509F042BA997FB0AD /* ThemePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePreference.swift; sourceTree = "<group>"; };
+		1A831877A709428DACAE01AA /* UIMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIMode.swift; sourceTree = "<group>"; };
+		31131F38DD8C4F71AB103C65 /* UnsavedChangesBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsavedChangesBanner.swift; sourceTree = "<group>"; };
+		122671E8CAD442C99A656D34 /* DateFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
+		820F8FD64D9F4831BF993A8D /* LocaleAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleAPI.swift; sourceTree = "<group>"; };
+		33CA37F7628145F8A5485536 /* LocalePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalePreferences.swift; sourceTree = "<group>"; };
+		BEABF3ECB7BD4EE28923328C /* Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localized.swift; sourceTree = "<group>"; };
+		876822D3381A4D0EB3AD2B13 /* AccountAccommodationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAccommodationModels.swift; sourceTree = "<group>"; };
+		46DC0271021341C49AEE4143 /* AccountIntegrationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogic.swift; sourceTree = "<group>"; };
+		D12E4F4CDA774754BBF2B46E /* AdvisingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogic.swift; sourceTree = "<group>"; };
+		0C94283167EE41B58D02C513 /* AiModelsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogic.swift; sourceTree = "<group>"; };
+		E26AB3D0F63B4B1484296E98 /* AnnouncementLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogic.swift; sourceTree = "<group>"; };
+		D9200E6719844BDFA2739BCD /* ArchivedCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogic.swift; sourceTree = "<group>"; };
+		F413FF3F2B574D8BA4A8641A /* AssignmentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogic.swift; sourceTree = "<group>"; };
+		6DA16EC96F3B47B7BB83472D /* AuditLogAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogic.swift; sourceTree = "<group>"; };
+		A8218A5DA074493A9E0C1A59 /* BehaviorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogic.swift; sourceTree = "<group>"; };
+		9FE3BC019E0A410DA462E0C9 /* BillingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogic.swift; sourceTree = "<group>"; };
+		9483963ED37B434EAC4A7F8C /* BoardRealtimeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardRealtimeLogic.swift; sourceTree = "<group>"; };
+		F1216ABCEF6C4A5092B7575B /* BoardsAdvancedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogic.swift; sourceTree = "<group>"; };
+		425CCC3EE56D42899515B90B /* BoardsGovernanceAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminLogic.swift; sourceTree = "<group>"; };
+		654A68FBFF004593A6234FEA /* BoardsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogic.swift; sourceTree = "<group>"; };
+		1AAD098C5D86467195AAEFB2 /* CanvasImportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogic.swift; sourceTree = "<group>"; };
+		9E2BC38FEABA48CFBA00F250 /* CanvasImportObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportObservability.swift; sourceTree = "<group>"; };
+		DA1B4CAE70324A789B0B2A32 /* CatalogLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogic.swift; sourceTree = "<group>"; };
+		902B8828157D4900A862C29C /* ConferenceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogic.swift; sourceTree = "<group>"; };
+		30416340D9054E0B99CD6FC9 /* CourseAccessibilityReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogic.swift; sourceTree = "<group>"; };
+		94EF43760CF14277B04B2E26 /* CourseArchivedContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogic.swift; sourceTree = "<group>"; };
+		20F96BF5345940B29F034AE7 /* CourseBlueprintLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogic.swift; sourceTree = "<group>"; };
+		82679475DB4F44808D9B2A80 /* CourseCreateDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateDraftStore.swift; sourceTree = "<group>"; };
+		010D8A6487C848EA8815BE13 /* CourseCreateLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogic.swift; sourceTree = "<group>"; };
+		CA41BD3596684A6B9A402E7E /* CourseCreateObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateObservability.swift; sourceTree = "<group>"; };
+		FECCB1A1680B415D932DA179 /* CourseFeaturesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogic.swift; sourceTree = "<group>"; };
+		90F1D7AAFF3346ECAB215A9A /* CourseFileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileLogic.swift; sourceTree = "<group>"; };
+		CA328ED019264948840DC527 /* CourseGradingAgentsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogic.swift; sourceTree = "<group>"; };
+		D8D4CE8302454BA09CB5BC24 /* CourseGradingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogic.swift; sourceTree = "<group>"; };
+		75E508006F4842A58668DB57 /* CourseHeroImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImage.swift; sourceTree = "<group>"; };
+		CC62A6B2B27441E5B7915806 /* CourseImportExportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogic.swift; sourceTree = "<group>"; };
+		0C8EA99BDF0A4AF6ACD0C05B /* CourseOutcomesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogic.swift; sourceTree = "<group>"; };
+		1B286388C9EC40C887371ED5 /* CoursePeopleLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogic.swift; sourceTree = "<group>"; };
+		89062806BF744D468AA7DFD1 /* CoursePeopleObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleObservability.swift; sourceTree = "<group>"; };
+		F8877458D0E44F6DB649AF12 /* CoursePlagiarismLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogic.swift; sourceTree = "<group>"; };
+		35E7C1D0E02D41ADBF4D5464 /* CourseReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogic.swift; sourceTree = "<group>"; };
+		CBA37BA46DFF4A6392FE691F /* CourseSectionsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogic.swift; sourceTree = "<group>"; };
+		4323122721FF43A98CBA77DD /* CourseSettingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogic.swift; sourceTree = "<group>"; };
+		D39DD7B13CC04A99B5EEF892 /* CourseTranslationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogic.swift; sourceTree = "<group>"; };
+		EA3388A3D4894C97907F21A6 /* CredentialsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogic.swift; sourceTree = "<group>"; };
+		19865D60BF49490CA83E3FC8 /* CurrencyExponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExponent.swift; sourceTree = "<group>"; };
+		821E07F7B3BD4516933FD25F /* DiscussionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogic.swift; sourceTree = "<group>"; };
+		5A5F20597F4246188C41BC16 /* EvaluationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogic.swift; sourceTree = "<group>"; };
+		802E14FA9C1E486E8320D4C9 /* FeedbackLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogic.swift; sourceTree = "<group>"; };
+		7DB1D45B7CFF4C63AE669D1A /* FileDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadManager.swift; sourceTree = "<group>"; };
+		D88B6AF6F97C420CA3528020 /* GamificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogic.swift; sourceTree = "<group>"; };
+		7E4EAB0E8322489395633B7F /* GradeCalculator+MyGrades.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GradeCalculator+MyGrades.swift"; sourceTree = "<group>"; };
+		9A3A0A78C0E24855A2FC15B9 /* GradeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculator.swift; sourceTree = "<group>"; };
+		2F3D19836EB74186A1414C77 /* GroupsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogic.swift; sourceTree = "<group>"; };
+		E21D78D26D264655AB76C425 /* InsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogic.swift; sourceTree = "<group>"; };
+		36A150CD947F4E56BFF48EAD /* InstructorInsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogic.swift; sourceTree = "<group>"; };
+		C016EA4D3A0B472CB5D1125D /* IntegrationsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogic.swift; sourceTree = "<group>"; };
+		92A43C87E3984E9097D25841 /* InteractiveLaunchLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogic.swift; sourceTree = "<group>"; };
+		919E594A7B8D4B6F98B0B1F7 /* IntroCourseLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogic.swift; sourceTree = "<group>"; };
+		6542DA2E77D24963B76CF7C2 /* IntroCourseObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseObservability.swift; sourceTree = "<group>"; };
+		966CD203A95F4B3B819D5965 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
+		60CDA1E5F1194D00ACE24EB7 /* LMSAPIAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAccountIntegrations.swift; sourceTree = "<group>"; };
+		97217C9DC56846FA9D63293B /* LMSAPIAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdmin.swift; sourceTree = "<group>"; };
+		E56A544993F04A8CBB03CEDD /* LMSAPIAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdvising.swift; sourceTree = "<group>"; };
+		A150DCF9F7224315B7B30C60 /* LMSAPIAnnouncements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAnnouncements.swift; sourceTree = "<group>"; };
+		7F9127F532CB4C378571046A /* LMSAPIAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAuditLog.swift; sourceTree = "<group>"; };
+		D5B851C9FA0E4125AC76F48A /* LMSAPIBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBehavior.swift; sourceTree = "<group>"; };
+		46A904A5B0DB4B3098645E2A /* LMSAPIBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBilling.swift; sourceTree = "<group>"; };
+		994BBFFE141A485DA43BC060 /* LMSAPIBoardAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAccess.swift; sourceTree = "<group>"; };
+		C71BA7EC2E36488D9549FC98 /* LMSAPIBoardAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAnalytics.swift; sourceTree = "<group>"; };
+		801E18789F664D0DA7B9F036 /* LMSAPIBoardEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardEngagement.swift; sourceTree = "<group>"; };
+		9A55EC392CA1443EB6FD698D /* LMSAPIBoardExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardExport.swift; sourceTree = "<group>"; };
+		EF09D800BBA244ADB1F89793 /* LMSAPIBoardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardLayout.swift; sourceTree = "<group>"; };
+		C464E7B7706B46A6A1EC6B2F /* LMSAPIBoardModeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardModeration.swift; sourceTree = "<group>"; };
+		86242101E8CC4D4D9DB48D1E /* LMSAPIBoardPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardPosts.swift; sourceTree = "<group>"; };
+		E02AE223E87C46CA849E4F4A /* LMSAPIBoardTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardTemplates.swift; sourceTree = "<group>"; };
+		7E9B571E7F1E4C1D8B0B8EB3 /* LMSAPIBoards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoards.swift; sourceTree = "<group>"; };
+		D8955E4A2CB0471DB37AB7E1 /* LMSAPICanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICanvasImport.swift; sourceTree = "<group>"; };
+		A728634557104CC48E4FA9FA /* LMSAPICatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICatalog.swift; sourceTree = "<group>"; };
+		E3060A84315140D48D885600 /* LMSAPICourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseAccessibility.swift; sourceTree = "<group>"; };
+		5AB86D9F3B774232B8B64374 /* LMSAPICourseArchivedContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseArchivedContent.swift; sourceTree = "<group>"; };
+		7A7649122040475593E51536 /* LMSAPICourseBlueprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseBlueprint.swift; sourceTree = "<group>"; };
+		F838E38FD3314A86A61313B3 /* LMSAPICourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseCreate.swift; sourceTree = "<group>"; };
+		02159D88D4604E099DC45F01 /* LMSAPICourseFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseFeatures.swift; sourceTree = "<group>"; };
+		1C84ED01FAFE4F6A866A68EF /* LMSAPICourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGrading.swift; sourceTree = "<group>"; };
+		E38FAB25C7DD43B284D8EFCD /* LMSAPICourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGradingAgents.swift; sourceTree = "<group>"; };
+		8AD72034B7394CDDB3C71596 /* LMSAPICourseImportExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseImportExport.swift; sourceTree = "<group>"; };
+		E4B5DBDBE0EA4FD6811B8A9C /* LMSAPICoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICoursePlagiarism.swift; sourceTree = "<group>"; };
+		9C5ECA1E769A42E8AB9D07AC /* LMSAPICourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseReviews.swift; sourceTree = "<group>"; };
+		668A5BEF50304DEEB227C929 /* LMSAPICourseSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSections.swift; sourceTree = "<group>"; };
+		7BF1717F955345CEB67D4387 /* LMSAPICourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSettings.swift; sourceTree = "<group>"; };
+		99E5D70AB65A4BD0842B8517 /* LMSAPICourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseTranslations.swift; sourceTree = "<group>"; };
+		4A29CB1E340146B2AB9FC2E4 /* LMSAPICredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICredentials.swift; sourceTree = "<group>"; };
+		068520BD32F0465EBD006759 /* LMSAPIDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIDiscussions.swift; sourceTree = "<group>"; };
+		3131373FEB59466C8AB0AC7C /* LMSAPIEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEportfolio.swift; sourceTree = "<group>"; };
+		306DA47EB9F146349ADE21A8 /* LMSAPIEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEvaluations.swift; sourceTree = "<group>"; };
+		9A5CE9C20A164A57A2912047 /* LMSAPIFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeatures.swift; sourceTree = "<group>"; };
+		5E2D7AF6A7E74E419C4E3E6D /* LMSAPIFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeed.swift; sourceTree = "<group>"; };
+		99D110AD56244378A93E0E15 /* LMSAPIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeedback.swift; sourceTree = "<group>"; };
+		894E2AD904124DDDB1BD3CBF /* LMSAPIGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGamification.swift; sourceTree = "<group>"; };
+		0AF12B79BA4A4F999CA668DF /* LMSAPIGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGroups.swift; sourceTree = "<group>"; };
+		9BAA3D5D9FD24A8B9B2EFDDF /* LMSAPIInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInsights.swift; sourceTree = "<group>"; };
+		80BDAE0779984913A3A462B8 /* LMSAPIInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInstructorInsights.swift; sourceTree = "<group>"; };
+		35A92F7A21E3452886DEB48E /* LMSAPIIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIIntroCourse.swift; sourceTree = "<group>"; };
+		9E4A56A3B3B84A10991DAF47 /* LMSAPILearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILearnerProfile.swift; sourceTree = "<group>"; };
+		2CDD6A07DA3446248362F3D7 /* LMSAPILiveQuiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILiveQuiz.swift; sourceTree = "<group>"; };
+		4288167DEBBD4889AE882767 /* LMSAPIMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMarketplace.swift; sourceTree = "<group>"; };
+		08FE81C12C6F499187483CE8 /* LMSAPIMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMastery.swift; sourceTree = "<group>"; };
+		AAD07E78BFB04381B3637B0E /* LMSAPIMobileWave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMobileWave.swift; sourceTree = "<group>"; };
+		C746D09F7AED46FC9EFF8F3A /* LMSAPIOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIOutcomes.swift; sourceTree = "<group>"; };
+		813EBA9635704CB7AA3ED889 /* LMSAPIParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIParent.swift; sourceTree = "<group>"; };
+		9675FBC57BC64C3F9111FD59 /* LMSAPIPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPaths.swift; sourceTree = "<group>"; };
+		33223C7241234E22923DE250 /* LMSAPIPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPeerReview.swift; sourceTree = "<group>"; };
+		64F5E609206F4CC4A2CF95E1 /* LMSAPIProctoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIProctoring.swift; sourceTree = "<group>"; };
+		48FE06D846ED40A58DCE2230 /* LMSAPIQuizCodeRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIQuizCodeRun.swift; sourceTree = "<group>"; };
+		DF8906D74CFF4701B255EAF4 /* LMSAPIReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReader.swift; sourceTree = "<group>"; };
+		10A0B299B0D94ADC97F88528 /* LMSAPIReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReading.swift; sourceTree = "<group>"; };
+		60B8FDE10B9B4CEC8A5C6F5E /* LMSAPIReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReview.swift; sourceTree = "<group>"; };
+		86ED0FB8585D46868F83CB1F /* LMSAPITutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPITutor.swift; sourceTree = "<group>"; };
+		207E7D9985164CD29E02D922 /* LMSAPIWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWallet.swift; sourceTree = "<group>"; };
+		C6D9DD802E174B83AE982827 /* LMSAPIWhiteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWhiteboard.swift; sourceTree = "<group>"; };
+		F7F968115560419084BFD1DA /* LMSBoardAdvancedModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardAdvancedModels.swift; sourceTree = "<group>"; };
+		904B49C91AD649B8ACE9FF53 /* LMSBoardModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardModels.swift; sourceTree = "<group>"; };
+		2F30BB03583A40CBACF8BAC7 /* LMSFeatureModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModels.swift; sourceTree = "<group>"; };
+		5D5AFDFFD4954154AA08B6F0 /* LMSFeatureModelsAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAccountIntegrations.swift; sourceTree = "<group>"; };
+		D80B84481BE743C8815CE2A1 /* LMSFeatureModelsAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAdvising.swift; sourceTree = "<group>"; };
+		3EEC8D940813443B82EF99FB /* LMSFeatureModelsAiAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAiAdmin.swift; sourceTree = "<group>"; };
+		B1A3ACCAF55B4CB3BC634A50 /* LMSFeatureModelsArchivedCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsArchivedCoursesAdmin.swift; sourceTree = "<group>"; };
+		DE63E84856084D178F811FA9 /* LMSFeatureModelsAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAuditLog.swift; sourceTree = "<group>"; };
+		A9C177FF51E7499F98FEB135 /* LMSFeatureModelsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBehavior.swift; sourceTree = "<group>"; };
+		1C8F213D1EFE4B02BE3EA0DC /* LMSFeatureModelsBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBilling.swift; sourceTree = "<group>"; };
+		189CE9ECC48A43A2934C6332 /* LMSFeatureModelsCanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCanvasImport.swift; sourceTree = "<group>"; };
+		E60FFEEF85CA49868E48854D /* LMSFeatureModelsCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCatalog.swift; sourceTree = "<group>"; };
+		5D140A0009994251829A8550 /* LMSFeatureModelsCourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseAccessibility.swift; sourceTree = "<group>"; };
+		DD8FE4612AF54B47AFEA77FC /* LMSFeatureModelsCourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseCreate.swift; sourceTree = "<group>"; };
+		024FE8FC67C4411EA992E641 /* LMSFeatureModelsCourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGrading.swift; sourceTree = "<group>"; };
+		D2290E19122C4493AE1EBD28 /* LMSFeatureModelsCourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGradingAgents.swift; sourceTree = "<group>"; };
+		55830F753A0046C981B6A5A6 /* LMSFeatureModelsCourseOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseOutcomes.swift; sourceTree = "<group>"; };
+		293E953D73FB46039E06FEA4 /* LMSFeatureModelsCoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCoursePlagiarism.swift; sourceTree = "<group>"; };
+		7CB7B6D7573A436D9EE6C0BD /* LMSFeatureModelsCourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseReviews.swift; sourceTree = "<group>"; };
+		32C78CFD171E4C50B5AC21BB /* LMSFeatureModelsCourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseSettings.swift; sourceTree = "<group>"; };
+		A6602EEA446149C0BF76FD4F /* LMSFeatureModelsCourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseTranslations.swift; sourceTree = "<group>"; };
+		215E096BEF9B47F68FB552A7 /* LMSFeatureModelsCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCredentials.swift; sourceTree = "<group>"; };
+		448F3041DA3349A4B85A5849 /* LMSFeatureModelsDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsDiscussions.swift; sourceTree = "<group>"; };
+		8F09DF8AF0BD45B195F3B93C /* LMSFeatureModelsEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEportfolio.swift; sourceTree = "<group>"; };
+		C1655E9A8D3C4BF089B81C17 /* LMSFeatureModelsEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEvaluations.swift; sourceTree = "<group>"; };
+		4B7D2B5DFB6D4597B12EC5CC /* LMSFeatureModelsFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeed.swift; sourceTree = "<group>"; };
+		750096FF04F847F08FA588EE /* LMSFeatureModelsFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeedback.swift; sourceTree = "<group>"; };
+		888D7AF98DAE4275B6026F44 /* LMSFeatureModelsGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGamification.swift; sourceTree = "<group>"; };
+		08DB93BEB74C4BDBA17AC808 /* LMSFeatureModelsGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGroups.swift; sourceTree = "<group>"; };
+		C0BD6CA3F08E413693067FCE /* LMSFeatureModelsInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInsights.swift; sourceTree = "<group>"; };
+		03308D4ECF2B43DB882A33FF /* LMSFeatureModelsInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInstructorInsights.swift; sourceTree = "<group>"; };
+		023909062EED4A2B9B375E4A /* LMSFeatureModelsIntegrationsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntegrationsAdmin.swift; sourceTree = "<group>"; };
+		CE321A529D7B4A4DA1F2EDB3 /* LMSFeatureModelsIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntroCourse.swift; sourceTree = "<group>"; };
+		734204250DE94773B2699164 /* LMSFeatureModelsLearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLearnerProfile.swift; sourceTree = "<group>"; };
+		98B548F6309447C3A3FBFF17 /* LMSFeatureModelsLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLive.swift; sourceTree = "<group>"; };
+		0CD04098A231494CA3F09F78 /* LMSFeatureModelsMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMarketplace.swift; sourceTree = "<group>"; };
+		39DDFFC0D69A491D9DA742FA /* LMSFeatureModelsMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMastery.swift; sourceTree = "<group>"; };
+		5CAE21F884C8447AA61BF858 /* LMSFeatureModelsMobile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMobile.swift; sourceTree = "<group>"; };
+		B1E0AB224456451DBA4E7994 /* LMSFeatureModelsOrgBrandingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgBrandingAdmin.swift; sourceTree = "<group>"; };
+		2C43119FFBC54D04B7C27FD9 /* LMSFeatureModelsOrgStructureAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgStructureAdmin.swift; sourceTree = "<group>"; };
+		550DB0C297164ED9880A4FD7 /* LMSFeatureModelsParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsParent.swift; sourceTree = "<group>"; };
+		F4790175587647C88099ADD4 /* LMSFeatureModelsPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPaths.swift; sourceTree = "<group>"; };
+		0F3143CD283049999A70EE00 /* LMSFeatureModelsPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeerReview.swift; sourceTree = "<group>"; };
+		72B0D6B8EA2C4B84993EA288 /* LMSFeatureModelsPeopleAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeopleAdmin.swift; sourceTree = "<group>"; };
+		21CCABD2171944B38CFFE643 /* LMSFeatureModelsPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatform.swift; sourceTree = "<group>"; };
+		B9DD0143BF514EB898AEEFAD /* LMSFeatureModelsPlatformCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformCoursesAdmin.swift; sourceTree = "<group>"; };
+		37F009617AFF417CABF397AE /* LMSFeatureModelsPlatformSettingsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformSettingsAdmin.swift; sourceTree = "<group>"; };
+		4643CE61530B4FD8971104A2 /* LMSFeatureModelsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReader.swift; sourceTree = "<group>"; };
+		96F39CB0482F4A64913BB349 /* LMSFeatureModelsReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReading.swift; sourceTree = "<group>"; };
+		E609EA910A5A463B99D7C222 /* LMSFeatureModelsRolesPermissionsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsRolesPermissionsAdmin.swift; sourceTree = "<group>"; };
+		3A9F3F51E5A245A1A459EF71 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTranscriptsAdvisingAdmin.swift; sourceTree = "<group>"; };
+		8E589186B3024558AE276C41 /* LMSFeatureModelsTutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTutor.swift; sourceTree = "<group>"; };
+		DB025E305E73486AB634D170 /* LMSFeatureModelsWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsWallet.swift; sourceTree = "<group>"; };
+		3B3AEDE2A3A24B1FB83AD8CD /* LMSInteractiveModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSInteractiveModels.swift; sourceTree = "<group>"; };
+		7C17447C206F491F86B62429 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
+		FE2DA8F783004A75B61C861E /* LearnerProfileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogic.swift; sourceTree = "<group>"; };
+		B520F7E9737D4C78B5511ADA /* LibraryResourceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogic.swift; sourceTree = "<group>"; };
+		C37D57FE7FD94B599A7462C4 /* LiveGameLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameLogic.swift; sourceTree = "<group>"; };
+		1968A81A18024476BACDA0C8 /* LiveMeetingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogic.swift; sourceTree = "<group>"; };
+		6C2A21241F6A48D79A316B25 /* LiveQuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogic.swift; sourceTree = "<group>"; };
+		48B6B3C5A0A44CF0BE0695FC /* MarketplaceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogic.swift; sourceTree = "<group>"; };
+		E0D94CAC8ADF4E77ADBCE34B /* MasteryLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogic.swift; sourceTree = "<group>"; };
+		76986149DC3348B4AB702714 /* ModuleContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentLogic.swift; sourceTree = "<group>"; };
+		11775417D81E4E9BAE6C9E95 /* ModuleLastVisited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleLastVisited.swift; sourceTree = "<group>"; };
+		D0EA30C7BA6041EF97247A7D /* NotificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLogic.swift; sourceTree = "<group>"; };
+		6855BB77F7A14D1EB6FC6F9B /* OfficeHoursLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogic.swift; sourceTree = "<group>"; };
+		1F81340A6FCF4880BBBA4791 /* OnboardingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModels.swift; sourceTree = "<group>"; };
+		86594C5CEF924F1DB75AEC45 /* OrgBrandingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogic.swift; sourceTree = "<group>"; };
+		8FF8F46759714555BDFE85ED /* OrgStructureAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogic.swift; sourceTree = "<group>"; };
+		E007BE645CB04728BEFB4B4B /* ParentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogic.swift; sourceTree = "<group>"; };
+		B07AEF18A77544789FA89FEA /* PathsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogic.swift; sourceTree = "<group>"; };
+		3CFB99E8194E4D8D91176740 /* PeerReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogic.swift; sourceTree = "<group>"; };
+		26155397F5234AE695039840 /* PeopleAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogic.swift; sourceTree = "<group>"; };
+		F25AC1FC6EA5428E8B72D682 /* PlannerLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerLogic.swift; sourceTree = "<group>"; };
+		5790510331EE4827B84DE958 /* PlannerSnapshotCoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerSnapshotCoding.swift; sourceTree = "<group>"; };
+		37D87AB33B084FB29D7A6D57 /* PlatformCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogic.swift; sourceTree = "<group>"; };
+		0F21F0185187479A99043D89 /* PlatformSettingsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogic.swift; sourceTree = "<group>"; };
+		56248BCF827943AC98A609E6 /* PortfolioLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogic.swift; sourceTree = "<group>"; };
+		D7979B9805F94AC3BA42C0A2 /* ProfileDepthLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogic.swift; sourceTree = "<group>"; };
+		E182B9799F5841BDA349CFB7 /* ProfileDepthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthModels.swift; sourceTree = "<group>"; };
+		CD9C4896A7134E4EBBB34EB7 /* QuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogic.swift; sourceTree = "<group>"; };
+		9C014105AAF843E483AA944A /* ReadingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogic.swift; sourceTree = "<group>"; };
+		B5F385DEC274498C97903AA4 /* RequirementsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogic.swift; sourceTree = "<group>"; };
+		A92202601E40437985EDDDBD /* ReviewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewModels.swift; sourceTree = "<group>"; };
+		7E1B974B7FBA4A0B829A0604 /* RolesPermissionsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogic.swift; sourceTree = "<group>"; };
+		45B5ECA2A97A41E096C017B9 /* SettingsMenuLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogic.swift; sourceTree = "<group>"; };
+		166A6BA560C44113A46D4988 /* TakeAttendanceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogic.swift; sourceTree = "<group>"; };
+		922C235D780B473CBC59D7F5 /* TranscriptsAdvisingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogic.swift; sourceTree = "<group>"; };
+		89473B285B5E49A0A79308DC /* TutorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogic.swift; sourceTree = "<group>"; };
+		EC2751D8B98E43CD9F62F7AD /* TutorStreamClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorStreamClient.swift; sourceTree = "<group>"; };
+		F25FA4F8614F4D7D9EEED7D3 /* VibeActivityLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogic.swift; sourceTree = "<group>"; };
+		24C019B8498C499AAE46FEF3 /* WalletLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogic.swift; sourceTree = "<group>"; };
+		A531E690F2CE4FEB86896985 /* WhiteboardLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogic.swift; sourceTree = "<group>"; };
+		3A2B972D59944A22A14CD382 /* WhiteboardRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardRenderer.swift; sourceTree = "<group>"; };
+		9539914B91EA4AC0A10CD744 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		B8C60DD35D434947B391DCCB /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		B87F886051A547F6B9915B17 /* NetworkAuthContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAuthContext.swift; sourceTree = "<group>"; };
+		034243060A9D460D8829F84B /* NetworkBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBootstrap.swift; sourceTree = "<group>"; };
+		6D674B0C9ED146939FC329F3 /* MarkdownTableLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTableLogic.swift; sourceTree = "<group>"; };
+		D83042AE2827442483E3E27C /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
+		FB326385E92C4DA1B823A4F4 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
+		0190BC6FDADE41CCB994CF1F /* NotebookSlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSlashCommands.swift; sourceTree = "<group>"; };
+		9BD6D10890F84565933F42DB /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
+		CDC8BA6757C24485B7248CA1 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
+		2A6CC2ED061F4414B31ABB71 /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
+		8D48D6ED18E84162ADDD9DFD /* CacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStore.swift; sourceTree = "<group>"; };
+		08584DB395634C77BC5D895C /* DownloadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadStore.swift; sourceTree = "<group>"; };
+		66CF0C8E08904DE4BA967198 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		7F1594BFF9A242A9A66BDC90 /* OfflineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModels.swift; sourceTree = "<group>"; };
+		5662A6252F164C63B7CDBA00 /* OfflineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineService.swift; sourceTree = "<group>"; };
+		748936187DFB496C964B1168 /* OutboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxStore.swift; sourceTree = "<group>"; };
+		01174D0301DC49278345703C /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
+		0F2AD54DF35243D08D0884D7 /* PushManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushManager.swift; sourceTree = "<group>"; };
+		28F8C9E8AEC94C8CB4048E6F /* RealtimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeManager.swift; sourceTree = "<group>"; };
+		BF143DA58EC349B88DE918D5 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
+		6A1E5E66145E42A1971D08A6 /* ContentLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLinkRouter.swift; sourceTree = "<group>"; };
+		3AD1758A01574A04BD37420F /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
+		CC3755F559B9448F87A2512D /* MobileDestinations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinations.swift; sourceTree = "<group>"; };
+		31CF4329D62D43529C92A419 /* MobileIaPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileIaPreferences.swift; sourceTree = "<group>"; };
+		129D441D1F9D47469C14936A /* MobileProfileDepthPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileProfileDepthPreferences.swift; sourceTree = "<group>"; };
+		18AB82BC37F649188244C769 /* SearchActionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchActionRegistry.swift; sourceTree = "<group>"; };
+		AB95D2CEDEF34154B27C0629 /* SearchModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModels.swift; sourceTree = "<group>"; };
+		F10471B9CC0341E191FCC111 /* SearchPathNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPathNavigator.swift; sourceTree = "<group>"; };
+		89C50C881A26455F812729AB /* SearchRecentsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRecentsStore.swift; sourceTree = "<group>"; };
+		1A3EC0B819B54DD1A3035E15 /* CodeEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditor.swift; sourceTree = "<group>"; };
+		20692C98F7CF4C5E9E630940 /* AdvisingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingView.swift; sourceTree = "<group>"; };
+		49E0B6EB1F464ADEABF0BBEE /* AssignmentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDetailView.swift; sourceTree = "<group>"; };
+		1FB370489A524C4494940128 /* AssignmentDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDraftStore.swift; sourceTree = "<group>"; };
+		0253694A82134E3AAEB30D97 /* AttachmentUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploader.swift; sourceTree = "<group>"; };
+		969DA09CDDFD40049CE615D0 /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
+		3C9B1359A4404825AE15F3A3 /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
+		F42150EF643F4D7D9FFFFAE0 /* GetStartedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStartedView.swift; sourceTree = "<group>"; };
+		10532DC1D669434B82A731A2 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		52FE0D2585394BF187ECA1B7 /* MFAChallengeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAChallengeView.swift; sourceTree = "<group>"; };
+		2D04881B017D42D59271A7FF /* MfaPasskeyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MfaPasskeyController.swift; sourceTree = "<group>"; };
+		2F813600B54249D3B9938C60 /* SSOAuthController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOAuthController.swift; sourceTree = "<group>"; };
+		64116C457D144592923CE953 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
+		FF6A680715844859B5AB1482 /* BehaviorRosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorRosterView.swift; sourceTree = "<group>"; };
+		1F834E7C7E2B4F83977CD393 /* HallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HallPassView.swift; sourceTree = "<group>"; };
+		589449D3174C412290E4395C /* MyHallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHallPassView.swift; sourceTree = "<group>"; };
+		A4D5E89F64034E519A897B39 /* BillingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingView.swift; sourceTree = "<group>"; };
+		002621179B3240B88E42D3BE /* CheckoutReturnHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutReturnHandler.swift; sourceTree = "<group>"; };
+		CEBA28AFA45B4196BA532489 /* PurchaseFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseFlow.swift; sourceTree = "<group>"; };
+		4CA12F2E861645A1980CF97B /* BoardAnalyticsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAnalyticsSheet.swift; sourceTree = "<group>"; };
+		8924613254124B5AA8FD0491 /* BoardComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardComposerView.swift; sourceTree = "<group>"; };
+		03216D95DEEE443283E5957E /* BoardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailView.swift; sourceTree = "<group>"; };
+		337088D4F5644F398827A1F8 /* BoardEngagementEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEngagementEnvironment.swift; sourceTree = "<group>"; };
+		BF51B8DD3EC1499B9B67BB98 /* BoardExportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardExportSheet.swift; sourceTree = "<group>"; };
+		83131615195A4ACC8EE64E7D /* BoardModerationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardModerationSettings.swift; sourceTree = "<group>"; };
+		259DF311E035446E813AA4DB /* BoardPostCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPostCard.swift; sourceTree = "<group>"; };
+		C2B34D6497C14CAC8663E762 /* BoardPresentModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPresentModeView.swift; sourceTree = "<group>"; };
+		5B437E7FBB6B460F8178C628 /* BoardSaveAsTemplateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSaveAsTemplateSheet.swift; sourceTree = "<group>"; };
+		1A2E9D9B7CC2408C88DC216F /* BoardShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardShareSheet.swift; sourceTree = "<group>"; };
+		9B45A1B0F53148FEACFB6231 /* BoardSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSocket.swift; sourceTree = "<group>"; };
+		CB51EF4DBC774C6DBD841565 /* BoardSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSurface.swift; sourceTree = "<group>"; };
+		886E207B6264422F8B23AB06 /* BoardSyncStatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSyncStatusChip.swift; sourceTree = "<group>"; };
+		8B3143CE3BEC4D3FB873211C /* BoardTemplatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTemplatePickerView.swift; sourceTree = "<group>"; };
+		490CFC138B7B46DDABD858C5 /* BoardsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsListView.swift; sourceTree = "<group>"; };
+		4D68ECFF7B644E71BC47AE87 /* CardArrangeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardArrangeMenu.swift; sourceTree = "<group>"; };
+		4FC767DDD02B4309BF4ADDC0 /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
+		DED68C4F898B4AA492F84347 /* GradeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSheet.swift; sourceTree = "<group>"; };
+		370BAE4B96A34903AB73ED0C /* CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasLayout.swift; sourceTree = "<group>"; };
+		78BA4EA8C1154A7EA1731CD8 /* ColumnsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnsLayout.swift; sourceTree = "<group>"; };
+		780DA182FF4043B38696D36C /* MapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLayout.swift; sourceTree = "<group>"; };
+		E7CB8C1BE7504CD9B7CEEAC6 /* TimelineLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLayout.swift; sourceTree = "<group>"; };
+		57FDCF46AF3E4B0DA1A173DB /* WallLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallLayout.swift; sourceTree = "<group>"; };
+		611830A137CA49C1959CDE8F /* ModerationQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationQueueView.swift; sourceTree = "<group>"; };
+		2F852E57D2D14F8A95455DBE /* BoardPublicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPublicView.swift; sourceTree = "<group>"; };
+		6055DB2C26AB4129A22E0F29 /* ReactionControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionControl.swift; sourceTree = "<group>"; };
+		8288AA0576624915998DFB6D /* ReportDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDialog.swift; sourceTree = "<group>"; };
+		133747F8014442AEB513EB08 /* CatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogView.swift; sourceTree = "<group>"; };
+		22DF8A394EE945B8B60D579F /* CourseLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLandingView.swift; sourceTree = "<group>"; };
+		02AB0F11CDF54868BE71CFF3 /* ReviewComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewComposer.swift; sourceTree = "<group>"; };
+		847219C1BF3A490581AAEF0D /* ContentPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentPageView.swift; sourceTree = "<group>"; };
+		BB770D3718FF4A90B5384778 /* CourseAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAttendanceView.swift; sourceTree = "<group>"; };
+		87682C9CFE11404282D85EDA /* CourseBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBanner.swift; sourceTree = "<group>"; };
+		6439F689A7D84336B9539BD9 /* CourseDestinationPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDestinationPlaceholder.swift; sourceTree = "<group>"; };
+		A0365B3EC4674A04B2BDFDFB /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
+		8263EB4500D544EE8D550D89 /* CourseGradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradesView.swift; sourceTree = "<group>"; };
+		1DCD2C6E51C24F738ED8C250 /* CourseLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLibraryView.swift; sourceTree = "<group>"; };
+		A025369C914A4C87867124F5 /* CourseMarkdownContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarkdownContentView.swift; sourceTree = "<group>"; };
+		54B6AC4FDA634026875BA2D4 /* CoursePeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleView.swift; sourceTree = "<group>"; };
+		C6DE8049A8EC481999C88093 /* CourseStructureSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseStructureSocket.swift; sourceTree = "<group>"; };
+		7557B966F73F4899BC996BB4 /* CourseSyllabusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyllabusView.swift; sourceTree = "<group>"; };
+		A564BD3178B141A79D7DADA8 /* CourseWorkspaceNav.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseWorkspaceNav.swift; sourceTree = "<group>"; };
+		40536B390EA3411BA49279F6 /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
+		35EB05D53C374ABEB6EA3DD0 /* CanvasImportComingSoonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportComingSoonView.swift; sourceTree = "<group>"; };
+		E9F823AB9D514792B470A794 /* CanvasImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportView.swift; sourceTree = "<group>"; };
+		2BCB46E9122846B5904855D6 /* CourseCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateView.swift; sourceTree = "<group>"; };
+		D1F747815F954B388C7CD9D6 /* ItemDetailRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailRows.swift; sourceTree = "<group>"; };
+		77028F77277348C399FE5293 /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
+		4A6F3A0A6E144C2E9E1DA262 /* LaunchContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContainerView.swift; sourceTree = "<group>"; };
+		41E68A635B7041AE8657D5F3 /* LibraryResourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceView.swift; sourceTree = "<group>"; };
+		A6CAC416D8494E778F4B9787 /* MarkdownCodeBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeBlockView.swift; sourceTree = "<group>"; };
+		E00898CE0B5A4D8F832F234E /* MarkdownTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTableView.swift; sourceTree = "<group>"; };
+		659D85899B3942718E0FCEF8 /* ModuleItemRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleItemRouteView.swift; sourceTree = "<group>"; };
+		B6A7F68903B0466686850D5D /* ModuleListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleListView.swift; sourceTree = "<group>"; };
+		EC0F193562AA48EA9D3B5751 /* RequirementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsView.swift; sourceTree = "<group>"; };
+		E895804DE50A41ED8B232135 /* CourseAccessibilityReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewView.swift; sourceTree = "<group>"; };
+		267410C1A41D49FF99FBB5C7 /* CourseArchivedContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentView.swift; sourceTree = "<group>"; };
+		FCBAB76F491F4138AED91A60 /* CourseBlueprintSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintSettingsView.swift; sourceTree = "<group>"; };
+		FC84EB24717C41269F150D07 /* CourseCrossListingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCrossListingView.swift; sourceTree = "<group>"; };
+		DD02BDC83DB8485CBCE81507 /* CourseFeaturesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesSettingsView.swift; sourceTree = "<group>"; };
+		BFB6A4245D294042A00AA6A4 /* CourseGeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGeneralSettingsView.swift; sourceTree = "<group>"; };
+		5349888EC0114570ACD831E4 /* CourseGradingAgentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsView.swift; sourceTree = "<group>"; };
+		59EF72CCCF474E3AAA676528 /* CourseGradingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingSettingsView.swift; sourceTree = "<group>"; };
+		EA41E9040649456DB33BC162 /* CourseHeroImageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImageEditor.swift; sourceTree = "<group>"; };
+		FBA181A953E14C468095768C /* CourseImportExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportView.swift; sourceTree = "<group>"; };
+		9BE3AA0F3A6F4471AA1C6E35 /* CourseMarketplaceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarketplaceSettingsView.swift; sourceTree = "<group>"; };
+		8BC1C07012AA400FB90CD1B1 /* CourseOutcomesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesSettingsView.swift; sourceTree = "<group>"; };
+		2225D9D07D9C459196127219 /* CoursePlagiarismSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismSettingsView.swift; sourceTree = "<group>"; };
+		4DE94582729E48E39E56B2E9 /* CourseSectionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsSettingsView.swift; sourceTree = "<group>"; };
+		713566F955A64593962A78CF /* CourseSettingsHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsHostView.swift; sourceTree = "<group>"; };
+		1FA5BBF44C9844CEA26C3C6A /* CourseTranslationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsSettingsView.swift; sourceTree = "<group>"; };
+		04F287EF609D48A587AE804D /* TakeAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceView.swift; sourceTree = "<group>"; };
+		8937A1E1F8C542699D4EFCE3 /* VibeActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityView.swift; sourceTree = "<group>"; };
+		D2D25A64C53F44E8A3DCA18F /* WebItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebItemView.swift; sourceTree = "<group>"; };
+		C4FF896DFF2C4573B7293396 /* CredentialDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDetailView.swift; sourceTree = "<group>"; };
+		5D1B0BC5160C4FAF85C3E3A9 /* CredentialsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsView.swift; sourceTree = "<group>"; };
+		2EFFCC5A901E49019C8EBA1D /* DashboardCoursesCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCoursesCarousel.swift; sourceTree = "<group>"; };
+		F4DC62FD64AE4B6D8014259E /* DashboardHeroPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardHeroPanel.swift; sourceTree = "<group>"; };
+		EDBAFCBF1764488498252FCB /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+		C1A1E7EAE66744EC93DF87FF /* LiveMeetingsRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsRail.swift; sourceTree = "<group>"; };
+		68F065BDB057427B997809FB /* CourseDiscussionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDiscussionsSection.swift; sourceTree = "<group>"; };
+		1E79761A651C453CAD0276FA /* DiscussionThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionThreadView.swift; sourceTree = "<group>"; };
+		6E4292E5B6E44215941C86AE /* DiscussionsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionsListView.swift; sourceTree = "<group>"; };
+		79B640B95186493C897B723A /* PostComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostComposerView.swift; sourceTree = "<group>"; };
+		1435004D17D84682BA71973A /* CourseEvaluationsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseEvaluationsSection.swift; sourceTree = "<group>"; };
+		2FF3D50943E74F2FB0FA5844 /* EvaluationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationFormView.swift; sourceTree = "<group>"; };
+		54C00764961C47D08D3E81CA /* EvaluationResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationResultsView.swift; sourceTree = "<group>"; };
+		5A9C93B850C1470B8EDD80F4 /* CourseFeedSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeedSection.swift; sourceTree = "<group>"; };
+		C7EDA538039A4B58AFB7F963 /* FeedChannelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelView.swift; sourceTree = "<group>"; };
+		B6E2315E98DE4E0595C568E0 /* FeedChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelsView.swift; sourceTree = "<group>"; };
+		767D634EA7C54421A5B762FC /* FeedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogic.swift; sourceTree = "<group>"; };
+		657339EC3D474DAAA0A66C9F /* FeedSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSocket.swift; sourceTree = "<group>"; };
+		E67E5F19F42C4743B164654A /* ShareFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackView.swift; sourceTree = "<group>"; };
+		62C3F47E3007496C8003BA97 /* CourseFilesSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesSocket.swift; sourceTree = "<group>"; };
+		3EBA60D42F624F89B59C7A13 /* CourseFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesView.swift; sourceTree = "<group>"; };
+		E12EC7DB66414805BFD47BEE /* FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.swift; sourceTree = "<group>"; };
+		50423B031C594FD081D8F3D3 /* MarkupOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkupOverlayView.swift; sourceTree = "<group>"; };
+		CF2B964842AE422AB1F8FE31 /* GamificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationView.swift; sourceTree = "<group>"; };
+		DE58E798DDE14728B7048B49 /* GradeFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeFeedbackView.swift; sourceTree = "<group>"; };
+		98606023BD664072A84363A2 /* WhatIfController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIfController.swift; sourceTree = "<group>"; };
+		F830C796E96842FC902C5B4A /* GradingBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradingBacklogView.swift; sourceTree = "<group>"; };
+		CD3539CFC6934AD2BB2F4EAE /* SpeedGraderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderView.swift; sourceTree = "<group>"; };
+		7EC7E1DD087A4E1489ADF74E /* CollabDocView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollabDocView.swift; sourceTree = "<group>"; };
+		E2AC07D555534757A7A76999 /* CourseCollabDocsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCollabDocsSection.swift; sourceTree = "<group>"; };
+		7A28AD16498A4136A77E5F6C /* CourseGroupsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGroupsSection.swift; sourceTree = "<group>"; };
+		E086F925E3C94E3DBF6D5B8D /* GroupSpaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSpaceView.swift; sourceTree = "<group>"; };
+		50C5179B7C504B4C9F06FE64 /* AnnouncementComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementComposerView.swift; sourceTree = "<group>"; };
+		19B357B269DD46DB9FB3C801 /* AnnouncementsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsViews.swift; sourceTree = "<group>"; };
+		9961BE2DA57F4F4ABD8656AB /* BroadcastComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastComposerView.swift; sourceTree = "<group>"; };
+		78DB00E3B5884F338081EA9C /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		903A8BB06DD34793B5FC272B /* MoreHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreHubView.swift; sourceTree = "<group>"; };
+		FC6A66930C9247509F766F7F /* ShellHeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHeaderBar.swift; sourceTree = "<group>"; };
+		B7ADBFE36AA24EB7B0908D7B /* TeachHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeachHubView.swift; sourceTree = "<group>"; };
+		4502383E9D304013A8EAB757 /* UniversalSearchPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchPlaceholder.swift; sourceTree = "<group>"; };
+		0396EAFDB8CD498F95D9E93A /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
+		A4B52603AD774852A54614C5 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
+		2B8B2EA90F7F474F93CF162D /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
+		06853E09C60842B0B32A7B61 /* DashboardInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardInsightsSection.swift; sourceTree = "<group>"; };
+		6080ADF9D3C34BBC9A31EA9B /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
+		0D8792C700AE49F4B0D8146F /* AtRiskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtRiskListView.swift; sourceTree = "<group>"; };
+		6BBD4F4A79CB4E4DBF2EE5F3 /* CourseInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseInsightsSection.swift; sourceTree = "<group>"; };
+		9AE1EBB432794F2DA01BFC0D /* StudentProgressDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentProgressDetailView.swift; sourceTree = "<group>"; };
+		6A903C2817C74B468239F028 /* WhatsWorkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsWorkingView.swift; sourceTree = "<group>"; };
+		E418402F1C0442649025F56A /* IntroCelebrationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCelebrationPresenter.swift; sourceTree = "<group>"; };
+		94E155C5C5BB47D28E97E754 /* IntroCompletionCelebrationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCompletionCelebrationSheet.swift; sourceTree = "<group>"; };
+		D0CE4282C6A94244BFF19D3C /* IntroCourseEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseEntryCard.swift; sourceTree = "<group>"; };
+		4180F25AFDF1407D98915D1C /* IntroCourseProgressRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseProgressRail.swift; sourceTree = "<group>"; };
+		5B80C1444C6A48B6A39E2FF2 /* LearnerProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileView.swift; sourceTree = "<group>"; };
+		C89023B353D84747859B117E /* LibraryBrowseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBrowseView.swift; sourceTree = "<group>"; };
+		9229467C210C4301B2D98D60 /* MeetingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailView.swift; sourceTree = "<group>"; };
+		1302D78379A34ED49391CD74 /* MeetingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListView.swift; sourceTree = "<group>"; };
+		C5EEEB959E8549A182B2DE40 /* WhiteboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardView.swift; sourceTree = "<group>"; };
+		EA6C74B0C8A24ADFA92DCB62 /* LiveGameSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameSocket.swift; sourceTree = "<group>"; };
+		9691EB7FB06A4E5DAF1ACA40 /* LiveQuizHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizHubView.swift; sourceTree = "<group>"; };
+		B65BBF0633EB45F0820C1161 /* LiveQuizPlaySurfaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlaySurfaces.swift; sourceTree = "<group>"; };
+		61FBF86F867A46CCACACAEFB /* LiveQuizPlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlayView.swift; sourceTree = "<group>"; };
+		AB840DC10A7340F085F9F10A /* MarketplaceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceDetailView.swift; sourceTree = "<group>"; };
+		68B11BF2897F4875B7A42317 /* MarketplaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceView.swift; sourceTree = "<group>"; };
+		BA2B0D06CC104264A7571102 /* MyPurchasesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPurchasesView.swift; sourceTree = "<group>"; };
+		2E773ADF53394F77BEAFB505 /* CourseMasterySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMasterySection.swift; sourceTree = "<group>"; };
+		2313BB40BCC74375989C45AC /* ReportCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCardListView.swift; sourceTree = "<group>"; };
+		62345060129B4913870E54C1 /* CourseDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDrawer.swift; sourceTree = "<group>"; };
+		6C0688DB90454A19A18E8185 /* DrawerScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScaffold.swift; sourceTree = "<group>"; };
+		4638969A0A9A4BC3AFD33B5F /* DrawerToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerToolbar.swift; sourceTree = "<group>"; };
+		0276213236EA41DD87B05021 /* GlobalDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalDrawer.swift; sourceTree = "<group>"; };
+		5685788C03E1478E8174A5CB /* NotebookDrawingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawingViews.swift; sourceTree = "<group>"; };
+		8E52B98F8D184587BFDA269B /* NotebookEditorSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorSupportViews.swift; sourceTree = "<group>"; };
+		B5408DF2B2B44228B3BEC80B /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
+		EAFF705789F14DA1A6B7774C /* NotebookPagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPagesView.swift; sourceTree = "<group>"; };
+		B43F54B92C1F4A8FB207FE48 /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
+		3BBBE5F676024C5A8546BD9E /* BookingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingSheet.swift; sourceTree = "<group>"; };
+		809FB33A0AD94818A168A9FA /* MyBookingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBookingsView.swift; sourceTree = "<group>"; };
+		6402F22622804592B0BD16AF /* OfficeHoursView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursView.swift; sourceTree = "<group>"; };
+		21416CD8DFA947858881FB67 /* DiagnosticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticView.swift; sourceTree = "<group>"; };
+		E7B8423CB03A421DB125FA7E /* OnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowView.swift; sourceTree = "<group>"; };
+		7495B658AA314BECB39FA0BC /* ConferenceBookingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceBookingView.swift; sourceTree = "<group>"; };
+		C9D4BF14581E46E1877105A7 /* MyConferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyConferencesView.swift; sourceTree = "<group>"; };
+		DF1BEB9B7C19486C90AF60B6 /* ParentAttendanceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentAttendanceDetailView.swift; sourceTree = "<group>"; };
+		028E88D3509D4581AD3B0D49 /* ParentDashboardSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardSections.swift; sourceTree = "<group>"; };
+		79E0738CB7DD4EDAAF0B898E /* ParentDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardView.swift; sourceTree = "<group>"; };
+		CBC689423511413EBBF6A2F0 /* ParentGradesDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGradesDetailView.swift; sourceTree = "<group>"; };
+		4C9913DD13854F259223B9CB /* ParentNotificationPrefsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentNotificationPrefsView.swift; sourceTree = "<group>"; };
+		20DDD4F6F0DF44B790377108 /* DashboardStudySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStudySection.swift; sourceTree = "<group>"; };
+		519A867DDBC343C2BD999131 /* MyPathsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPathsView.swift; sourceTree = "<group>"; };
+		9CFABD1859A945CFB9EE0177 /* PathLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathLandingView.swift; sourceTree = "<group>"; };
+		1C84307E2BC94C6FA15D3BDE /* PathRunnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathRunnerView.swift; sourceTree = "<group>"; };
+		2BB94EA892F64D8D9B8737C2 /* PathsCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsCatalogView.swift; sourceTree = "<group>"; };
+		5D2AD1BAB40F4D73A5DD2DBE /* PeerReviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewDetailView.swift; sourceTree = "<group>"; };
+		7F3BBE2A5AFB4B66ABFEA6C5 /* PeerReviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewListView.swift; sourceTree = "<group>"; };
+		144BCB7F170F41D9B763AE01 /* ReviewsReceivedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsReceivedView.swift; sourceTree = "<group>"; };
+		D62C5B28B5F148DAB9EAC51C /* RubricScorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricScorerView.swift; sourceTree = "<group>"; };
+		60236CCDF7AA48738D0D49FB /* CalendarSubscribeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSubscribeSheet.swift; sourceTree = "<group>"; };
+		7E3F8A9FCD1249E79F8CC819 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
+		8C606E34F9144B64A777B6FC /* ConferenceReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceReminderScheduler.swift; sourceTree = "<group>"; };
+		CAD1CE39301A41058120A843 /* DueReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DueReminderScheduler.swift; sourceTree = "<group>"; };
+		427B5B7A544441FF83DAB84F /* OfficeHoursReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursReminderScheduler.swift; sourceTree = "<group>"; };
+		35482D532A2149B080CD6765 /* PlannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModel.swift; sourceTree = "<group>"; };
+		BADAEEFB6B414AA287062F8B /* PlannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerView.swift; sourceTree = "<group>"; };
+		33C7B900B7ED4925A1869D55 /* TodosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodosView.swift; sourceTree = "<group>"; };
+		A35BC5FD1AF146CBAF2065AB /* ArtifactDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailView.swift; sourceTree = "<group>"; };
+		01E149F4B7DA48DD9F801DD0 /* ArtifactEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactEditorView.swift; sourceTree = "<group>"; };
+		5004097E1B874DDB93242DA0 /* PortfolioArtifactUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioArtifactUploader.swift; sourceTree = "<group>"; };
+		4A30B10FF37F4C73B99B56B6 /* PortfolioDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioDetailView.swift; sourceTree = "<group>"; };
+		5F1211C341964513B98889F4 /* PortfolioView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioView.swift; sourceTree = "<group>"; };
+		849FD0BE416241E8A1617D59 /* AiAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminEntryCard.swift; sourceTree = "<group>"; };
+		68F339E576E4464982A315D3 /* ArchivedCoursesAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminEntryCard.swift; sourceTree = "<group>"; };
+		269BBDA8E3F84DEA9DEA260D /* BiometricLockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricLockView.swift; sourceTree = "<group>"; };
+		72BD8DB3522843548EDB368A /* DeviceSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceSessionsView.swift; sourceTree = "<group>"; };
+		F1D7198549954D4CA1AC7026 /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
+		AF071116BC2F446789DB95AC /* IntegrationsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminEntryCard.swift; sourceTree = "<group>"; };
+		8CF54036E6B3426390D72262 /* IntegrationsEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsEntryCard.swift; sourceTree = "<group>"; };
+		F9E6FEAC28BF4ECBB2548552 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
+		292E60D74B50449DBF81B8D6 /* LearnerProfileEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileEntryCard.swift; sourceTree = "<group>"; };
+		612542398DB34253A6686424 /* MyAccommodationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccommodationsView.swift; sourceTree = "<group>"; };
+		36BBC380C7B14E1C97904F62 /* NotificationPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesView.swift; sourceTree = "<group>"; };
+		366826087F904BB7BC321C08 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+		D5CEB80575D4484FBEFD5CC5 /* OrgBrandingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminEntryCard.swift; sourceTree = "<group>"; };
+		283D9CE400334AC49AFD50AC /* OrgStructureAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminEntryCard.swift; sourceTree = "<group>"; };
+		CEFE73F8C7ED4996B392B117 /* PeopleAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminEntryCard.swift; sourceTree = "<group>"; };
+		918C26A90C7045FD93FF96C1 /* PlatformSettingsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminEntryCard.swift; sourceTree = "<group>"; };
+		90E99FC07CB54E0C96EA10BD /* ProfileDepthCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthCards.swift; sourceTree = "<group>"; };
+		5FCFBF1C1FCF47BB84AEAF38 /* ProfilePersonalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePersonalDetailsView.swift; sourceTree = "<group>"; };
+		C12BAF195789448DB078C7CF /* ProfileSecurityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSecurityCard.swift; sourceTree = "<group>"; };
+		E057149B676F46098DDDBD1A /* ProfileSettingsCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsCards.swift; sourceTree = "<group>"; };
+		A7F1FD9E84874180BAD8D5DC /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		77BF6067904E4A2087EC27CE /* ProfileViewSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewSections.swift; sourceTree = "<group>"; };
+		53305DC75B204D9C81F3585B /* ResearchStudiesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResearchStudiesView.swift; sourceTree = "<group>"; };
+		0A4320E0C0E24EB9BE1B7F58 /* RolesPermissionsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminEntryCard.swift; sourceTree = "<group>"; };
+		D5E6AEEF26D44D3EA65A25A0 /* SettingsAdminHubEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubEntryCard.swift; sourceTree = "<group>"; };
+		F67308866EF5479FA01FC732 /* ShareFeedbackEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackEntryCard.swift; sourceTree = "<group>"; };
+		8BD739C270344ADEB1A3142D /* TranscriptsAdvisingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminEntryCard.swift; sourceTree = "<group>"; };
+		F8BCD90D8A8E4EF4AFB9D583 /* CodeQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeQuestionView.swift; sourceTree = "<group>"; };
+		633C85BCCB7941E5BD24D270 /* LockdownController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockdownController.swift; sourceTree = "<group>"; };
+		7CC57DD00547498A8F4FB307 /* QuizIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizIntroView.swift; sourceTree = "<group>"; };
+		0B9DCCE9B89246218C4CE8EF /* QuizQuestionViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizQuestionViews.swift; sourceTree = "<group>"; };
+		34504285543C4C9A8CD6F5EA /* QuizResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResultsView.swift; sourceTree = "<group>"; };
+		1B81ADC20ABF47A3AD5C31F4 /* QuizTakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizTakerView.swift; sourceTree = "<group>"; };
+		41EC5757A7B946098AC5B893 /* CaptionedPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionedPlayerView.swift; sourceTree = "<group>"; };
+		CAACDFB103B9456BBC73750E /* ContentTranslationControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTranslationControls.swift; sourceTree = "<group>"; };
+		49467C0BBC9C415780029214 /* ImmersiveReaderCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersiveReaderCapabilities.swift; sourceTree = "<group>"; };
+		990F430024144399B37A91A2 /* ReaderLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogic.swift; sourceTree = "<group>"; };
+		9F495ED7A44B4C73968DA21E /* ReaderToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderToolbar.swift; sourceTree = "<group>"; };
+		BBDA47FBE9DE454C9CD75E5D /* ReadingPreferencesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesSheet.swift; sourceTree = "<group>"; };
+		D4AB029FB1A444B3BEA5D695 /* ReadingPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesStore.swift; sourceTree = "<group>"; };
+		56111FF37D29429987AB0096 /* LeveledLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeveledLibraryView.swift; sourceTree = "<group>"; };
+		3B3A83C44B84487CB01EFF3C /* LogReadingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReadingSheet.swift; sourceTree = "<group>"; };
+		9F5A6D6A50874B1FAB312EE8 /* ReadingDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardView.swift; sourceTree = "<group>"; };
+		4BBB673CA4DB420BA37B9208 /* ReviewHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHomeView.swift; sourceTree = "<group>"; };
+		A6440ADA1E9544ECBF69F85E /* ReviewReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReminderScheduler.swift; sourceTree = "<group>"; };
+		A31DE89C777B4A51887F141C /* ReviewSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionView.swift; sourceTree = "<group>"; };
+		F0A178AEF05541188021889B /* UniversalSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchView.swift; sourceTree = "<group>"; };
+		B97B6F26B6DC4092BAB78F26 /* AdminMetricCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminMetricCards.swift; sourceTree = "<group>"; };
+		DB36A44F66604F3C843C50D9 /* AdvisingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingSettingsView.swift; sourceTree = "<group>"; };
+		4C9843014D154611A7BFD0C9 /* AiAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminHubView.swift; sourceTree = "<group>"; };
+		44A56979663249C4AFE83221 /* AiGovernanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiGovernanceView.swift; sourceTree = "<group>"; };
+		889FAFAF774142C2BA86329C /* AiModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsSettingsView.swift; sourceTree = "<group>"; };
+		B3C29C92B3B24E5C86725EE7 /* AiProviderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiProviderSettingsView.swift; sourceTree = "<group>"; };
+		CA28E77314484396AB0AE64A /* AiReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiReportsView.swift; sourceTree = "<group>"; };
+		C4355CA566304FBAAB98D098 /* ArchivedCoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminView.swift; sourceTree = "<group>"; };
+		942584F491914827B95F3282 /* AuditLogAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminView.swift; sourceTree = "<group>"; };
+		88724DBA10A14C4BB795E26F /* BoardsGovernanceAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminView.swift; sourceTree = "<group>"; };
+		914CCB5EAAF34214B8885432 /* CoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesAdminView.swift; sourceTree = "<group>"; };
+		43BFDD3B36BC48A8B13DE360 /* IntegrationsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminView.swift; sourceTree = "<group>"; };
+		79E256FCB9F14A47B25202B5 /* OrgBrandingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminView.swift; sourceTree = "<group>"; };
+		B1B6653C12AF4B4395D2650A /* OrgBrandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingView.swift; sourceTree = "<group>"; };
+		9F3124434EF14E0F9A93AF28 /* OrgStructureAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminView.swift; sourceTree = "<group>"; };
+		12EEAD3B385B4D19A7EE0841 /* OrgStructureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureView.swift; sourceTree = "<group>"; };
+		41EF610BF1484F9AADE2AA95 /* PeopleAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminView.swift; sourceTree = "<group>"; };
+		FF4A03C39AFE47918DBCC377 /* PlatformSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsView.swift; sourceTree = "<group>"; };
+		F67E4C60CD8D4042A5591FEE /* RolesPermissionsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminView.swift; sourceTree = "<group>"; };
+		AE2FA99DD121458D8201C26C /* SystemPromptsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptsView.swift; sourceTree = "<group>"; };
+		D1AF5D02D2464887B58449B2 /* TermsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAdminView.swift; sourceTree = "<group>"; };
+		4D5AD5CA80204A4D9F4EDB14 /* TranscriptsAdvisingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminView.swift; sourceTree = "<group>"; };
+		12B3CD2CBADB4D5CB7B5CD36 /* TranscriptsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsSettingsView.swift; sourceTree = "<group>"; };
+		9240550142D1439DB32F9DDA /* UserDetailAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailAdminView.swift; sourceTree = "<group>"; };
+		EC90322BE577468290B4551A /* SettingsAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubView.swift; sourceTree = "<group>"; };
+		8C311030F725471CBF67D6F8 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		871BFA5C95E049CBAFEC0731 /* TutorChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatModel.swift; sourceTree = "<group>"; };
+		9452C8D2829F4FB6B21CAB26 /* TutorChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatView.swift; sourceTree = "<group>"; };
+		3CAB6ED9091E4B3E94718267 /* TutorFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorFlowLayout.swift; sourceTree = "<group>"; };
+		A66A524C7AAC4FB2B017F128 /* TutorLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLauncher.swift; sourceTree = "<group>"; };
+		F9F9005EEE2744EBB7D096EC /* WalletCCRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCCRDetailView.swift; sourceTree = "<group>"; };
+		0BF4CF0A377A4ED5B3DC1AA0 /* WalletCETranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCETranscriptDetailView.swift; sourceTree = "<group>"; };
+		7AACA18723DA4543805BE85B /* WalletOfficialTranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletOfficialTranscriptDetailView.swift; sourceTree = "<group>"; };
+		A9F06C20D3B941B69051DDA0 /* WalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletView.swift; sourceTree = "<group>"; };
+		373523C32EB949A5B9CAA82A /* AccessibilitySupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupportTests.swift; sourceTree = "<group>"; };
+		5A13B3495F1F4A4F819B53AF /* AccountIntegrationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogicTests.swift; sourceTree = "<group>"; };
+		865591C44DA943BAAF006BA8 /* AdvisingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogicTests.swift; sourceTree = "<group>"; };
+		3CCE179E631F4F1587E17C1A /* AiModelsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogicTests.swift; sourceTree = "<group>"; };
+		49FF81B2344C47318DA46DEA /* AnnouncementLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogicTests.swift; sourceTree = "<group>"; };
+		6B763FBAF0F348CEA7B7F700 /* AppleSignInLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInLogicTests.swift; sourceTree = "<group>"; };
+		33B046C3491242F78AFC62B5 /* ArchivedCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
+		ACBA7D88E4324BAA8C417F29 /* AssignmentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogicTests.swift; sourceTree = "<group>"; };
+		2D03F861BB2F42CFA59E0822 /* AuditLogAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogicTests.swift; sourceTree = "<group>"; };
+		8BBC569F456A4BD3B900F0B4 /* AuthCallbackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParserTests.swift; sourceTree = "<group>"; };
+		54F482AACC614C47BB93AC3A /* BehaviorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogicTests.swift; sourceTree = "<group>"; };
+		AFFB9831EC6A4D94810B09A2 /* BillingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogicTests.swift; sourceTree = "<group>"; };
+		A7E50B8DE72E4B06BF467B31 /* BiometricGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGateTests.swift; sourceTree = "<group>"; };
+		5BFF89736CCA439C94F43B27 /* BoardsAdvancedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogicTests.swift; sourceTree = "<group>"; };
+		39F97E50BCA747C9BD1D9FA2 /* BoardsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogicTests.swift; sourceTree = "<group>"; };
+		38FC3FBB11F247FBA7765A55 /* CanvasImportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogicTests.swift; sourceTree = "<group>"; };
+		805240352A4542E6B904D4AC /* CatalogLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogicTests.swift; sourceTree = "<group>"; };
+		E480CDFCB0E5428393B4648B /* ConferenceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogicTests.swift; sourceTree = "<group>"; };
+		F21EB256086B4484BE067D42 /* CourseAccessibilityReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogicTests.swift; sourceTree = "<group>"; };
+		550DA196AE6B43B6B903B0FA /* CourseArchivedContentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogicTests.swift; sourceTree = "<group>"; };
+		C86F2841498A4C32AA7093AA /* CourseBlueprintLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogicTests.swift; sourceTree = "<group>"; };
+		A9D1F7E879D54243A4DA10E1 /* CourseCreateLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogicTests.swift; sourceTree = "<group>"; };
+		47E7A2D79A0A47F1ABD4C3AC /* CourseFeaturesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogicTests.swift; sourceTree = "<group>"; };
+		16533B0965BB4F4DA160F03E /* CourseFileModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileModelsTests.swift; sourceTree = "<group>"; };
+		566A8F4AA7BB49848E5D5552 /* CourseGradingAgentsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogicTests.swift; sourceTree = "<group>"; };
+		CAF4C3297E884354ADDEDFC6 /* CourseGradingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogicTests.swift; sourceTree = "<group>"; };
+		B2A6BF2D82C24B07A02D4F16 /* CourseImportExportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogicTests.swift; sourceTree = "<group>"; };
+		E4FD447ED651463297DB49D6 /* CourseOutcomesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogicTests.swift; sourceTree = "<group>"; };
+		A19A901DA16C44A98BCFC878 /* CoursePeopleLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogicTests.swift; sourceTree = "<group>"; };
+		F2E96F164ACF476A90625A44 /* CoursePlagiarismLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogicTests.swift; sourceTree = "<group>"; };
+		E7FC803557FA400798E517D6 /* CourseReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogicTests.swift; sourceTree = "<group>"; };
+		B15DCDA7BE5F4D968FD8C654 /* CourseSectionsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogicTests.swift; sourceTree = "<group>"; };
+		CEDD54F128A34514B52E92C3 /* CourseSettingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogicTests.swift; sourceTree = "<group>"; };
+		2A9DE4A71F4B41C1A155FAA9 /* CourseTranslationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogicTests.swift; sourceTree = "<group>"; };
+		70C40E4D7ACF46108CCE6999 /* CredentialsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogicTests.swift; sourceTree = "<group>"; };
+		E0EF8D14F18747E4B15D7672 /* DiscussionLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogicTests.swift; sourceTree = "<group>"; };
+		262B5F96B46D4D66AB310255 /* EvaluationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogicTests.swift; sourceTree = "<group>"; };
+		D43ECD1F3A5847A08AA8D7AE /* FeedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogicTests.swift; sourceTree = "<group>"; };
+		32EDCFA8D4C441EC8D01E20E /* FeedbackLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogicTests.swift; sourceTree = "<group>"; };
+		FB4F84C218644FC898D5E1A5 /* GamificationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogicTests.swift; sourceTree = "<group>"; };
+		59A73FC830CB4D27A8DD4B25 /* GradeCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculatorTests.swift; sourceTree = "<group>"; };
+		70912832963940B79AFA8373 /* GroupsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogicTests.swift; sourceTree = "<group>"; };
+		D4DF14D128D64FE3913D78F3 /* I18nTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18nTests.swift; sourceTree = "<group>"; };
+		A0686994B5D846CF87F347DF /* InsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogicTests.swift; sourceTree = "<group>"; };
+		FBF2B2D6C6B44BC2866C2D93 /* InstructorInsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogicTests.swift; sourceTree = "<group>"; };
+		FF38019511514A39A5938F26 /* IntegrationsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogicTests.swift; sourceTree = "<group>"; };
+		2BD8FA95ACA24505AAD62EE7 /* InteractiveLaunchLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogicTests.swift; sourceTree = "<group>"; };
+		8F44242ADD2F4D4384FB8217 /* IntroCourseLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogicTests.swift; sourceTree = "<group>"; };
+		F74498D27D0A423F9F710088 /* LearnerProfileLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogicTests.swift; sourceTree = "<group>"; };
+		0D31802C470C412595FA718E /* LexturesMotionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotionTests.swift; sourceTree = "<group>"; };
+		2BF702B17A3744F4AE9A21DB /* LibraryResourceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogicTests.swift; sourceTree = "<group>"; };
+		14872F45A72248E591C80A5C /* LiveMeetingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogicTests.swift; sourceTree = "<group>"; };
+		71B152116F1844EA939CD2B0 /* LiveQuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogicTests.swift; sourceTree = "<group>"; };
+		4BAEFB24E3C34525BC2F040B /* MarketplaceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogicTests.swift; sourceTree = "<group>"; };
+		53E6ECF6C15C455F86415C69 /* MasteryLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogicTests.swift; sourceTree = "<group>"; };
+		A9D65C9AD65F4155AC1B2C74 /* MobileDestinationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinationsTests.swift; sourceTree = "<group>"; };
+		D553BFCCA75D4ADDB8E03FDA /* ModuleContentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentModelsTests.swift; sourceTree = "<group>"; };
+		DE8A5CE055EE4CBB875FFC50 /* NotificationModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModelsTests.swift; sourceTree = "<group>"; };
+		6453702A8CC84167A99D06FC /* OfficeHoursLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogicTests.swift; sourceTree = "<group>"; };
+		5A17E2E10AB14AF1A4BC0A20 /* OnboardingModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModelsTests.swift; sourceTree = "<group>"; };
+		5E7C6AF633234B11B05AC8B3 /* OrgBrandingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogicTests.swift; sourceTree = "<group>"; };
+		3030AF2E57974257827BCD97 /* OrgStructureAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogicTests.swift; sourceTree = "<group>"; };
+		114DE315F90F46428790C499 /* ParentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogicTests.swift; sourceTree = "<group>"; };
+		5B278631504942649E2B10A7 /* PathsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogicTests.swift; sourceTree = "<group>"; };
+		ABE0AAD7BE7F4DE4A0E2E97E /* PeerReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogicTests.swift; sourceTree = "<group>"; };
+		E780269A3774488C96081F4D /* PeopleAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogicTests.swift; sourceTree = "<group>"; };
+		B1122C950BA74EC3B0F4C4BA /* PeopleAdminMetricsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminMetricsLogicTests.swift; sourceTree = "<group>"; };
+		201E3DED9B6B4C7D9E3CDBA1 /* PlannerModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModelsTests.swift; sourceTree = "<group>"; };
+		3ADE113A4F7D4363B71AAB5D /* PlatformCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
+		4E20A89C03B34AE681FE9B7C /* PlatformSettingsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogicTests.swift; sourceTree = "<group>"; };
+		F6BFD385E20E4874B208B6E8 /* PortfolioLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogicTests.swift; sourceTree = "<group>"; };
+		ED465D36A86D429D8D927E4D /* ProfileDepthLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogicTests.swift; sourceTree = "<group>"; };
+		5BF03A123F79457888EEB315 /* QuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogicTests.swift; sourceTree = "<group>"; };
+		D59CEBA182BF44B2BE3FCADD /* ReaderLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogicTests.swift; sourceTree = "<group>"; };
+		B82D214349F34003A916A5BD /* ReadingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogicTests.swift; sourceTree = "<group>"; };
+		583B845B981A489A80BD757D /* RequirementsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogicTests.swift; sourceTree = "<group>"; };
+		164416E4C983431883516796 /* ReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLogicTests.swift; sourceTree = "<group>"; };
+		C6C08E0BEB834A3EB334C08A /* RolesPermissionsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogicTests.swift; sourceTree = "<group>"; };
+		232FFCED0306441FA66F4EB3 /* SchoolCodeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogicTests.swift; sourceTree = "<group>"; };
+		B291A3D998D4494EB5BF4F69 /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
+		DBB038F7ADFA40A0958FCA12 /* SettingsAccommodationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccommodationsTests.swift; sourceTree = "<group>"; };
+		A0C23C8D85854FB8A73C1AE1 /* SettingsMenuLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogicTests.swift; sourceTree = "<group>"; };
+		8D33288F5C5A4CC4967D0503 /* TakeAttendanceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogicTests.swift; sourceTree = "<group>"; };
+		1A1410FB35F44CC4B312DD2A /* TranscriptsAdvisingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogicTests.swift; sourceTree = "<group>"; };
+		C4BC8DA818EC4DBEB21CB6A3 /* TutorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogicTests.swift; sourceTree = "<group>"; };
+		77D38DC81AAE47D78174340E /* UIModeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIModeLogicTests.swift; sourceTree = "<group>"; };
+		3DECA44A9D514EB9B68544FB /* VibeActivityLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogicTests.swift; sourceTree = "<group>"; };
+		04481C8E09DD46DB93EA9D47 /* WalletLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogicTests.swift; sourceTree = "<group>"; };
+		6C2F1DCD549844B092CD0466 /* WhiteboardLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogicTests.swift; sourceTree = "<group>"; };
+		F1D492B110A3479A86B62F45 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6678AEC9159340A695FD20AD /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		D332EEC5808342AEBD540892 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		399F75F7EF59410184CBA37C /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		8EF0D9ADBE7346B5A68E4717 /* Frameworks */ = {
+		28DFD09374804ACA94378472 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
+			runOnlyForDeploymentPostprocessing = 0;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BDE4E5309997457083163CAF /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		027B6869EE014770A03FA833 /* Billing */ = {
+		229B30A95B9B4F4894F99558 /* Lextures */ = {
 			isa = PBXGroup;
 			children = (
-				2B69A18DEB4845679ACC432E /* BillingView.swift */,
-				5046D83BAA2F43A2B50F3C01 /* CheckoutReturnHandler.swift */,
-				2B3550FF35F84CD5BEC85D1C /* PurchaseFlow.swift */,
-			);
-			path = Billing;
-			sourceTree = "<group>";
-		};
-		074295BAE653445AA91FB9F4 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				E87C8E6C2A4C410D924FE3B4 /* Accessibility */,
-				B1BFE5F2E52042FEB09A6275 /* Auth */,
-				E6962D0C3B40464F822596DA /* Config */,
-				4BDEA0AFBF1D4C31BE39C262 /* Design */,
-				27749EA7EB10427DBB57C957 /* I18n */,
-				630BADA95788483A83E3459C /* LMS */,
-				8DD5AD50C6A34E0EA83FAE41 /* Networking */,
-				B93AACD62BBD44FA928F1AC9 /* Notebook */,
-				7D19CD69E63A4B8BB597C2E5 /* Offline */,
-				81670F744CC94D25A7F0AA32 /* Push */,
-				8DB491D21D83410F97315F3B /* Realtime */,
-				30218B4D815541DBA2F7F112 /* Routing */,
-				73EA32457EF947B4AB07D15B /* Search */,
-				9BF705F0511F4FE394BDF1EB /* UI */,
-			);
-			path = Core;
-			sourceTree = "<group>";
-		};
-		0BBA7498B7F045D2AB2C13E1 /* Home */ = {
-			isa = PBXGroup;
-			children = (
-				E991BA3545AB4BC385CE6C61 /* AnnouncementComposerView.swift */,
-				F6F0CC36B0D345C2A65A5BCB /* AnnouncementsViews.swift */,
-				465192747C534F43B060EC6B /* BroadcastComposerView.swift */,
-				DED2D76C465F4BD3A914E66F /* MainTabView.swift */,
-				04FF8C29DFDB4864A97108C4 /* MoreHubView.swift */,
-				637BB24D553749F082807972 /* ShellHeaderBar.swift */,
-				3CCBB607EB6E46AFB189E9DB /* TeachHubView.swift */,
-				F8105C3C25FB4042BF1C0D5F /* UniversalSearchPlaceholder.swift */,
-			);
-			path = Home;
-			sourceTree = "<group>";
-		};
-		0D19BF8F16B84EDDB26640E0 /* Profile */ = {
-			isa = PBXGroup;
-			children = (
-				4CE3F78583244C0A93866713 /* AiAdminEntryCard.swift */,
-				DED5945B8F2F4E24ABA319D9 /* ArchivedCoursesAdminEntryCard.swift */,
-				9B6F89F9E8DE46B6A9B578C7 /* BiometricLockView.swift */,
-				32B9C62DD66C4A6BA003B1E1 /* DeviceSessionsView.swift */,
-				EC286797DB05465394303FE5 /* EditProfileView.swift */,
-				DBC9A2DB205E407EA3EE4C4A /* IntegrationsAdminEntryCard.swift */,
-				ABBDFEA71D5348138DDD69DA /* IntegrationsEntryCard.swift */,
-				FAC032FFE898494AAE5AD290 /* IntegrationsView.swift */,
-				240D0977D3CB497F9CCE0202 /* LearnerProfileEntryCard.swift */,
-				B43743C8A7CD4D20AE020BE1 /* MyAccommodationsView.swift */,
-				CC9E51F3B6C244E5825F2FDC /* NotificationPreferencesView.swift */,
-				64AB7C2F52454D92AD0A2C92 /* NotificationsView.swift */,
-				49DFAF51AD274252905975DE /* OrgBrandingAdminEntryCard.swift */,
-				0D5F89E5B4424EB0BA488C06 /* OrgStructureAdminEntryCard.swift */,
-				7894ED56BEAE4FFA8F993DF6 /* PeopleAdminEntryCard.swift */,
-				313C6A1E76CE4919943436F5 /* PlatformSettingsAdminEntryCard.swift */,
-				D0A45DEFCF3A452B878ED663 /* ProfileDepthCards.swift */,
-				EAC4CDCB033A463DA0A746E2 /* ProfilePersonalDetailsView.swift */,
-				30A51A7141A04A35853163AC /* ProfileSecurityCard.swift */,
-				F187B38EA4C4471788C5E79A /* ProfileSettingsCards.swift */,
-				D2D394A203B748D98B1B875F /* ProfileView.swift */,
-				723ADB534980465A86521896 /* ProfileViewSections.swift */,
-				F59A779E94104C6FB2954401 /* ResearchStudiesView.swift */,
-				1AC54A0C4908441CA4EA494D /* RolesPermissionsAdminEntryCard.swift */,
-				E561164FBBA14C149AF35828 /* SettingsAdminHubEntryCard.swift */,
-				4B5882273D98498585C2F544 /* ShareFeedbackEntryCard.swift */,
-				AFD0F17DDF344DF38730C3D6 /* TranscriptsAdvisingAdminEntryCard.swift */,
-			);
-			path = Profile;
-			sourceTree = "<group>";
-		};
-		0D56DC70048340BBBACC402A /* Feed */ = {
-			isa = PBXGroup;
-			children = (
-				8506C9F6826D472A81CE4394 /* CourseFeedSection.swift */,
-				6F039D646CDE4631BA5F4F4F /* FeedChannelView.swift */,
-				71E16F188C46420487CB8AD0 /* FeedChannelsView.swift */,
-				B39A6C065DBD48999414206D /* FeedLogic.swift */,
-				F467FA654D6E4F58A25DFCBB /* FeedSocket.swift */,
-			);
-			path = Feed;
-			sourceTree = "<group>";
-		};
-		0E29332E8DC140DA88322793 /* Splash */ = {
-			isa = PBXGroup;
-			children = (
-				648A52DA434F46EA8E2C9636 /* SplashView.swift */,
-			);
-			path = Splash;
-			sourceTree = "<group>";
-		};
-		0E4FE3FCE5DE4DF4996EAE37 /* Lextures */ = {
-			isa = PBXGroup;
-			children = (
-				3F174484341E432E8DCE7C66 /* Resources */,
-				32FDD9FBD1D54B1A9A2F4F32 /* App */,
-				074295BAE653445AA91FB9F4 /* Core */,
-				2296BCD30E3445ADBECE5071 /* Features */,
+				A57DBE192A5549CEB700D64B /* Resources */,
+				2E4D604D3217464FB7714146 /* App */,
+				D4FD305EE8564D5CAEE9C2C1 /* Core */,
+				BF3A1AF775F745A09D339A54 /* Features */,
 			);
 			path = Lextures;
 			sourceTree = "<group>";
 		};
-		114EE575F6AC48169415144F /* Grades */ = {
+		06964482C25142FFB07CE05C /* LexturesTests */ = {
 			isa = PBXGroup;
 			children = (
-				4BD084088C724283AC56BFCD /* GradeFeedbackView.swift */,
-				C5519F8BD0DD462CAE1644A4 /* WhatIfController.swift */,
-			);
-			path = Grades;
-			sourceTree = "<group>";
-		};
-		1856B34A25924BA6A4512BE2 /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-				68CC6E171D1E4F0B8835516F /* AppleSignInController.swift */,
-				4DD1261709BF44839AA1260B /* AuthFlowView.swift */,
-				2271CD0EF66D45C0AFEEF21D /* GetStartedView.swift */,
-				9F62442A38E64FFCBB19CDB7 /* LoginView.swift */,
-				8E40DCAB8ADF428C916AB163 /* MFAChallengeView.swift */,
-				4B233796BCC544B687DE6F83 /* MfaPasskeyController.swift */,
-				694B3CE6841D49A0A0534073 /* SSOAuthController.swift */,
-				892AD94103F8491FB5EB73D8 /* SignupView.swift */,
-			);
-			path = Auth;
-			sourceTree = "<group>";
-		};
-		1FA14959D1654245A5F8A3F1 /* Layouts */ = {
-			isa = PBXGroup;
-			children = (
-				40D928A1285449689FE64A0A /* CanvasLayout.swift */,
-				6C744D517A0C43CC92157CEE /* ColumnsLayout.swift */,
-				49CD21D146CC427BA8F4DB93 /* MapLayout.swift */,
-				91374B24492642BCB4E88D1B /* TimelineLayout.swift */,
-				40D90C8248E34AC48BA0EDE8 /* WallLayout.swift */,
-			);
-			path = Layouts;
-			sourceTree = "<group>";
-		};
-		2296BCD30E3445ADBECE5071 /* Features */ = {
-			isa = PBXGroup;
-			children = (
-				A4C909628E8D440DB30483D1 /* Advising */,
-				9CFA731B2E7B445F85B8E4E6 /* Assignments */,
-				1856B34A25924BA6A4512BE2 /* Auth */,
-				3282E3DF15774146B3037B83 /* Behavior */,
-				027B6869EE014770A03FA833 /* Billing */,
-				59F5FB7E76A1495D82BA2ADF /* Boards */,
-				3FD46E5477FA4ECF827DBD62 /* Catalog */,
-				B73D391B99F7425C893C05C6 /* Courses */,
-				BDFE461876724F299562F3D7 /* Credentials */,
-				AC4005CB9E8840DBACB24094 /* Dashboard */,
-				E11399A78C494CCC80D541A8 /* Discussions */,
-				BB48E7135AB2460797165E93 /* Evaluations */,
-				0D56DC70048340BBBACC402A /* Feed */,
-				4AC2421AFE764EDB8E8823A9 /* Feedback */,
-				37F4BA939D254F49A7F4507B /* Files */,
-				790E9D7289F34AA9990BA549 /* Gamification */,
-				114EE575F6AC48169415144F /* Grades */,
-				AA9538CD491D464E9FA7CE86 /* Grading */,
-				3075D8B8DCFF49C195A4B293 /* Groups */,
-				0BBA7498B7F045D2AB2C13E1 /* Home */,
-				302756CC6B2045DE94389E52 /* Inbox */,
-				ECF8219BF4634EB5A5CE32D5 /* Insights */,
-				5408075553D04DDCAB6B59BE /* InstructorInsights */,
-				8A4C2094A0684D80AACBBDEA /* IntroCourse */,
-				C30D7B6C6236438CA122B11D /* LearnerProfile */,
-				82943090C9C441B98C4B2A7A /* Library */,
-				9DC8FAC5008F4827AA1BC4DE /* Live */,
-				7334947EAAA04E50B4BC0D6F /* LiveQuiz */,
-				4B5390FB64304AD69F3F53AA /* Marketplace */,
-				A5B83118DA8A4BDD8A114224 /* Mastery */,
-				49D9968F02784638A409AFFE /* Navigation */,
-				5BECC6CC8D824BEF8EEC47A7 /* Notebooks */,
-				87A1CFDA865E4E9BAF3EE215 /* OfficeHours */,
-				7493F482C80C4F8EB57F5DD8 /* Onboarding */,
-				72742C24C2D649508686F4DA /* Parent */,
-				8D909F4188D04FA78370CDB1 /* Paths */,
-				B53FA372CE584C278AD8519C /* PeerReview */,
-				5EEF5933279249E498241AB7 /* Planner */,
-				E186BDD1AF8E4310BE0718E7 /* Portfolio */,
-				0D19BF8F16B84EDDB26640E0 /* Profile */,
-				9C66BA6BB5C9481198F7C937 /* Quiz */,
-				2631920A1F3E44FB920C82BE /* Reader */,
-				4D4EC867C0EE409F8E475B44 /* Reading */,
-				BE187FC1E4CE4CA6851BC5B2 /* Review */,
-				A40B98CB398C40499147421C /* Search */,
-				389375EBE5AE41D7A5F061B7 /* Settings */,
-				0E29332E8DC140DA88322793 /* Splash */,
-				54A0B88C37994302840EE94A /* Tutor */,
-				975688E3FFC1471592D9BD6A /* Wallet */,
-			);
-			path = Features;
-			sourceTree = "<group>";
-		};
-		2631920A1F3E44FB920C82BE /* Reader */ = {
-			isa = PBXGroup;
-			children = (
-				62644DCDC2764C268460E21A /* CaptionedPlayerView.swift */,
-				615EF6F7090B489EA056E254 /* ContentTranslationControls.swift */,
-				8B5D9232E0D949B1AE165711 /* ImmersiveReaderCapabilities.swift */,
-				40AF719197EF4E2890D94BFD /* ReaderLogic.swift */,
-				64303C4AF6544D0CB0E892DB /* ReaderToolbar.swift */,
-				A65FBEB6E44745D48D2CBB62 /* ReadingPreferencesSheet.swift */,
-				E76CCF94A8004D79A1A51F20 /* ReadingPreferencesStore.swift */,
-			);
-			path = Reader;
-			sourceTree = "<group>";
-		};
-		27749EA7EB10427DBB57C957 /* I18n */ = {
-			isa = PBXGroup;
-			children = (
-				CED83CBC0CCA40219F4F2D41 /* DateFormatting.swift */,
-				2F90EFE7623642A7A924062F /* LocaleAPI.swift */,
-				EF5CD5F306E14A0795C85D3F /* LocalePreferences.swift */,
-				3B6100991B98475EA6F3E955 /* Localized.swift */,
-			);
-			path = I18n;
-			sourceTree = "<group>";
-		};
-		30218B4D815541DBA2F7F112 /* Routing */ = {
-			isa = PBXGroup;
-			children = (
-				11E19E2D4DAE44EE97DA583C /* ContentLinkRouter.swift */,
-				8E5714502F0C4952B43A0969 /* DeepLinkRouter.swift */,
-				81EA2F1D66A6499B8343CCE3 /* MobileDestinations.swift */,
-				DBF4E68A7EFD4FE7A3E90097 /* MobileIaPreferences.swift */,
-				4AF4DDCB19714EE3920D1984 /* MobileProfileDepthPreferences.swift */,
-			);
-			path = Routing;
-			sourceTree = "<group>";
-		};
-		302756CC6B2045DE94389E52 /* Inbox */ = {
-			isa = PBXGroup;
-			children = (
-				6B3D2D2779EA474EBEA0EF8C /* ComposeMessageView.swift */,
-				782888F21CBE4F09860D4AE5 /* InboxView.swift */,
-				D551415EA1FA4987A692152F /* MessageDetailView.swift */,
-			);
-			path = Inbox;
-			sourceTree = "<group>";
-		};
-		3075D8B8DCFF49C195A4B293 /* Groups */ = {
-			isa = PBXGroup;
-			children = (
-				CCADC30404644DCCB14F7CF5 /* CollabDocView.swift */,
-				F235B995F649415F8E39B499 /* CourseCollabDocsSection.swift */,
-				50B73CD6651445D8BA65B37A /* CourseGroupsSection.swift */,
-				557C836ABA0F405BA0BA8274 /* GroupSpaceView.swift */,
-			);
-			path = Groups;
-			sourceTree = "<group>";
-		};
-		3282E3DF15774146B3037B83 /* Behavior */ = {
-			isa = PBXGroup;
-			children = (
-				DB52324C18734849B0964957 /* BehaviorRosterView.swift */,
-				BCD19D41247C463A95E4F3F4 /* HallPassView.swift */,
-				43DF7A75D2F5426A9F1E024F /* MyHallPassView.swift */,
-			);
-			path = Behavior;
-			sourceTree = "<group>";
-		};
-		32FDD9FBD1D54B1A9A2F4F32 /* App */ = {
-			isa = PBXGroup;
-			children = (
-				78059E120F4442BE99182CA5 /* AppDelegate.swift */,
-				8251DF9545D842B18E522D83 /* LexturesApp.swift */,
-				070F6C739E7B45298D747A0F /* RootView.swift */,
-			);
-			path = App;
-			sourceTree = "<group>";
-		};
-		37F4BA939D254F49A7F4507B /* Files */ = {
-			isa = PBXGroup;
-			children = (
-				297CEFFC74494B8595F618C1 /* CourseFilesSocket.swift */,
-				020F6153ECD64C1EA66A5402 /* CourseFilesView.swift */,
-				22F14CDD80314E2496D1007F /* FilePreviewView.swift */,
-				9FE949E1B6E74D0F88D2EFB9 /* MarkupOverlayView.swift */,
-			);
-			path = Files;
-			sourceTree = "<group>";
-		};
-		389375EBE5AE41D7A5F061B7 /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				45F5F4C9973B45CBA7C299C0 /* Admin */,
-				644B81595D4A419AB600062F /* SettingsAdminHubView.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		3F174484341E432E8DCE7C66 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				1882D9B3000C4B87B0033111 /* Assets.xcassets */,
-				5FEFA96C5EB24052B0050712 /* Localizable.xcstrings */,
-				62432DC303004EB1A855EFAB /* Info.plist */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		3FD46E5477FA4ECF827DBD62 /* Catalog */ = {
-			isa = PBXGroup;
-			children = (
-				5D83CC2AB82D4112A681BF79 /* CatalogView.swift */,
-				E2FFEC5BD1A44C7D9086AFCF /* CourseLandingView.swift */,
-				B4EB0008863344FBB6D12DD1 /* ReviewComposer.swift */,
-			);
-			path = Catalog;
-			sourceTree = "<group>";
-		};
-		45F5F4C9973B45CBA7C299C0 /* Admin */ = {
-			isa = PBXGroup;
-			children = (
-				C0A1F002C0URSESADM1N01 /* CoursesAdminView.swift */,
-				C0A1F001ADM1NMETR1C001 /* AdminMetricCards.swift */,
-				D350AD0B0A59450F897F8526 /* AdvisingSettingsView.swift */,
-				347F90498E3C41F9864483A5 /* AiAdminHubView.swift */,
-				F71BDC82DDF14C3E8F5AD1BE /* AiGovernanceView.swift */,
-				AECAFA063878407F86C7AE46 /* AiModelsSettingsView.swift */,
-				A997C2E681E14B0E86E1FF00 /* AiProviderSettingsView.swift */,
-				97E0CE51BDA342C7B099E9A8 /* AiReportsView.swift */,
-				4AAED5AF179C46369218ABFF /* ArchivedCoursesAdminView.swift */,
-				E981A936247546DDAB493E9B /* AuditLogAdminView.swift */,
-				45A87EB3831A4D58834A404D /* BoardsGovernanceAdminView.swift */,
-				CB248334F51E4753BD8F22EC /* IntegrationsAdminView.swift */,
-				92CA6F2ABD004BB7A7F2DCF3 /* OrgBrandingAdminView.swift */,
-				11B7258426C748C9A0963E97 /* OrgBrandingView.swift */,
-				8AC78C8052ED4603B861F8F4 /* OrgStructureAdminView.swift */,
-				25EBE6EBF35344B88F675AC3 /* OrgStructureView.swift */,
-				0D4560C89AB641FE9EAB8247 /* PeopleAdminView.swift */,
-				72AAB74BD74D449794D722DE /* PlatformSettingsView.swift */,
-				1666B71154D94DEA9810E776 /* RolesPermissionsAdminView.swift */,
-				A299331660DE48E19E79E2EB /* SystemPromptsView.swift */,
-				668F646A938C431F9B20C7C3 /* TermsAdminView.swift */,
-				A6284CF037D04D2E8BA40A82 /* TranscriptsAdvisingAdminView.swift */,
-				F71FB03292EB479498E7C037 /* TranscriptsSettingsView.swift */,
-				CA2E44F6E66F42A8A779A6F8 /* UserDetailAdminView.swift */,
-			);
-			path = Admin;
-			sourceTree = "<group>";
-		};
-		49D9968F02784638A409AFFE /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				99582A786E0C487C9B97290C /* CourseDrawer.swift */,
-				6BCEA38143AB4CF89C166D39 /* DrawerScaffold.swift */,
-				B972F34DA69F49E59B3D03BD /* DrawerToolbar.swift */,
-				9130A525300541639EDC6BF7 /* GlobalDrawer.swift */,
-			);
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		4AC2421AFE764EDB8E8823A9 /* Feedback */ = {
-			isa = PBXGroup;
-			children = (
-				04E31B7BEE5E4E86AF1E1C02 /* ShareFeedbackView.swift */,
-			);
-			path = Feedback;
-			sourceTree = "<group>";
-		};
-		4B5390FB64304AD69F3F53AA /* Marketplace */ = {
-			isa = PBXGroup;
-			children = (
-				8FEC8E71FF2547BB9A2A2115 /* MarketplaceDetailView.swift */,
-				2E78A8DCB3D94B559F5A54F3 /* MarketplaceView.swift */,
-				B12A8567D2FD4F96A46A78C9 /* MyPurchasesView.swift */,
-			);
-			path = Marketplace;
-			sourceTree = "<group>";
-		};
-		4BDEA0AFBF1D4C31BE39C262 /* Design */ = {
-			isa = PBXGroup;
-			children = (
-				FA7F372F388643E186403729 /* AuthFieldRepresentable.swift */,
-				1B0F185E5E3B4478B06AA959 /* BrandLogoView.swift */,
-				296DA335A83B4D89A5E3627B /* Haptics.swift */,
-				D81BD291938946D2B18D20F9 /* LexturesMotion.swift */,
-				E200FDE72EBE45E695A23ABD /* LexturesTheme.swift */,
-				C4E1D67CF59949ED8000FA8C /* LexturesType.swift */,
-				E11BE50906624153A159A9F0 /* ProfileAvatarView.swift */,
-				2A66CC7AA25B4A5EB14CBA22 /* SyncStatusView.swift */,
-				3D487ABD3C434B2BAF2F4156 /* ThemePreference.swift */,
-				9F3FB578E5284EC9A48F5A1E /* UIMode.swift */,
-				3768F85B792C4240B933C599 /* UnsavedChangesBanner.swift */,
-			);
-			path = Design;
-			sourceTree = "<group>";
-		};
-		4D4EC867C0EE409F8E475B44 /* Reading */ = {
-			isa = PBXGroup;
-			children = (
-				E0E7205FF51040FCB72CBF82 /* LeveledLibraryView.swift */,
-				D63C8BCE65AE45F9A02332C7 /* LogReadingSheet.swift */,
-				795D3DC0AE54485C94EC51BE /* ReadingDashboardView.swift */,
-			);
-			path = Reading;
-			sourceTree = "<group>";
-		};
-		5408075553D04DDCAB6B59BE /* InstructorInsights */ = {
-			isa = PBXGroup;
-			children = (
-				CA88F6127DEA4B3298045809 /* AtRiskListView.swift */,
-				C48A86F51A83443090DAAD20 /* CourseInsightsSection.swift */,
-				586AB25CB90C40D69E0DAE6D /* StudentProgressDetailView.swift */,
-				AE3ECBF38B134BCBAFE1BECF /* WhatsWorkingView.swift */,
-			);
-			path = InstructorInsights;
-			sourceTree = "<group>";
-		};
-		54A0B88C37994302840EE94A /* Tutor */ = {
-			isa = PBXGroup;
-			children = (
-				03FEF491388147718568247F /* TutorChatModel.swift */,
-				51FB7231D19640CBBFC5BF0C /* TutorChatView.swift */,
-				DE97C894473F4880BF6E4146 /* TutorFlowLayout.swift */,
-				CA87ABBDD9C04C21B75E1AB9 /* TutorLauncher.swift */,
-			);
-			path = Tutor;
-			sourceTree = "<group>";
-		};
-		57178DF3D8B24E09AFB5D058 /* LexturesTests */ = {
-			isa = PBXGroup;
-			children = (
-				C0A1F006PE0PLEMETR1C01 /* PeopleAdminMetricsLogicTests.swift */,
-				C0A1F005PLATCRSTEST001 /* PlatformCoursesAdminLogicTests.swift */,
-				4DFAFCB274D143E49E22EF3F /* AccessibilitySupportTests.swift */,
-				6C1A952B8DE848359F5BE2B7 /* AccountIntegrationsLogicTests.swift */,
-				A99FC059348942538237B214 /* AdvisingLogicTests.swift */,
-				6F1607A9155C488EBDACD2AD /* AiModelsAdminLogicTests.swift */,
-				37018A24C2F34F659FA49BA9 /* AnnouncementLogicTests.swift */,
-				765ABC1C76234576883D0A1D /* AppleSignInLogicTests.swift */,
-				FA969D6F8EDD4E3E93C80B2B /* ArchivedCoursesAdminLogicTests.swift */,
-				6DAD6803550D45479F900217 /* AssignmentLogicTests.swift */,
-				D1886274024544B18C648429 /* AuditLogAdminLogicTests.swift */,
-				E704138E9AFA40C68C28E541 /* AuthCallbackParserTests.swift */,
-				F457C4A9A120463BBD81621A /* BehaviorLogicTests.swift */,
-				04E04D370DCA4C4595C4A250 /* BillingLogicTests.swift */,
-				713361602A46405A9A79A692 /* BiometricGateTests.swift */,
-				445772B2379849AEAED2E890 /* BoardsAdvancedLogicTests.swift */,
-				5D07E28ABBB84F81A39AA430 /* BoardsLogicTests.swift */,
-				6613F6EF4E9F48B990DE7564 /* CanvasImportLogicTests.swift */,
-				8B1465ECA6ED41A7A88945E1 /* CatalogLogicTests.swift */,
-				610E01F509854A408EC0210D /* ConferenceLogicTests.swift */,
-				46261D0C61D7422C825EBEF6 /* CourseAccessibilityReviewLogicTests.swift */,
-				7891F7914C1F4E758EB25057 /* CourseArchivedContentLogicTests.swift */,
-				A759FB2A25A544B09FA669EB /* CourseBlueprintLogicTests.swift */,
-				E2DE8DE61E0F493AA4729F3A /* CourseCreateLogicTests.swift */,
-				0EF5D397892B4D0183985779 /* CourseFeaturesLogicTests.swift */,
-				31218713E083457A8317C488 /* CourseFileModelsTests.swift */,
-				7CD7F20E5292421A917DF686 /* CourseGradingAgentsLogicTests.swift */,
-				C2BDB5DFC156485BA2DF8135 /* CourseGradingLogicTests.swift */,
-				5FD5634B0DB5409A948EDF25 /* CourseImportExportLogicTests.swift */,
-				04F5044EA5764DB8B55673CF /* CourseOutcomesLogicTests.swift */,
-				B38BE72075F141C68C01C98A /* CoursePeopleLogicTests.swift */,
-				F11D7E51AFDE402A9CB4C5F1 /* CoursePlagiarismLogicTests.swift */,
-				344E381A27B44C94816F4DC9 /* CourseReviewLogicTests.swift */,
-				0B064CC9A4244A1597D63D68 /* CourseSectionsLogicTests.swift */,
-				77AECEE1A5A6439D9F9DCF5D /* CourseSettingsLogicTests.swift */,
-				1A8A7858007741A4B4A579AC /* CourseTranslationsLogicTests.swift */,
-				56ACCFF75AEF4A9CAFECD03C /* CredentialsLogicTests.swift */,
-				42A2A1B1786447C9A1046778 /* DiscussionLogicTests.swift */,
-				C82102C0304A41AF8F9EE470 /* EvaluationLogicTests.swift */,
-				0D290C583E4A4DFAAE942E2D /* FeedLogicTests.swift */,
-				6E8C2C87D8DC48378C6A5E31 /* FeedbackLogicTests.swift */,
-				2132267FD5B84E9CB733911B /* GamificationLogicTests.swift */,
-				4209468B67084C02BC930593 /* GradeCalculatorTests.swift */,
-				C275EF4E0C8D4533A9029498 /* GroupsLogicTests.swift */,
-				8E39200EE6C94FF29BED5934 /* I18nTests.swift */,
-				03E5D05AABFB4BA784539EEB /* InsightsLogicTests.swift */,
-				4357F04E9A14427CA177B76D /* InstructorInsightsLogicTests.swift */,
-				A9E7ED12235D492B881A0413 /* IntegrationsAdminLogicTests.swift */,
-				C79ADB99674041B1A81298EC /* InteractiveLaunchLogicTests.swift */,
-				4669164521A846B6B7E232AD /* IntroCourseLogicTests.swift */,
-				B88B7EA19C784143BC7DB84C /* LearnerProfileLogicTests.swift */,
-				D5DCDD29E5BE4924BCAA2BAE /* LexturesMotionTests.swift */,
-				DE7B7A922ACC43F2B1141439 /* LibraryResourceLogicTests.swift */,
-				30078A0DFE254665B1DC7212 /* LiveMeetingsLogicTests.swift */,
-				41A099A324C6434C8EEF58F6 /* LiveQuizLogicTests.swift */,
-				3CD0319136154E8D83B21269 /* MarketplaceLogicTests.swift */,
-				65989912D7B347D1AAC83331 /* MasteryLogicTests.swift */,
-				28C5E4D851054C9F90CE7AD1 /* MobileDestinationsTests.swift */,
-				961A69EC01BB40BC82BE203E /* ModuleContentModelsTests.swift */,
-				1C9C5B54B7744E1D889061AF /* NotificationModelsTests.swift */,
-				3302C2097D714588B442C1BE /* OfficeHoursLogicTests.swift */,
-				6DAA8CDE1474473E9595C951 /* OnboardingModelsTests.swift */,
-				9EDEF702EFA243D189990239 /* OrgBrandingAdminLogicTests.swift */,
-				87B0F151D42A4B7BBBE595A4 /* OrgStructureAdminLogicTests.swift */,
-				18E53C28079A4E6C983463A8 /* ParentLogicTests.swift */,
-				BDDA8F0165E34D14AABAE818 /* PathsLogicTests.swift */,
-				DAAEE7BF812449FDB58A6F5A /* PeerReviewLogicTests.swift */,
-				2618AC2137984A458564EC23 /* PeopleAdminLogicTests.swift */,
-				40154251D5324D6BAA158FF2 /* PlannerModelsTests.swift */,
-				021982ACCF24416286E33E7F /* PlatformSettingsAdminLogicTests.swift */,
-				AB7140D08ECB4DD8828FD4DC /* PortfolioLogicTests.swift */,
-				E77A51CF0586468F99A3FD17 /* ProfileDepthLogicTests.swift */,
-				3FE653D023FE4E3F90297048 /* QuizLogicTests.swift */,
-				4B6F4926954A4E40BE6D0026 /* ReaderLogicTests.swift */,
-				9EEBE28F0AD44768B60A3E99 /* ReadingLogicTests.swift */,
-				06C23B8331634027B6EF19AB /* RequirementsLogicTests.swift */,
-				A694B01E62B9474ABFEC7892 /* ReviewLogicTests.swift */,
-				6824A619F9FF47138869EE22 /* RolesPermissionsAdminLogicTests.swift */,
-				DD0F2E71D5D9404484B63E87 /* SchoolCodeLogicTests.swift */,
-				4BC615D5EE204BECA3AF4DA5 /* SearchTests.swift */,
-				AD48DE61916044ADBA57ED63 /* SettingsAccommodationsTests.swift */,
-				E9FA30ED87A2472F9C9CA9F4 /* SettingsMenuLogicTests.swift */,
-				EF28D43D9F054B83A90FD9A1 /* TakeAttendanceLogicTests.swift */,
-				66435D97765F43E49613CCE8 /* TranscriptsAdvisingAdminLogicTests.swift */,
-				8DBFC1A8B3044BAE9F7CA51A /* TutorLogicTests.swift */,
-				5D58D84855D54A859F14F9D3 /* UIModeLogicTests.swift */,
-				208785AC35264E2F844BC2B0 /* VibeActivityLogicTests.swift */,
-				E89A96A62A294B11B053B1BF /* WalletLogicTests.swift */,
-				3BA2F9A7AD954C8B88AD6E9A /* WhiteboardLogicTests.swift */,
+				373523C32EB949A5B9CAA82A /* AccessibilitySupportTests.swift */,
+				5A13B3495F1F4A4F819B53AF /* AccountIntegrationsLogicTests.swift */,
+				865591C44DA943BAAF006BA8 /* AdvisingLogicTests.swift */,
+				3CCE179E631F4F1587E17C1A /* AiModelsAdminLogicTests.swift */,
+				49FF81B2344C47318DA46DEA /* AnnouncementLogicTests.swift */,
+				6B763FBAF0F348CEA7B7F700 /* AppleSignInLogicTests.swift */,
+				33B046C3491242F78AFC62B5 /* ArchivedCoursesAdminLogicTests.swift */,
+				ACBA7D88E4324BAA8C417F29 /* AssignmentLogicTests.swift */,
+				2D03F861BB2F42CFA59E0822 /* AuditLogAdminLogicTests.swift */,
+				8BBC569F456A4BD3B900F0B4 /* AuthCallbackParserTests.swift */,
+				54F482AACC614C47BB93AC3A /* BehaviorLogicTests.swift */,
+				AFFB9831EC6A4D94810B09A2 /* BillingLogicTests.swift */,
+				A7E50B8DE72E4B06BF467B31 /* BiometricGateTests.swift */,
+				5BFF89736CCA439C94F43B27 /* BoardsAdvancedLogicTests.swift */,
+				39F97E50BCA747C9BD1D9FA2 /* BoardsLogicTests.swift */,
+				38FC3FBB11F247FBA7765A55 /* CanvasImportLogicTests.swift */,
+				805240352A4542E6B904D4AC /* CatalogLogicTests.swift */,
+				E480CDFCB0E5428393B4648B /* ConferenceLogicTests.swift */,
+				F21EB256086B4484BE067D42 /* CourseAccessibilityReviewLogicTests.swift */,
+				550DA196AE6B43B6B903B0FA /* CourseArchivedContentLogicTests.swift */,
+				C86F2841498A4C32AA7093AA /* CourseBlueprintLogicTests.swift */,
+				A9D1F7E879D54243A4DA10E1 /* CourseCreateLogicTests.swift */,
+				47E7A2D79A0A47F1ABD4C3AC /* CourseFeaturesLogicTests.swift */,
+				16533B0965BB4F4DA160F03E /* CourseFileModelsTests.swift */,
+				566A8F4AA7BB49848E5D5552 /* CourseGradingAgentsLogicTests.swift */,
+				CAF4C3297E884354ADDEDFC6 /* CourseGradingLogicTests.swift */,
+				B2A6BF2D82C24B07A02D4F16 /* CourseImportExportLogicTests.swift */,
+				E4FD447ED651463297DB49D6 /* CourseOutcomesLogicTests.swift */,
+				A19A901DA16C44A98BCFC878 /* CoursePeopleLogicTests.swift */,
+				F2E96F164ACF476A90625A44 /* CoursePlagiarismLogicTests.swift */,
+				E7FC803557FA400798E517D6 /* CourseReviewLogicTests.swift */,
+				B15DCDA7BE5F4D968FD8C654 /* CourseSectionsLogicTests.swift */,
+				CEDD54F128A34514B52E92C3 /* CourseSettingsLogicTests.swift */,
+				2A9DE4A71F4B41C1A155FAA9 /* CourseTranslationsLogicTests.swift */,
+				70C40E4D7ACF46108CCE6999 /* CredentialsLogicTests.swift */,
+				E0EF8D14F18747E4B15D7672 /* DiscussionLogicTests.swift */,
+				262B5F96B46D4D66AB310255 /* EvaluationLogicTests.swift */,
+				D43ECD1F3A5847A08AA8D7AE /* FeedLogicTests.swift */,
+				32EDCFA8D4C441EC8D01E20E /* FeedbackLogicTests.swift */,
+				FB4F84C218644FC898D5E1A5 /* GamificationLogicTests.swift */,
+				59A73FC830CB4D27A8DD4B25 /* GradeCalculatorTests.swift */,
+				70912832963940B79AFA8373 /* GroupsLogicTests.swift */,
+				D4DF14D128D64FE3913D78F3 /* I18nTests.swift */,
+				A0686994B5D846CF87F347DF /* InsightsLogicTests.swift */,
+				FBF2B2D6C6B44BC2866C2D93 /* InstructorInsightsLogicTests.swift */,
+				FF38019511514A39A5938F26 /* IntegrationsAdminLogicTests.swift */,
+				2BD8FA95ACA24505AAD62EE7 /* InteractiveLaunchLogicTests.swift */,
+				8F44242ADD2F4D4384FB8217 /* IntroCourseLogicTests.swift */,
+				F74498D27D0A423F9F710088 /* LearnerProfileLogicTests.swift */,
+				0D31802C470C412595FA718E /* LexturesMotionTests.swift */,
+				2BF702B17A3744F4AE9A21DB /* LibraryResourceLogicTests.swift */,
+				14872F45A72248E591C80A5C /* LiveMeetingsLogicTests.swift */,
+				71B152116F1844EA939CD2B0 /* LiveQuizLogicTests.swift */,
+				4BAEFB24E3C34525BC2F040B /* MarketplaceLogicTests.swift */,
+				53E6ECF6C15C455F86415C69 /* MasteryLogicTests.swift */,
+				A9D65C9AD65F4155AC1B2C74 /* MobileDestinationsTests.swift */,
+				D553BFCCA75D4ADDB8E03FDA /* ModuleContentModelsTests.swift */,
+				DE8A5CE055EE4CBB875FFC50 /* NotificationModelsTests.swift */,
+				6453702A8CC84167A99D06FC /* OfficeHoursLogicTests.swift */,
+				5A17E2E10AB14AF1A4BC0A20 /* OnboardingModelsTests.swift */,
+				5E7C6AF633234B11B05AC8B3 /* OrgBrandingAdminLogicTests.swift */,
+				3030AF2E57974257827BCD97 /* OrgStructureAdminLogicTests.swift */,
+				114DE315F90F46428790C499 /* ParentLogicTests.swift */,
+				5B278631504942649E2B10A7 /* PathsLogicTests.swift */,
+				ABE0AAD7BE7F4DE4A0E2E97E /* PeerReviewLogicTests.swift */,
+				E780269A3774488C96081F4D /* PeopleAdminLogicTests.swift */,
+				B1122C950BA74EC3B0F4C4BA /* PeopleAdminMetricsLogicTests.swift */,
+				201E3DED9B6B4C7D9E3CDBA1 /* PlannerModelsTests.swift */,
+				3ADE113A4F7D4363B71AAB5D /* PlatformCoursesAdminLogicTests.swift */,
+				4E20A89C03B34AE681FE9B7C /* PlatformSettingsAdminLogicTests.swift */,
+				F6BFD385E20E4874B208B6E8 /* PortfolioLogicTests.swift */,
+				ED465D36A86D429D8D927E4D /* ProfileDepthLogicTests.swift */,
+				5BF03A123F79457888EEB315 /* QuizLogicTests.swift */,
+				D59CEBA182BF44B2BE3FCADD /* ReaderLogicTests.swift */,
+				B82D214349F34003A916A5BD /* ReadingLogicTests.swift */,
+				583B845B981A489A80BD757D /* RequirementsLogicTests.swift */,
+				164416E4C983431883516796 /* ReviewLogicTests.swift */,
+				C6C08E0BEB834A3EB334C08A /* RolesPermissionsAdminLogicTests.swift */,
+				232FFCED0306441FA66F4EB3 /* SchoolCodeLogicTests.swift */,
+				B291A3D998D4494EB5BF4F69 /* SearchTests.swift */,
+				DBB038F7ADFA40A0958FCA12 /* SettingsAccommodationsTests.swift */,
+				A0C23C8D85854FB8A73C1AE1 /* SettingsMenuLogicTests.swift */,
+				8D33288F5C5A4CC4967D0503 /* TakeAttendanceLogicTests.swift */,
+				1A1410FB35F44CC4B312DD2A /* TranscriptsAdvisingAdminLogicTests.swift */,
+				C4BC8DA818EC4DBEB21CB6A3 /* TutorLogicTests.swift */,
+				77D38DC81AAE47D78174340E /* UIModeLogicTests.swift */,
+				3DECA44A9D514EB9B68544FB /* VibeActivityLogicTests.swift */,
+				04481C8E09DD46DB93EA9D47 /* WalletLogicTests.swift */,
+				6C2F1DCD549844B092CD0466 /* WhiteboardLogicTests.swift */,
 			);
 			path = LexturesTests;
 			sourceTree = "<group>";
 		};
-		59F5FB7E76A1495D82BA2ADF /* Boards */ = {
+		2E4D604D3217464FB7714146 /* App */ = {
 			isa = PBXGroup;
 			children = (
-				1FA14959D1654245A5F8A3F1 /* Layouts */,
-				CBC44C6E3CB64AC2BF57D7CE /* Public */,
-				96269A903D444BCB8403956F /* BoardAnalyticsSheet.swift */,
-				26384B47056D4A18B88BCD9C /* BoardComposerView.swift */,
-				2E39FC12B86C4A3E99379A39 /* BoardDetailView.swift */,
-				7EBC8AD22D194FB5866E18E7 /* BoardEngagementEnvironment.swift */,
-				A9EEE24B337F47059EB78C3C /* BoardExportSheet.swift */,
-				031BBD2CE9D144BDB505C1E8 /* BoardModerationSettings.swift */,
-				F04F85EB97CD424DAADB983F /* BoardPostCard.swift */,
-				CCC7A71C1FDD4B25A97267EB /* BoardPresentModeView.swift */,
-				D848E3CFF3564E8F8F3EF421 /* BoardSaveAsTemplateSheet.swift */,
-				632A81DB862E42068731DE45 /* BoardShareSheet.swift */,
-				8B03553DDF274E11BA2DED01 /* BoardSocket.swift */,
-				BEB9B0BCE84B4831B9EF48BE /* BoardSurface.swift */,
-				2C4965994E3A406CB9E590BC /* BoardSyncStatusChip.swift */,
-				0B0A6784B8734FF38D6BD93C /* BoardTemplatePickerView.swift */,
-				7573C7EAB3B14B0BA16D68D6 /* BoardsListView.swift */,
-				292955293ECD44C08E3482A0 /* CardArrangeMenu.swift */,
-				1CEE4E31021C4DC598C25815 /* CommentSheet.swift */,
-				22DEB663DFBA45DAA3D18684 /* GradeSheet.swift */,
-				6DE8CEA9C7BE482BA8631124 /* ModerationQueueView.swift */,
-				5038E5EB4FF249EFBC5C63FC /* ReactionControl.swift */,
-				7744DD60219447E28F115D42 /* ReportDialog.swift */,
+				BCC21ED0D16140FA8E128181 /* AppDelegate.swift */,
+				2DB3CC07877B4410A1AA5030 /* LexturesApp.swift */,
+				46F09135218740BEA6B986E5 /* RootView.swift */,
 			);
-			path = Boards;
+			path = App;
 			sourceTree = "<group>";
 		};
-		5BECC6CC8D824BEF8EEC47A7 /* Notebooks */ = {
+		D4FD305EE8564D5CAEE9C2C1 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				0A7D2973CAE543D4874EBE06 /* NotebookDrawingViews.swift */,
-				155369C709104486B5CEF414 /* NotebookEditorSupportViews.swift */,
-				183F16CF73A64A6CBF0F9517 /* NotebookEditorView.swift */,
-				41405FFAA6E74123B7CD71F8 /* NotebookPagesView.swift */,
-				F2CE45281D2C45AEB0062B4B /* NotebooksListView.swift */,
+				65338EDF21EF493B9961ADDB /* Accessibility */,
+				962FE4F908C44BC480944DA2 /* Auth */,
+				A907BA58CCFA4E83B2A1DA2C /* Config */,
+				2898A9809A6147F692C2BA59 /* Design */,
+				5D12CF01069C4AB28CBEBDC3 /* I18n */,
+				27231CB0D753412EB241184B /* LMS */,
+				C26454A1C21349CC82CD4A81 /* Networking */,
+				48A959D7B391440691EDC3E9 /* Notebook */,
+				FA86CD845606477697C280BC /* Offline */,
+				405ADFE6368846B5BD802C2D /* Push */,
+				84B0AE89B9E7411E8C7B1161 /* Realtime */,
+				C089B853FDAD4D3BA43BBE1C /* Routing */,
+				2A57ECDF8FAB4563A60CDDE3 /* Search */,
+				54403642A92F4A7B9CC784F4 /* UI */,
 			);
-			path = Notebooks;
+			path = Core;
 			sourceTree = "<group>";
 		};
-		5EEF5933279249E498241AB7 /* Planner */ = {
+		BF3A1AF775F745A09D339A54 /* Features */ = {
 			isa = PBXGroup;
 			children = (
-				E1EABEF6DC594B13AB302015 /* CalendarSubscribeSheet.swift */,
-				FE968F8454A7464DBA2E7DCE /* CalendarView.swift */,
-				5555FB34667B4BB896B33481 /* ConferenceReminderScheduler.swift */,
-				4121BC5624904F929BFA590A /* DueReminderScheduler.swift */,
-				43A30C3BE3E94FFA8D4579CF /* OfficeHoursReminderScheduler.swift */,
-				19FF8D7F7E1742BF81FB0E02 /* PlannerModel.swift */,
-				92EC2F62124947CFA5753E97 /* PlannerView.swift */,
-				29CB6F1A4D534109BD3F78A5 /* TodosView.swift */,
+				8F4FC60E7F9A491B822BEC85 /* Advising */,
+				701D7DF457B14945AF961FB7 /* Assignments */,
+				868E51DFC861421388C8F051 /* Auth */,
+				18F7C9AD9EF54301BC952A4B /* Behavior */,
+				CE2A192438064ADD8CD29594 /* Billing */,
+				87A0EC2E02864041B872FD28 /* Boards */,
+				59658F1ED52246CC8C1222BD /* Catalog */,
+				4AC0D2069A314057A02EFF94 /* Courses */,
+				279E9605180441408A086781 /* Credentials */,
+				660ECF58D7484A1E96CA4C6E /* Dashboard */,
+				0E2973A16C4745AC84DAE787 /* Discussions */,
+				E17E34FD698E4FB1AC724740 /* Evaluations */,
+				043D3E3832C94B41B1F5C614 /* Feed */,
+				E264AE8CB1604CFAA6B13031 /* Feedback */,
+				2D431D38870B44D8905DFF75 /* Files */,
+				D3D59D8988BF410DB2E957D2 /* Gamification */,
+				F6916FBEC6744373B5442108 /* Grades */,
+				A5E76690DDB947A4A80A942B /* Grading */,
+				7878921E3EE94F9085FFAD2D /* Groups */,
+				118A2CF722A84D8FBD93B030 /* Home */,
+				87B67464B37C42ABAD2BF16C /* Inbox */,
+				0F9E926F79CF4392AB2FE1A0 /* Insights */,
+				CD2AB0C3B8EA4EC190369661 /* InstructorInsights */,
+				D3D7D044D9F3465088659F6D /* IntroCourse */,
+				8756C2EE1A6F4AD2BB2A5D32 /* LearnerProfile */,
+				3602C182B393418AB4BB41A4 /* Library */,
+				B65CCA6818A6488C8DC3AD71 /* Live */,
+				7635445760EC40668163A347 /* LiveQuiz */,
+				FEB514283FBA4FA19EA3050A /* Marketplace */,
+				3EE8B30769534A8280558EF0 /* Mastery */,
+				275746F45C544CD59C5755D0 /* Navigation */,
+				8230BF9ACD524647BD94450E /* Notebooks */,
+				95160559E82849F4B6C38B1C /* OfficeHours */,
+				F9DF03E42271490AA7DAA449 /* Onboarding */,
+				511CF8B4AC24421299F8C3DD /* Parent */,
+				7A434A96FCB542F6955BAC95 /* Paths */,
+				391A0103663844CF9D4CE213 /* PeerReview */,
+				AEB080EC28654582A5F5C698 /* Planner */,
+				E2079ED3F1014028BE86AA6B /* Portfolio */,
+				D36507EDCE7F4C758048399C /* Profile */,
+				AC8ADF7A4E63412184F152A6 /* Quiz */,
+				237D6A2B598547BD86AFBCDE /* Reader */,
+				90F66E03E1134348965E60B3 /* Reading */,
+				46868CAEEAB6446F8ABEC2B2 /* Review */,
+				E1A4436428CA4458B73960A1 /* Search */,
+				210F88C32584464BBEE31669 /* Settings */,
+				CA7B2E95CAF54885B79E2BC5 /* Splash */,
+				79EEC603F04B48FBAB3B099C /* Tutor */,
+				7E4FC5D1155B4BB3942A3651 /* Wallet */,
 			);
-			path = Planner;
+			path = Features;
 			sourceTree = "<group>";
 		};
-		62AA531857C04618AE8815A5 /* Create */ = {
+		A57DBE192A5549CEB700D64B /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				8C37D5824D0F4AB4884B0646 /* CanvasImportComingSoonView.swift */,
-				116CD8D82EB84CC5913B763F /* CanvasImportView.swift */,
-				E30D0CBFA914409C9C34D400 /* CourseCreateView.swift */,
+				F1D492B110A3479A86B62F45 /* Assets.xcassets */,
+				6678AEC9159340A695FD20AD /* Localizable.xcstrings */,
+				D332EEC5808342AEBD540892 /* Info.plist */,
 			);
-			path = Create;
+			path = Resources;
 			sourceTree = "<group>";
 		};
-		630BADA95788483A83E3459C /* LMS */ = {
+		65338EDF21EF493B9961ADDB /* Accessibility */ = {
 			isa = PBXGroup;
 			children = (
-				C0A1F004PLATCRSL0G1C01 /* PlatformCoursesAdminLogic.swift */,
-				C0A1F003PLATCRSM0DEL01 /* LMSFeatureModelsPlatformCoursesAdmin.swift */,
-				E65E08AAAF35435F91EC11E2 /* AccountAccommodationModels.swift */,
-				06E1315641EA4B12952161FD /* AccountIntegrationsLogic.swift */,
-				337A072C810F475DAB09B979 /* AdvisingLogic.swift */,
-				C5432BC7753842708D3C91B8 /* AiModelsAdminLogic.swift */,
-				A9EBA7A16ACA4AAA9668C226 /* AnnouncementLogic.swift */,
-				072DD96ED19D4F2AB9F0B99E /* ArchivedCoursesAdminLogic.swift */,
-				ACF60F0181744AD795AA80A6 /* AssignmentLogic.swift */,
-				65E12F1F50BC4094A28B6222 /* AuditLogAdminLogic.swift */,
-				A97A8E72069448ECA7AA73A8 /* BehaviorLogic.swift */,
-				40B60F313BAA4EECB7EE8839 /* BillingLogic.swift */,
-				261ED70950AB4FF497C90164 /* BoardRealtimeLogic.swift */,
-				28BEE84922AA4F1FAE0FE787 /* BoardsAdvancedLogic.swift */,
-				A8E4F8B061E74A2DA6074099 /* BoardsGovernanceAdminLogic.swift */,
-				71EBFCEDAB574DD18062254A /* BoardsLogic.swift */,
-				6736D5AB4D3C4D27B4D6F79D /* CanvasImportLogic.swift */,
-				AF68DEFDB6F644F1B49AE7FC /* CanvasImportObservability.swift */,
-				C721A4D0AE2C4562AD5DD503 /* CatalogLogic.swift */,
-				10F6ED1EE5D0457B909BE417 /* ConferenceLogic.swift */,
-				B2987419F9724F8BAE46DE7C /* CourseAccessibilityReviewLogic.swift */,
-				BB40ECDD371D46629FA4B0B9 /* CourseArchivedContentLogic.swift */,
-				46CF1F6145E94FBDA9B42BCF /* CourseBlueprintLogic.swift */,
-				68A90396389242E6AE275FBA /* CourseCreateDraftStore.swift */,
-				23A99646D93646DAABE7B029 /* CourseCreateLogic.swift */,
-				DDD1CD8513FF46B4B9547A10 /* CourseCreateObservability.swift */,
-				CEEDAAA8C69F4E3A95F27EF9 /* CourseFeaturesLogic.swift */,
-				D5512688359B4814B37EEE73 /* CourseFileLogic.swift */,
-				E5D99243ADB74AE28BAEA1FA /* CourseGradingAgentsLogic.swift */,
-				6EB60E6F45C645AD83B3A357 /* CourseGradingLogic.swift */,
-				B41F92002E874326A55667BD /* CourseHeroImage.swift */,
-				3AD2BD7E08934ECF89E37976 /* CourseImportExportLogic.swift */,
-				33C59803EB384ED2BD2E4FF4 /* CourseOutcomesLogic.swift */,
-				E673943775FD47B9A98EE557 /* CoursePeopleLogic.swift */,
-				93D3F6FF903E49CE90FB8282 /* CoursePeopleObservability.swift */,
-				FC9468E3BCBC43738DFFE9C5 /* CoursePlagiarismLogic.swift */,
-				6B7BF5493ABE454C931A4633 /* CourseReviewLogic.swift */,
-				BC3BE6AB5EEA4770B176F672 /* CourseSectionsLogic.swift */,
-				02FCB109F4F14696B51C6CBF /* CourseSettingsLogic.swift */,
-				FFC1AC4481FC4833BF1B61A7 /* CourseTranslationsLogic.swift */,
-				9AF14C133F894FDCA69C54A7 /* CredentialsLogic.swift */,
-				08D4CB337387490E9E66310D /* CurrencyExponent.swift */,
-				DDA80204536948B28987E9D2 /* DiscussionLogic.swift */,
-				7EA86C4C8DEE43549744766D /* EvaluationLogic.swift */,
-				DF85BA6B55D24B0F9AB635D9 /* FeedbackLogic.swift */,
-				D8028537BA35401A846CBE77 /* FileDownloadManager.swift */,
-				E46DCEFAEE87493A9E31AC43 /* GamificationLogic.swift */,
-				E837FD6AE64B48B89B9DFDB1 /* GradeCalculator+MyGrades.swift */,
-				522BA4E302B345C7B5F5D022 /* GradeCalculator.swift */,
-				9E8970BD54EE4C13BCB58BE0 /* GroupsLogic.swift */,
-				95897DDA808D4572AA50C4D1 /* InsightsLogic.swift */,
-				0E6FD13AFC9F41AE93B53166 /* InstructorInsightsLogic.swift */,
-				770C736B28C0432396B68FFA /* IntegrationsAdminLogic.swift */,
-				527B4669637B4F1DB8F64BA3 /* InteractiveLaunchLogic.swift */,
-				1F97983553124510BC455373 /* IntroCourseLogic.swift */,
-				469622045ED645C9875B5506 /* IntroCourseObservability.swift */,
-				10EDF93341CE47D0B74C0CC0 /* LMSAPI.swift */,
-				9BD0733539D4466E9CC056C3 /* LMSAPIAccountIntegrations.swift */,
-				AC33ACFE534B42289892ACD0 /* LMSAPIAdmin.swift */,
-				449CD77DD2A04631B9B1513A /* LMSAPIAdvising.swift */,
-				9982456D8DA5490FBF00392F /* LMSAPIAnnouncements.swift */,
-				051235EB53344CE182F9407C /* LMSAPIAuditLog.swift */,
-				2AC45FE1DCB94FB796DCD2D2 /* LMSAPIBehavior.swift */,
-				7E678B5431544F439C1072C9 /* LMSAPIBilling.swift */,
-				768BFDBA7AC042C189053972 /* LMSAPIBoardAccess.swift */,
-				C2815C9121014FFEBFF015F6 /* LMSAPIBoardAnalytics.swift */,
-				55FBFE8589904567948142C6 /* LMSAPIBoardEngagement.swift */,
-				8624F5F731494067A6E5226A /* LMSAPIBoardExport.swift */,
-				BCF38853657840A195A73F41 /* LMSAPIBoardLayout.swift */,
-				51DA237C4E1F4A17A205FC81 /* LMSAPIBoardModeration.swift */,
-				D7C394658B9549BF840C6BF0 /* LMSAPIBoardPosts.swift */,
-				1420DA486C9F41B7B6B205CE /* LMSAPIBoardTemplates.swift */,
-				FC2DA51DD8EE4449921CEDE6 /* LMSAPIBoards.swift */,
-				AFA06F4519974FCA96FB76DB /* LMSAPICanvasImport.swift */,
-				DDBB5CE865524C7E9FE8EFCE /* LMSAPICatalog.swift */,
-				2C382B37AD7B41FDACBBF68A /* LMSAPICourseAccessibility.swift */,
-				103F7EB8AA2543D486ADD013 /* LMSAPICourseArchivedContent.swift */,
-				24D56D54A5114FC7AD4449A3 /* LMSAPICourseBlueprint.swift */,
-				86976AC5DBF94CE0B9E2A282 /* LMSAPICourseCreate.swift */,
-				BA8F92237382472281728AF9 /* LMSAPICourseFeatures.swift */,
-				155DA7CBBE5949828B3DFB89 /* LMSAPICourseGrading.swift */,
-				80B1442FD4F64EBBABDA4E2A /* LMSAPICourseGradingAgents.swift */,
-				B5BA849320AE4B2590B89819 /* LMSAPICourseImportExport.swift */,
-				53D6F3EF92B24D05B2B7779C /* LMSAPICoursePlagiarism.swift */,
-				6D516E4132064312ADC97EF2 /* LMSAPICourseReviews.swift */,
-				99BCA544511647D2BFD0A74D /* LMSAPICourseSections.swift */,
-				2D03F374531E48A2A2D19B4B /* LMSAPICourseSettings.swift */,
-				FBB46D38E74640FB9DF737ED /* LMSAPICourseTranslations.swift */,
-				02639B5CAA2949FEBA60BCA6 /* LMSAPICredentials.swift */,
-				01AA4EFD58D94D15B395E243 /* LMSAPIDiscussions.swift */,
-				40B096DDAC85418AA92EDA6F /* LMSAPIEportfolio.swift */,
-				632C23893BC2467DBF9316C1 /* LMSAPIEvaluations.swift */,
-				91894EFBAE034F79870527FD /* LMSAPIFeatures.swift */,
-				6EABAF87B38948CD96516C1B /* LMSAPIFeed.swift */,
-				AC2EBD3E2D3D4385A04B65EB /* LMSAPIFeedback.swift */,
-				6419C9F06DE54C3691051BFE /* LMSAPIGamification.swift */,
-				8CCEF8D2D48C4BA8A47E49A3 /* LMSAPIGroups.swift */,
-				BC5A4318357444D5A1424EF0 /* LMSAPIInsights.swift */,
-				52756647D9D34EB1B5B6DAAA /* LMSAPIInstructorInsights.swift */,
-				C305FCC30ECF400C98CA8785 /* LMSAPIIntroCourse.swift */,
-				4020BC9FB68D42DF8A8A9DE9 /* LMSAPILearnerProfile.swift */,
-				55EE7AE153204335AEBBBB6C /* LMSAPILiveQuiz.swift */,
-				D76B7EDA320347C8BB92749F /* LMSAPIMarketplace.swift */,
-				9FA6CF17C66741A7B273C184 /* LMSAPIMastery.swift */,
-				3CE5438B1B5A4AEDB8356E07 /* LMSAPIMobileWave.swift */,
-				12DBB0D86C7348E1BE18B3EC /* LMSAPIOutcomes.swift */,
-				DD3219C169154315A1EABC2A /* LMSAPIParent.swift */,
-				B76565B44E7040E494081414 /* LMSAPIPaths.swift */,
-				5E7361328A9343E697C079EC /* LMSAPIPeerReview.swift */,
-				594CE084CFFA400D985A7E3E /* LMSAPIProctoring.swift */,
-				951CD3FD737C4BA195298FBB /* LMSAPIQuizCodeRun.swift */,
-				AE7BE364B12F4037819B6D7E /* LMSAPIReader.swift */,
-				20636E18011042CE8BC078EF /* LMSAPIReading.swift */,
-				C685DDE626FD43AE8E794DF9 /* LMSAPIReview.swift */,
-				ACB23DB1F524420EB1691BFB /* LMSAPITutor.swift */,
-				5E06DECBA6A543058452BA6D /* LMSAPIWallet.swift */,
-				FDC498FBB0BB41AD957F3E63 /* LMSAPIWhiteboard.swift */,
-				DDF3F1B270A24C95A700749A /* LMSBoardAdvancedModels.swift */,
-				3F35B5D01D274083BC601865 /* LMSBoardModels.swift */,
-				584D006BF6E14023B0544198 /* LMSFeatureModels.swift */,
-				4C9CCBAC5A95489D952F732F /* LMSFeatureModelsAccountIntegrations.swift */,
-				F6BCA8EBF7554564B0C4B34E /* LMSFeatureModelsAdvising.swift */,
-				AF67DD138BFE4DD691D2B8E2 /* LMSFeatureModelsAiAdmin.swift */,
-				9B942CB11F344BE2AB8E0022 /* LMSFeatureModelsArchivedCoursesAdmin.swift */,
-				AAC108680F91495A91524028 /* LMSFeatureModelsAuditLog.swift */,
-				6AE959B3CFB24B54AC6FD2B9 /* LMSFeatureModelsBehavior.swift */,
-				6CE83F7AD58240F982BBBBE5 /* LMSFeatureModelsBilling.swift */,
-				C4188B26349243DDA32FD60F /* LMSFeatureModelsCanvasImport.swift */,
-				DD996D1B848646BCB3808AC4 /* LMSFeatureModelsCatalog.swift */,
-				B42C097F349F4294B8245A75 /* LMSFeatureModelsCourseAccessibility.swift */,
-				F39505FFCCC24326BBC0C3EF /* LMSFeatureModelsCourseCreate.swift */,
-				98363B34BAB64153B9744806 /* LMSFeatureModelsCourseGrading.swift */,
-				68B7198BC9464E688E63632D /* LMSFeatureModelsCourseGradingAgents.swift */,
-				C0CD6077FE5D40CC8319EE83 /* LMSFeatureModelsCourseOutcomes.swift */,
-				4B6BEA02246548DEAAA0FD65 /* LMSFeatureModelsCoursePlagiarism.swift */,
-				08C5DA8502AC42DC8309F82B /* LMSFeatureModelsCourseReviews.swift */,
-				AC61B89E581D4A3BB74AEFF3 /* LMSFeatureModelsCourseSettings.swift */,
-				690FDA97D2744AB58F335445 /* LMSFeatureModelsCourseTranslations.swift */,
-				065C3BABC11144C79BFC5D7D /* LMSFeatureModelsCredentials.swift */,
-				33BE7B6F9FD24732B3294FD1 /* LMSFeatureModelsDiscussions.swift */,
-				4B8BA50BE7B246D9A14E56C5 /* LMSFeatureModelsEportfolio.swift */,
-				D51738328C8246AB882B8626 /* LMSFeatureModelsEvaluations.swift */,
-				1787B1BC4C704921B47965ED /* LMSFeatureModelsFeed.swift */,
-				5FDA8AE824C84289A9FE74D8 /* LMSFeatureModelsFeedback.swift */,
-				3A756F9E12E3420D93F19CE8 /* LMSFeatureModelsGamification.swift */,
-				0D21A57EA87849F38CB40E33 /* LMSFeatureModelsGroups.swift */,
-				C2857A249A7D44D8A35F0588 /* LMSFeatureModelsInsights.swift */,
-				C84310772875447D85E385CA /* LMSFeatureModelsInstructorInsights.swift */,
-				854660018C6A49E286436E73 /* LMSFeatureModelsIntegrationsAdmin.swift */,
-				DD685807326846CF91C2CFCF /* LMSFeatureModelsIntroCourse.swift */,
-				C509211B07064B4880574F26 /* LMSFeatureModelsLearnerProfile.swift */,
-				A6658747E5AE4132BE360D97 /* LMSFeatureModelsLive.swift */,
-				690BD68F0A574B6093EE8CA6 /* LMSFeatureModelsMarketplace.swift */,
-				3F3BA1A6B9704FB5883A71F1 /* LMSFeatureModelsMastery.swift */,
-				C9F5389E48194F8389E80AEB /* LMSFeatureModelsMobile.swift */,
-				1BAB1373F79548DFB5272E36 /* LMSFeatureModelsOrgBrandingAdmin.swift */,
-				1B98EFBE72814209BD850A7A /* LMSFeatureModelsOrgStructureAdmin.swift */,
-				BABF3BEB66C6415D92AF68B4 /* LMSFeatureModelsParent.swift */,
-				7C479EBF1A114D379C503F12 /* LMSFeatureModelsPaths.swift */,
-				5290AAD24C2D4FE1A55D21BC /* LMSFeatureModelsPeerReview.swift */,
-				354CF5EEFB1F4B59B969EF86 /* LMSFeatureModelsPeopleAdmin.swift */,
-				D5D37E2CCEE04493954CCD08 /* LMSFeatureModelsPlatform.swift */,
-				5541BAAA56DC484EBDE23C5D /* LMSFeatureModelsPlatformSettingsAdmin.swift */,
-				D82BB8F7A48F4902A8AC0ACB /* LMSFeatureModelsReader.swift */,
-				7195D6BC0113463F990C5A7B /* LMSFeatureModelsReading.swift */,
-				92102CDBB0764704BED6B9E4 /* LMSFeatureModelsRolesPermissionsAdmin.swift */,
-				B7284D67AEFA4B6B89CFABB4 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */,
-				B67E1F886BFA47138686710E /* LMSFeatureModelsTutor.swift */,
-				59A05827BFF2447A9E87D715 /* LMSFeatureModelsWallet.swift */,
-				235B2EBE17694F38AFF7765D /* LMSInteractiveModels.swift */,
-				5A5654BC08D54F1399A7B456 /* LMSModels.swift */,
-				1D3144D60E9447C49C7D4F48 /* LearnerProfileLogic.swift */,
-				5439138D5A6245AF937F5AE1 /* LibraryResourceLogic.swift */,
-				4BC55BD9D73F44EAAB068187 /* LiveGameLogic.swift */,
-				2E6FB26236674F82B674D4CD /* LiveMeetingsLogic.swift */,
-				B76D6B8EFF32425AB3F621A6 /* LiveQuizLogic.swift */,
-				4CE3837997044C3CAF1F81E5 /* MarketplaceLogic.swift */,
-				61078B95908641F0AE74BC4F /* MasteryLogic.swift */,
-				F642FE17A2E047EEB5479210 /* ModuleContentLogic.swift */,
-				0932C48BD6084509935F6B79 /* ModuleLastVisited.swift */,
-				E7E447C0DDD144B88568A961 /* NotificationLogic.swift */,
-				0CB42BCF7AD14051AF1410B1 /* OfficeHoursLogic.swift */,
-				F1B3270831A346DE871D0F76 /* OnboardingModels.swift */,
-				5F26CD37E0CC46E89928A002 /* OrgBrandingAdminLogic.swift */,
-				1C82E80113694021ACA9D6D5 /* OrgStructureAdminLogic.swift */,
-				002B42EDB8C1480AB39F9343 /* ParentLogic.swift */,
-				CEAC489BE3F34CCCACE6AAEF /* PathsLogic.swift */,
-				336D69F1011A4C2195F49B24 /* PeerReviewLogic.swift */,
-				FC40644EAAB4420E81ECB0DC /* PeopleAdminLogic.swift */,
-				1F7A122FBFBF44F68381972E /* PlannerLogic.swift */,
-				64AC5AB4C0254A5DA652C1D7 /* PlannerSnapshotCoding.swift */,
-				A31AE65FEEC54DDBB83A298F /* PlatformSettingsAdminLogic.swift */,
-				1BEE775C57A94F28B6998EF4 /* PortfolioLogic.swift */,
-				B16A062E54DF456CB2FF8087 /* ProfileDepthLogic.swift */,
-				757045ECE48246F1A51BCB30 /* ProfileDepthModels.swift */,
-				0C78F9BCAE5848B082A3E3BA /* QuizLogic.swift */,
-				02995DB88EE8419CA408DF6E /* ReadingLogic.swift */,
-				82D1C10DF9A741DFA99D3799 /* RequirementsLogic.swift */,
-				673BC88CC18C46119E3F0DD0 /* ReviewModels.swift */,
-				5F64F258911C48999538A5B1 /* RolesPermissionsAdminLogic.swift */,
-				966EEB61DF6A41CDA5A6C782 /* SettingsMenuLogic.swift */,
-				EDA908ADC182496F9D55A70E /* TakeAttendanceLogic.swift */,
-				4C8615D5FFDF4DF89B01879B /* TranscriptsAdvisingAdminLogic.swift */,
-				C5112DB5AF7744BB89E98CAE /* TutorLogic.swift */,
-				9D47730AC9BC474B8D83E60B /* TutorStreamClient.swift */,
-				0A875C09B2EE4A7CB6000B43 /* VibeActivityLogic.swift */,
-				E5977781DE424B91B8554838 /* WalletLogic.swift */,
-				BD00E38E54FD44BE9006F19E /* WhiteboardLogic.swift */,
-				AF64DD759A2F4B9AA6EC6761 /* WhiteboardRenderer.swift */,
-			);
-			path = LMS;
-			sourceTree = "<group>";
-		};
-		72742C24C2D649508686F4DA /* Parent */ = {
-			isa = PBXGroup;
-			children = (
-				A0E2BE4578F448E6A93627A1 /* ConferenceBookingView.swift */,
-				1DFE38EA90FA4B9A9F425D60 /* MyConferencesView.swift */,
-				01ED855614454B92A2BBC138 /* ParentAttendanceDetailView.swift */,
-				9CF5525DC9214A36B17416A0 /* ParentDashboardSections.swift */,
-				65ED18B763EA41E4BF2F9905 /* ParentDashboardView.swift */,
-				083115F582E34B1F8B9EC068 /* ParentGradesDetailView.swift */,
-				3A1EA664D9A84F93BFDD12A8 /* ParentNotificationPrefsView.swift */,
-			);
-			path = Parent;
-			sourceTree = "<group>";
-		};
-		7334947EAAA04E50B4BC0D6F /* LiveQuiz */ = {
-			isa = PBXGroup;
-			children = (
-				B6C18FF32FA146DB8FDDABCB /* LiveGameSocket.swift */,
-				7E4A233AE9004DF38E177479 /* LiveQuizHubView.swift */,
-				96DD77A6498641D8973F640C /* LiveQuizPlaySurfaces.swift */,
-				C7F6726D741A41E98A42A7C1 /* LiveQuizPlayView.swift */,
-			);
-			path = LiveQuiz;
-			sourceTree = "<group>";
-		};
-		73EA32457EF947B4AB07D15B /* Search */ = {
-			isa = PBXGroup;
-			children = (
-				CF79059A94514B73B029F985 /* SearchActionRegistry.swift */,
-				3A9D7743E1014F0EBEA6C333 /* SearchModels.swift */,
-				E9773DCAC81940CEBCADCAD9 /* SearchPathNavigator.swift */,
-				406DBB9303244C2E838EDC19 /* SearchRecentsStore.swift */,
-			);
-			path = Search;
-			sourceTree = "<group>";
-		};
-		7493F482C80C4F8EB57F5DD8 /* Onboarding */ = {
-			isa = PBXGroup;
-			children = (
-				25CA850819B142608E94AFA4 /* DiagnosticView.swift */,
-				8745232550FC42459DEC5E9D /* OnboardingFlowView.swift */,
-			);
-			path = Onboarding;
-			sourceTree = "<group>";
-		};
-		790E9D7289F34AA9990BA549 /* Gamification */ = {
-			isa = PBXGroup;
-			children = (
-				449E8BCF335C4BBA82508BBC /* GamificationView.swift */,
-			);
-			path = Gamification;
-			sourceTree = "<group>";
-		};
-		7AD75FA4D6F1417DBEE5EFCE /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				E436753DC586426DB8B8D712 /* CourseAccessibilityReviewView.swift */,
-				02B059A1DA5B4AFC81AE8CD4 /* CourseArchivedContentView.swift */,
-				40B6A04F2AA847F2B0007D9D /* CourseBlueprintSettingsView.swift */,
-				88574A59D8B1410D805D6E5A /* CourseCrossListingView.swift */,
-				5973534E35CB4A26ABFD0B07 /* CourseFeaturesSettingsView.swift */,
-				09BCF61797854B9C836948B6 /* CourseGeneralSettingsView.swift */,
-				28FFBD5BE01745E38AD2E525 /* CourseGradingAgentsView.swift */,
-				73DC931CE51A495DAE55C450 /* CourseGradingSettingsView.swift */,
-				22020B8EFBB44AB1893DE536 /* CourseHeroImageEditor.swift */,
-				F2E05AF8855940BB80BD7CD3 /* CourseImportExportView.swift */,
-				4BA15B2844A64677B6B8EED6 /* CourseMarketplaceSettingsView.swift */,
-				2EB4D5F9613E4B4995CEDA4D /* CourseOutcomesSettingsView.swift */,
-				9C4578D962A54EDD87A1FB1C /* CoursePlagiarismSettingsView.swift */,
-				86AF8D8B29A346D78F4869DC /* CourseSectionsSettingsView.swift */,
-				97A77838A5C244C1B33172C8 /* CourseSettingsHostView.swift */,
-				40C0CC13B9314D539C1DF7F0 /* CourseTranslationsSettingsView.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		7D19CD69E63A4B8BB597C2E5 /* Offline */ = {
-			isa = PBXGroup;
-			children = (
-				7B4365834BD24B03815205C4 /* CacheStore.swift */,
-				B156EC63DA0545DFA9886B4E /* DownloadStore.swift */,
-				B331630BBB724A7BB2500383 /* NetworkMonitor.swift */,
-				299F11BDA0A444EBB3960E99 /* OfflineModels.swift */,
-				FD624932F9E643898448AF98 /* OfflineService.swift */,
-				C09E3B692B6B4DCDBADC1A24 /* OutboxStore.swift */,
-				01C2429040EA4973B3CA5ABE /* SyncEngine.swift */,
-			);
-			path = Offline;
-			sourceTree = "<group>";
-		};
-		81670F744CC94D25A7F0AA32 /* Push */ = {
-			isa = PBXGroup;
-			children = (
-				1E7C3074787D4757B344CBA0 /* PushManager.swift */,
-			);
-			path = Push;
-			sourceTree = "<group>";
-		};
-		82943090C9C441B98C4B2A7A /* Library */ = {
-			isa = PBXGroup;
-			children = (
-				D33CF3B2534542B097B35C1B /* LibraryBrowseView.swift */,
-			);
-			path = Library;
-			sourceTree = "<group>";
-		};
-		87A1CFDA865E4E9BAF3EE215 /* OfficeHours */ = {
-			isa = PBXGroup;
-			children = (
-				B924B190901D424E95E8A674 /* BookingSheet.swift */,
-				15102891D765497683B09AF7 /* MyBookingsView.swift */,
-				F13F5C2201A9439FB4B346EC /* OfficeHoursView.swift */,
-			);
-			path = OfficeHours;
-			sourceTree = "<group>";
-		};
-		8A4C2094A0684D80AACBBDEA /* IntroCourse */ = {
-			isa = PBXGroup;
-			children = (
-				8509D815EB5A4DACB3D86D38 /* IntroCelebrationPresenter.swift */,
-				9396F92336A244AC8D3467B3 /* IntroCompletionCelebrationSheet.swift */,
-				109D480447DC4C5EA88DE50D /* IntroCourseEntryCard.swift */,
-				7773C1A7F21548E789E11ABA /* IntroCourseProgressRail.swift */,
-			);
-			path = IntroCourse;
-			sourceTree = "<group>";
-		};
-		8D909F4188D04FA78370CDB1 /* Paths */ = {
-			isa = PBXGroup;
-			children = (
-				7D82BBCDF07940DDA04B4A68 /* DashboardStudySection.swift */,
-				8EA3A1F78B7C4590A20AD7D5 /* MyPathsView.swift */,
-				C8B2AB155D494CB797E298B3 /* PathLandingView.swift */,
-				3AD75FD7E8C547E0AE275195 /* PathRunnerView.swift */,
-				A3D0423652744C3FBF159CA4 /* PathsCatalogView.swift */,
-			);
-			path = Paths;
-			sourceTree = "<group>";
-		};
-		8DB491D21D83410F97315F3B /* Realtime */ = {
-			isa = PBXGroup;
-			children = (
-				B55B25BC6CFB43AEA7AB087B /* RealtimeManager.swift */,
-				AB1FF550C55542478C92B16C /* WebSocketClient.swift */,
-			);
-			path = Realtime;
-			sourceTree = "<group>";
-		};
-		8DD5AD50C6A34E0EA83FAE41 /* Networking */ = {
-			isa = PBXGroup;
-			children = (
-				2E55D7EA8B6844EF97A42FA9 /* APIClient.swift */,
-				E71A55C4A7074EA98B82BDE4 /* APIError.swift */,
-				C22647F342CB4244ACAE5B64 /* NetworkAuthContext.swift */,
-				314FC24136554488997DDFA3 /* NetworkBootstrap.swift */,
-			);
-			path = Networking;
-			sourceTree = "<group>";
-		};
-		975688E3FFC1471592D9BD6A /* Wallet */ = {
-			isa = PBXGroup;
-			children = (
-				5F2E48B8E6094ACCB33C40E2 /* WalletCCRDetailView.swift */,
-				ECF8A0F2606F4936A8D63310 /* WalletCETranscriptDetailView.swift */,
-				47C9F5B4AB07403FBE7C47AF /* WalletOfficialTranscriptDetailView.swift */,
-				47BF4BA121A54F69A6B4B087 /* WalletView.swift */,
-			);
-			path = Wallet;
-			sourceTree = "<group>";
-		};
-		9BF705F0511F4FE394BDF1EB /* UI */ = {
-			isa = PBXGroup;
-			children = (
-				75B96E9CD4CA4F5886D935BB /* CodeEditor.swift */,
-			);
-			path = UI;
-			sourceTree = "<group>";
-		};
-		9C66BA6BB5C9481198F7C937 /* Quiz */ = {
-			isa = PBXGroup;
-			children = (
-				EB2824972F97472BB707A125 /* CodeQuestionView.swift */,
-				DDF6A6D215824225A7D9D6B8 /* LockdownController.swift */,
-				45DC16A66FAA4EF59125ED21 /* QuizIntroView.swift */,
-				2E28E12F37D5457B9235362A /* QuizQuestionViews.swift */,
-				804D6FAE7F334402992FAD26 /* QuizResultsView.swift */,
-				0FD0B3FACC5C4B82BA453CF5 /* QuizTakerView.swift */,
-			);
-			path = Quiz;
-			sourceTree = "<group>";
-		};
-		9CFA731B2E7B445F85B8E4E6 /* Assignments */ = {
-			isa = PBXGroup;
-			children = (
-				7ECD8CDF78FE4E4597E38BA6 /* AssignmentDetailView.swift */,
-				6488B616A5044FB4AA42FBC6 /* AssignmentDraftStore.swift */,
-				D3164BC03EC448AB8E97BFCC /* AttachmentUploader.swift */,
-			);
-			path = Assignments;
-			sourceTree = "<group>";
-		};
-		9DC8FAC5008F4827AA1BC4DE /* Live */ = {
-			isa = PBXGroup;
-			children = (
-				ACC452CCAFEE4E4291B522E8 /* MeetingDetailView.swift */,
-				E6537BE01A4D4E8B9ABD4AD9 /* MeetingListView.swift */,
-				E370F1CBBF124190ACEA5B92 /* WhiteboardView.swift */,
-			);
-			path = Live;
-			sourceTree = "<group>";
-		};
-		A40B98CB398C40499147421C /* Search */ = {
-			isa = PBXGroup;
-			children = (
-				5744E69F63C645F1AD96AF32 /* UniversalSearchView.swift */,
-			);
-			path = Search;
-			sourceTree = "<group>";
-		};
-		A4C909628E8D440DB30483D1 /* Advising */ = {
-			isa = PBXGroup;
-			children = (
-				204CAA8F0D0E4729A71B3AF6 /* AdvisingView.swift */,
-			);
-			path = Advising;
-			sourceTree = "<group>";
-		};
-		A5B83118DA8A4BDD8A114224 /* Mastery */ = {
-			isa = PBXGroup;
-			children = (
-				C9FC4DBC336D4409B223A7F6 /* CourseMasterySection.swift */,
-				9BABCA4837CF46C386214596 /* ReportCardListView.swift */,
-			);
-			path = Mastery;
-			sourceTree = "<group>";
-		};
-		AA9538CD491D464E9FA7CE86 /* Grading */ = {
-			isa = PBXGroup;
-			children = (
-				14D53CC2405F4082A1898623 /* GradingBacklogView.swift */,
-				C46B0315581D446E95672C86 /* SpeedGraderView.swift */,
-			);
-			path = Grading;
-			sourceTree = "<group>";
-		};
-		AC4005CB9E8840DBACB24094 /* Dashboard */ = {
-			isa = PBXGroup;
-			children = (
-				6A640A9490874D41B2FE85CE /* DashboardCoursesCarousel.swift */,
-				256C35FFC6634439A4CAB04C /* DashboardHeroPanel.swift */,
-				90F1B79344C9455A9C5AAE37 /* DashboardView.swift */,
-				E614255DE8BB4580933D77CA /* LiveMeetingsRail.swift */,
-			);
-			path = Dashboard;
-			sourceTree = "<group>";
-		};
-		B1BFE5F2E52042FEB09A6275 /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-				F0FF5714CDFC4F2297B585A4 /* AuthAPI.swift */,
-				2C42D131DBC6453CB932AEE1 /* AuthCallbackParser.swift */,
-				9812B27E05DF4E7FAFD2FCF2 /* AuthConstants.swift */,
-				2FEFBF6E80EE49B6954E7C68 /* AuthSession.swift */,
-				BE376101F5F4402BABE066E3 /* BiometricGate.swift */,
-				E0093B5FC2AE4D6C89B920C8 /* KeychainStore.swift */,
-				0AB237F0D62A433293C8F48B /* SessionsAPI.swift */,
-			);
-			path = Auth;
-			sourceTree = "<group>";
-		};
-		B53FA372CE584C278AD8519C /* PeerReview */ = {
-			isa = PBXGroup;
-			children = (
-				8E69FE71D6B24F72878DD03A /* PeerReviewDetailView.swift */,
-				6F7AB62D36E9483EB9CC13E9 /* PeerReviewListView.swift */,
-				C5D2103B93B3402AA7D1EF93 /* ReviewsReceivedView.swift */,
-				FD87B9822FB747678C319A5C /* RubricScorerView.swift */,
-			);
-			path = PeerReview;
-			sourceTree = "<group>";
-		};
-		B73D391B99F7425C893C05C6 /* Courses */ = {
-			isa = PBXGroup;
-			children = (
-				62AA531857C04618AE8815A5 /* Create */,
-				7AD75FA4D6F1417DBEE5EFCE /* Settings */,
-				575351DD2E5D49499CE32173 /* ContentPageView.swift */,
-				657FC23688AA48E4A477065F /* CourseAttendanceView.swift */,
-				2C4ECFC2BCFB4C1D9488BC4F /* CourseBanner.swift */,
-				2726DACD8D1D4766BB8F4362 /* CourseDestinationPlaceholder.swift */,
-				4A76441B24A6450683771C3B /* CourseDetailView.swift */,
-				6E07BDA89F7B432F9D56D98E /* CourseGradesView.swift */,
-				F62DF94E4C7246ABAA19151C /* CourseLibraryView.swift */,
-				7B83DE1E8D134EE693DAF4D2 /* CourseMarkdownContentView.swift */,
-				5CE4D23B8C9546599886D708 /* CoursePeopleView.swift */,
-				21E5F6DFCA5C437BA9E687FC /* CourseStructureSocket.swift */,
-				8BA38C62A4B543D68D3F8753 /* CourseSyllabusView.swift */,
-				1F4C83568F874AAE8808D52D /* CourseWorkspaceNav.swift */,
-				3D524FD4C47D48D4B04D660A /* CoursesListView.swift */,
-				E49305A5741A448B873B01D0 /* ItemDetailRows.swift */,
-				84BDC37551114E39AA3542F2 /* ItemDetailView.swift */,
-				45098D4AA2AE48DBB30EEBA5 /* LaunchContainerView.swift */,
-				80D6B748A1844AD086CFF7D5 /* LibraryResourceView.swift */,
-				E9F2DB59FA2D4A86B9F6A2E6 /* ModuleItemRouteView.swift */,
-				5EBE9B830C2C4543A4ED7B2F /* ModuleListView.swift */,
-				90BE19A504844A7C80D5C190 /* RequirementsView.swift */,
-				8409A897679140FBBAE8A1C6 /* TakeAttendanceView.swift */,
-				A8D8486728CD49FB9B7E622C /* VibeActivityView.swift */,
-				04F8E99D3FF94297B94B02D7 /* WebItemView.swift */,
-			);
-			path = Courses;
-			sourceTree = "<group>";
-		};
-		B93AACD62BBD44FA928F1AC9 /* Notebook */ = {
-			isa = PBXGroup;
-			children = (
-				A11E9DFFAE1F4090888340AE /* NotebookDrawing.swift */,
-				04636FB552D74F78AE3481B3 /* NotebookMarkdown.swift */,
-				4903F7AD608C4E9094700387 /* NotebookSlashCommands.swift */,
-				CAD79463AC6B4EBBBD437217 /* NotebookStore.swift */,
-				2AB69423EE1D42BEBC5443D7 /* NotebookSync.swift */,
-				7890AD9B99F44F78915DF506 /* NotebookTree.swift */,
-			);
-			path = Notebook;
-			sourceTree = "<group>";
-		};
-		BB48E7135AB2460797165E93 /* Evaluations */ = {
-			isa = PBXGroup;
-			children = (
-				48146640FF274D49B1CE65F3 /* CourseEvaluationsSection.swift */,
-				29903FC1ACA442DBB5CA908C /* EvaluationFormView.swift */,
-				A6A85E757F674DDCAFB5FAE6 /* EvaluationResultsView.swift */,
-			);
-			path = Evaluations;
-			sourceTree = "<group>";
-		};
-		BDFE461876724F299562F3D7 /* Credentials */ = {
-			isa = PBXGroup;
-			children = (
-				841CBC287D8A49CEA4A0FDD8 /* CredentialDetailView.swift */,
-				753E4D89CC4142DC8B5EA353 /* CredentialsView.swift */,
-			);
-			path = Credentials;
-			sourceTree = "<group>";
-		};
-		BE187FC1E4CE4CA6851BC5B2 /* Review */ = {
-			isa = PBXGroup;
-			children = (
-				4DE69070781249E88461A5A6 /* ReviewHomeView.swift */,
-				045BD75FC50049ACB642089C /* ReviewReminderScheduler.swift */,
-				CF348B6075744E14A3B51A5E /* ReviewSessionView.swift */,
-			);
-			path = Review;
-			sourceTree = "<group>";
-		};
-		BE91F836B2244CD9BF44A3A3 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				FDC0C405F08447CA83B590F7 /* Lextures.app */,
-				4F805878F1A84A8EB6882D47 /* LexturesTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		C30D7B6C6236438CA122B11D /* LearnerProfile */ = {
-			isa = PBXGroup;
-			children = (
-				EC4B319C0A3744029706BEB9 /* LearnerProfileView.swift */,
-			);
-			path = LearnerProfile;
-			sourceTree = "<group>";
-		};
-		C6202B5B81D64D90A2E5F743 = {
-			isa = PBXGroup;
-			children = (
-				0E4FE3FCE5DE4DF4996EAE37 /* Lextures */,
-				57178DF3D8B24E09AFB5D058 /* LexturesTests */,
-				F2587B01ECD24748B8D0E5AE /* Config */,
-				BE91F836B2244CD9BF44A3A3 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		CBC44C6E3CB64AC2BF57D7CE /* Public */ = {
-			isa = PBXGroup;
-			children = (
-				D7FDF50245D841AABC037498 /* BoardPublicView.swift */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		E11399A78C494CCC80D541A8 /* Discussions */ = {
-			isa = PBXGroup;
-			children = (
-				0DF03CFAC83945FF948F2D9F /* CourseDiscussionsSection.swift */,
-				18ECF1EC4F824EFAA02F45F1 /* DiscussionThreadView.swift */,
-				757E4E8E95AD4AC5A8E4A56F /* DiscussionsListView.swift */,
-				6A1EFCDD4B1B414CAE377ADA /* PostComposerView.swift */,
-			);
-			path = Discussions;
-			sourceTree = "<group>";
-		};
-		E186BDD1AF8E4310BE0718E7 /* Portfolio */ = {
-			isa = PBXGroup;
-			children = (
-				C867B43E2703464F877FC979 /* ArtifactDetailView.swift */,
-				9A49502E6AB94ABE82C6B9C5 /* ArtifactEditorView.swift */,
-				2C9E74A13E01474490F478FB /* PortfolioArtifactUploader.swift */,
-				6142AEC908E24BA28DC2FD5C /* PortfolioDetailView.swift */,
-				A21EC9AD051A47708EF12C64 /* PortfolioView.swift */,
-			);
-			path = Portfolio;
-			sourceTree = "<group>";
-		};
-		E6962D0C3B40464F822596DA /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				63AB4FFE358F4BFA92960BD5 /* AppConfiguration.swift */,
-				24A93B7496D0403F9F843B37 /* EnvironmentStore.swift */,
-				F9CA34F0EAA343E1AE64BF5F /* SchoolCodeLogic.swift */,
-			);
-			path = Config;
-			sourceTree = "<group>";
-		};
-		E87C8E6C2A4C410D924FE3B4 /* Accessibility */ = {
-			isa = PBXGroup;
-			children = (
-				F7CD3105B0534368AEDBC4E5 /* AccessibilityPreferences.swift */,
-				1BC704C864B14285BA2F8CF8 /* AccessibilitySupport.swift */,
-				6CA6A21122004750A3F1AE37 /* DictationField.swift */,
-				9A6108A205AC48FEB57A2C55 /* ReadAloud.swift */,
+				2391332DEEEF49AB92138DD9 /* AccessibilityPreferences.swift */,
+				D877139FEBC4481391B5DD95 /* AccessibilitySupport.swift */,
+				7F9F43CFA29B464B8321DE60 /* DictationField.swift */,
+				0C08405046034F249A8E4203 /* ReadAloud.swift */,
 			);
 			path = Accessibility;
 			sourceTree = "<group>";
 		};
-		ECF8219BF4634EB5A5CE32D5 /* Insights */ = {
+		962FE4F908C44BC480944DA2 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				8B40BD2EBAA6468D83358962 /* DashboardInsightsSection.swift */,
-				F894CB179FB2419991AC1D55 /* InsightsView.swift */,
+				236584CA08EB4D21A75CB359 /* AuthAPI.swift */,
+				42A6C2CF29B94FD8ACF73AA1 /* AuthCallbackParser.swift */,
+				7CB15491376F47848D44B281 /* AuthConstants.swift */,
+				2B7BD34CEB384CB3B4A718A6 /* AuthSession.swift */,
+				7552797A53BB4FCE9FE53E6D /* BiometricGate.swift */,
+				0E8C1ED70666464594D7B357 /* KeychainStore.swift */,
+				EC0B98E8DFAD4FD4870B4B32 /* SessionsAPI.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		A907BA58CCFA4E83B2A1DA2C /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				DCECD071C74C40B592761510 /* AppConfiguration.swift */,
+				706824795CA64D6CA900F6FD /* EnvironmentStore.swift */,
+				A72B5AE8D40842608ED2A93B /* SchoolCodeLogic.swift */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
+		2898A9809A6147F692C2BA59 /* Design */ = {
+			isa = PBXGroup;
+			children = (
+				3D9E89A08F9048A498A3C2C9 /* AuthFieldRepresentable.swift */,
+				1E602BC87C274EB8BF6D2F82 /* BrandLogoView.swift */,
+				94A4411A8DB948DBBC52AB07 /* Haptics.swift */,
+				217B50509F7E4605A3AEA934 /* LexturesMotion.swift */,
+				8C13D65F0331422587A7251A /* LexturesTheme.swift */,
+				39991ABDC8984C10936F533E /* LexturesType.swift */,
+				788BE3FA0266441F8EE51DDA /* ProfileAvatarView.swift */,
+				118A196BFF72440985648417 /* SyncStatusView.swift */,
+				C3F9FFA509F042BA997FB0AD /* ThemePreference.swift */,
+				1A831877A709428DACAE01AA /* UIMode.swift */,
+				31131F38DD8C4F71AB103C65 /* UnsavedChangesBanner.swift */,
+			);
+			path = Design;
+			sourceTree = "<group>";
+		};
+		5D12CF01069C4AB28CBEBDC3 /* I18n */ = {
+			isa = PBXGroup;
+			children = (
+				122671E8CAD442C99A656D34 /* DateFormatting.swift */,
+				820F8FD64D9F4831BF993A8D /* LocaleAPI.swift */,
+				33CA37F7628145F8A5485536 /* LocalePreferences.swift */,
+				BEABF3ECB7BD4EE28923328C /* Localized.swift */,
+			);
+			path = I18n;
+			sourceTree = "<group>";
+		};
+		27231CB0D753412EB241184B /* LMS */ = {
+			isa = PBXGroup;
+			children = (
+				876822D3381A4D0EB3AD2B13 /* AccountAccommodationModels.swift */,
+				46DC0271021341C49AEE4143 /* AccountIntegrationsLogic.swift */,
+				D12E4F4CDA774754BBF2B46E /* AdvisingLogic.swift */,
+				0C94283167EE41B58D02C513 /* AiModelsAdminLogic.swift */,
+				E26AB3D0F63B4B1484296E98 /* AnnouncementLogic.swift */,
+				D9200E6719844BDFA2739BCD /* ArchivedCoursesAdminLogic.swift */,
+				F413FF3F2B574D8BA4A8641A /* AssignmentLogic.swift */,
+				6DA16EC96F3B47B7BB83472D /* AuditLogAdminLogic.swift */,
+				A8218A5DA074493A9E0C1A59 /* BehaviorLogic.swift */,
+				9FE3BC019E0A410DA462E0C9 /* BillingLogic.swift */,
+				9483963ED37B434EAC4A7F8C /* BoardRealtimeLogic.swift */,
+				F1216ABCEF6C4A5092B7575B /* BoardsAdvancedLogic.swift */,
+				425CCC3EE56D42899515B90B /* BoardsGovernanceAdminLogic.swift */,
+				654A68FBFF004593A6234FEA /* BoardsLogic.swift */,
+				1AAD098C5D86467195AAEFB2 /* CanvasImportLogic.swift */,
+				9E2BC38FEABA48CFBA00F250 /* CanvasImportObservability.swift */,
+				DA1B4CAE70324A789B0B2A32 /* CatalogLogic.swift */,
+				902B8828157D4900A862C29C /* ConferenceLogic.swift */,
+				30416340D9054E0B99CD6FC9 /* CourseAccessibilityReviewLogic.swift */,
+				94EF43760CF14277B04B2E26 /* CourseArchivedContentLogic.swift */,
+				20F96BF5345940B29F034AE7 /* CourseBlueprintLogic.swift */,
+				82679475DB4F44808D9B2A80 /* CourseCreateDraftStore.swift */,
+				010D8A6487C848EA8815BE13 /* CourseCreateLogic.swift */,
+				CA41BD3596684A6B9A402E7E /* CourseCreateObservability.swift */,
+				FECCB1A1680B415D932DA179 /* CourseFeaturesLogic.swift */,
+				90F1D7AAFF3346ECAB215A9A /* CourseFileLogic.swift */,
+				CA328ED019264948840DC527 /* CourseGradingAgentsLogic.swift */,
+				D8D4CE8302454BA09CB5BC24 /* CourseGradingLogic.swift */,
+				75E508006F4842A58668DB57 /* CourseHeroImage.swift */,
+				CC62A6B2B27441E5B7915806 /* CourseImportExportLogic.swift */,
+				0C8EA99BDF0A4AF6ACD0C05B /* CourseOutcomesLogic.swift */,
+				1B286388C9EC40C887371ED5 /* CoursePeopleLogic.swift */,
+				89062806BF744D468AA7DFD1 /* CoursePeopleObservability.swift */,
+				F8877458D0E44F6DB649AF12 /* CoursePlagiarismLogic.swift */,
+				35E7C1D0E02D41ADBF4D5464 /* CourseReviewLogic.swift */,
+				CBA37BA46DFF4A6392FE691F /* CourseSectionsLogic.swift */,
+				4323122721FF43A98CBA77DD /* CourseSettingsLogic.swift */,
+				D39DD7B13CC04A99B5EEF892 /* CourseTranslationsLogic.swift */,
+				EA3388A3D4894C97907F21A6 /* CredentialsLogic.swift */,
+				19865D60BF49490CA83E3FC8 /* CurrencyExponent.swift */,
+				821E07F7B3BD4516933FD25F /* DiscussionLogic.swift */,
+				5A5F20597F4246188C41BC16 /* EvaluationLogic.swift */,
+				802E14FA9C1E486E8320D4C9 /* FeedbackLogic.swift */,
+				7DB1D45B7CFF4C63AE669D1A /* FileDownloadManager.swift */,
+				D88B6AF6F97C420CA3528020 /* GamificationLogic.swift */,
+				7E4EAB0E8322489395633B7F /* GradeCalculator+MyGrades.swift */,
+				9A3A0A78C0E24855A2FC15B9 /* GradeCalculator.swift */,
+				2F3D19836EB74186A1414C77 /* GroupsLogic.swift */,
+				E21D78D26D264655AB76C425 /* InsightsLogic.swift */,
+				36A150CD947F4E56BFF48EAD /* InstructorInsightsLogic.swift */,
+				C016EA4D3A0B472CB5D1125D /* IntegrationsAdminLogic.swift */,
+				92A43C87E3984E9097D25841 /* InteractiveLaunchLogic.swift */,
+				919E594A7B8D4B6F98B0B1F7 /* IntroCourseLogic.swift */,
+				6542DA2E77D24963B76CF7C2 /* IntroCourseObservability.swift */,
+				966CD203A95F4B3B819D5965 /* LMSAPI.swift */,
+				60CDA1E5F1194D00ACE24EB7 /* LMSAPIAccountIntegrations.swift */,
+				97217C9DC56846FA9D63293B /* LMSAPIAdmin.swift */,
+				E56A544993F04A8CBB03CEDD /* LMSAPIAdvising.swift */,
+				A150DCF9F7224315B7B30C60 /* LMSAPIAnnouncements.swift */,
+				7F9127F532CB4C378571046A /* LMSAPIAuditLog.swift */,
+				D5B851C9FA0E4125AC76F48A /* LMSAPIBehavior.swift */,
+				46A904A5B0DB4B3098645E2A /* LMSAPIBilling.swift */,
+				994BBFFE141A485DA43BC060 /* LMSAPIBoardAccess.swift */,
+				C71BA7EC2E36488D9549FC98 /* LMSAPIBoardAnalytics.swift */,
+				801E18789F664D0DA7B9F036 /* LMSAPIBoardEngagement.swift */,
+				9A55EC392CA1443EB6FD698D /* LMSAPIBoardExport.swift */,
+				EF09D800BBA244ADB1F89793 /* LMSAPIBoardLayout.swift */,
+				C464E7B7706B46A6A1EC6B2F /* LMSAPIBoardModeration.swift */,
+				86242101E8CC4D4D9DB48D1E /* LMSAPIBoardPosts.swift */,
+				E02AE223E87C46CA849E4F4A /* LMSAPIBoardTemplates.swift */,
+				7E9B571E7F1E4C1D8B0B8EB3 /* LMSAPIBoards.swift */,
+				D8955E4A2CB0471DB37AB7E1 /* LMSAPICanvasImport.swift */,
+				A728634557104CC48E4FA9FA /* LMSAPICatalog.swift */,
+				E3060A84315140D48D885600 /* LMSAPICourseAccessibility.swift */,
+				5AB86D9F3B774232B8B64374 /* LMSAPICourseArchivedContent.swift */,
+				7A7649122040475593E51536 /* LMSAPICourseBlueprint.swift */,
+				F838E38FD3314A86A61313B3 /* LMSAPICourseCreate.swift */,
+				02159D88D4604E099DC45F01 /* LMSAPICourseFeatures.swift */,
+				1C84ED01FAFE4F6A866A68EF /* LMSAPICourseGrading.swift */,
+				E38FAB25C7DD43B284D8EFCD /* LMSAPICourseGradingAgents.swift */,
+				8AD72034B7394CDDB3C71596 /* LMSAPICourseImportExport.swift */,
+				E4B5DBDBE0EA4FD6811B8A9C /* LMSAPICoursePlagiarism.swift */,
+				9C5ECA1E769A42E8AB9D07AC /* LMSAPICourseReviews.swift */,
+				668A5BEF50304DEEB227C929 /* LMSAPICourseSections.swift */,
+				7BF1717F955345CEB67D4387 /* LMSAPICourseSettings.swift */,
+				99E5D70AB65A4BD0842B8517 /* LMSAPICourseTranslations.swift */,
+				4A29CB1E340146B2AB9FC2E4 /* LMSAPICredentials.swift */,
+				068520BD32F0465EBD006759 /* LMSAPIDiscussions.swift */,
+				3131373FEB59466C8AB0AC7C /* LMSAPIEportfolio.swift */,
+				306DA47EB9F146349ADE21A8 /* LMSAPIEvaluations.swift */,
+				9A5CE9C20A164A57A2912047 /* LMSAPIFeatures.swift */,
+				5E2D7AF6A7E74E419C4E3E6D /* LMSAPIFeed.swift */,
+				99D110AD56244378A93E0E15 /* LMSAPIFeedback.swift */,
+				894E2AD904124DDDB1BD3CBF /* LMSAPIGamification.swift */,
+				0AF12B79BA4A4F999CA668DF /* LMSAPIGroups.swift */,
+				9BAA3D5D9FD24A8B9B2EFDDF /* LMSAPIInsights.swift */,
+				80BDAE0779984913A3A462B8 /* LMSAPIInstructorInsights.swift */,
+				35A92F7A21E3452886DEB48E /* LMSAPIIntroCourse.swift */,
+				9E4A56A3B3B84A10991DAF47 /* LMSAPILearnerProfile.swift */,
+				2CDD6A07DA3446248362F3D7 /* LMSAPILiveQuiz.swift */,
+				4288167DEBBD4889AE882767 /* LMSAPIMarketplace.swift */,
+				08FE81C12C6F499187483CE8 /* LMSAPIMastery.swift */,
+				AAD07E78BFB04381B3637B0E /* LMSAPIMobileWave.swift */,
+				C746D09F7AED46FC9EFF8F3A /* LMSAPIOutcomes.swift */,
+				813EBA9635704CB7AA3ED889 /* LMSAPIParent.swift */,
+				9675FBC57BC64C3F9111FD59 /* LMSAPIPaths.swift */,
+				33223C7241234E22923DE250 /* LMSAPIPeerReview.swift */,
+				64F5E609206F4CC4A2CF95E1 /* LMSAPIProctoring.swift */,
+				48FE06D846ED40A58DCE2230 /* LMSAPIQuizCodeRun.swift */,
+				DF8906D74CFF4701B255EAF4 /* LMSAPIReader.swift */,
+				10A0B299B0D94ADC97F88528 /* LMSAPIReading.swift */,
+				60B8FDE10B9B4CEC8A5C6F5E /* LMSAPIReview.swift */,
+				86ED0FB8585D46868F83CB1F /* LMSAPITutor.swift */,
+				207E7D9985164CD29E02D922 /* LMSAPIWallet.swift */,
+				C6D9DD802E174B83AE982827 /* LMSAPIWhiteboard.swift */,
+				F7F968115560419084BFD1DA /* LMSBoardAdvancedModels.swift */,
+				904B49C91AD649B8ACE9FF53 /* LMSBoardModels.swift */,
+				2F30BB03583A40CBACF8BAC7 /* LMSFeatureModels.swift */,
+				5D5AFDFFD4954154AA08B6F0 /* LMSFeatureModelsAccountIntegrations.swift */,
+				D80B84481BE743C8815CE2A1 /* LMSFeatureModelsAdvising.swift */,
+				3EEC8D940813443B82EF99FB /* LMSFeatureModelsAiAdmin.swift */,
+				B1A3ACCAF55B4CB3BC634A50 /* LMSFeatureModelsArchivedCoursesAdmin.swift */,
+				DE63E84856084D178F811FA9 /* LMSFeatureModelsAuditLog.swift */,
+				A9C177FF51E7499F98FEB135 /* LMSFeatureModelsBehavior.swift */,
+				1C8F213D1EFE4B02BE3EA0DC /* LMSFeatureModelsBilling.swift */,
+				189CE9ECC48A43A2934C6332 /* LMSFeatureModelsCanvasImport.swift */,
+				E60FFEEF85CA49868E48854D /* LMSFeatureModelsCatalog.swift */,
+				5D140A0009994251829A8550 /* LMSFeatureModelsCourseAccessibility.swift */,
+				DD8FE4612AF54B47AFEA77FC /* LMSFeatureModelsCourseCreate.swift */,
+				024FE8FC67C4411EA992E641 /* LMSFeatureModelsCourseGrading.swift */,
+				D2290E19122C4493AE1EBD28 /* LMSFeatureModelsCourseGradingAgents.swift */,
+				55830F753A0046C981B6A5A6 /* LMSFeatureModelsCourseOutcomes.swift */,
+				293E953D73FB46039E06FEA4 /* LMSFeatureModelsCoursePlagiarism.swift */,
+				7CB7B6D7573A436D9EE6C0BD /* LMSFeatureModelsCourseReviews.swift */,
+				32C78CFD171E4C50B5AC21BB /* LMSFeatureModelsCourseSettings.swift */,
+				A6602EEA446149C0BF76FD4F /* LMSFeatureModelsCourseTranslations.swift */,
+				215E096BEF9B47F68FB552A7 /* LMSFeatureModelsCredentials.swift */,
+				448F3041DA3349A4B85A5849 /* LMSFeatureModelsDiscussions.swift */,
+				8F09DF8AF0BD45B195F3B93C /* LMSFeatureModelsEportfolio.swift */,
+				C1655E9A8D3C4BF089B81C17 /* LMSFeatureModelsEvaluations.swift */,
+				4B7D2B5DFB6D4597B12EC5CC /* LMSFeatureModelsFeed.swift */,
+				750096FF04F847F08FA588EE /* LMSFeatureModelsFeedback.swift */,
+				888D7AF98DAE4275B6026F44 /* LMSFeatureModelsGamification.swift */,
+				08DB93BEB74C4BDBA17AC808 /* LMSFeatureModelsGroups.swift */,
+				C0BD6CA3F08E413693067FCE /* LMSFeatureModelsInsights.swift */,
+				03308D4ECF2B43DB882A33FF /* LMSFeatureModelsInstructorInsights.swift */,
+				023909062EED4A2B9B375E4A /* LMSFeatureModelsIntegrationsAdmin.swift */,
+				CE321A529D7B4A4DA1F2EDB3 /* LMSFeatureModelsIntroCourse.swift */,
+				734204250DE94773B2699164 /* LMSFeatureModelsLearnerProfile.swift */,
+				98B548F6309447C3A3FBFF17 /* LMSFeatureModelsLive.swift */,
+				0CD04098A231494CA3F09F78 /* LMSFeatureModelsMarketplace.swift */,
+				39DDFFC0D69A491D9DA742FA /* LMSFeatureModelsMastery.swift */,
+				5CAE21F884C8447AA61BF858 /* LMSFeatureModelsMobile.swift */,
+				B1E0AB224456451DBA4E7994 /* LMSFeatureModelsOrgBrandingAdmin.swift */,
+				2C43119FFBC54D04B7C27FD9 /* LMSFeatureModelsOrgStructureAdmin.swift */,
+				550DB0C297164ED9880A4FD7 /* LMSFeatureModelsParent.swift */,
+				F4790175587647C88099ADD4 /* LMSFeatureModelsPaths.swift */,
+				0F3143CD283049999A70EE00 /* LMSFeatureModelsPeerReview.swift */,
+				72B0D6B8EA2C4B84993EA288 /* LMSFeatureModelsPeopleAdmin.swift */,
+				21CCABD2171944B38CFFE643 /* LMSFeatureModelsPlatform.swift */,
+				B9DD0143BF514EB898AEEFAD /* LMSFeatureModelsPlatformCoursesAdmin.swift */,
+				37F009617AFF417CABF397AE /* LMSFeatureModelsPlatformSettingsAdmin.swift */,
+				4643CE61530B4FD8971104A2 /* LMSFeatureModelsReader.swift */,
+				96F39CB0482F4A64913BB349 /* LMSFeatureModelsReading.swift */,
+				E609EA910A5A463B99D7C222 /* LMSFeatureModelsRolesPermissionsAdmin.swift */,
+				3A9F3F51E5A245A1A459EF71 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */,
+				8E589186B3024558AE276C41 /* LMSFeatureModelsTutor.swift */,
+				DB025E305E73486AB634D170 /* LMSFeatureModelsWallet.swift */,
+				3B3AEDE2A3A24B1FB83AD8CD /* LMSInteractiveModels.swift */,
+				7C17447C206F491F86B62429 /* LMSModels.swift */,
+				FE2DA8F783004A75B61C861E /* LearnerProfileLogic.swift */,
+				B520F7E9737D4C78B5511ADA /* LibraryResourceLogic.swift */,
+				C37D57FE7FD94B599A7462C4 /* LiveGameLogic.swift */,
+				1968A81A18024476BACDA0C8 /* LiveMeetingsLogic.swift */,
+				6C2A21241F6A48D79A316B25 /* LiveQuizLogic.swift */,
+				48B6B3C5A0A44CF0BE0695FC /* MarketplaceLogic.swift */,
+				E0D94CAC8ADF4E77ADBCE34B /* MasteryLogic.swift */,
+				76986149DC3348B4AB702714 /* ModuleContentLogic.swift */,
+				11775417D81E4E9BAE6C9E95 /* ModuleLastVisited.swift */,
+				D0EA30C7BA6041EF97247A7D /* NotificationLogic.swift */,
+				6855BB77F7A14D1EB6FC6F9B /* OfficeHoursLogic.swift */,
+				1F81340A6FCF4880BBBA4791 /* OnboardingModels.swift */,
+				86594C5CEF924F1DB75AEC45 /* OrgBrandingAdminLogic.swift */,
+				8FF8F46759714555BDFE85ED /* OrgStructureAdminLogic.swift */,
+				E007BE645CB04728BEFB4B4B /* ParentLogic.swift */,
+				B07AEF18A77544789FA89FEA /* PathsLogic.swift */,
+				3CFB99E8194E4D8D91176740 /* PeerReviewLogic.swift */,
+				26155397F5234AE695039840 /* PeopleAdminLogic.swift */,
+				F25AC1FC6EA5428E8B72D682 /* PlannerLogic.swift */,
+				5790510331EE4827B84DE958 /* PlannerSnapshotCoding.swift */,
+				37D87AB33B084FB29D7A6D57 /* PlatformCoursesAdminLogic.swift */,
+				0F21F0185187479A99043D89 /* PlatformSettingsAdminLogic.swift */,
+				56248BCF827943AC98A609E6 /* PortfolioLogic.swift */,
+				D7979B9805F94AC3BA42C0A2 /* ProfileDepthLogic.swift */,
+				E182B9799F5841BDA349CFB7 /* ProfileDepthModels.swift */,
+				CD9C4896A7134E4EBBB34EB7 /* QuizLogic.swift */,
+				9C014105AAF843E483AA944A /* ReadingLogic.swift */,
+				B5F385DEC274498C97903AA4 /* RequirementsLogic.swift */,
+				A92202601E40437985EDDDBD /* ReviewModels.swift */,
+				7E1B974B7FBA4A0B829A0604 /* RolesPermissionsAdminLogic.swift */,
+				45B5ECA2A97A41E096C017B9 /* SettingsMenuLogic.swift */,
+				166A6BA560C44113A46D4988 /* TakeAttendanceLogic.swift */,
+				922C235D780B473CBC59D7F5 /* TranscriptsAdvisingAdminLogic.swift */,
+				89473B285B5E49A0A79308DC /* TutorLogic.swift */,
+				EC2751D8B98E43CD9F62F7AD /* TutorStreamClient.swift */,
+				F25FA4F8614F4D7D9EEED7D3 /* VibeActivityLogic.swift */,
+				24C019B8498C499AAE46FEF3 /* WalletLogic.swift */,
+				A531E690F2CE4FEB86896985 /* WhiteboardLogic.swift */,
+				3A2B972D59944A22A14CD382 /* WhiteboardRenderer.swift */,
+			);
+			path = LMS;
+			sourceTree = "<group>";
+		};
+		C26454A1C21349CC82CD4A81 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				9539914B91EA4AC0A10CD744 /* APIClient.swift */,
+				B8C60DD35D434947B391DCCB /* APIError.swift */,
+				B87F886051A547F6B9915B17 /* NetworkAuthContext.swift */,
+				034243060A9D460D8829F84B /* NetworkBootstrap.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		48A959D7B391440691EDC3E9 /* Notebook */ = {
+			isa = PBXGroup;
+			children = (
+				6D674B0C9ED146939FC329F3 /* MarkdownTableLogic.swift */,
+				D83042AE2827442483E3E27C /* NotebookDrawing.swift */,
+				FB326385E92C4DA1B823A4F4 /* NotebookMarkdown.swift */,
+				0190BC6FDADE41CCB994CF1F /* NotebookSlashCommands.swift */,
+				9BD6D10890F84565933F42DB /* NotebookStore.swift */,
+				CDC8BA6757C24485B7248CA1 /* NotebookSync.swift */,
+				2A6CC2ED061F4414B31ABB71 /* NotebookTree.swift */,
+			);
+			path = Notebook;
+			sourceTree = "<group>";
+		};
+		FA86CD845606477697C280BC /* Offline */ = {
+			isa = PBXGroup;
+			children = (
+				8D48D6ED18E84162ADDD9DFD /* CacheStore.swift */,
+				08584DB395634C77BC5D895C /* DownloadStore.swift */,
+				66CF0C8E08904DE4BA967198 /* NetworkMonitor.swift */,
+				7F1594BFF9A242A9A66BDC90 /* OfflineModels.swift */,
+				5662A6252F164C63B7CDBA00 /* OfflineService.swift */,
+				748936187DFB496C964B1168 /* OutboxStore.swift */,
+				01174D0301DC49278345703C /* SyncEngine.swift */,
+			);
+			path = Offline;
+			sourceTree = "<group>";
+		};
+		405ADFE6368846B5BD802C2D /* Push */ = {
+			isa = PBXGroup;
+			children = (
+				0F2AD54DF35243D08D0884D7 /* PushManager.swift */,
+			);
+			path = Push;
+			sourceTree = "<group>";
+		};
+		84B0AE89B9E7411E8C7B1161 /* Realtime */ = {
+			isa = PBXGroup;
+			children = (
+				28F8C9E8AEC94C8CB4048E6F /* RealtimeManager.swift */,
+				BF143DA58EC349B88DE918D5 /* WebSocketClient.swift */,
+			);
+			path = Realtime;
+			sourceTree = "<group>";
+		};
+		C089B853FDAD4D3BA43BBE1C /* Routing */ = {
+			isa = PBXGroup;
+			children = (
+				6A1E5E66145E42A1971D08A6 /* ContentLinkRouter.swift */,
+				3AD1758A01574A04BD37420F /* DeepLinkRouter.swift */,
+				CC3755F559B9448F87A2512D /* MobileDestinations.swift */,
+				31CF4329D62D43529C92A419 /* MobileIaPreferences.swift */,
+				129D441D1F9D47469C14936A /* MobileProfileDepthPreferences.swift */,
+			);
+			path = Routing;
+			sourceTree = "<group>";
+		};
+		2A57ECDF8FAB4563A60CDDE3 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				18AB82BC37F649188244C769 /* SearchActionRegistry.swift */,
+				AB95D2CEDEF34154B27C0629 /* SearchModels.swift */,
+				F10471B9CC0341E191FCC111 /* SearchPathNavigator.swift */,
+				89C50C881A26455F812729AB /* SearchRecentsStore.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		54403642A92F4A7B9CC784F4 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				1A3EC0B819B54DD1A3035E15 /* CodeEditor.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
+		8F4FC60E7F9A491B822BEC85 /* Advising */ = {
+			isa = PBXGroup;
+			children = (
+				20692C98F7CF4C5E9E630940 /* AdvisingView.swift */,
+			);
+			path = Advising;
+			sourceTree = "<group>";
+		};
+		701D7DF457B14945AF961FB7 /* Assignments */ = {
+			isa = PBXGroup;
+			children = (
+				49E0B6EB1F464ADEABF0BBEE /* AssignmentDetailView.swift */,
+				1FB370489A524C4494940128 /* AssignmentDraftStore.swift */,
+				0253694A82134E3AAEB30D97 /* AttachmentUploader.swift */,
+			);
+			path = Assignments;
+			sourceTree = "<group>";
+		};
+		868E51DFC861421388C8F051 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				969DA09CDDFD40049CE615D0 /* AppleSignInController.swift */,
+				3C9B1359A4404825AE15F3A3 /* AuthFlowView.swift */,
+				F42150EF643F4D7D9FFFFAE0 /* GetStartedView.swift */,
+				10532DC1D669434B82A731A2 /* LoginView.swift */,
+				52FE0D2585394BF187ECA1B7 /* MFAChallengeView.swift */,
+				2D04881B017D42D59271A7FF /* MfaPasskeyController.swift */,
+				2F813600B54249D3B9938C60 /* SSOAuthController.swift */,
+				64116C457D144592923CE953 /* SignupView.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		18F7C9AD9EF54301BC952A4B /* Behavior */ = {
+			isa = PBXGroup;
+			children = (
+				FF6A680715844859B5AB1482 /* BehaviorRosterView.swift */,
+				1F834E7C7E2B4F83977CD393 /* HallPassView.swift */,
+				589449D3174C412290E4395C /* MyHallPassView.swift */,
+			);
+			path = Behavior;
+			sourceTree = "<group>";
+		};
+		CE2A192438064ADD8CD29594 /* Billing */ = {
+			isa = PBXGroup;
+			children = (
+				A4D5E89F64034E519A897B39 /* BillingView.swift */,
+				002621179B3240B88E42D3BE /* CheckoutReturnHandler.swift */,
+				CEBA28AFA45B4196BA532489 /* PurchaseFlow.swift */,
+			);
+			path = Billing;
+			sourceTree = "<group>";
+		};
+		87A0EC2E02864041B872FD28 /* Boards */ = {
+			isa = PBXGroup;
+			children = (
+				4DAABF4AA127483AB5410F31 /* Layouts */,
+				8390046B0AF344AABF74161A /* Public */,
+				4CA12F2E861645A1980CF97B /* BoardAnalyticsSheet.swift */,
+				8924613254124B5AA8FD0491 /* BoardComposerView.swift */,
+				03216D95DEEE443283E5957E /* BoardDetailView.swift */,
+				337088D4F5644F398827A1F8 /* BoardEngagementEnvironment.swift */,
+				BF51B8DD3EC1499B9B67BB98 /* BoardExportSheet.swift */,
+				83131615195A4ACC8EE64E7D /* BoardModerationSettings.swift */,
+				259DF311E035446E813AA4DB /* BoardPostCard.swift */,
+				C2B34D6497C14CAC8663E762 /* BoardPresentModeView.swift */,
+				5B437E7FBB6B460F8178C628 /* BoardSaveAsTemplateSheet.swift */,
+				1A2E9D9B7CC2408C88DC216F /* BoardShareSheet.swift */,
+				9B45A1B0F53148FEACFB6231 /* BoardSocket.swift */,
+				CB51EF4DBC774C6DBD841565 /* BoardSurface.swift */,
+				886E207B6264422F8B23AB06 /* BoardSyncStatusChip.swift */,
+				8B3143CE3BEC4D3FB873211C /* BoardTemplatePickerView.swift */,
+				490CFC138B7B46DDABD858C5 /* BoardsListView.swift */,
+				4D68ECFF7B644E71BC47AE87 /* CardArrangeMenu.swift */,
+				4FC767DDD02B4309BF4ADDC0 /* CommentSheet.swift */,
+				DED68C4F898B4AA492F84347 /* GradeSheet.swift */,
+				611830A137CA49C1959CDE8F /* ModerationQueueView.swift */,
+				6055DB2C26AB4129A22E0F29 /* ReactionControl.swift */,
+				8288AA0576624915998DFB6D /* ReportDialog.swift */,
+			);
+			path = Boards;
+			sourceTree = "<group>";
+		};
+		59658F1ED52246CC8C1222BD /* Catalog */ = {
+			isa = PBXGroup;
+			children = (
+				133747F8014442AEB513EB08 /* CatalogView.swift */,
+				22DF8A394EE945B8B60D579F /* CourseLandingView.swift */,
+				02AB0F11CDF54868BE71CFF3 /* ReviewComposer.swift */,
+			);
+			path = Catalog;
+			sourceTree = "<group>";
+		};
+		4AC0D2069A314057A02EFF94 /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+				1C2E30F913D24B4E82AC0C48 /* Create */,
+				7392CA5A807B44BEAA14C8B4 /* Settings */,
+				847219C1BF3A490581AAEF0D /* ContentPageView.swift */,
+				BB770D3718FF4A90B5384778 /* CourseAttendanceView.swift */,
+				87682C9CFE11404282D85EDA /* CourseBanner.swift */,
+				6439F689A7D84336B9539BD9 /* CourseDestinationPlaceholder.swift */,
+				A0365B3EC4674A04B2BDFDFB /* CourseDetailView.swift */,
+				8263EB4500D544EE8D550D89 /* CourseGradesView.swift */,
+				1DCD2C6E51C24F738ED8C250 /* CourseLibraryView.swift */,
+				A025369C914A4C87867124F5 /* CourseMarkdownContentView.swift */,
+				54B6AC4FDA634026875BA2D4 /* CoursePeopleView.swift */,
+				C6DE8049A8EC481999C88093 /* CourseStructureSocket.swift */,
+				7557B966F73F4899BC996BB4 /* CourseSyllabusView.swift */,
+				A564BD3178B141A79D7DADA8 /* CourseWorkspaceNav.swift */,
+				40536B390EA3411BA49279F6 /* CoursesListView.swift */,
+				D1F747815F954B388C7CD9D6 /* ItemDetailRows.swift */,
+				77028F77277348C399FE5293 /* ItemDetailView.swift */,
+				4A6F3A0A6E144C2E9E1DA262 /* LaunchContainerView.swift */,
+				41E68A635B7041AE8657D5F3 /* LibraryResourceView.swift */,
+				A6CAC416D8494E778F4B9787 /* MarkdownCodeBlockView.swift */,
+				E00898CE0B5A4D8F832F234E /* MarkdownTableView.swift */,
+				659D85899B3942718E0FCEF8 /* ModuleItemRouteView.swift */,
+				B6A7F68903B0466686850D5D /* ModuleListView.swift */,
+				EC0F193562AA48EA9D3B5751 /* RequirementsView.swift */,
+				04F287EF609D48A587AE804D /* TakeAttendanceView.swift */,
+				8937A1E1F8C542699D4EFCE3 /* VibeActivityView.swift */,
+				D2D25A64C53F44E8A3DCA18F /* WebItemView.swift */,
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
+		279E9605180441408A086781 /* Credentials */ = {
+			isa = PBXGroup;
+			children = (
+				C4FF896DFF2C4573B7293396 /* CredentialDetailView.swift */,
+				5D1B0BC5160C4FAF85C3E3A9 /* CredentialsView.swift */,
+			);
+			path = Credentials;
+			sourceTree = "<group>";
+		};
+		660ECF58D7484A1E96CA4C6E /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				2EFFCC5A901E49019C8EBA1D /* DashboardCoursesCarousel.swift */,
+				F4DC62FD64AE4B6D8014259E /* DashboardHeroPanel.swift */,
+				EDBAFCBF1764488498252FCB /* DashboardView.swift */,
+				C1A1E7EAE66744EC93DF87FF /* LiveMeetingsRail.swift */,
+			);
+			path = Dashboard;
+			sourceTree = "<group>";
+		};
+		0E2973A16C4745AC84DAE787 /* Discussions */ = {
+			isa = PBXGroup;
+			children = (
+				68F065BDB057427B997809FB /* CourseDiscussionsSection.swift */,
+				1E79761A651C453CAD0276FA /* DiscussionThreadView.swift */,
+				6E4292E5B6E44215941C86AE /* DiscussionsListView.swift */,
+				79B640B95186493C897B723A /* PostComposerView.swift */,
+			);
+			path = Discussions;
+			sourceTree = "<group>";
+		};
+		E17E34FD698E4FB1AC724740 /* Evaluations */ = {
+			isa = PBXGroup;
+			children = (
+				1435004D17D84682BA71973A /* CourseEvaluationsSection.swift */,
+				2FF3D50943E74F2FB0FA5844 /* EvaluationFormView.swift */,
+				54C00764961C47D08D3E81CA /* EvaluationResultsView.swift */,
+			);
+			path = Evaluations;
+			sourceTree = "<group>";
+		};
+		043D3E3832C94B41B1F5C614 /* Feed */ = {
+			isa = PBXGroup;
+			children = (
+				5A9C93B850C1470B8EDD80F4 /* CourseFeedSection.swift */,
+				C7EDA538039A4B58AFB7F963 /* FeedChannelView.swift */,
+				B6E2315E98DE4E0595C568E0 /* FeedChannelsView.swift */,
+				767D634EA7C54421A5B762FC /* FeedLogic.swift */,
+				657339EC3D474DAAA0A66C9F /* FeedSocket.swift */,
+			);
+			path = Feed;
+			sourceTree = "<group>";
+		};
+		E264AE8CB1604CFAA6B13031 /* Feedback */ = {
+			isa = PBXGroup;
+			children = (
+				E67E5F19F42C4743B164654A /* ShareFeedbackView.swift */,
+			);
+			path = Feedback;
+			sourceTree = "<group>";
+		};
+		2D431D38870B44D8905DFF75 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+				62C3F47E3007496C8003BA97 /* CourseFilesSocket.swift */,
+				3EBA60D42F624F89B59C7A13 /* CourseFilesView.swift */,
+				E12EC7DB66414805BFD47BEE /* FilePreviewView.swift */,
+				50423B031C594FD081D8F3D3 /* MarkupOverlayView.swift */,
+			);
+			path = Files;
+			sourceTree = "<group>";
+		};
+		D3D59D8988BF410DB2E957D2 /* Gamification */ = {
+			isa = PBXGroup;
+			children = (
+				CF2B964842AE422AB1F8FE31 /* GamificationView.swift */,
+			);
+			path = Gamification;
+			sourceTree = "<group>";
+		};
+		F6916FBEC6744373B5442108 /* Grades */ = {
+			isa = PBXGroup;
+			children = (
+				DE58E798DDE14728B7048B49 /* GradeFeedbackView.swift */,
+				98606023BD664072A84363A2 /* WhatIfController.swift */,
+			);
+			path = Grades;
+			sourceTree = "<group>";
+		};
+		A5E76690DDB947A4A80A942B /* Grading */ = {
+			isa = PBXGroup;
+			children = (
+				F830C796E96842FC902C5B4A /* GradingBacklogView.swift */,
+				CD3539CFC6934AD2BB2F4EAE /* SpeedGraderView.swift */,
+			);
+			path = Grading;
+			sourceTree = "<group>";
+		};
+		7878921E3EE94F9085FFAD2D /* Groups */ = {
+			isa = PBXGroup;
+			children = (
+				7EC7E1DD087A4E1489ADF74E /* CollabDocView.swift */,
+				E2AC07D555534757A7A76999 /* CourseCollabDocsSection.swift */,
+				7A28AD16498A4136A77E5F6C /* CourseGroupsSection.swift */,
+				E086F925E3C94E3DBF6D5B8D /* GroupSpaceView.swift */,
+			);
+			path = Groups;
+			sourceTree = "<group>";
+		};
+		118A2CF722A84D8FBD93B030 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				50C5179B7C504B4C9F06FE64 /* AnnouncementComposerView.swift */,
+				19B357B269DD46DB9FB3C801 /* AnnouncementsViews.swift */,
+				9961BE2DA57F4F4ABD8656AB /* BroadcastComposerView.swift */,
+				78DB00E3B5884F338081EA9C /* MainTabView.swift */,
+				903A8BB06DD34793B5FC272B /* MoreHubView.swift */,
+				FC6A66930C9247509F766F7F /* ShellHeaderBar.swift */,
+				B7ADBFE36AA24EB7B0908D7B /* TeachHubView.swift */,
+				4502383E9D304013A8EAB757 /* UniversalSearchPlaceholder.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		87B67464B37C42ABAD2BF16C /* Inbox */ = {
+			isa = PBXGroup;
+			children = (
+				0396EAFDB8CD498F95D9E93A /* ComposeMessageView.swift */,
+				A4B52603AD774852A54614C5 /* InboxView.swift */,
+				2B8B2EA90F7F474F93CF162D /* MessageDetailView.swift */,
+			);
+			path = Inbox;
+			sourceTree = "<group>";
+		};
+		0F9E926F79CF4392AB2FE1A0 /* Insights */ = {
+			isa = PBXGroup;
+			children = (
+				06853E09C60842B0B32A7B61 /* DashboardInsightsSection.swift */,
+				6080ADF9D3C34BBC9A31EA9B /* InsightsView.swift */,
 			);
 			path = Insights;
 			sourceTree = "<group>";
 		};
-		F2587B01ECD24748B8D0E5AE /* Config */ = {
+		CD2AB0C3B8EA4EC190369661 /* InstructorInsights */ = {
 			isa = PBXGroup;
 			children = (
-				A764804AD4B4428D98B9BBBE /* Development.xcconfig */,
+				0D8792C700AE49F4B0D8146F /* AtRiskListView.swift */,
+				6BBD4F4A79CB4E4DBF2EE5F3 /* CourseInsightsSection.swift */,
+				9AE1EBB432794F2DA01BFC0D /* StudentProgressDetailView.swift */,
+				6A903C2817C74B468239F028 /* WhatsWorkingView.swift */,
+			);
+			path = InstructorInsights;
+			sourceTree = "<group>";
+		};
+		D3D7D044D9F3465088659F6D /* IntroCourse */ = {
+			isa = PBXGroup;
+			children = (
+				E418402F1C0442649025F56A /* IntroCelebrationPresenter.swift */,
+				94E155C5C5BB47D28E97E754 /* IntroCompletionCelebrationSheet.swift */,
+				D0CE4282C6A94244BFF19D3C /* IntroCourseEntryCard.swift */,
+				4180F25AFDF1407D98915D1C /* IntroCourseProgressRail.swift */,
+			);
+			path = IntroCourse;
+			sourceTree = "<group>";
+		};
+		8756C2EE1A6F4AD2BB2A5D32 /* LearnerProfile */ = {
+			isa = PBXGroup;
+			children = (
+				5B80C1444C6A48B6A39E2FF2 /* LearnerProfileView.swift */,
+			);
+			path = LearnerProfile;
+			sourceTree = "<group>";
+		};
+		3602C182B393418AB4BB41A4 /* Library */ = {
+			isa = PBXGroup;
+			children = (
+				C89023B353D84747859B117E /* LibraryBrowseView.swift */,
+			);
+			path = Library;
+			sourceTree = "<group>";
+		};
+		B65CCA6818A6488C8DC3AD71 /* Live */ = {
+			isa = PBXGroup;
+			children = (
+				9229467C210C4301B2D98D60 /* MeetingDetailView.swift */,
+				1302D78379A34ED49391CD74 /* MeetingListView.swift */,
+				C5EEEB959E8549A182B2DE40 /* WhiteboardView.swift */,
+			);
+			path = Live;
+			sourceTree = "<group>";
+		};
+		7635445760EC40668163A347 /* LiveQuiz */ = {
+			isa = PBXGroup;
+			children = (
+				EA6C74B0C8A24ADFA92DCB62 /* LiveGameSocket.swift */,
+				9691EB7FB06A4E5DAF1ACA40 /* LiveQuizHubView.swift */,
+				B65BBF0633EB45F0820C1161 /* LiveQuizPlaySurfaces.swift */,
+				61FBF86F867A46CCACACAEFB /* LiveQuizPlayView.swift */,
+			);
+			path = LiveQuiz;
+			sourceTree = "<group>";
+		};
+		FEB514283FBA4FA19EA3050A /* Marketplace */ = {
+			isa = PBXGroup;
+			children = (
+				AB840DC10A7340F085F9F10A /* MarketplaceDetailView.swift */,
+				68B11BF2897F4875B7A42317 /* MarketplaceView.swift */,
+				BA2B0D06CC104264A7571102 /* MyPurchasesView.swift */,
+			);
+			path = Marketplace;
+			sourceTree = "<group>";
+		};
+		3EE8B30769534A8280558EF0 /* Mastery */ = {
+			isa = PBXGroup;
+			children = (
+				2E773ADF53394F77BEAFB505 /* CourseMasterySection.swift */,
+				2313BB40BCC74375989C45AC /* ReportCardListView.swift */,
+			);
+			path = Mastery;
+			sourceTree = "<group>";
+		};
+		275746F45C544CD59C5755D0 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				62345060129B4913870E54C1 /* CourseDrawer.swift */,
+				6C0688DB90454A19A18E8185 /* DrawerScaffold.swift */,
+				4638969A0A9A4BC3AFD33B5F /* DrawerToolbar.swift */,
+				0276213236EA41DD87B05021 /* GlobalDrawer.swift */,
+			);
+			path = Navigation;
+			sourceTree = "<group>";
+		};
+		8230BF9ACD524647BD94450E /* Notebooks */ = {
+			isa = PBXGroup;
+			children = (
+				5685788C03E1478E8174A5CB /* NotebookDrawingViews.swift */,
+				8E52B98F8D184587BFDA269B /* NotebookEditorSupportViews.swift */,
+				B5408DF2B2B44228B3BEC80B /* NotebookEditorView.swift */,
+				EAFF705789F14DA1A6B7774C /* NotebookPagesView.swift */,
+				B43F54B92C1F4A8FB207FE48 /* NotebooksListView.swift */,
+			);
+			path = Notebooks;
+			sourceTree = "<group>";
+		};
+		95160559E82849F4B6C38B1C /* OfficeHours */ = {
+			isa = PBXGroup;
+			children = (
+				3BBBE5F676024C5A8546BD9E /* BookingSheet.swift */,
+				809FB33A0AD94818A168A9FA /* MyBookingsView.swift */,
+				6402F22622804592B0BD16AF /* OfficeHoursView.swift */,
+			);
+			path = OfficeHours;
+			sourceTree = "<group>";
+		};
+		F9DF03E42271490AA7DAA449 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				21416CD8DFA947858881FB67 /* DiagnosticView.swift */,
+				E7B8423CB03A421DB125FA7E /* OnboardingFlowView.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		511CF8B4AC24421299F8C3DD /* Parent */ = {
+			isa = PBXGroup;
+			children = (
+				7495B658AA314BECB39FA0BC /* ConferenceBookingView.swift */,
+				C9D4BF14581E46E1877105A7 /* MyConferencesView.swift */,
+				DF1BEB9B7C19486C90AF60B6 /* ParentAttendanceDetailView.swift */,
+				028E88D3509D4581AD3B0D49 /* ParentDashboardSections.swift */,
+				79E0738CB7DD4EDAAF0B898E /* ParentDashboardView.swift */,
+				CBC689423511413EBBF6A2F0 /* ParentGradesDetailView.swift */,
+				4C9913DD13854F259223B9CB /* ParentNotificationPrefsView.swift */,
+			);
+			path = Parent;
+			sourceTree = "<group>";
+		};
+		7A434A96FCB542F6955BAC95 /* Paths */ = {
+			isa = PBXGroup;
+			children = (
+				20DDD4F6F0DF44B790377108 /* DashboardStudySection.swift */,
+				519A867DDBC343C2BD999131 /* MyPathsView.swift */,
+				9CFABD1859A945CFB9EE0177 /* PathLandingView.swift */,
+				1C84307E2BC94C6FA15D3BDE /* PathRunnerView.swift */,
+				2BB94EA892F64D8D9B8737C2 /* PathsCatalogView.swift */,
+			);
+			path = Paths;
+			sourceTree = "<group>";
+		};
+		391A0103663844CF9D4CE213 /* PeerReview */ = {
+			isa = PBXGroup;
+			children = (
+				5D2AD1BAB40F4D73A5DD2DBE /* PeerReviewDetailView.swift */,
+				7F3BBE2A5AFB4B66ABFEA6C5 /* PeerReviewListView.swift */,
+				144BCB7F170F41D9B763AE01 /* ReviewsReceivedView.swift */,
+				D62C5B28B5F148DAB9EAC51C /* RubricScorerView.swift */,
+			);
+			path = PeerReview;
+			sourceTree = "<group>";
+		};
+		AEB080EC28654582A5F5C698 /* Planner */ = {
+			isa = PBXGroup;
+			children = (
+				60236CCDF7AA48738D0D49FB /* CalendarSubscribeSheet.swift */,
+				7E3F8A9FCD1249E79F8CC819 /* CalendarView.swift */,
+				8C606E34F9144B64A777B6FC /* ConferenceReminderScheduler.swift */,
+				CAD1CE39301A41058120A843 /* DueReminderScheduler.swift */,
+				427B5B7A544441FF83DAB84F /* OfficeHoursReminderScheduler.swift */,
+				35482D532A2149B080CD6765 /* PlannerModel.swift */,
+				BADAEEFB6B414AA287062F8B /* PlannerView.swift */,
+				33C7B900B7ED4925A1869D55 /* TodosView.swift */,
+			);
+			path = Planner;
+			sourceTree = "<group>";
+		};
+		E2079ED3F1014028BE86AA6B /* Portfolio */ = {
+			isa = PBXGroup;
+			children = (
+				A35BC5FD1AF146CBAF2065AB /* ArtifactDetailView.swift */,
+				01E149F4B7DA48DD9F801DD0 /* ArtifactEditorView.swift */,
+				5004097E1B874DDB93242DA0 /* PortfolioArtifactUploader.swift */,
+				4A30B10FF37F4C73B99B56B6 /* PortfolioDetailView.swift */,
+				5F1211C341964513B98889F4 /* PortfolioView.swift */,
+			);
+			path = Portfolio;
+			sourceTree = "<group>";
+		};
+		D36507EDCE7F4C758048399C /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				849FD0BE416241E8A1617D59 /* AiAdminEntryCard.swift */,
+				68F339E576E4464982A315D3 /* ArchivedCoursesAdminEntryCard.swift */,
+				269BBDA8E3F84DEA9DEA260D /* BiometricLockView.swift */,
+				72BD8DB3522843548EDB368A /* DeviceSessionsView.swift */,
+				F1D7198549954D4CA1AC7026 /* EditProfileView.swift */,
+				AF071116BC2F446789DB95AC /* IntegrationsAdminEntryCard.swift */,
+				8CF54036E6B3426390D72262 /* IntegrationsEntryCard.swift */,
+				F9E6FEAC28BF4ECBB2548552 /* IntegrationsView.swift */,
+				292E60D74B50449DBF81B8D6 /* LearnerProfileEntryCard.swift */,
+				612542398DB34253A6686424 /* MyAccommodationsView.swift */,
+				36BBC380C7B14E1C97904F62 /* NotificationPreferencesView.swift */,
+				366826087F904BB7BC321C08 /* NotificationsView.swift */,
+				D5CEB80575D4484FBEFD5CC5 /* OrgBrandingAdminEntryCard.swift */,
+				283D9CE400334AC49AFD50AC /* OrgStructureAdminEntryCard.swift */,
+				CEFE73F8C7ED4996B392B117 /* PeopleAdminEntryCard.swift */,
+				918C26A90C7045FD93FF96C1 /* PlatformSettingsAdminEntryCard.swift */,
+				90E99FC07CB54E0C96EA10BD /* ProfileDepthCards.swift */,
+				5FCFBF1C1FCF47BB84AEAF38 /* ProfilePersonalDetailsView.swift */,
+				C12BAF195789448DB078C7CF /* ProfileSecurityCard.swift */,
+				E057149B676F46098DDDBD1A /* ProfileSettingsCards.swift */,
+				A7F1FD9E84874180BAD8D5DC /* ProfileView.swift */,
+				77BF6067904E4A2087EC27CE /* ProfileViewSections.swift */,
+				53305DC75B204D9C81F3585B /* ResearchStudiesView.swift */,
+				0A4320E0C0E24EB9BE1B7F58 /* RolesPermissionsAdminEntryCard.swift */,
+				D5E6AEEF26D44D3EA65A25A0 /* SettingsAdminHubEntryCard.swift */,
+				F67308866EF5479FA01FC732 /* ShareFeedbackEntryCard.swift */,
+				8BD739C270344ADEB1A3142D /* TranscriptsAdvisingAdminEntryCard.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		AC8ADF7A4E63412184F152A6 /* Quiz */ = {
+			isa = PBXGroup;
+			children = (
+				F8BCD90D8A8E4EF4AFB9D583 /* CodeQuestionView.swift */,
+				633C85BCCB7941E5BD24D270 /* LockdownController.swift */,
+				7CC57DD00547498A8F4FB307 /* QuizIntroView.swift */,
+				0B9DCCE9B89246218C4CE8EF /* QuizQuestionViews.swift */,
+				34504285543C4C9A8CD6F5EA /* QuizResultsView.swift */,
+				1B81ADC20ABF47A3AD5C31F4 /* QuizTakerView.swift */,
+			);
+			path = Quiz;
+			sourceTree = "<group>";
+		};
+		237D6A2B598547BD86AFBCDE /* Reader */ = {
+			isa = PBXGroup;
+			children = (
+				41EC5757A7B946098AC5B893 /* CaptionedPlayerView.swift */,
+				CAACDFB103B9456BBC73750E /* ContentTranslationControls.swift */,
+				49467C0BBC9C415780029214 /* ImmersiveReaderCapabilities.swift */,
+				990F430024144399B37A91A2 /* ReaderLogic.swift */,
+				9F495ED7A44B4C73968DA21E /* ReaderToolbar.swift */,
+				BBDA47FBE9DE454C9CD75E5D /* ReadingPreferencesSheet.swift */,
+				D4AB029FB1A444B3BEA5D695 /* ReadingPreferencesStore.swift */,
+			);
+			path = Reader;
+			sourceTree = "<group>";
+		};
+		90F66E03E1134348965E60B3 /* Reading */ = {
+			isa = PBXGroup;
+			children = (
+				56111FF37D29429987AB0096 /* LeveledLibraryView.swift */,
+				3B3A83C44B84487CB01EFF3C /* LogReadingSheet.swift */,
+				9F5A6D6A50874B1FAB312EE8 /* ReadingDashboardView.swift */,
+			);
+			path = Reading;
+			sourceTree = "<group>";
+		};
+		46868CAEEAB6446F8ABEC2B2 /* Review */ = {
+			isa = PBXGroup;
+			children = (
+				4BBB673CA4DB420BA37B9208 /* ReviewHomeView.swift */,
+				A6440ADA1E9544ECBF69F85E /* ReviewReminderScheduler.swift */,
+				A31DE89C777B4A51887F141C /* ReviewSessionView.swift */,
+			);
+			path = Review;
+			sourceTree = "<group>";
+		};
+		E1A4436428CA4458B73960A1 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				F0A178AEF05541188021889B /* UniversalSearchView.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		210F88C32584464BBEE31669 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				0D1E0D02D4B644B89A64B37E /* Admin */,
+				EC90322BE577468290B4551A /* SettingsAdminHubView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		CA7B2E95CAF54885B79E2BC5 /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				8C311030F725471CBF67D6F8 /* SplashView.swift */,
+			);
+			path = Splash;
+			sourceTree = "<group>";
+		};
+		79EEC603F04B48FBAB3B099C /* Tutor */ = {
+			isa = PBXGroup;
+			children = (
+				871BFA5C95E049CBAFEC0731 /* TutorChatModel.swift */,
+				9452C8D2829F4FB6B21CAB26 /* TutorChatView.swift */,
+				3CAB6ED9091E4B3E94718267 /* TutorFlowLayout.swift */,
+				A66A524C7AAC4FB2B017F128 /* TutorLauncher.swift */,
+			);
+			path = Tutor;
+			sourceTree = "<group>";
+		};
+		7E4FC5D1155B4BB3942A3651 /* Wallet */ = {
+			isa = PBXGroup;
+			children = (
+				F9F9005EEE2744EBB7D096EC /* WalletCCRDetailView.swift */,
+				0BF4CF0A377A4ED5B3DC1AA0 /* WalletCETranscriptDetailView.swift */,
+				7AACA18723DA4543805BE85B /* WalletOfficialTranscriptDetailView.swift */,
+				A9F06C20D3B941B69051DDA0 /* WalletView.swift */,
+			);
+			path = Wallet;
+			sourceTree = "<group>";
+		};
+		4DAABF4AA127483AB5410F31 /* Layouts */ = {
+			isa = PBXGroup;
+			children = (
+				370BAE4B96A34903AB73ED0C /* CanvasLayout.swift */,
+				78BA4EA8C1154A7EA1731CD8 /* ColumnsLayout.swift */,
+				780DA182FF4043B38696D36C /* MapLayout.swift */,
+				E7CB8C1BE7504CD9B7CEEAC6 /* TimelineLayout.swift */,
+				57FDCF46AF3E4B0DA1A173DB /* WallLayout.swift */,
+			);
+			path = Layouts;
+			sourceTree = "<group>";
+		};
+		8390046B0AF344AABF74161A /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				2F852E57D2D14F8A95455DBE /* BoardPublicView.swift */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		1C2E30F913D24B4E82AC0C48 /* Create */ = {
+			isa = PBXGroup;
+			children = (
+				35EB05D53C374ABEB6EA3DD0 /* CanvasImportComingSoonView.swift */,
+				E9F823AB9D514792B470A794 /* CanvasImportView.swift */,
+				2BCB46E9122846B5904855D6 /* CourseCreateView.swift */,
+			);
+			path = Create;
+			sourceTree = "<group>";
+		};
+		7392CA5A807B44BEAA14C8B4 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				E895804DE50A41ED8B232135 /* CourseAccessibilityReviewView.swift */,
+				267410C1A41D49FF99FBB5C7 /* CourseArchivedContentView.swift */,
+				FCBAB76F491F4138AED91A60 /* CourseBlueprintSettingsView.swift */,
+				FC84EB24717C41269F150D07 /* CourseCrossListingView.swift */,
+				DD02BDC83DB8485CBCE81507 /* CourseFeaturesSettingsView.swift */,
+				BFB6A4245D294042A00AA6A4 /* CourseGeneralSettingsView.swift */,
+				5349888EC0114570ACD831E4 /* CourseGradingAgentsView.swift */,
+				59EF72CCCF474E3AAA676528 /* CourseGradingSettingsView.swift */,
+				EA41E9040649456DB33BC162 /* CourseHeroImageEditor.swift */,
+				FBA181A953E14C468095768C /* CourseImportExportView.swift */,
+				9BE3AA0F3A6F4471AA1C6E35 /* CourseMarketplaceSettingsView.swift */,
+				8BC1C07012AA400FB90CD1B1 /* CourseOutcomesSettingsView.swift */,
+				2225D9D07D9C459196127219 /* CoursePlagiarismSettingsView.swift */,
+				4DE94582729E48E39E56B2E9 /* CourseSectionsSettingsView.swift */,
+				713566F955A64593962A78CF /* CourseSettingsHostView.swift */,
+				1FA5BBF44C9844CEA26C3C6A /* CourseTranslationsSettingsView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		0D1E0D02D4B644B89A64B37E /* Admin */ = {
+			isa = PBXGroup;
+			children = (
+				B97B6F26B6DC4092BAB78F26 /* AdminMetricCards.swift */,
+				DB36A44F66604F3C843C50D9 /* AdvisingSettingsView.swift */,
+				4C9843014D154611A7BFD0C9 /* AiAdminHubView.swift */,
+				44A56979663249C4AFE83221 /* AiGovernanceView.swift */,
+				889FAFAF774142C2BA86329C /* AiModelsSettingsView.swift */,
+				B3C29C92B3B24E5C86725EE7 /* AiProviderSettingsView.swift */,
+				CA28E77314484396AB0AE64A /* AiReportsView.swift */,
+				C4355CA566304FBAAB98D098 /* ArchivedCoursesAdminView.swift */,
+				942584F491914827B95F3282 /* AuditLogAdminView.swift */,
+				88724DBA10A14C4BB795E26F /* BoardsGovernanceAdminView.swift */,
+				914CCB5EAAF34214B8885432 /* CoursesAdminView.swift */,
+				43BFDD3B36BC48A8B13DE360 /* IntegrationsAdminView.swift */,
+				79E256FCB9F14A47B25202B5 /* OrgBrandingAdminView.swift */,
+				B1B6653C12AF4B4395D2650A /* OrgBrandingView.swift */,
+				9F3124434EF14E0F9A93AF28 /* OrgStructureAdminView.swift */,
+				12EEAD3B385B4D19A7EE0841 /* OrgStructureView.swift */,
+				41EF610BF1484F9AADE2AA95 /* PeopleAdminView.swift */,
+				FF4A03C39AFE47918DBCC377 /* PlatformSettingsView.swift */,
+				F67E4C60CD8D4042A5591FEE /* RolesPermissionsAdminView.swift */,
+				AE2FA99DD121458D8201C26C /* SystemPromptsView.swift */,
+				D1AF5D02D2464887B58449B2 /* TermsAdminView.swift */,
+				4D5AD5CA80204A4D9F4EDB14 /* TranscriptsAdvisingAdminView.swift */,
+				12B3CD2CBADB4D5CB7B5CD36 /* TranscriptsSettingsView.swift */,
+				9240550142D1439DB32F9DDA /* UserDetailAdminView.swift */,
+			);
+			path = Admin;
+			sourceTree = "<group>";
+		};
+		EEA8A3DCA53849119D2E55D7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				45A94E45545C4385825A8FAB /* Lextures.app */,
+				15F81775D0274CCC924659BA /* LexturesTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		18E195655DA64C658129CFC0 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				399F75F7EF59410184CBA37C /* Development.xcconfig */,
 			);
 			path = Config;
+			sourceTree = "<group>";
+		};
+		C58FCA5712CE40849BA70C07 = {
+			isa = PBXGroup;
+			children = (
+				229B30A95B9B4F4894F99558 /* Lextures */,
+				06964482C25142FFB07CE05C /* LexturesTests */,
+				18E195655DA64C658129CFC0 /* Config */,
+				EEA8A3DCA53849119D2E55D7 /* Products */,
+			);
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		6EEA82F92F494FFC8178DEC6 /* LexturesTests */ = {
+		1C95EA15BFA249F09F2F233C /* Lextures */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C664F8D7A3DB40C390274DF7 /* Build configuration list for PBXNativeTarget "LexturesTests" */;
+			buildConfigurationList = 124F22003E48492986BF0C64 /* Build configuration list for PBXNativeTarget "Lextures" */;
 			buildPhases = (
-				D3E44D77E6284235B1466959 /* Sources */,
-				8EF0D9ADBE7346B5A68E4717 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				BEC4E2EC998448EE83091471 /* PBXTargetDependency */,
-			);
-			name = LexturesTests;
-			productName = LexturesTests;
-			productReference = 4F805878F1A84A8EB6882D47 /* LexturesTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		A1DE4D1C828A4CC1860443E6 /* Lextures */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7BA77D9C7C584CFCA77925DB /* Build configuration list for PBXNativeTarget "Lextures" */;
-			buildPhases = (
-				4183970C10224A8C82615471 /* Sources */,
-				BDE4E5309997457083163CAF /* Frameworks */,
-				088BFC505C1F4AA681F7A693 /* Resources */,
+				B327D2048BCD48B6A95C384A /* Sources */,
+				28DFD09374804ACA94378472 /* Frameworks */,
+				C85E3401A43E47C29247FEB8 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = Lextures;
+			name = "Lextures";
 			productName = Lextures;
-			productReference = FDC0C405F08447CA83B590F7 /* Lextures.app */;
+			productReference = 45A94E45545C4385825A8FAB /* Lextures.app */;
 			productType = "com.apple.product-type.application";
+		};
+		895620D25C8A4BCA974315E7 /* LexturesTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5778F2DD9CE041F4A88C1C97 /* Build configuration list for PBXNativeTarget "LexturesTests" */;
+			buildPhases = (
+				9E1E6DA8B52A40FDB2B4C866 /* Sources */,
+				B9D3D80715914553984DCBCF /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9FABE0A0696C4FADA1748E80 /* PBXTargetDependency */,
+			);
+			name = "LexturesTests";
+			productName = LexturesTests;
+			productReference = 15F81775D0274CCC924659BA /* LexturesTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
+/* Begin PBXContainerItemProxy section */
+		F81C8C90259945C7A1597CF7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 23ED123BADD24061AF867515 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C95EA15BFA249F09F2F233C;
+			remoteInfo = Lextures;
+			};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+		9FABE0A0696C4FADA1748E80 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1C95EA15BFA249F09F2F233C /* Lextures */;
+			targetProxy = F81C8C90259945C7A1597CF7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXProject section */
-		1EB58D3E83FF4D9A87F5844C /* Project object */ = {
+		23ED123BADD24061AF867515 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
-					A1DE4D1C828A4CC1860443E6 = {
+					1C95EA15BFA249F09F2F233C = {
 						CreatedOnToolsVersion = 16.0;
 					};
 				};
 			};
-			buildConfigurationList = BE1D86F1FE79430185CE70F9 /* Build configuration list for PBXProject "Lextures" */;
+			buildConfigurationList = C0539B66D38A4C3D80C6B2D5 /* Build configuration list for PBXProject "Lextures" */;
 			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -2651,743 +2661,705 @@
 				en,
 				Base,
 			);
-			mainGroup = C6202B5B81D64D90A2E5F743;
-			productRefGroup = BE91F836B2244CD9BF44A3A3 /* Products */;
+			mainGroup = C58FCA5712CE40849BA70C07;
+			productRefGroup = EEA8A3DCA53849119D2E55D7 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				A1DE4D1C828A4CC1860443E6 /* Lextures */,
-				6EEA82F92F494FFC8178DEC6 /* LexturesTests */,
+				1C95EA15BFA249F09F2F233C /* Lextures */,
+				895620D25C8A4BCA974315E7 /* LexturesTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		088BFC505C1F4AA681F7A693 /* Resources */ = {
+		C85E3401A43E47C29247FEB8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				515012AE71E84025AE4F1333 /* Assets.xcassets in Resources */,
-				0859F752E2E44CDE99BB3EC6 /* Localizable.xcstrings in Resources */,
-			);
 			runOnlyForDeploymentPostprocessing = 0;
+			files = (
+				40E58270E8384B91A6D7D8D9 /* Assets.xcassets in Resources */,
+				86440F50A4684F768EF22A0B /* Localizable.xcstrings in Resources */,
+			);
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		4183970C10224A8C82615471 /* Sources */ = {
+		B327D2048BCD48B6A95C384A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				C0A1B004PLATCRSL0G1C01 /* PlatformCoursesAdminLogic.swift in Sources */,
-				C0A1B003PLATCRSM0DEL01 /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */,
-				C0A1B002C0URSESADM1N01 /* CoursesAdminView.swift in Sources */,
-				C0A1B001ADM1NMETR1C001 /* AdminMetricCards.swift in Sources */,
-				DD01F14F19C240E3966087C1 /* AppDelegate.swift in Sources */,
-				9CEB41E78B014578999FE1E7 /* LexturesApp.swift in Sources */,
-				DBF280805E3546E29FCF6B60 /* RootView.swift in Sources */,
-				CB366B3DD19946AE90A11436 /* AccessibilityPreferences.swift in Sources */,
-				68B3FD62633745B19917CBF4 /* AccessibilitySupport.swift in Sources */,
-				2B5F5B470EBE437788CCB53A /* DictationField.swift in Sources */,
-				0FF9D649AEEC4D50B096AEE6 /* ReadAloud.swift in Sources */,
-				B566482BBE204054B150DBDD /* AuthAPI.swift in Sources */,
-				1E46551F66494BDEB2A88D3E /* AuthCallbackParser.swift in Sources */,
-				BEF2ABCB07A24CAB84BC8469 /* AuthConstants.swift in Sources */,
-				5227F0973A5E4FC29A61FC44 /* AuthSession.swift in Sources */,
-				E4642D50AEDE412D9A2C05EE /* BiometricGate.swift in Sources */,
-				11F8FBDE407A40D8A682F6BF /* KeychainStore.swift in Sources */,
-				B35512518F934CDB82F896EC /* SessionsAPI.swift in Sources */,
-				C87C7F322D0A43B9B8C2290F /* AppConfiguration.swift in Sources */,
-				9E50A3A5CE2C4BAD857A4559 /* EnvironmentStore.swift in Sources */,
-				C55A4ADDE3AE482BB4EEC346 /* SchoolCodeLogic.swift in Sources */,
-				152B51588C0844068C99EA7B /* AuthFieldRepresentable.swift in Sources */,
-				F64D2168D658458588B868EB /* BrandLogoView.swift in Sources */,
-				601BF591C4F04942B5061CEE /* Haptics.swift in Sources */,
-				7E666BF9EA5E44FB872C6A94 /* LexturesMotion.swift in Sources */,
-				EC101926F0BC469E84DD9FFE /* LexturesTheme.swift in Sources */,
-				2A64E06493784F7F93868D88 /* LexturesType.swift in Sources */,
-				ECF3AF3EC60F437A826A62A5 /* ProfileAvatarView.swift in Sources */,
-				372174549C0B424A9A21B394 /* SyncStatusView.swift in Sources */,
-				DF5D56D9893C4925BE14E0B3 /* ThemePreference.swift in Sources */,
-				C5D5309EBCC6480690671859 /* UIMode.swift in Sources */,
-				055BFD1A7F664F52A1482A96 /* UnsavedChangesBanner.swift in Sources */,
-				2B2AF9E2736C4E8980FF32C0 /* DateFormatting.swift in Sources */,
-				F429E05333FF47F19016DE5C /* LocaleAPI.swift in Sources */,
-				7306496064624237B8BD3849 /* LocalePreferences.swift in Sources */,
-				5C3C84050A8A4B42823C0B15 /* Localized.swift in Sources */,
-				F1FD6FB304A3456BAF766F57 /* AccountAccommodationModels.swift in Sources */,
-				8607C609107B4A8A91889CC2 /* AccountIntegrationsLogic.swift in Sources */,
-				7BE38577F5CA48439F03BC39 /* AdvisingLogic.swift in Sources */,
-				11280210EE584BCEB52E0D65 /* AiModelsAdminLogic.swift in Sources */,
-				DC512FF97B8641538792E11F /* AnnouncementLogic.swift in Sources */,
-				F947C01BFAAE4BC29C197A19 /* ArchivedCoursesAdminLogic.swift in Sources */,
-				063E54D3CDDD40488EB8CF56 /* AssignmentLogic.swift in Sources */,
-				C98FAC049F824C8C98829EA2 /* AuditLogAdminLogic.swift in Sources */,
-				9EA5FB66CC4A48998BA81C67 /* BehaviorLogic.swift in Sources */,
-				B6CEBCA1A4574809A241F8A2 /* BillingLogic.swift in Sources */,
-				A240815877394C7E99D051FA /* BoardRealtimeLogic.swift in Sources */,
-				A71747CAB1B24A74B64877B6 /* BoardsAdvancedLogic.swift in Sources */,
-				8875D5B55E1348EFBD056A23 /* BoardsGovernanceAdminLogic.swift in Sources */,
-				2CBC37EBAA694A7F9B87A33D /* BoardsLogic.swift in Sources */,
-				4DC46457177E4D40AB442A4B /* CanvasImportLogic.swift in Sources */,
-				48696B5FE1804FAD83864AFB /* CanvasImportObservability.swift in Sources */,
-				DFC265F701554105BFF4BEFE /* CatalogLogic.swift in Sources */,
-				FA892EEB0AB543C18F77C530 /* ConferenceLogic.swift in Sources */,
-				7E4812A8D58B45FEA782EEFD /* CourseAccessibilityReviewLogic.swift in Sources */,
-				676FDF2B65E642F19A0A2627 /* CourseArchivedContentLogic.swift in Sources */,
-				4D68557B07644E6BA10DF57F /* CourseBlueprintLogic.swift in Sources */,
-				6DE87F208E28448393E40E3B /* CourseCreateDraftStore.swift in Sources */,
-				642F072D628E41F9AFCEA6FA /* CourseCreateLogic.swift in Sources */,
-				F5D784051A4641D79D500CD7 /* CourseCreateObservability.swift in Sources */,
-				E0853E7BD04E41E7AFFC4ED5 /* CourseFeaturesLogic.swift in Sources */,
-				5AF3CA042B8E47CFA2D48C32 /* CourseFileLogic.swift in Sources */,
-				2458C373E24043C29532B285 /* CourseGradingAgentsLogic.swift in Sources */,
-				66FEF12457A947CFA3928C46 /* CourseGradingLogic.swift in Sources */,
-				BD6BE1F17ED54BDA80A82AE8 /* CourseHeroImage.swift in Sources */,
-				AD90C099CDD04360A7C08F12 /* CourseImportExportLogic.swift in Sources */,
-				E755406C7057458298AEC62C /* CourseOutcomesLogic.swift in Sources */,
-				C46336EB5EB44D109CACF82C /* CoursePeopleLogic.swift in Sources */,
-				41A794A270F3482F8D29FD17 /* CoursePeopleObservability.swift in Sources */,
-				4941EBAB677E4EF1BA57291F /* CoursePlagiarismLogic.swift in Sources */,
-				659584D8810544F991297122 /* CourseReviewLogic.swift in Sources */,
-				C35E03710A2442D4BBF94057 /* CourseSectionsLogic.swift in Sources */,
-				4AFB47AF0D794E44B80BE4BD /* CourseSettingsLogic.swift in Sources */,
-				F907DA13E1E5489D8A2FC191 /* CourseTranslationsLogic.swift in Sources */,
-				27801420702A4194B69AA17A /* CredentialsLogic.swift in Sources */,
-				60D36AB086624FA6A917BA6E /* CurrencyExponent.swift in Sources */,
-				354AC34CCC7245F88FCE0FE8 /* DiscussionLogic.swift in Sources */,
-				10543BC17F9243F5BAE1A492 /* EvaluationLogic.swift in Sources */,
-				1E5BFE03C54543E198D0A42D /* FeedbackLogic.swift in Sources */,
-				972F35CF808C4FEAA9C04BA8 /* FileDownloadManager.swift in Sources */,
-				5369BEC3ECC641139A1A206D /* GamificationLogic.swift in Sources */,
-				A02D365906FA47298A46828C /* GradeCalculator+MyGrades.swift in Sources */,
-				66554CA03B054EB7B8AADC75 /* GradeCalculator.swift in Sources */,
-				FECC0401D1544AD187F86779 /* GroupsLogic.swift in Sources */,
-				4764BA623AA6458489258500 /* InsightsLogic.swift in Sources */,
-				02459F671A994F438714916C /* InstructorInsightsLogic.swift in Sources */,
-				3F74682A50FE429EA4297D96 /* IntegrationsAdminLogic.swift in Sources */,
-				5E04043E5E7C43238F5AE319 /* InteractiveLaunchLogic.swift in Sources */,
-				95DE329B5E834CA2AD2AB423 /* IntroCourseLogic.swift in Sources */,
-				C64789CA8B5244B5A3C989F8 /* IntroCourseObservability.swift in Sources */,
-				5DED8AF9AD2D4F9D93314DFD /* LMSAPI.swift in Sources */,
-				16ECA9917F444FA1A1918CEA /* LMSAPIAccountIntegrations.swift in Sources */,
-				F0B7AFBBEFCC448C970FAB5B /* LMSAPIAdmin.swift in Sources */,
-				2683BEB70FC64E038D00AF14 /* LMSAPIAdvising.swift in Sources */,
-				158B9F3437A646F48BF49449 /* LMSAPIAnnouncements.swift in Sources */,
-				C44FFEBEDCB84839A0DDEF54 /* LMSAPIAuditLog.swift in Sources */,
-				6D92F9DD68F94B528B680B08 /* LMSAPIBehavior.swift in Sources */,
-				4800B6BD78CC47F6A256900F /* LMSAPIBilling.swift in Sources */,
-				2D6401AEC1504603B1AE2401 /* LMSAPIBoardAccess.swift in Sources */,
-				95C256B92C994F73BD37211F /* LMSAPIBoardAnalytics.swift in Sources */,
-				BAE0A5E289CC4C0A89C3B4AB /* LMSAPIBoardEngagement.swift in Sources */,
-				A6C16B9917BE4C8293D40720 /* LMSAPIBoardExport.swift in Sources */,
-				ED26D8D24D4F4D78A8AABE89 /* LMSAPIBoardLayout.swift in Sources */,
-				E349ED31E28947629CE58754 /* LMSAPIBoardModeration.swift in Sources */,
-				CC43F800E0EC4217A63E99CA /* LMSAPIBoardPosts.swift in Sources */,
-				A14BDA044959488C8B91C7C5 /* LMSAPIBoardTemplates.swift in Sources */,
-				E6FC3898DB844C9380D8F183 /* LMSAPIBoards.swift in Sources */,
-				DBF150A642F0430589B8A399 /* LMSAPICanvasImport.swift in Sources */,
-				F6B61D39B8A84528B42BE86C /* LMSAPICatalog.swift in Sources */,
-				1EFBE40ACCF6448493B79835 /* LMSAPICourseAccessibility.swift in Sources */,
-				D3772A45DD6B453EB920673F /* LMSAPICourseArchivedContent.swift in Sources */,
-				37747D0BE8544ABB914D5AA8 /* LMSAPICourseBlueprint.swift in Sources */,
-				A18CE0C0CDB941F19A87EA34 /* LMSAPICourseCreate.swift in Sources */,
-				BA2BA693E4C647998B56C23A /* LMSAPICourseFeatures.swift in Sources */,
-				B3320B8C932C4BB99864A678 /* LMSAPICourseGrading.swift in Sources */,
-				8991DE6555DF4A7B890608C7 /* LMSAPICourseGradingAgents.swift in Sources */,
-				B2C2AFB0C35343BC8A3BAB35 /* LMSAPICourseImportExport.swift in Sources */,
-				32CCFC36F06242FA9E84674F /* LMSAPICoursePlagiarism.swift in Sources */,
-				255B2A9B0A7D46FDB8C9FA76 /* LMSAPICourseReviews.swift in Sources */,
-				953ABDF98FEE4D8C85EE68F3 /* LMSAPICourseSections.swift in Sources */,
-				AA60FEC0522240959A5F3295 /* LMSAPICourseSettings.swift in Sources */,
-				A2E33B214B2B4592A5250C26 /* LMSAPICourseTranslations.swift in Sources */,
-				3FAE014984844B32AA2A4A09 /* LMSAPICredentials.swift in Sources */,
-				31E7CD33FC6F469590F0DC38 /* LMSAPIDiscussions.swift in Sources */,
-				128540713D8F44B3A8C17260 /* LMSAPIEportfolio.swift in Sources */,
-				FDC1E1234C6141499E94BEB6 /* LMSAPIEvaluations.swift in Sources */,
-				BFEC5D70F8EB4D378B27CE88 /* LMSAPIFeatures.swift in Sources */,
-				3C26EDC7951C4EA9A8F87280 /* LMSAPIFeed.swift in Sources */,
-				F0234D51F3E34E3AB05D0885 /* LMSAPIFeedback.swift in Sources */,
-				991719A67D81438F9C8F25A1 /* LMSAPIGamification.swift in Sources */,
-				D4FE653951F7491A93236667 /* LMSAPIGroups.swift in Sources */,
-				727B3BDFAD1F40ABB93B9024 /* LMSAPIInsights.swift in Sources */,
-				57C6DBA3DFCE486C8EE2496F /* LMSAPIInstructorInsights.swift in Sources */,
-				66D0F48F34544C2FB44434DA /* LMSAPIIntroCourse.swift in Sources */,
-				C30188EF2EDC45FB8F0DFA14 /* LMSAPILearnerProfile.swift in Sources */,
-				295E887EBB29498D818FEFC9 /* LMSAPILiveQuiz.swift in Sources */,
-				C8F9053AE3C5456D9772702F /* LMSAPIMarketplace.swift in Sources */,
-				2CB0D9BB9B8D4DBA86AE023F /* LMSAPIMastery.swift in Sources */,
-				33991E4F08F5489890DC1D8A /* LMSAPIMobileWave.swift in Sources */,
-				01E9158AEBE6416BAA8A83D8 /* LMSAPIOutcomes.swift in Sources */,
-				524EA0BC49FE44B1B1D9243F /* LMSAPIParent.swift in Sources */,
-				E3DEEA2352E24C0893D51C4C /* LMSAPIPaths.swift in Sources */,
-				7BF4836E3E2E4E0EA2E8758A /* LMSAPIPeerReview.swift in Sources */,
-				4870EA14D21F4ED3A5CEB5CE /* LMSAPIProctoring.swift in Sources */,
-				3D6F154A9E0042DEBCA6163A /* LMSAPIQuizCodeRun.swift in Sources */,
-				1A9CCA400B374FBDB1F282C5 /* LMSAPIReader.swift in Sources */,
-				E6AE8BA5F5C8457EA0B981EF /* LMSAPIReading.swift in Sources */,
-				3B9EA2147C274086B2623EA0 /* LMSAPIReview.swift in Sources */,
-				E6F7BA4AB67A4195B80148C1 /* LMSAPITutor.swift in Sources */,
-				0041FE5FA6BB46839C7C23EC /* LMSAPIWallet.swift in Sources */,
-				434EEA1081F14774B6C15627 /* LMSAPIWhiteboard.swift in Sources */,
-				9528176BD8A94834852673A4 /* LMSBoardAdvancedModels.swift in Sources */,
-				4412D47BDD0A407D954FD936 /* LMSBoardModels.swift in Sources */,
-				605E48EACCCA45C983B7EE5B /* LMSFeatureModels.swift in Sources */,
-				4F582EC491774E0CB6D3916F /* LMSFeatureModelsAccountIntegrations.swift in Sources */,
-				524C2D5121224121959AB240 /* LMSFeatureModelsAdvising.swift in Sources */,
-				5519921AD5AC4370A4A53280 /* LMSFeatureModelsAiAdmin.swift in Sources */,
-				C362C2969A9D4F49928AAA0B /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */,
-				C591DE04D7F74F1484BC6D41 /* LMSFeatureModelsAuditLog.swift in Sources */,
-				B5208F0E41D24AC29B919F33 /* LMSFeatureModelsBehavior.swift in Sources */,
-				A02910682A4C4B1AB72246E7 /* LMSFeatureModelsBilling.swift in Sources */,
-				469CF13396A64D35AD52F151 /* LMSFeatureModelsCanvasImport.swift in Sources */,
-				9B79351E323A481189C13F49 /* LMSFeatureModelsCatalog.swift in Sources */,
-				CA56948D75944FC9B722340E /* LMSFeatureModelsCourseAccessibility.swift in Sources */,
-				E45A30BA2EC641FDB8A2C9EB /* LMSFeatureModelsCourseCreate.swift in Sources */,
-				60C2FAC9ECF540C7B51A1F4A /* LMSFeatureModelsCourseGrading.swift in Sources */,
-				576ED90154C9470EA4AD3DDF /* LMSFeatureModelsCourseGradingAgents.swift in Sources */,
-				3DD822D36CEF44358FA5B609 /* LMSFeatureModelsCourseOutcomes.swift in Sources */,
-				DB438FB7C27C48C398716228 /* LMSFeatureModelsCoursePlagiarism.swift in Sources */,
-				AB233BEEBF544D92ABA91E94 /* LMSFeatureModelsCourseReviews.swift in Sources */,
-				71313E28BE5A45D4A88D1B66 /* LMSFeatureModelsCourseSettings.swift in Sources */,
-				25226443E8C5498E9C28A047 /* LMSFeatureModelsCourseTranslations.swift in Sources */,
-				247E109255614CD7975F7F90 /* LMSFeatureModelsCredentials.swift in Sources */,
-				573D2C6B67AF45B29139D737 /* LMSFeatureModelsDiscussions.swift in Sources */,
-				153281B8E32648E885845203 /* LMSFeatureModelsEportfolio.swift in Sources */,
-				99D64CAF336F41938B344B15 /* LMSFeatureModelsEvaluations.swift in Sources */,
-				A9611AC4DDD64335821B7EC0 /* LMSFeatureModelsFeed.swift in Sources */,
-				6D2B87FCC7F743BA879421DC /* LMSFeatureModelsFeedback.swift in Sources */,
-				BD73621956374867A01EC4BC /* LMSFeatureModelsGamification.swift in Sources */,
-				3823C380D04E4AF2A770AE6C /* LMSFeatureModelsGroups.swift in Sources */,
-				257F3C5CB2634E30B3975B81 /* LMSFeatureModelsInsights.swift in Sources */,
-				F959393EF196487DB536229A /* LMSFeatureModelsInstructorInsights.swift in Sources */,
-				9EBFC64B85254654BD48655B /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */,
-				A15836F484374FA993B3B0E5 /* LMSFeatureModelsIntroCourse.swift in Sources */,
-				9557877184F043BAA7DFCAD5 /* LMSFeatureModelsLearnerProfile.swift in Sources */,
-				1AC9F9A2670742629BCAF122 /* LMSFeatureModelsLive.swift in Sources */,
-				5634E0E8A20C43BA966DDA02 /* LMSFeatureModelsMarketplace.swift in Sources */,
-				6BB282A21DFD4A38911028B3 /* LMSFeatureModelsMastery.swift in Sources */,
-				B9D0B7E434E241E2B6BD4180 /* LMSFeatureModelsMobile.swift in Sources */,
-				9A230916D0B949F28B918F74 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */,
-				B2153F40E84A45C58D908328 /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */,
-				B025112610394F9C8DCB9F2D /* LMSFeatureModelsParent.swift in Sources */,
-				59D814C31C044B6FB0162D41 /* LMSFeatureModelsPaths.swift in Sources */,
-				F31F08EB76764695B403A9A9 /* LMSFeatureModelsPeerReview.swift in Sources */,
-				C4ED048BD8BB42BE87CAD4D4 /* LMSFeatureModelsPeopleAdmin.swift in Sources */,
-				B0522468284A4DEB8844C558 /* LMSFeatureModelsPlatform.swift in Sources */,
-				83DBFDAA0CBB4B2BA29320C7 /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */,
-				2B6CA9651A464E7899854C5E /* LMSFeatureModelsReader.swift in Sources */,
-				79A5C647C7AA4F71AEDEC710 /* LMSFeatureModelsReading.swift in Sources */,
-				A147E26E557B4E058E36D615 /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */,
-				526275159DF64DD0AA38775B /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */,
-				4C3BEBC752E0497C8B14AD2F /* LMSFeatureModelsTutor.swift in Sources */,
-				EF5559D223E24EB086B5B0AA /* LMSFeatureModelsWallet.swift in Sources */,
-				3411C7861AB84C11A17B2781 /* LMSInteractiveModels.swift in Sources */,
-				E634B36AFA6546CA8DB2F8B5 /* LMSModels.swift in Sources */,
-				B73D98CA5E7143FDAE4DB880 /* LearnerProfileLogic.swift in Sources */,
-				6B205032F85E4421AF1886AD /* LibraryResourceLogic.swift in Sources */,
-				E70F747DE25948609EBD9DEB /* LiveGameLogic.swift in Sources */,
-				9012C4718113455798FBCE75 /* LiveMeetingsLogic.swift in Sources */,
-				59C74B928DD44749B179287E /* LiveQuizLogic.swift in Sources */,
-				15FC4425DCCF467BB295B342 /* MarketplaceLogic.swift in Sources */,
-				129D89573F524425AE2F41DB /* MasteryLogic.swift in Sources */,
-				E16394C2194F4C52B99DBF90 /* ModuleContentLogic.swift in Sources */,
-				647F1978D5334FD3A73FE0DC /* ModuleLastVisited.swift in Sources */,
-				15941DA9DB624FEE9207726F /* NotificationLogic.swift in Sources */,
-				F761DF8CE6444D838E713B66 /* OfficeHoursLogic.swift in Sources */,
-				817B6C6161E24FA89B2A6BE4 /* OnboardingModels.swift in Sources */,
-				4E9014A25F7E4942A0F8D69D /* OrgBrandingAdminLogic.swift in Sources */,
-				0511972636604627A87F2339 /* OrgStructureAdminLogic.swift in Sources */,
-				E7292817B6D74199944410C1 /* ParentLogic.swift in Sources */,
-				12A86CE4267D47BDA20E665D /* PathsLogic.swift in Sources */,
-				DE99DCACAD624C59B98DB912 /* PeerReviewLogic.swift in Sources */,
-				0C9BFA3B36E0462A9450735F /* PeopleAdminLogic.swift in Sources */,
-				5319DF83F3254430A3E7F4E8 /* PlannerLogic.swift in Sources */,
-				0FCDF694BC1C4F1C913A9E10 /* PlannerSnapshotCoding.swift in Sources */,
-				50D84A8CE65B498A90F0154A /* PlatformSettingsAdminLogic.swift in Sources */,
-				507D3C9F02F64883A5BAFB77 /* PortfolioLogic.swift in Sources */,
-				165CCB3A2AD94B48B358F967 /* ProfileDepthLogic.swift in Sources */,
-				57441831B33A4FEBB6EF1DEC /* ProfileDepthModels.swift in Sources */,
-				3B5C9B7266CE49A68E8C4BB2 /* QuizLogic.swift in Sources */,
-				9F1AAC1F6ACB4BE585C06C9E /* ReadingLogic.swift in Sources */,
-				9E04EFC7D6594743B97742ED /* RequirementsLogic.swift in Sources */,
-				4E2FB52EBA3A4F89A6E4D640 /* ReviewModels.swift in Sources */,
-				2FBA4F6CEEAD4E5A80EDFCF1 /* RolesPermissionsAdminLogic.swift in Sources */,
-				4D19C536B8884E54BA534406 /* SettingsMenuLogic.swift in Sources */,
-				1107800C47D74FD9862ECABC /* TakeAttendanceLogic.swift in Sources */,
-				0F32C3FBBA54462191A025A7 /* TranscriptsAdvisingAdminLogic.swift in Sources */,
-				A0ADEDE3F45A4A5199AF6613 /* TutorLogic.swift in Sources */,
-				ED95D3D339554D458903D81C /* TutorStreamClient.swift in Sources */,
-				6413FAEE66EA48BDBBB249E9 /* VibeActivityLogic.swift in Sources */,
-				6CFDBC0C1A644BC48BB42EC7 /* WalletLogic.swift in Sources */,
-				1234040BAAF643D1BFC48E73 /* WhiteboardLogic.swift in Sources */,
-				E4315CBD0D0F46C7968EA63F /* WhiteboardRenderer.swift in Sources */,
-				794F748BFAB642C08B8E2D6C /* APIClient.swift in Sources */,
-				693493C628D9452B8528B6A0 /* APIError.swift in Sources */,
-				A6F27E3FE6AF4F8882C16D17 /* NetworkAuthContext.swift in Sources */,
-				FF364A4117834E9683396B41 /* NetworkBootstrap.swift in Sources */,
-				94189DBC6AC34E4BB3DE7F27 /* NotebookDrawing.swift in Sources */,
-				4BC3D5CEFE5548908076E216 /* NotebookMarkdown.swift in Sources */,
-				8154BF2BBE6745FAA9CB652D /* NotebookSlashCommands.swift in Sources */,
-				CE7BB247BFFC498A872814C1 /* NotebookStore.swift in Sources */,
-				A651CF55A5A44D0E8787B832 /* NotebookSync.swift in Sources */,
-				0B1536152886452A8897C6D9 /* NotebookTree.swift in Sources */,
-				75E28D2258C84C498D5A951B /* CacheStore.swift in Sources */,
-				3AABCAF0D9F245F6B4750B52 /* DownloadStore.swift in Sources */,
-				FB8406AD901D4394B37589E5 /* NetworkMonitor.swift in Sources */,
-				361251740E774FCAA7F2D1DE /* OfflineModels.swift in Sources */,
-				F4069A4A72F94E33AA8C3889 /* OfflineService.swift in Sources */,
-				60035C8CE27646DD87B88612 /* OutboxStore.swift in Sources */,
-				4E9ED2F500CC489EB0217A92 /* SyncEngine.swift in Sources */,
-				E4D173DFB1EA4C40B42F4259 /* PushManager.swift in Sources */,
-				12BB2217AB3E40B9A82AE187 /* RealtimeManager.swift in Sources */,
-				3B070D29D7B144DDB3ACE13D /* WebSocketClient.swift in Sources */,
-				3745C6A65FA44A1EBB68DE4F /* ContentLinkRouter.swift in Sources */,
-				396E059A46FD4E69BEC89F4E /* DeepLinkRouter.swift in Sources */,
-				2163DE54E70F475FBC157C13 /* MobileDestinations.swift in Sources */,
-				609992B1A1834EC39CE7E208 /* MobileIaPreferences.swift in Sources */,
-				2BC0ED5C27E14886BD6B39D8 /* MobileProfileDepthPreferences.swift in Sources */,
-				920E81216AA94D969E724F53 /* SearchActionRegistry.swift in Sources */,
-				72CC2EFD7E8E42659F71F51B /* SearchModels.swift in Sources */,
-				D41D277FA28640088FA00B73 /* SearchPathNavigator.swift in Sources */,
-				8F3C8B7B258E4B7E89CFCF7A /* SearchRecentsStore.swift in Sources */,
-				D7ABC29F9F3A4FE8AFB7FE7A /* CodeEditor.swift in Sources */,
-				E898B6C0799B45E6ABD7EEA3 /* AdvisingView.swift in Sources */,
-				6B5A6E7C1C58495491AF6D40 /* AssignmentDetailView.swift in Sources */,
-				74180EB939174351A09B2FC9 /* AssignmentDraftStore.swift in Sources */,
-				D19DDD2E2F584485B6411D75 /* AttachmentUploader.swift in Sources */,
-				E947D06ABECB4B61B11F88A2 /* AppleSignInController.swift in Sources */,
-				D4E0FDBA645A463E8DBCCFBD /* AuthFlowView.swift in Sources */,
-				4937DEA49B2F472BB2346E9C /* GetStartedView.swift in Sources */,
-				3D6137C08EDA4006944CB2CD /* LoginView.swift in Sources */,
-				A635E9A54F7A480B97EE4CB6 /* MFAChallengeView.swift in Sources */,
-				F2FB5B6F614D4BE7B7603084 /* MfaPasskeyController.swift in Sources */,
-				C90C9B199371472391DEF7E0 /* SSOAuthController.swift in Sources */,
-				A6EF6BFB82EE4E239C201717 /* SignupView.swift in Sources */,
-				EF2ABACFDB8047E9877199E5 /* BehaviorRosterView.swift in Sources */,
-				EB60030B24C04B33968AEAB3 /* HallPassView.swift in Sources */,
-				91680EBC953B407498410AF0 /* MyHallPassView.swift in Sources */,
-				4EA26CA0154F45C39BF013D5 /* BillingView.swift in Sources */,
-				6F5AB077A8DB43F38FAF5FF4 /* CheckoutReturnHandler.swift in Sources */,
-				24CE6910263A41578FEA0F0F /* PurchaseFlow.swift in Sources */,
-				46A16472B9CE4506AD378C1E /* BoardAnalyticsSheet.swift in Sources */,
-				6DFA5CEDE5F84448AAE9B24E /* BoardComposerView.swift in Sources */,
-				109D1E0CD38D4C2FBEBFF9D5 /* BoardDetailView.swift in Sources */,
-				8CECDE4CA48E46B68194DE68 /* BoardEngagementEnvironment.swift in Sources */,
-				1BCAAB480A9649CAB28C70D2 /* BoardExportSheet.swift in Sources */,
-				C1E46A52153A4B2FABE3E7FC /* BoardModerationSettings.swift in Sources */,
-				E7CEBF08E70545698FE082B1 /* BoardPostCard.swift in Sources */,
-				CAA8331B4EF74E0C84947274 /* BoardPresentModeView.swift in Sources */,
-				1EF082CD18674F1F928B7FFF /* BoardSaveAsTemplateSheet.swift in Sources */,
-				580DF4E568C442BF8D09CD35 /* BoardShareSheet.swift in Sources */,
-				A38D622CC1C04C5399C07A35 /* BoardSocket.swift in Sources */,
-				D53D91119D9245968AE48A9C /* BoardSurface.swift in Sources */,
-				ACC1FD10C6CF45E6AEDEE3C2 /* BoardSyncStatusChip.swift in Sources */,
-				E1D3DE4D48B148AC90BC77AE /* BoardTemplatePickerView.swift in Sources */,
-				292A13FC17864E9EA4DFE416 /* BoardsListView.swift in Sources */,
-				62306CC29174472B802EF4F9 /* CardArrangeMenu.swift in Sources */,
-				6097F22C2B83482D8362FE34 /* CommentSheet.swift in Sources */,
-				95FBD7141783422994CB342B /* GradeSheet.swift in Sources */,
-				C5E6FF0F69AD4632B081682C /* CanvasLayout.swift in Sources */,
-				8049C3444D6C491193106550 /* ColumnsLayout.swift in Sources */,
-				FE302E99CF2F4D909E55DEEA /* MapLayout.swift in Sources */,
-				38600437A0944CE59A03CB4C /* TimelineLayout.swift in Sources */,
-				90D4320268704514890D85B7 /* WallLayout.swift in Sources */,
-				ADB2122E83B24A3791404387 /* ModerationQueueView.swift in Sources */,
-				8229F77CB1934F048EF06DA9 /* BoardPublicView.swift in Sources */,
-				397D4FEDEE754D49B2F21136 /* ReactionControl.swift in Sources */,
-				1E9E82FEBEBE490EB273A5E5 /* ReportDialog.swift in Sources */,
-				161E1A5C0A464881ABBD6F9C /* CatalogView.swift in Sources */,
-				55862CD7195C4FCD9B727DA2 /* CourseLandingView.swift in Sources */,
-				B8AD3EF6548E4ACBAD1200B2 /* ReviewComposer.swift in Sources */,
-				88706E79220242D78EC8A779 /* ContentPageView.swift in Sources */,
-				E595ECAF8AB64A7094BFB118 /* CourseAttendanceView.swift in Sources */,
-				8E5A7026DB48466D91B97274 /* CourseBanner.swift in Sources */,
-				E028EB4D5B7D4EF69AFA1833 /* CourseDestinationPlaceholder.swift in Sources */,
-				3B490906D5444BF5BB87DF14 /* CourseDetailView.swift in Sources */,
-				CBB27F7B883A4E3BA3B1F709 /* CourseGradesView.swift in Sources */,
-				091AC461C9D646F6AC1B8506 /* CourseLibraryView.swift in Sources */,
-				C5423EDB54A849D8A000FCFF /* CourseMarkdownContentView.swift in Sources */,
-				B8D3B06811A446FF9E119A9C /* CoursePeopleView.swift in Sources */,
-				AF0E06604C84491997B9EC96 /* CourseStructureSocket.swift in Sources */,
-				B971CC8D53FF4223A926F0B4 /* CourseSyllabusView.swift in Sources */,
-				9B0C6FC09973444385C1852A /* CourseWorkspaceNav.swift in Sources */,
-				1FFB778E822C4DBDB715A916 /* CoursesListView.swift in Sources */,
-				F76BB5BAC0484A378052D930 /* CanvasImportComingSoonView.swift in Sources */,
-				098D44D05D004C3BA8C100BB /* CanvasImportView.swift in Sources */,
-				2DDD559AB54B469182552EF2 /* CourseCreateView.swift in Sources */,
-				04692B741C304CDA9A684869 /* ItemDetailRows.swift in Sources */,
-				A6D9165159F348E18D67E94F /* ItemDetailView.swift in Sources */,
-				87D839F0C4A74FD98256B176 /* LaunchContainerView.swift in Sources */,
-				9A762A2C9AC2401BA56F698E /* LibraryResourceView.swift in Sources */,
-				26FC2540641745239230A199 /* ModuleItemRouteView.swift in Sources */,
-				456FBCCE4C5E41829C383E3D /* ModuleListView.swift in Sources */,
-				A8B3DA894B934F2FA0DF77E5 /* RequirementsView.swift in Sources */,
-				E4C618B17FBF4C78BBAAB056 /* CourseAccessibilityReviewView.swift in Sources */,
-				27D31B7E47704438A8E8A2BA /* CourseArchivedContentView.swift in Sources */,
-				3EACCA5C1D4B4F90846510B7 /* CourseBlueprintSettingsView.swift in Sources */,
-				8D607FC0027B424B89FACB72 /* CourseCrossListingView.swift in Sources */,
-				1310FF7496424B90B8B83BEF /* CourseFeaturesSettingsView.swift in Sources */,
-				97288F004307499D820EA091 /* CourseGeneralSettingsView.swift in Sources */,
-				7BB65235FC394C68A9AAC834 /* CourseGradingAgentsView.swift in Sources */,
-				AA69E28B703142DB95EC39E1 /* CourseGradingSettingsView.swift in Sources */,
-				89A7EC38C520488BA9761223 /* CourseHeroImageEditor.swift in Sources */,
-				CF097B32F73C4183BF542E7E /* CourseImportExportView.swift in Sources */,
-				B986C054028344EBB72DA919 /* CourseMarketplaceSettingsView.swift in Sources */,
-				E36DB36496D5439F8CB9AD1D /* CourseOutcomesSettingsView.swift in Sources */,
-				310AB9BA30434CABBF8B79CA /* CoursePlagiarismSettingsView.swift in Sources */,
-				A8F5431C58BA4182A46D7200 /* CourseSectionsSettingsView.swift in Sources */,
-				4B7EB06DE842446380DC8B5A /* CourseSettingsHostView.swift in Sources */,
-				89E8D81B4C9A4C47AF4BDC13 /* CourseTranslationsSettingsView.swift in Sources */,
-				ACCE80FA96CA40DD91B04FE3 /* TakeAttendanceView.swift in Sources */,
-				3E733C4250324F8ABC2BA381 /* VibeActivityView.swift in Sources */,
-				2220CC5287354BADB428FAC8 /* WebItemView.swift in Sources */,
-				D13E762EE5044E77B6902CBA /* CredentialDetailView.swift in Sources */,
-				78A071596C2D41D7BFA782EC /* CredentialsView.swift in Sources */,
-				35E90F21E769441F818D9EB8 /* DashboardCoursesCarousel.swift in Sources */,
-				13FEC5FC6B4443B5A56A9708 /* DashboardHeroPanel.swift in Sources */,
-				D5AE0A8DD0404E0296584135 /* DashboardView.swift in Sources */,
-				6D9C6A2E7707486294527846 /* LiveMeetingsRail.swift in Sources */,
-				75FC1D426AAC43B2A13AF26C /* CourseDiscussionsSection.swift in Sources */,
-				DA579C13C6C6414CB3B8BA4F /* DiscussionThreadView.swift in Sources */,
-				750C491D7D234795A0F271C6 /* DiscussionsListView.swift in Sources */,
-				6139DF3DE59A4A1EA4B45C4E /* PostComposerView.swift in Sources */,
-				0AFD410D254F4754AD2F322E /* CourseEvaluationsSection.swift in Sources */,
-				5F2EAB1BC0DC4C91836F6058 /* EvaluationFormView.swift in Sources */,
-				8FD3844A4F6D447194A0FD9F /* EvaluationResultsView.swift in Sources */,
-				119AA9A0A2E24657813981E7 /* CourseFeedSection.swift in Sources */,
-				B63422443B8D4320AF5CCEA5 /* FeedChannelView.swift in Sources */,
-				297D6F0367774B138A7B7DE2 /* FeedChannelsView.swift in Sources */,
-				787573EB0DD34C91BB1E38B3 /* FeedLogic.swift in Sources */,
-				7619C558C00844668589F149 /* FeedSocket.swift in Sources */,
-				6504D2530A984BEBA5F3A89C /* ShareFeedbackView.swift in Sources */,
-				98C001A02FBC42D4AC15B4E1 /* CourseFilesSocket.swift in Sources */,
-				822C5A8DA93F4267A997CCA9 /* CourseFilesView.swift in Sources */,
-				7C87294D17684717BDF67ADD /* FilePreviewView.swift in Sources */,
-				62FDBE7FC0464006B5C44C6B /* MarkupOverlayView.swift in Sources */,
-				10E80F150668454D882A4CE8 /* GamificationView.swift in Sources */,
-				2ED9D4A0907A45A593C5DC0F /* GradeFeedbackView.swift in Sources */,
-				CA7BA9E0E964449BB6722446 /* WhatIfController.swift in Sources */,
-				FCD30F4144FB421D83445546 /* GradingBacklogView.swift in Sources */,
-				EB69BC34D6464A0EA3F83BCB /* SpeedGraderView.swift in Sources */,
-				3F025BCC323E4D21BBE26743 /* CollabDocView.swift in Sources */,
-				580FAF0A4DBE4AC19ED1CF9B /* CourseCollabDocsSection.swift in Sources */,
-				1B26EF24172B4093BCC12644 /* CourseGroupsSection.swift in Sources */,
-				008DC40656C04572BF7B3DB2 /* GroupSpaceView.swift in Sources */,
-				B3A185F449E843EEB3EAC82B /* AnnouncementComposerView.swift in Sources */,
-				CE5643BA1BFE4434AF87E34C /* AnnouncementsViews.swift in Sources */,
-				A1DC4A6E047E4995BEE9BA58 /* BroadcastComposerView.swift in Sources */,
-				DB9F1913047B4D559ED54CBC /* MainTabView.swift in Sources */,
-				C3B92074B29C4EDE96BCB5FC /* MoreHubView.swift in Sources */,
-				C3CC188EF9D849A1870DFB39 /* ShellHeaderBar.swift in Sources */,
-				8DF4FC36D0844CD7A279D8CD /* TeachHubView.swift in Sources */,
-				6FA00E86E84E4E3BBB0A517D /* UniversalSearchPlaceholder.swift in Sources */,
-				12D8E3453B06466F8FAB1740 /* ComposeMessageView.swift in Sources */,
-				819E8697D0E049FAA19E2001 /* InboxView.swift in Sources */,
-				7B07D6700B1D4D6EB54C262C /* MessageDetailView.swift in Sources */,
-				6F6E3EBB771E42DDAC20F64C /* DashboardInsightsSection.swift in Sources */,
-				356934E3D5634817AE72D22D /* InsightsView.swift in Sources */,
-				163FD7A39FEE4E59969E3D76 /* AtRiskListView.swift in Sources */,
-				9ADD6D058085441AB9284F62 /* CourseInsightsSection.swift in Sources */,
-				3971550B4A6C4B43A275676C /* StudentProgressDetailView.swift in Sources */,
-				4474D014A704412E90E1E026 /* WhatsWorkingView.swift in Sources */,
-				7048A2ACDAA345FCA49CD79A /* IntroCelebrationPresenter.swift in Sources */,
-				E906AB146A44454D852FD825 /* IntroCompletionCelebrationSheet.swift in Sources */,
-				0FD9988E24D04968B1D2F705 /* IntroCourseEntryCard.swift in Sources */,
-				7F5654D27B1C4FE3B689362F /* IntroCourseProgressRail.swift in Sources */,
-				A5E21BECBD9A460B9E0E86FF /* LearnerProfileView.swift in Sources */,
-				33F28A8B9D994F8E9F3AB4D8 /* LibraryBrowseView.swift in Sources */,
-				C4F67C5E531D4ECC94B62E1C /* MeetingDetailView.swift in Sources */,
-				28F63354CA3047B295664F71 /* MeetingListView.swift in Sources */,
-				55309946A5694048A3776B6C /* WhiteboardView.swift in Sources */,
-				1680DEF5581A4058BDD95FAA /* LiveGameSocket.swift in Sources */,
-				02E84C176207435C97F45A2B /* LiveQuizHubView.swift in Sources */,
-				9A0A50254C844A608B6D253D /* LiveQuizPlaySurfaces.swift in Sources */,
-				FC8804F6A7204CEE924E6182 /* LiveQuizPlayView.swift in Sources */,
-				C3C9C20AF0B74AF1A5AD6C06 /* MarketplaceDetailView.swift in Sources */,
-				0DA2B8FB6825458EB63265B0 /* MarketplaceView.swift in Sources */,
-				45B4DE5DE02E4620BBD116BD /* MyPurchasesView.swift in Sources */,
-				552D04812A7F4D669B929277 /* CourseMasterySection.swift in Sources */,
-				F719C280E9E34F8F831EE571 /* ReportCardListView.swift in Sources */,
-				65D059F874154C65A971BAEB /* CourseDrawer.swift in Sources */,
-				851F70CB0C8E4808A602384D /* DrawerScaffold.swift in Sources */,
-				E0BC6DAB406D450894E30308 /* DrawerToolbar.swift in Sources */,
-				F575310A5D1045F797CF0E79 /* GlobalDrawer.swift in Sources */,
-				0B5BC9E20E9A49BAAD6FEFA6 /* NotebookDrawingViews.swift in Sources */,
-				03E7E70C3AA343B7A4B7A704 /* NotebookEditorSupportViews.swift in Sources */,
-				983C270449494C999A874F30 /* NotebookEditorView.swift in Sources */,
-				3C4437AEBF744DF084943225 /* NotebookPagesView.swift in Sources */,
-				576B43B37B5A408EA923E0C9 /* NotebooksListView.swift in Sources */,
-				6176747AED8E456FB77751E6 /* BookingSheet.swift in Sources */,
-				5C7B03E9B1C742DCBE69369A /* MyBookingsView.swift in Sources */,
-				18C0E38F7C7D410BBA29BACE /* OfficeHoursView.swift in Sources */,
-				85BEC9615D3A4D51B5E11BEE /* DiagnosticView.swift in Sources */,
-				933D49527AE1422A98DEA987 /* OnboardingFlowView.swift in Sources */,
-				B16FD4BF444C4BBAA4F34B19 /* ConferenceBookingView.swift in Sources */,
-				596AA128B6654471A916A463 /* MyConferencesView.swift in Sources */,
-				D6F0905A26F24194A1353962 /* ParentAttendanceDetailView.swift in Sources */,
-				DD54C72E4CD54C31A9385D96 /* ParentDashboardSections.swift in Sources */,
-				F043F1D16C2840E9B6BC72BD /* ParentDashboardView.swift in Sources */,
-				5C27043D5C43469C953ED076 /* ParentGradesDetailView.swift in Sources */,
-				8FBCA5C6CFF64F42A4A5BF38 /* ParentNotificationPrefsView.swift in Sources */,
-				CDF518E09F7846E1BDFBED53 /* DashboardStudySection.swift in Sources */,
-				17EDAAD651CC447698885CF4 /* MyPathsView.swift in Sources */,
-				BD54CED1BAB14879A22E37B9 /* PathLandingView.swift in Sources */,
-				3C2B7EF9D8FC43AD99E0A7FA /* PathRunnerView.swift in Sources */,
-				AAD47D38AA4D4C358A6467F6 /* PathsCatalogView.swift in Sources */,
-				B3CF1349C7904FD4A72E2A59 /* PeerReviewDetailView.swift in Sources */,
-				912611A92A2041A9A8296D12 /* PeerReviewListView.swift in Sources */,
-				D85D2090E85246F3A6505493 /* ReviewsReceivedView.swift in Sources */,
-				6BCCAB5D1C05434AB871CA24 /* RubricScorerView.swift in Sources */,
-				50B50058AA824B3AAF879DF8 /* CalendarSubscribeSheet.swift in Sources */,
-				00DE2F91BB654728ADFF6E0A /* CalendarView.swift in Sources */,
-				DE9DEBCF0BAC4A07B9451383 /* ConferenceReminderScheduler.swift in Sources */,
-				B7843FBA8342426A82563859 /* DueReminderScheduler.swift in Sources */,
-				0783785EA4884A2CAC9E37BA /* OfficeHoursReminderScheduler.swift in Sources */,
-				9861C3C32A19487F84BD7255 /* PlannerModel.swift in Sources */,
-				1A6E9681B15C4946BA49F402 /* PlannerView.swift in Sources */,
-				53832ACC0D8140FB84A3037A /* TodosView.swift in Sources */,
-				1820FF2D48634943A1170F63 /* ArtifactDetailView.swift in Sources */,
-				410A494F5DCF4E7FAA734EE4 /* ArtifactEditorView.swift in Sources */,
-				FD0F1770733F48D4B2DCE847 /* PortfolioArtifactUploader.swift in Sources */,
-				29A616DCD45648508FD20238 /* PortfolioDetailView.swift in Sources */,
-				27BD31BB7E6244DCBEEF50F7 /* PortfolioView.swift in Sources */,
-				0CEB505A9C73423E9EB7D46F /* AiAdminEntryCard.swift in Sources */,
-				D7C434F123F942FD80F15BB4 /* ArchivedCoursesAdminEntryCard.swift in Sources */,
-				D41C88D9B069467AB7056B5A /* BiometricLockView.swift in Sources */,
-				1F4F38E4463846D0A7DB99FE /* DeviceSessionsView.swift in Sources */,
-				ECC896B994C148D5BD7BFF89 /* EditProfileView.swift in Sources */,
-				0406ADE00F654602A624A7F0 /* IntegrationsAdminEntryCard.swift in Sources */,
-				990606FDE8B247DD949E7704 /* IntegrationsEntryCard.swift in Sources */,
-				5D8AE7AC158248C7B143ABB8 /* IntegrationsView.swift in Sources */,
-				8E09A5C7101F42FCA97FFDC9 /* LearnerProfileEntryCard.swift in Sources */,
-				291C866A8BA34F9AA7432278 /* MyAccommodationsView.swift in Sources */,
-				59A0EE6FC1AF4DF98D4A8114 /* NotificationPreferencesView.swift in Sources */,
-				891D058966D8460491A1A4FF /* NotificationsView.swift in Sources */,
-				EC94861422944F95A1428DD4 /* OrgBrandingAdminEntryCard.swift in Sources */,
-				1C5BFD491EC3485D84E82AAE /* OrgStructureAdminEntryCard.swift in Sources */,
-				26262FED1F804D2AB50D384A /* PeopleAdminEntryCard.swift in Sources */,
-				EAB177196F6D49E0AD5DD062 /* PlatformSettingsAdminEntryCard.swift in Sources */,
-				BD7FF3CD17854CD49E4B67F4 /* ProfileDepthCards.swift in Sources */,
-				E5B1B4CC641A4592B39BA00E /* ProfilePersonalDetailsView.swift in Sources */,
-				0E01CAF9578B4E70A3D01BAD /* ProfileSecurityCard.swift in Sources */,
-				2BE42B7168E74AC9BB49AA37 /* ProfileSettingsCards.swift in Sources */,
-				7A9DEAD3BF094E5B92D46A85 /* ProfileView.swift in Sources */,
-				597DBA421E844192926BB697 /* ProfileViewSections.swift in Sources */,
-				AA5786ADF9914096A04A2584 /* ResearchStudiesView.swift in Sources */,
-				3C457332F57045D2A151F797 /* RolesPermissionsAdminEntryCard.swift in Sources */,
-				B47F885782034415824A6D81 /* SettingsAdminHubEntryCard.swift in Sources */,
-				0EBF7149F3FF447794A33532 /* ShareFeedbackEntryCard.swift in Sources */,
-				AADCEDE334814AF3B877F04D /* TranscriptsAdvisingAdminEntryCard.swift in Sources */,
-				EDEBA37D69784BE28AEE5C43 /* CodeQuestionView.swift in Sources */,
-				E454F05444F64D7F8973BBC7 /* LockdownController.swift in Sources */,
-				AF86C7809C9941BDAD77AB55 /* QuizIntroView.swift in Sources */,
-				6F0C6280A791470EB163B49A /* QuizQuestionViews.swift in Sources */,
-				208D01F988FD4F2CAA8D1860 /* QuizResultsView.swift in Sources */,
-				C220BB4C21C64514A3C662AA /* QuizTakerView.swift in Sources */,
-				CC7499DCBED24814BEB2A59A /* CaptionedPlayerView.swift in Sources */,
-				6BEC30E92FE54787B4898C97 /* ContentTranslationControls.swift in Sources */,
-				8E3DFB4100A14025B5EF5B4E /* ImmersiveReaderCapabilities.swift in Sources */,
-				5E5748296D024B9DA11004B2 /* ReaderLogic.swift in Sources */,
-				2EE42BB2867E42EAB056D0D6 /* ReaderToolbar.swift in Sources */,
-				58FEBB43733842C98EFCBADB /* ReadingPreferencesSheet.swift in Sources */,
-				C56862C1F9404A1FA04CF5D8 /* ReadingPreferencesStore.swift in Sources */,
-				591F119EEF2E442DA605DAD4 /* LeveledLibraryView.swift in Sources */,
-				F9D06D4B1D5E4609AF061941 /* LogReadingSheet.swift in Sources */,
-				6EBCCA48836F457786310E63 /* ReadingDashboardView.swift in Sources */,
-				194E3E78461E4738B9BCA0C3 /* ReviewHomeView.swift in Sources */,
-				68D54D78AA3A4E2B8CD5979C /* ReviewReminderScheduler.swift in Sources */,
-				2D7172CF2B3B4C839652F631 /* ReviewSessionView.swift in Sources */,
-				E266A835E7DA46E99FFC81CA /* UniversalSearchView.swift in Sources */,
-				BA84C45015DE496786BAB636 /* AdvisingSettingsView.swift in Sources */,
-				B36EC8CF5A284C509DDB1989 /* AiAdminHubView.swift in Sources */,
-				8559064BF9E24F80AC2B7FDB /* AiGovernanceView.swift in Sources */,
-				1A24A73E846F4746AB5A37D0 /* AiModelsSettingsView.swift in Sources */,
-				5A8F0E83430A48BFB8D69806 /* AiProviderSettingsView.swift in Sources */,
-				486652BD754D4CDAB7F6BF97 /* AiReportsView.swift in Sources */,
-				C73F30631A4F4D4CB340F5F2 /* ArchivedCoursesAdminView.swift in Sources */,
-				C2AC1B4DEEED4A299B09F2FA /* AuditLogAdminView.swift in Sources */,
-				B8C0054D9158489391E87711 /* BoardsGovernanceAdminView.swift in Sources */,
-				6B0362DAAFE04A728FD8B85B /* IntegrationsAdminView.swift in Sources */,
-				2FCF2AE17D474A7DAA8B706C /* OrgBrandingAdminView.swift in Sources */,
-				743A5EAE7224446E9F39C0C5 /* OrgBrandingView.swift in Sources */,
-				E2294CDD0B1244019A5C469A /* OrgStructureAdminView.swift in Sources */,
-				BB84C992D90D48D5BED3A40C /* OrgStructureView.swift in Sources */,
-				B9F19E82434F4B5CAEECA496 /* PeopleAdminView.swift in Sources */,
-				99985465AED1482D95C45191 /* PlatformSettingsView.swift in Sources */,
-				7A76604B2B5645FCB6D07009 /* RolesPermissionsAdminView.swift in Sources */,
-				FF594D97F2CF4F11B0F7A966 /* SystemPromptsView.swift in Sources */,
-				E1FE3D42398F4D4C9BD402E6 /* TermsAdminView.swift in Sources */,
-				6BA592160CFA49FD8CA9EE80 /* TranscriptsAdvisingAdminView.swift in Sources */,
-				32B897C4893F43F89995CCD7 /* TranscriptsSettingsView.swift in Sources */,
-				D39CDD05A8254115A4756B70 /* UserDetailAdminView.swift in Sources */,
-				28241AD74F904A5EA30F0639 /* SettingsAdminHubView.swift in Sources */,
-				F7E1C56837724308A8402DA2 /* SplashView.swift in Sources */,
-				34233CB7D4294DAC88E3098F /* TutorChatModel.swift in Sources */,
-				8DFB3B8F33C845A2BD3C5A74 /* TutorChatView.swift in Sources */,
-				4B985EBA95714ABFA51EE528 /* TutorFlowLayout.swift in Sources */,
-				AA239B3F83A746C7B77D500A /* TutorLauncher.swift in Sources */,
-				722C60492C1441E2B1F0FFAC /* WalletCCRDetailView.swift in Sources */,
-				878B5AAA493B40A589D99AF3 /* WalletCETranscriptDetailView.swift in Sources */,
-				45680A9D32DF41EB8F0D216A /* WalletOfficialTranscriptDetailView.swift in Sources */,
-				FC92EFBF854F4B7AA0074550 /* WalletView.swift in Sources */,
-			);
 			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D3E44D77E6284235B1466959 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
-				C0A1B006PE0PLEMETR1C01 /* PeopleAdminMetricsLogicTests.swift in Sources */,
-				C0A1B005PLATCRSTEST001 /* PlatformCoursesAdminLogicTests.swift in Sources */,
-				6420BD61D1E740B183DAFD10 /* AccessibilitySupportTests.swift in Sources */,
-				F90102CE23744A3391050289 /* AccountIntegrationsLogicTests.swift in Sources */,
-				635A79E2C2EB4C2C9FE2D9A5 /* AdvisingLogicTests.swift in Sources */,
-				2BA96659F8894261B1CD5646 /* AiModelsAdminLogicTests.swift in Sources */,
-				60449CE622584C98B5FAF9ED /* AnnouncementLogicTests.swift in Sources */,
-				37970C43701C4ADC9044BF83 /* AppleSignInLogicTests.swift in Sources */,
-				AF54E52BC1C6470888809DC2 /* ArchivedCoursesAdminLogicTests.swift in Sources */,
-				4B4025DA85014201BAE6D0BF /* AssignmentLogicTests.swift in Sources */,
-				76E759BFEC0A479598FD3523 /* AuditLogAdminLogicTests.swift in Sources */,
-				4AE4429A16C447A89EC97BA9 /* AuthCallbackParserTests.swift in Sources */,
-				D4AB1717C654406A9E932690 /* BehaviorLogicTests.swift in Sources */,
-				B2C44709C9B041A1AB99A6BD /* BillingLogicTests.swift in Sources */,
-				C8493F93F95641B9971E021A /* BiometricGateTests.swift in Sources */,
-				F7DF2D5D6DB341B48B48470A /* BoardsAdvancedLogicTests.swift in Sources */,
-				AB6B5EF2EB6C4D75BDECC9CA /* BoardsLogicTests.swift in Sources */,
-				692ECF1A1EB54EEDB701CA0E /* CanvasImportLogicTests.swift in Sources */,
-				A2E2866C0B334CAFB2C324B3 /* CatalogLogicTests.swift in Sources */,
-				9C87E7A7679D47F4A6E530D9 /* ConferenceLogicTests.swift in Sources */,
-				4C088F6EA1B34C28A0C60EEA /* CourseAccessibilityReviewLogicTests.swift in Sources */,
-				0AF60812256C4354A7B797B2 /* CourseArchivedContentLogicTests.swift in Sources */,
-				1EC08E8B5C39426D93A6936D /* CourseBlueprintLogicTests.swift in Sources */,
-				549AA37529FE4D44B120602C /* CourseCreateLogicTests.swift in Sources */,
-				399915F355844D0F9F23FA14 /* CourseFeaturesLogicTests.swift in Sources */,
-				D8A5A1065E68428397BB2D5F /* CourseFileModelsTests.swift in Sources */,
-				E2E7715996814C6C993BDA21 /* CourseGradingAgentsLogicTests.swift in Sources */,
-				C94508C2EF92492F875C0646 /* CourseGradingLogicTests.swift in Sources */,
-				AA81A482F50144E4A99DABD5 /* CourseImportExportLogicTests.swift in Sources */,
-				566F6E0C129248239B6B757F /* CourseOutcomesLogicTests.swift in Sources */,
-				E25179C92C1C41C6B8296680 /* CoursePeopleLogicTests.swift in Sources */,
-				E4DD0AF80B6044DE907EDFAC /* CoursePlagiarismLogicTests.swift in Sources */,
-				331DC6E1A2054E6DB46BAA22 /* CourseReviewLogicTests.swift in Sources */,
-				7E11880E31C3449793E33DFD /* CourseSectionsLogicTests.swift in Sources */,
-				FF26EBE988684E61A6DCAE00 /* CourseSettingsLogicTests.swift in Sources */,
-				DCED5394ECDC43CABFE96B3F /* CourseTranslationsLogicTests.swift in Sources */,
-				1E6745D4204E45B39A469D71 /* CredentialsLogicTests.swift in Sources */,
-				60513E6280134638A5FA83DA /* DiscussionLogicTests.swift in Sources */,
-				A9EF899DEBA64BD6BEEBC2DE /* EvaluationLogicTests.swift in Sources */,
-				6B208988F688450F91BF27AE /* FeedLogicTests.swift in Sources */,
-				A432FE3D812444A48D727D8D /* FeedbackLogicTests.swift in Sources */,
-				EE351684AEA54BC3860A64DC /* GamificationLogicTests.swift in Sources */,
-				39A25DA310FD4B8983EBFCE9 /* GradeCalculatorTests.swift in Sources */,
-				C1E5B10A52344EF6B03E631A /* GroupsLogicTests.swift in Sources */,
-				35E9126EBAEA4A61A95F8F81 /* I18nTests.swift in Sources */,
-				81267E68B4824E49A31C8C56 /* InsightsLogicTests.swift in Sources */,
-				A45AA81CBC434A33B7A4C765 /* InstructorInsightsLogicTests.swift in Sources */,
-				C264B03AEBC4479196BBA7E6 /* IntegrationsAdminLogicTests.swift in Sources */,
-				40A5CFCB2F5D4551BF1FB546 /* InteractiveLaunchLogicTests.swift in Sources */,
-				E3C3FF22577D486189E530CD /* IntroCourseLogicTests.swift in Sources */,
-				DDDFCC770E2749F08589BE80 /* LearnerProfileLogicTests.swift in Sources */,
-				8E390168F0A24280B46A6D7A /* LexturesMotionTests.swift in Sources */,
-				E6253EE8BBD04AFE979562E9 /* LibraryResourceLogicTests.swift in Sources */,
-				AD749EEA1C2149FA9A37229E /* LiveMeetingsLogicTests.swift in Sources */,
-				6BB2750A1155418585023080 /* LiveQuizLogicTests.swift in Sources */,
-				1E63F70BA0DA47E5B48BCBCD /* MarketplaceLogicTests.swift in Sources */,
-				221C5AE6E9D94734A5ABDAF4 /* MasteryLogicTests.swift in Sources */,
-				474EF57FA52447A9AE7C0BF0 /* MobileDestinationsTests.swift in Sources */,
-				F164235052EE4101A339407F /* ModuleContentModelsTests.swift in Sources */,
-				E705CA697ED4496F9C907066 /* NotificationModelsTests.swift in Sources */,
-				1F980C19CAC7471AB1E8D74D /* OfficeHoursLogicTests.swift in Sources */,
-				88865EAA088343F18C3DFA57 /* OnboardingModelsTests.swift in Sources */,
-				B419FF488647475FA61F50EF /* OrgBrandingAdminLogicTests.swift in Sources */,
-				38BFAC36FA7A40D388A87AC9 /* OrgStructureAdminLogicTests.swift in Sources */,
-				1EB946BBC07C4F0E91562AFA /* ParentLogicTests.swift in Sources */,
-				F2241D95566E44E2BB850323 /* PathsLogicTests.swift in Sources */,
-				C1CC5F8E6EA44BCEA5A7E64B /* PeerReviewLogicTests.swift in Sources */,
-				140738F3D7924103861E9C4C /* PeopleAdminLogicTests.swift in Sources */,
-				AA9595DACD5F458788C054D6 /* PlannerModelsTests.swift in Sources */,
-				427867C6638644B7A5D65A77 /* PlatformSettingsAdminLogicTests.swift in Sources */,
-				31C2123B782547B3ACA82701 /* PortfolioLogicTests.swift in Sources */,
-				27A8F5F29E9B4570B09D83DD /* ProfileDepthLogicTests.swift in Sources */,
-				BA1E91FD69E148888F72EA8D /* QuizLogicTests.swift in Sources */,
-				A843B32C407142939A8EE54E /* ReaderLogicTests.swift in Sources */,
-				37922A070862498D854F5FC6 /* ReadingLogicTests.swift in Sources */,
-				759C660E0B414925B7C9087A /* RequirementsLogicTests.swift in Sources */,
-				30A55546C8BF414EA6AB0B96 /* ReviewLogicTests.swift in Sources */,
-				E2AFB406791A4921A0F75ADA /* RolesPermissionsAdminLogicTests.swift in Sources */,
-				795FED7D1CD749E18284AA7C /* SchoolCodeLogicTests.swift in Sources */,
-				7285275760BC45C6897E5B88 /* SearchTests.swift in Sources */,
-				A072A5B86D3246518D8C2746 /* SettingsAccommodationsTests.swift in Sources */,
-				E6D0C83BDB0D471D93DA5D65 /* SettingsMenuLogicTests.swift in Sources */,
-				6F501F5B83B649C39170BE6E /* TakeAttendanceLogicTests.swift in Sources */,
-				A800A691052949D6842829D5 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */,
-				A936B5A7E89F494CA7638183 /* TutorLogicTests.swift in Sources */,
-				367A30D7717C4098B90DD527 /* UIModeLogicTests.swift in Sources */,
-				27760B53231046E2A5894CB3 /* VibeActivityLogicTests.swift in Sources */,
-				1E21D92794304E6E9529AF69 /* WalletLogicTests.swift in Sources */,
-				245E9ED1537E44F59EB5B52A /* WhiteboardLogicTests.swift in Sources */,
+				6ED369A7EE154CDCBE032887 /* AppDelegate.swift in Sources */,
+				15E1F90879A9406FBBBA92F6 /* LexturesApp.swift in Sources */,
+				20454A04869B4B678FA6157E /* RootView.swift in Sources */,
+				F4F1D79C0F53493EBAF31CCA /* AccessibilityPreferences.swift in Sources */,
+				A3D8BE5BBE4E4EC6922FB9AE /* AccessibilitySupport.swift in Sources */,
+				DC933262AF1C4EE78BDDD135 /* DictationField.swift in Sources */,
+				6A559EEE76EA40B0B5E919D7 /* ReadAloud.swift in Sources */,
+				1F84B57453EC443DBD850C7C /* AuthAPI.swift in Sources */,
+				625DE845245045A9B259C8F2 /* AuthCallbackParser.swift in Sources */,
+				751CB6CA908C42AAA8A799EA /* AuthConstants.swift in Sources */,
+				9B9E21406160409F8D81FB5F /* AuthSession.swift in Sources */,
+				6123B63B7BBD44C0B9A5EEF9 /* BiometricGate.swift in Sources */,
+				AC0EE35E21034BB5BAAD78AC /* KeychainStore.swift in Sources */,
+				BE6ED0BBA1EB4014BEA5B85C /* SessionsAPI.swift in Sources */,
+				41A7DB60D97B43A5ACCDA312 /* AppConfiguration.swift in Sources */,
+				7C05A81CDD024AF5B53CF947 /* EnvironmentStore.swift in Sources */,
+				DBA2446EE0D343D08044259A /* SchoolCodeLogic.swift in Sources */,
+				30F64C0A143A46F59F00F5A1 /* AuthFieldRepresentable.swift in Sources */,
+				45145825BFEA43AC83DDBDD5 /* BrandLogoView.swift in Sources */,
+				D7AA30F9E7B44FBF9D2327B8 /* Haptics.swift in Sources */,
+				62107BFEAA9B4D66973F2017 /* LexturesMotion.swift in Sources */,
+				49400339D9134FFFA49CE52A /* LexturesTheme.swift in Sources */,
+				B22762E1FBD14F85A0D0C148 /* LexturesType.swift in Sources */,
+				5FAA6C38FD1C480DAEE2D729 /* ProfileAvatarView.swift in Sources */,
+				F3CDAC973F184CF48652D5D9 /* SyncStatusView.swift in Sources */,
+				38B668077E8B49F5ACB6FFE0 /* ThemePreference.swift in Sources */,
+				5A9724DB099341E79DA96A47 /* UIMode.swift in Sources */,
+				0E6CE5FAF63D463BAE988E9D /* UnsavedChangesBanner.swift in Sources */,
+				88CA2A3A7A47431DA028824C /* DateFormatting.swift in Sources */,
+				5286BF63D688419CB52D762D /* LocaleAPI.swift in Sources */,
+				AA7440F0963E49EABD664063 /* LocalePreferences.swift in Sources */,
+				5864916C8AA948DA91B23021 /* Localized.swift in Sources */,
+				A77698B1846F4D6E9EFA6BAC /* AccountAccommodationModels.swift in Sources */,
+				47C0179CEEAB4D6F999ECF72 /* AccountIntegrationsLogic.swift in Sources */,
+				DD92909F887D4008BD46B6FE /* AdvisingLogic.swift in Sources */,
+				C81BC21475CA478EA4075B85 /* AiModelsAdminLogic.swift in Sources */,
+				A6C6FCAC87AB4EE381972F02 /* AnnouncementLogic.swift in Sources */,
+				DD96F4097EF446199697B80D /* ArchivedCoursesAdminLogic.swift in Sources */,
+				1A31F1D6D90C4955BD1F573A /* AssignmentLogic.swift in Sources */,
+				30E996A34E254F359D5524D5 /* AuditLogAdminLogic.swift in Sources */,
+				584C5965CF674DBABA550E10 /* BehaviorLogic.swift in Sources */,
+				80CC735067BD4E049A911122 /* BillingLogic.swift in Sources */,
+				D2DA16D6D49B4DD9BBC1742D /* BoardRealtimeLogic.swift in Sources */,
+				F0BD139076674FDC9CBEB5EB /* BoardsAdvancedLogic.swift in Sources */,
+				EEC299626D5E41C8BE6863AA /* BoardsGovernanceAdminLogic.swift in Sources */,
+				B1626F1EDB1940F6B09877D4 /* BoardsLogic.swift in Sources */,
+				64577D94F29F41D69F3429FB /* CanvasImportLogic.swift in Sources */,
+				1F2F3185DD6743408FDD59E7 /* CanvasImportObservability.swift in Sources */,
+				AF97D393CA304376A3EBECFA /* CatalogLogic.swift in Sources */,
+				1CBD8E88A0E746268004C5A7 /* ConferenceLogic.swift in Sources */,
+				04B226DB102E4A8D8F8940D4 /* CourseAccessibilityReviewLogic.swift in Sources */,
+				51951A19C75B49CFB079BAC2 /* CourseArchivedContentLogic.swift in Sources */,
+				2EE334A9DD8843D7B8FED259 /* CourseBlueprintLogic.swift in Sources */,
+				58251CFEB17E4330BC32050D /* CourseCreateDraftStore.swift in Sources */,
+				E0BF1ACE45BE4777989D0FDC /* CourseCreateLogic.swift in Sources */,
+				B25B4B8A5947421BBC083268 /* CourseCreateObservability.swift in Sources */,
+				79F9D65C98C945F28936F111 /* CourseFeaturesLogic.swift in Sources */,
+				9832E919FE9E433DB05F6712 /* CourseFileLogic.swift in Sources */,
+				851C32BA90434973909B7C7C /* CourseGradingAgentsLogic.swift in Sources */,
+				2C7F8DB9A7C74FC09536B274 /* CourseGradingLogic.swift in Sources */,
+				17B40FA2B7084F90BA44AA56 /* CourseHeroImage.swift in Sources */,
+				1BCCDB4F8B184F498D1BA398 /* CourseImportExportLogic.swift in Sources */,
+				B6AC338EF20A481080AAEC66 /* CourseOutcomesLogic.swift in Sources */,
+				044E734121B04AD4AF133F21 /* CoursePeopleLogic.swift in Sources */,
+				E0034CBC4A4A44AA9ACA8F84 /* CoursePeopleObservability.swift in Sources */,
+				5604F5CF805A4EACA96AD8E6 /* CoursePlagiarismLogic.swift in Sources */,
+				964A3784221D48699021420C /* CourseReviewLogic.swift in Sources */,
+				34AE4236646B4DFA92E7EE27 /* CourseSectionsLogic.swift in Sources */,
+				57A71865D4EE48F7946F95E9 /* CourseSettingsLogic.swift in Sources */,
+				56A36D1DABC144AE8BA8EDC2 /* CourseTranslationsLogic.swift in Sources */,
+				D13E48A8AE0A44568B32D385 /* CredentialsLogic.swift in Sources */,
+				31449678DAE74DD994F3444C /* CurrencyExponent.swift in Sources */,
+				98F5A359170E43508EBC1010 /* DiscussionLogic.swift in Sources */,
+				5B293A532CB94B5C8CAC371D /* EvaluationLogic.swift in Sources */,
+				D7E0841ECCFC4A3395EC04C0 /* FeedbackLogic.swift in Sources */,
+				7F239EB29E674FEF9874B4A7 /* FileDownloadManager.swift in Sources */,
+				AFF61B9106234F7D83EBC362 /* GamificationLogic.swift in Sources */,
+				4091BD957DE54482B0A0C8C4 /* GradeCalculator+MyGrades.swift in Sources */,
+				A408256D4D144E1B95481536 /* GradeCalculator.swift in Sources */,
+				B7EF464315D54771870EB1A1 /* GroupsLogic.swift in Sources */,
+				0369207C3D5E44EBA0BEB2C4 /* InsightsLogic.swift in Sources */,
+				002905AB12F64D788195ADD0 /* InstructorInsightsLogic.swift in Sources */,
+				FB2CC0967E66475D95256EBA /* IntegrationsAdminLogic.swift in Sources */,
+				B8320F5DF6B9400F8A47EE47 /* InteractiveLaunchLogic.swift in Sources */,
+				75511354CC734D89A7A9C046 /* IntroCourseLogic.swift in Sources */,
+				9FE504583E704A828E3CBBDC /* IntroCourseObservability.swift in Sources */,
+				DD52F82C382945D2988DB8E3 /* LMSAPI.swift in Sources */,
+				FC08960D992547B69F6FB9EA /* LMSAPIAccountIntegrations.swift in Sources */,
+				2A82B52122014896A389E3CB /* LMSAPIAdmin.swift in Sources */,
+				D5EA0BE7DFD747188BC89A0D /* LMSAPIAdvising.swift in Sources */,
+				FCA20985E69A47AB8768D75D /* LMSAPIAnnouncements.swift in Sources */,
+				CD3E2665C37C4A2CBEB05C30 /* LMSAPIAuditLog.swift in Sources */,
+				5FB0E4CE699F408D908CD65B /* LMSAPIBehavior.swift in Sources */,
+				DE38858E481D4A97B0078961 /* LMSAPIBilling.swift in Sources */,
+				9E8BDF3EE56A4D038A7EC6CA /* LMSAPIBoardAccess.swift in Sources */,
+				77BE2015AE5E4F1EADDE9A8B /* LMSAPIBoardAnalytics.swift in Sources */,
+				BD3D62016549414B9854CC64 /* LMSAPIBoardEngagement.swift in Sources */,
+				9DFF1DA4BB314351964D9086 /* LMSAPIBoardExport.swift in Sources */,
+				2BE5A0593D3A48EBB96A507C /* LMSAPIBoardLayout.swift in Sources */,
+				D47A6CCBA23D418F9A53E695 /* LMSAPIBoardModeration.swift in Sources */,
+				163081DACD874AFC9CEBB4CB /* LMSAPIBoardPosts.swift in Sources */,
+				3F3F700D8EBD494F860E258F /* LMSAPIBoardTemplates.swift in Sources */,
+				3CAF4BC52EE14E59AA9AA375 /* LMSAPIBoards.swift in Sources */,
+				1EC0B2C122144589AD10A89D /* LMSAPICanvasImport.swift in Sources */,
+				AAF254745FA145C4978E8767 /* LMSAPICatalog.swift in Sources */,
+				1074AE412E3D45479E3FC24B /* LMSAPICourseAccessibility.swift in Sources */,
+				B402E25ADDA4412DA067751D /* LMSAPICourseArchivedContent.swift in Sources */,
+				05224A5A9E0D4046809E2B0D /* LMSAPICourseBlueprint.swift in Sources */,
+				1357C78D319D4F308D52A8F8 /* LMSAPICourseCreate.swift in Sources */,
+				BC762DECD0C844329C7F10F9 /* LMSAPICourseFeatures.swift in Sources */,
+				67538CE802674998AE77B463 /* LMSAPICourseGrading.swift in Sources */,
+				A2BF109AE8C949C6937E69CD /* LMSAPICourseGradingAgents.swift in Sources */,
+				8B8F3F12483D438983936BB7 /* LMSAPICourseImportExport.swift in Sources */,
+				4E904AB3021B4420B0C06A3B /* LMSAPICoursePlagiarism.swift in Sources */,
+				48823DAE80D24C32B3F4873D /* LMSAPICourseReviews.swift in Sources */,
+				B2295608748A41B7AC205BCC /* LMSAPICourseSections.swift in Sources */,
+				70BE875893DA41728EF11CF0 /* LMSAPICourseSettings.swift in Sources */,
+				574940E35AB04C66B966557F /* LMSAPICourseTranslations.swift in Sources */,
+				031BF94EDA8941B58ED65CFB /* LMSAPICredentials.swift in Sources */,
+				80612637EAEF448CA0384CBC /* LMSAPIDiscussions.swift in Sources */,
+				B6494DA38A7547888D36551B /* LMSAPIEportfolio.swift in Sources */,
+				9B69CCFEB0034CFEA7F815A6 /* LMSAPIEvaluations.swift in Sources */,
+				5D61EF685351448BA9E2CEE8 /* LMSAPIFeatures.swift in Sources */,
+				E9B249DC0717464180E51A62 /* LMSAPIFeed.swift in Sources */,
+				0CDB3FDC6C064673A5C9FADC /* LMSAPIFeedback.swift in Sources */,
+				59E4A13C071A48CAAE16D8E1 /* LMSAPIGamification.swift in Sources */,
+				0F52C3C798F4427B81D6C8A6 /* LMSAPIGroups.swift in Sources */,
+				E5C077722D6940F78A4293E7 /* LMSAPIInsights.swift in Sources */,
+				7DD3C39B0D0D4D5CAB137BFE /* LMSAPIInstructorInsights.swift in Sources */,
+				99DB368B3BC14B77AED0EA42 /* LMSAPIIntroCourse.swift in Sources */,
+				983CDB5358764FD6989EE994 /* LMSAPILearnerProfile.swift in Sources */,
+				1F65E5A34F584D36BC87EF70 /* LMSAPILiveQuiz.swift in Sources */,
+				6D88B5874E204CF3A2E31F39 /* LMSAPIMarketplace.swift in Sources */,
+				D6CC17B5DA7540AFB7D53BBD /* LMSAPIMastery.swift in Sources */,
+				25BED0BFCE244FDDB113467B /* LMSAPIMobileWave.swift in Sources */,
+				0107441311A1498BA49C74AD /* LMSAPIOutcomes.swift in Sources */,
+				8A9259E216124941B7AAA60B /* LMSAPIParent.swift in Sources */,
+				B89E19B30F1A4B31A8FF9534 /* LMSAPIPaths.swift in Sources */,
+				B9641A3904A14311B0ACECCD /* LMSAPIPeerReview.swift in Sources */,
+				F80F0668233D435AA9111D91 /* LMSAPIProctoring.swift in Sources */,
+				4E0F55A6CE1947508C936550 /* LMSAPIQuizCodeRun.swift in Sources */,
+				F658066BAB224F77B2EE617C /* LMSAPIReader.swift in Sources */,
+				07D34EE7807A46B59DEBC009 /* LMSAPIReading.swift in Sources */,
+				F4F7980EFE93464DA5512090 /* LMSAPIReview.swift in Sources */,
+				4FC4D8989506445D8A22D96B /* LMSAPITutor.swift in Sources */,
+				07E475945B75494B86C0EDD3 /* LMSAPIWallet.swift in Sources */,
+				6BFE443C16D44678883081EF /* LMSAPIWhiteboard.swift in Sources */,
+				4D015EF64B97490DAB901F99 /* LMSBoardAdvancedModels.swift in Sources */,
+				73A688D46E3E48FCA0EE3FBD /* LMSBoardModels.swift in Sources */,
+				57B5A846FD164DA1854CD044 /* LMSFeatureModels.swift in Sources */,
+				955A8DFB29674447B8015D2A /* LMSFeatureModelsAccountIntegrations.swift in Sources */,
+				EC4CFF3700DC422A8E2DFFD7 /* LMSFeatureModelsAdvising.swift in Sources */,
+				13161AA1ADBC4A6685BE7F95 /* LMSFeatureModelsAiAdmin.swift in Sources */,
+				6975DE522A664A1EB37B7F4C /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */,
+				BEA8298EE5BE471F8CF2C10B /* LMSFeatureModelsAuditLog.swift in Sources */,
+				B8AAEFE9A7EF494AA858B3C7 /* LMSFeatureModelsBehavior.swift in Sources */,
+				18B2F850A925428E8F668D01 /* LMSFeatureModelsBilling.swift in Sources */,
+				65B52B889BD547BC9A4643DC /* LMSFeatureModelsCanvasImport.swift in Sources */,
+				E042CA4A3D2F4EC6A718B836 /* LMSFeatureModelsCatalog.swift in Sources */,
+				11725BAAC0164B4F934DDEEE /* LMSFeatureModelsCourseAccessibility.swift in Sources */,
+				D6C37562AEBD4CEA8739A1DE /* LMSFeatureModelsCourseCreate.swift in Sources */,
+				930D5585356C42E6B1E714D3 /* LMSFeatureModelsCourseGrading.swift in Sources */,
+				625835250AA44CAB8BD357AF /* LMSFeatureModelsCourseGradingAgents.swift in Sources */,
+				C0681F597D194C86A516158D /* LMSFeatureModelsCourseOutcomes.swift in Sources */,
+				E33E8694BA8747CF9DA48BD7 /* LMSFeatureModelsCoursePlagiarism.swift in Sources */,
+				76595C5CC6AA4AD09A6DCD57 /* LMSFeatureModelsCourseReviews.swift in Sources */,
+				95816DE8A5154BAAB8FC9CFA /* LMSFeatureModelsCourseSettings.swift in Sources */,
+				8E74170077DB4DE9808236D9 /* LMSFeatureModelsCourseTranslations.swift in Sources */,
+				8944F1C9147041929F16AB50 /* LMSFeatureModelsCredentials.swift in Sources */,
+				B39FDDFD04C94707ABD777F0 /* LMSFeatureModelsDiscussions.swift in Sources */,
+				9F23BC5B6D4740F1B1A95C87 /* LMSFeatureModelsEportfolio.swift in Sources */,
+				D3D780D070DF42ACAA1FFF82 /* LMSFeatureModelsEvaluations.swift in Sources */,
+				4DB2AB512BDB4A53AEE8BB95 /* LMSFeatureModelsFeed.swift in Sources */,
+				742C8A710730478F9387553E /* LMSFeatureModelsFeedback.swift in Sources */,
+				29886400FBD04A58B95CC0B2 /* LMSFeatureModelsGamification.swift in Sources */,
+				8385C939AD84420C94FF12E3 /* LMSFeatureModelsGroups.swift in Sources */,
+				FD948DD685444BF9BCF318B5 /* LMSFeatureModelsInsights.swift in Sources */,
+				6D88CE52C986453A8BF5B0C6 /* LMSFeatureModelsInstructorInsights.swift in Sources */,
+				093D43FBB19545D2AC4E75BD /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */,
+				6894134B17314822902FFAF9 /* LMSFeatureModelsIntroCourse.swift in Sources */,
+				179BA98C79DC4A5E95C34E79 /* LMSFeatureModelsLearnerProfile.swift in Sources */,
+				AA25A097B4D54E04ADEC2434 /* LMSFeatureModelsLive.swift in Sources */,
+				0C741C7AE32844099FB1FBB5 /* LMSFeatureModelsMarketplace.swift in Sources */,
+				0BB69957873C40A780B86B3F /* LMSFeatureModelsMastery.swift in Sources */,
+				4A098125BC2C473F9073B74E /* LMSFeatureModelsMobile.swift in Sources */,
+				494414593D924216A78D4AD8 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */,
+				34EE6AF8F3554C1CAC6172B3 /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */,
+				6ACCA3B209314501B5AA46CD /* LMSFeatureModelsParent.swift in Sources */,
+				FA454F66A1264FBEA9C2B06A /* LMSFeatureModelsPaths.swift in Sources */,
+				4610A27CBA494A13930F773F /* LMSFeatureModelsPeerReview.swift in Sources */,
+				6DF84F2D562042BE961B6EDD /* LMSFeatureModelsPeopleAdmin.swift in Sources */,
+				93D366EE1FF142819422301B /* LMSFeatureModelsPlatform.swift in Sources */,
+				29396971F24F4367A238A82D /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */,
+				9A52A294619B4BA18EC8E197 /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */,
+				7029802B224848E9A126865B /* LMSFeatureModelsReader.swift in Sources */,
+				44F05A1005114E37884E5375 /* LMSFeatureModelsReading.swift in Sources */,
+				2C5D91394CC1432A9C1C7AEB /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */,
+				61D3278D97E84FC39DF35584 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */,
+				F50DD76D2D8A4868B51A8C3E /* LMSFeatureModelsTutor.swift in Sources */,
+				C6F366B4969647F4AEFCC95E /* LMSFeatureModelsWallet.swift in Sources */,
+				B718690ECB8C4105B00637EF /* LMSInteractiveModels.swift in Sources */,
+				628623E4AE6B4DA19322109F /* LMSModels.swift in Sources */,
+				82B05DA5BBF04F6CA95B08A3 /* LearnerProfileLogic.swift in Sources */,
+				5A300C2DE1AB4D8BAB2ABA39 /* LibraryResourceLogic.swift in Sources */,
+				9DBAA00087EE44908764E3A5 /* LiveGameLogic.swift in Sources */,
+				D507791B8EAB4DC28817850A /* LiveMeetingsLogic.swift in Sources */,
+				A3584F94A1494D57BCCBD4CF /* LiveQuizLogic.swift in Sources */,
+				D7807865C9EA4116A413AE18 /* MarketplaceLogic.swift in Sources */,
+				AD5D29047CA546C58B133BCC /* MasteryLogic.swift in Sources */,
+				3CD94916407742879D20E044 /* ModuleContentLogic.swift in Sources */,
+				5D01EB754B7645A6A12F9E6A /* ModuleLastVisited.swift in Sources */,
+				345219F117C0489D85F68966 /* NotificationLogic.swift in Sources */,
+				C02086BBF39A4D788E013067 /* OfficeHoursLogic.swift in Sources */,
+				597F6B4BE5874F68868530FA /* OnboardingModels.swift in Sources */,
+				D73F09E1288A4DDF9D908386 /* OrgBrandingAdminLogic.swift in Sources */,
+				0BB946A1AB534B6085F62EED /* OrgStructureAdminLogic.swift in Sources */,
+				53E1827781ED439DAE9BF12A /* ParentLogic.swift in Sources */,
+				EFD3A6E385E44BF5977B429F /* PathsLogic.swift in Sources */,
+				E4CE1F7DE7F544EB823E2729 /* PeerReviewLogic.swift in Sources */,
+				BE55CC8650BC46489079B9B4 /* PeopleAdminLogic.swift in Sources */,
+				D7784F2CEA6F4CBC924DA81D /* PlannerLogic.swift in Sources */,
+				5D1D2935B55E48899286F045 /* PlannerSnapshotCoding.swift in Sources */,
+				7C17718ECC9E4DE98F4CF7E1 /* PlatformCoursesAdminLogic.swift in Sources */,
+				12A7174B46624AB19D10DEA1 /* PlatformSettingsAdminLogic.swift in Sources */,
+				6E4BFD606DEF461492C0CC34 /* PortfolioLogic.swift in Sources */,
+				A9348C0F85494A02A4D7CE38 /* ProfileDepthLogic.swift in Sources */,
+				31B51BA5175E4674B9955071 /* ProfileDepthModels.swift in Sources */,
+				6F6A3A5298B6448F8C99A3E7 /* QuizLogic.swift in Sources */,
+				3D4B2B612A2C4206A769AACC /* ReadingLogic.swift in Sources */,
+				FF885585D39642C0B45C160C /* RequirementsLogic.swift in Sources */,
+				F9C7058850944E8F95807196 /* ReviewModels.swift in Sources */,
+				D1EE55FB461F463DAB742BBC /* RolesPermissionsAdminLogic.swift in Sources */,
+				A1FBE83DFE4149CEB92B8765 /* SettingsMenuLogic.swift in Sources */,
+				B2E07FFB481C4A5BBE6EF8E0 /* TakeAttendanceLogic.swift in Sources */,
+				C7567ACBBD6F4EECACCE2E4E /* TranscriptsAdvisingAdminLogic.swift in Sources */,
+				232E17A4D7494AE1B6B77E79 /* TutorLogic.swift in Sources */,
+				C044F6B123904CB2A77EB75A /* TutorStreamClient.swift in Sources */,
+				36B0A7F4F4B44BC2A74438AA /* VibeActivityLogic.swift in Sources */,
+				F27F3356FE4F482D8BDBE836 /* WalletLogic.swift in Sources */,
+				768E9C7C01454C198C99336C /* WhiteboardLogic.swift in Sources */,
+				A066A4DDEEE34F5495CD715F /* WhiteboardRenderer.swift in Sources */,
+				81164CE867B049079A45A29D /* APIClient.swift in Sources */,
+				FF6ADB7EFBA647D89ACCDB96 /* APIError.swift in Sources */,
+				18883053C2CF44569CD0FF76 /* NetworkAuthContext.swift in Sources */,
+				648C39D5C7FE43B8B1F16146 /* NetworkBootstrap.swift in Sources */,
+				10385B466EC84FDBA0825283 /* MarkdownTableLogic.swift in Sources */,
+				EC8703EC21534F22B998CF6D /* NotebookDrawing.swift in Sources */,
+				ACEE34B68C1745D38686B7EC /* NotebookMarkdown.swift in Sources */,
+				508C1E9687124A349438D5EE /* NotebookSlashCommands.swift in Sources */,
+				B4D601C0AC7741FAB409722A /* NotebookStore.swift in Sources */,
+				98EF53753BB04B84A456942D /* NotebookSync.swift in Sources */,
+				3172F3227AF54990B74FB813 /* NotebookTree.swift in Sources */,
+				681E8B1C40D540969DF80B6F /* CacheStore.swift in Sources */,
+				E71CF5810718438B94805D18 /* DownloadStore.swift in Sources */,
+				5954DCD025F74B1DAB907502 /* NetworkMonitor.swift in Sources */,
+				64342B0D4ADB4EA7913D491D /* OfflineModels.swift in Sources */,
+				6CE5D9B0001044E7A96C0C1C /* OfflineService.swift in Sources */,
+				DE91392DAAF24F848649990B /* OutboxStore.swift in Sources */,
+				167A204A3A04495A94282ECB /* SyncEngine.swift in Sources */,
+				D77CDD1A60F04BDA84A8AC2A /* PushManager.swift in Sources */,
+				65C54D08FE8A45C7BB5AFF62 /* RealtimeManager.swift in Sources */,
+				BADCC8AA27914AD39AD39E8D /* WebSocketClient.swift in Sources */,
+				CF4AB5B897894BD1BE2F2648 /* ContentLinkRouter.swift in Sources */,
+				7BE976C048F842CE82F153A5 /* DeepLinkRouter.swift in Sources */,
+				567EA4491007481BA5DF9EEE /* MobileDestinations.swift in Sources */,
+				1ED73BFD03AD49F7966024C1 /* MobileIaPreferences.swift in Sources */,
+				D492EBF9575B43CCB7D00891 /* MobileProfileDepthPreferences.swift in Sources */,
+				583F78BCFE074771AFB8CA3A /* SearchActionRegistry.swift in Sources */,
+				406EC6322EBB4CA38E0EF6A1 /* SearchModels.swift in Sources */,
+				74B0E82EE4094B42B32DEB3A /* SearchPathNavigator.swift in Sources */,
+				4BC8D3E45C984AEF8E9EA992 /* SearchRecentsStore.swift in Sources */,
+				25C1DAC6628B40E4B7BB1764 /* CodeEditor.swift in Sources */,
+				4F3D564DFDAA45D485DC08BC /* AdvisingView.swift in Sources */,
+				2B5AC6605D1C41C197E6144E /* AssignmentDetailView.swift in Sources */,
+				44288896B6304DC8833C55B1 /* AssignmentDraftStore.swift in Sources */,
+				0C506D3676A448019F3501F8 /* AttachmentUploader.swift in Sources */,
+				9E093827852844E099424DD5 /* AppleSignInController.swift in Sources */,
+				E71DA52069B94A41A248DC44 /* AuthFlowView.swift in Sources */,
+				3A41AC17DEE546AE8292162B /* GetStartedView.swift in Sources */,
+				9B69C172AE4C4CBB98B3D3AA /* LoginView.swift in Sources */,
+				0DDB95AAB94640099A401E97 /* MFAChallengeView.swift in Sources */,
+				7D119A5127964CCD8B9A239D /* MfaPasskeyController.swift in Sources */,
+				22DDAE6A06A24FDAAFE0A0D3 /* SSOAuthController.swift in Sources */,
+				A6BDD382DFCB4C6CBFC6AEBD /* SignupView.swift in Sources */,
+				CD9CF44DD51A41D4BB5EE71E /* BehaviorRosterView.swift in Sources */,
+				7ED3B55E2F194A148E68FB20 /* HallPassView.swift in Sources */,
+				EAF60A9E783D4A6AA27B1BA4 /* MyHallPassView.swift in Sources */,
+				90DB3F5A985C452CA2BEFF3E /* BillingView.swift in Sources */,
+				2CFDE3DCAFD943DFA374506A /* CheckoutReturnHandler.swift in Sources */,
+				07AC8CA9D7B745DF959322CF /* PurchaseFlow.swift in Sources */,
+				7DFC6F1AB6804EB0B9AD139D /* BoardAnalyticsSheet.swift in Sources */,
+				3087F31746B0445F88163E16 /* BoardComposerView.swift in Sources */,
+				513201C8086B4D4ABAB2D2B6 /* BoardDetailView.swift in Sources */,
+				112B5FC6A26A4C239DEA5E68 /* BoardEngagementEnvironment.swift in Sources */,
+				B628B4D06766416D85DB280C /* BoardExportSheet.swift in Sources */,
+				9350312EFD914AA18023A16A /* BoardModerationSettings.swift in Sources */,
+				E34650CFE1F245C7A1D446E0 /* BoardPostCard.swift in Sources */,
+				9CBB67B45CD6442AAF18BEA6 /* BoardPresentModeView.swift in Sources */,
+				462A976E735E43448BB18912 /* BoardSaveAsTemplateSheet.swift in Sources */,
+				4467D7B9B3724D79AE2541D8 /* BoardShareSheet.swift in Sources */,
+				F0DBF31E806B493FBE728A77 /* BoardSocket.swift in Sources */,
+				CE9000050C4C46DD86BD15AD /* BoardSurface.swift in Sources */,
+				522B18E83695425299B42E93 /* BoardSyncStatusChip.swift in Sources */,
+				55419C0568874D84A05F9222 /* BoardTemplatePickerView.swift in Sources */,
+				DA3CB0D8439B43F9B04AAFC1 /* BoardsListView.swift in Sources */,
+				B1C0367397C4440ABD4A3FF1 /* CardArrangeMenu.swift in Sources */,
+				E632825BF32E431EAB2DC308 /* CommentSheet.swift in Sources */,
+				C33E125522F6463B8588D9DC /* GradeSheet.swift in Sources */,
+				E9500E279FD84474B49E2767 /* CanvasLayout.swift in Sources */,
+				F097D9E47BBD48E4B2995514 /* ColumnsLayout.swift in Sources */,
+				9D718AC9F4EA40A6B67DBBFC /* MapLayout.swift in Sources */,
+				35B8C5A588124A2495CEF149 /* TimelineLayout.swift in Sources */,
+				C4FB2773115A4272B35A725D /* WallLayout.swift in Sources */,
+				B22FFB3070274427A9BA052C /* ModerationQueueView.swift in Sources */,
+				5DDFD0CD90AA4D949D3F81A6 /* BoardPublicView.swift in Sources */,
+				2CBEB5B6A97E4AD49B8E9B90 /* ReactionControl.swift in Sources */,
+				7E6946757D0347E1A59361C3 /* ReportDialog.swift in Sources */,
+				ACDCFD35679449A495D39680 /* CatalogView.swift in Sources */,
+				CF786EBFF6C5411A86A78307 /* CourseLandingView.swift in Sources */,
+				3762E2C6D0CA48B7A02CD6BA /* ReviewComposer.swift in Sources */,
+				68FC92E933224C5AB8D3C8A7 /* ContentPageView.swift in Sources */,
+				086E2770AE5E4D4AA34E78AF /* CourseAttendanceView.swift in Sources */,
+				C9E28C386F1E45C4980FBFBE /* CourseBanner.swift in Sources */,
+				83260790D9E748C38AC0A640 /* CourseDestinationPlaceholder.swift in Sources */,
+				4DD69D0912AF47218F88D530 /* CourseDetailView.swift in Sources */,
+				853F5994106A4F3AB990ECC8 /* CourseGradesView.swift in Sources */,
+				24C3085C652641CD947EC5CC /* CourseLibraryView.swift in Sources */,
+				49E8E80342304542BED428A5 /* CourseMarkdownContentView.swift in Sources */,
+				800AC77153994AE1AB074F25 /* CoursePeopleView.swift in Sources */,
+				6460CCE4EDF641E9AB43BC36 /* CourseStructureSocket.swift in Sources */,
+				43420264D4024516951C37A9 /* CourseSyllabusView.swift in Sources */,
+				6F2FA487AD9A474FBA27747A /* CourseWorkspaceNav.swift in Sources */,
+				03AA2BD5DC0843E29F26566D /* CoursesListView.swift in Sources */,
+				16ACA5E324634EBD9F5D8FEC /* CanvasImportComingSoonView.swift in Sources */,
+				E33361292D104B2FBC9EBD97 /* CanvasImportView.swift in Sources */,
+				9F2FF5D8602D49BB9EF3AAB4 /* CourseCreateView.swift in Sources */,
+				EF354F667A754B4CB3B2E808 /* ItemDetailRows.swift in Sources */,
+				59B70927C9A94595AF643F78 /* ItemDetailView.swift in Sources */,
+				DCEC40B738504791ACDF80AA /* LaunchContainerView.swift in Sources */,
+				3E6A765D21D14E129AB3740E /* LibraryResourceView.swift in Sources */,
+				068C3531D6A04E219A9A8DE0 /* MarkdownCodeBlockView.swift in Sources */,
+				916DEA86CCB2455EB02B79C2 /* MarkdownTableView.swift in Sources */,
+				7E62025B1F4348478529176A /* ModuleItemRouteView.swift in Sources */,
+				4BE9EB7CC590462388982E9D /* ModuleListView.swift in Sources */,
+				69207C1393864BDCAE39E998 /* RequirementsView.swift in Sources */,
+				7821EF2DCC1D4F36A7BDDCF0 /* CourseAccessibilityReviewView.swift in Sources */,
+				30464CEA6CC54B44A858A09C /* CourseArchivedContentView.swift in Sources */,
+				26EE54861D354BF990E116DF /* CourseBlueprintSettingsView.swift in Sources */,
+				5AA3C4A008D749E688257943 /* CourseCrossListingView.swift in Sources */,
+				5AB361DED5A14AB09E19E088 /* CourseFeaturesSettingsView.swift in Sources */,
+				8B2102DFDD9C498D8547CBFB /* CourseGeneralSettingsView.swift in Sources */,
+				E7025A24B32745AEA3557CC6 /* CourseGradingAgentsView.swift in Sources */,
+				6D313D94411C4894945CF1D9 /* CourseGradingSettingsView.swift in Sources */,
+				509D8DAA646A45E284DCCC7B /* CourseHeroImageEditor.swift in Sources */,
+				E1BAD5B13167480E9754514E /* CourseImportExportView.swift in Sources */,
+				C6B6CAB5BF834B7C87C57651 /* CourseMarketplaceSettingsView.swift in Sources */,
+				8A9ACCD6B4C54455887861BB /* CourseOutcomesSettingsView.swift in Sources */,
+				5C6F24975F844463975AB0EF /* CoursePlagiarismSettingsView.swift in Sources */,
+				15846C31C0F34E3997155B24 /* CourseSectionsSettingsView.swift in Sources */,
+				05DDF2F21D4247DA95411261 /* CourseSettingsHostView.swift in Sources */,
+				717C57DFB68848F9BDABD762 /* CourseTranslationsSettingsView.swift in Sources */,
+				DE2BB701059B41B2B66D9BF9 /* TakeAttendanceView.swift in Sources */,
+				7E0CB8C2CDAB46E79723EE12 /* VibeActivityView.swift in Sources */,
+				09E2975018AA4483B41E86CA /* WebItemView.swift in Sources */,
+				402D0BB774624382981F9F26 /* CredentialDetailView.swift in Sources */,
+				78BA3A76893147B4A5737ABB /* CredentialsView.swift in Sources */,
+				3CF154ACD0AF4C26850C3895 /* DashboardCoursesCarousel.swift in Sources */,
+				078F8DA5217C45208D255A55 /* DashboardHeroPanel.swift in Sources */,
+				5C0F730A8CCC4506A5496BBC /* DashboardView.swift in Sources */,
+				1D5E3116179641499E19A849 /* LiveMeetingsRail.swift in Sources */,
+				651F92E886654DF18ABF24B3 /* CourseDiscussionsSection.swift in Sources */,
+				8DC2AFB29CB44E3CB810C74D /* DiscussionThreadView.swift in Sources */,
+				2F9DC1F6EE32484CBBABCC71 /* DiscussionsListView.swift in Sources */,
+				566E104CBB1D406C922336C0 /* PostComposerView.swift in Sources */,
+				3298E94176FD4C4FBDF2852A /* CourseEvaluationsSection.swift in Sources */,
+				20D72CFD7A78479C8F207651 /* EvaluationFormView.swift in Sources */,
+				DE82C7D29D4741279DAA8153 /* EvaluationResultsView.swift in Sources */,
+				B100473493A545AC974176CD /* CourseFeedSection.swift in Sources */,
+				3FA12DC95AA74C2C9EC4BCAC /* FeedChannelView.swift in Sources */,
+				F47EF201B61B48F7BACDBD03 /* FeedChannelsView.swift in Sources */,
+				DDEBC7E31C0045D68325CD41 /* FeedLogic.swift in Sources */,
+				DCB152BA4C474975930194DA /* FeedSocket.swift in Sources */,
+				5F44382D41CB4D548EAB9004 /* ShareFeedbackView.swift in Sources */,
+				7426989562E9444DB451C246 /* CourseFilesSocket.swift in Sources */,
+				F61A96F44BC7447D9A85ACF5 /* CourseFilesView.swift in Sources */,
+				27250EF2EC844ECFB41A423E /* FilePreviewView.swift in Sources */,
+				22C990D73BB54604A866A4B6 /* MarkupOverlayView.swift in Sources */,
+				426C6FBF61FE47208BF75BF1 /* GamificationView.swift in Sources */,
+				66B9B406167D4F02B7E088F1 /* GradeFeedbackView.swift in Sources */,
+				03E52BCDB01948F1A6CD0C84 /* WhatIfController.swift in Sources */,
+				F96BE9C647734EDAAF73934C /* GradingBacklogView.swift in Sources */,
+				1350A36283514ED3AE5B98B6 /* SpeedGraderView.swift in Sources */,
+				7A61CF28A0C5485EA1F34718 /* CollabDocView.swift in Sources */,
+				0FCDDDBD482C46DDA0461CC1 /* CourseCollabDocsSection.swift in Sources */,
+				15D8976AFB32451EB3D4CCDA /* CourseGroupsSection.swift in Sources */,
+				B4EB528F99D34C3F83091138 /* GroupSpaceView.swift in Sources */,
+				0ED62D425A4E451FBF6E7E0A /* AnnouncementComposerView.swift in Sources */,
+				A54A6D3D36D04795AD7F553D /* AnnouncementsViews.swift in Sources */,
+				9AB309A4D92B488DA1EB2DAC /* BroadcastComposerView.swift in Sources */,
+				283F45906F944EAE81A97E84 /* MainTabView.swift in Sources */,
+				A169C2814F1A42D8A7284907 /* MoreHubView.swift in Sources */,
+				D64647424591472CB12CC11B /* ShellHeaderBar.swift in Sources */,
+				1EFCE70315F94C0C92EEF4E4 /* TeachHubView.swift in Sources */,
+				8DC73E8306284B74A24AB14A /* UniversalSearchPlaceholder.swift in Sources */,
+				B97CB5F54C204F83A2274DA9 /* ComposeMessageView.swift in Sources */,
+				C4B4AFAF23E444D684C74E7F /* InboxView.swift in Sources */,
+				6BA3AA98591D46448467F24F /* MessageDetailView.swift in Sources */,
+				7C69AE1F574F4047A3EF86DC /* DashboardInsightsSection.swift in Sources */,
+				241714943727494EBFB5FF96 /* InsightsView.swift in Sources */,
+				740A06DFD62F4D29B36AFC9C /* AtRiskListView.swift in Sources */,
+				73C6E16C6E484470B9E7B784 /* CourseInsightsSection.swift in Sources */,
+				7A0C884A584B4D2FB584B571 /* StudentProgressDetailView.swift in Sources */,
+				606693184E4E4BA39AABB2BE /* WhatsWorkingView.swift in Sources */,
+				5D2F4FB5C52F4FA595A14104 /* IntroCelebrationPresenter.swift in Sources */,
+				EF16E79934FD4222BF0282C4 /* IntroCompletionCelebrationSheet.swift in Sources */,
+				B7F02A7A8E994A0F9731E277 /* IntroCourseEntryCard.swift in Sources */,
+				88956425ADC64D098DB484A6 /* IntroCourseProgressRail.swift in Sources */,
+				36D53233307941019D2C7BFC /* LearnerProfileView.swift in Sources */,
+				B3F5555053E046309DAEC51E /* LibraryBrowseView.swift in Sources */,
+				E5BF3CA3C75442C0915A16B5 /* MeetingDetailView.swift in Sources */,
+				24CEFEFAC27D484D8CA4488A /* MeetingListView.swift in Sources */,
+				50524B78462E46138E798C76 /* WhiteboardView.swift in Sources */,
+				31A43E223AE64CF7B317B52D /* LiveGameSocket.swift in Sources */,
+				54A3749733E34452AABF49F0 /* LiveQuizHubView.swift in Sources */,
+				C3713CE5BCD84D13A708233F /* LiveQuizPlaySurfaces.swift in Sources */,
+				576FE9B632694797BF162106 /* LiveQuizPlayView.swift in Sources */,
+				013DB38E476047E5B10E42C4 /* MarketplaceDetailView.swift in Sources */,
+				FD825CB92D9F4E53B6C36931 /* MarketplaceView.swift in Sources */,
+				0F0885C1A7A442658E9C26BB /* MyPurchasesView.swift in Sources */,
+				8879708009664DF28200AABA /* CourseMasterySection.swift in Sources */,
+				48BF5A9124F8434C87C1624B /* ReportCardListView.swift in Sources */,
+				86BB5688245243B0BA1DE5E6 /* CourseDrawer.swift in Sources */,
+				983B748754844B6F8577C6EB /* DrawerScaffold.swift in Sources */,
+				B381D36A6BA443FAB2EF7852 /* DrawerToolbar.swift in Sources */,
+				3A5938FDCD9243E9A370FB22 /* GlobalDrawer.swift in Sources */,
+				6E60D3E912F14800A3BFDBEC /* NotebookDrawingViews.swift in Sources */,
+				3C32289AF75C4E309711EA94 /* NotebookEditorSupportViews.swift in Sources */,
+				FA31A98E26824E12877C62B9 /* NotebookEditorView.swift in Sources */,
+				C442C7E0CC254DD5975BAE3E /* NotebookPagesView.swift in Sources */,
+				2A0A014EBAF04CEA98BD74EE /* NotebooksListView.swift in Sources */,
+				5DD96E804585487A93D22342 /* BookingSheet.swift in Sources */,
+				23392DD7C8324AEBAA7FCBCA /* MyBookingsView.swift in Sources */,
+				8BFEB92094DD4A6CAD797E5A /* OfficeHoursView.swift in Sources */,
+				7D513B71CE1D44A4B1949DF0 /* DiagnosticView.swift in Sources */,
+				260854A2B9AE45B0A1C9FC0C /* OnboardingFlowView.swift in Sources */,
+				BCB3CC5EF20E4AAC9FF804CF /* ConferenceBookingView.swift in Sources */,
+				2F406664162147C2BD5E3C8E /* MyConferencesView.swift in Sources */,
+				168A2E2592844CF78FEBB370 /* ParentAttendanceDetailView.swift in Sources */,
+				8826351567BC4109BDF7381B /* ParentDashboardSections.swift in Sources */,
+				AF30AF67DF5446A98623E2CB /* ParentDashboardView.swift in Sources */,
+				785871EE701340E2B507B3DF /* ParentGradesDetailView.swift in Sources */,
+				0BD013A4452946769F5F4A6F /* ParentNotificationPrefsView.swift in Sources */,
+				004B2E95410C4CE693140269 /* DashboardStudySection.swift in Sources */,
+				5889497F36044AA98D79B813 /* MyPathsView.swift in Sources */,
+				3A24DF561FD049CE89E0824C /* PathLandingView.swift in Sources */,
+				B9FCFF1F9A0F4A4B9557491E /* PathRunnerView.swift in Sources */,
+				9A195E6758A34DDF8BA6D4EA /* PathsCatalogView.swift in Sources */,
+				2464507F608B4D9F86E0A739 /* PeerReviewDetailView.swift in Sources */,
+				F62CC3ECE02147AF98727689 /* PeerReviewListView.swift in Sources */,
+				FB2A2F3E3B674353B9C1ABAB /* ReviewsReceivedView.swift in Sources */,
+				110B95E7D06F41D98EEE593C /* RubricScorerView.swift in Sources */,
+				93C936E6351E42909BEFFF64 /* CalendarSubscribeSheet.swift in Sources */,
+				271722C4C86E428FA661E784 /* CalendarView.swift in Sources */,
+				1629C666F31944FFAC72E301 /* ConferenceReminderScheduler.swift in Sources */,
+				489FCA1B438644B3965E6729 /* DueReminderScheduler.swift in Sources */,
+				BBB85B31F17F444AA4F67A07 /* OfficeHoursReminderScheduler.swift in Sources */,
+				6FCF7610FB9B4724A89499D1 /* PlannerModel.swift in Sources */,
+				38A42102E27A4C2483A4337C /* PlannerView.swift in Sources */,
+				B53D8D2674ED4316A7691858 /* TodosView.swift in Sources */,
+				658C1E186EA74FAEAA965EE8 /* ArtifactDetailView.swift in Sources */,
+				1CE32F92A4DD4B6797B7BB87 /* ArtifactEditorView.swift in Sources */,
+				912AC1F1D73A4DA3BFCE09C5 /* PortfolioArtifactUploader.swift in Sources */,
+				50C833577E5147D79BAFD02E /* PortfolioDetailView.swift in Sources */,
+				3F563D375D0842BC8CF659C8 /* PortfolioView.swift in Sources */,
+				988D1AE76D7449ABBE80B402 /* AiAdminEntryCard.swift in Sources */,
+				D5B2C7631A3C41D2B3CE4699 /* ArchivedCoursesAdminEntryCard.swift in Sources */,
+				18E7D3CBDC874492BE473861 /* BiometricLockView.swift in Sources */,
+				65BA9A19ECD34E46B75F0388 /* DeviceSessionsView.swift in Sources */,
+				A461B3DDA25A400B8E47CF0A /* EditProfileView.swift in Sources */,
+				EE46711E174C4CF8A90DAD74 /* IntegrationsAdminEntryCard.swift in Sources */,
+				A058ED27325C4EDF80191061 /* IntegrationsEntryCard.swift in Sources */,
+				232A98A3944642D0B5191DDF /* IntegrationsView.swift in Sources */,
+				AE8F3E64ECA24E65A0F62C42 /* LearnerProfileEntryCard.swift in Sources */,
+				DD2BB5D7D51B43E1AD072233 /* MyAccommodationsView.swift in Sources */,
+				5C31A7F145FC463D9F6F5200 /* NotificationPreferencesView.swift in Sources */,
+				6490751995BB44478A5830CC /* NotificationsView.swift in Sources */,
+				D7521F8FD5314D019530DEC1 /* OrgBrandingAdminEntryCard.swift in Sources */,
+				43BDD65562BA4828A30FDE61 /* OrgStructureAdminEntryCard.swift in Sources */,
+				C1DA398745A3417792CDA221 /* PeopleAdminEntryCard.swift in Sources */,
+				51A96095D86A48D99E716480 /* PlatformSettingsAdminEntryCard.swift in Sources */,
+				1B5CD9DECC884CD2AFFF2EA5 /* ProfileDepthCards.swift in Sources */,
+				DBD0B30AA580420AA2E283B0 /* ProfilePersonalDetailsView.swift in Sources */,
+				5698DCD9EA9B44068CDDB85D /* ProfileSecurityCard.swift in Sources */,
+				981C208401B74B6C9998AB92 /* ProfileSettingsCards.swift in Sources */,
+				81DEECEC9D914F06AE2B5B2F /* ProfileView.swift in Sources */,
+				8206C4C37F2949B4B3302494 /* ProfileViewSections.swift in Sources */,
+				209D699F24D347E39DA62895 /* ResearchStudiesView.swift in Sources */,
+				63622B33B9F34BF7973C9FF7 /* RolesPermissionsAdminEntryCard.swift in Sources */,
+				F2F2C8589D5C4364A43B4E4E /* SettingsAdminHubEntryCard.swift in Sources */,
+				5AED2A42200C417D901A3AAA /* ShareFeedbackEntryCard.swift in Sources */,
+				B5CCD9D022344044B331EA01 /* TranscriptsAdvisingAdminEntryCard.swift in Sources */,
+				1A87D70734574A048A8DC349 /* CodeQuestionView.swift in Sources */,
+				E17908C4CA6446149BE0EC97 /* LockdownController.swift in Sources */,
+				E04539B73C8E44DE96E3C469 /* QuizIntroView.swift in Sources */,
+				FA7CC2716D954890A3F5890C /* QuizQuestionViews.swift in Sources */,
+				1FD2CDA0ADAB418B997BA63D /* QuizResultsView.swift in Sources */,
+				A6ED01A672094CE3B09AA985 /* QuizTakerView.swift in Sources */,
+				0BA36578549C4277A43ECCCD /* CaptionedPlayerView.swift in Sources */,
+				E1F0BF5110DB4C24A97D4986 /* ContentTranslationControls.swift in Sources */,
+				6747A8A5EFF84C2D9C98F46D /* ImmersiveReaderCapabilities.swift in Sources */,
+				8CD1372F58304586963CF984 /* ReaderLogic.swift in Sources */,
+				588A85CFE0F0414794AFB234 /* ReaderToolbar.swift in Sources */,
+				42A1556AAD4B4AD1BC0042AB /* ReadingPreferencesSheet.swift in Sources */,
+				D288A4AEBF374F039E752C9A /* ReadingPreferencesStore.swift in Sources */,
+				FB5C34E084D24E9594C76212 /* LeveledLibraryView.swift in Sources */,
+				8D420F0E8EED450E856C6A86 /* LogReadingSheet.swift in Sources */,
+				775B51A27C5345ABBB0D23EF /* ReadingDashboardView.swift in Sources */,
+				1ED91D14ABB64871BA5D370B /* ReviewHomeView.swift in Sources */,
+				11AC31C299564C5FBE87051E /* ReviewReminderScheduler.swift in Sources */,
+				FA96F45D033F489AB83FDE81 /* ReviewSessionView.swift in Sources */,
+				F709C02F211E476BB1FF7DDA /* UniversalSearchView.swift in Sources */,
+				A89A4C91638E4106A0EE487A /* AdminMetricCards.swift in Sources */,
+				5FAB919A843A440E82EE8D04 /* AdvisingSettingsView.swift in Sources */,
+				F2214A1D92FC45BB9CE2ADD2 /* AiAdminHubView.swift in Sources */,
+				50367A9E1471406B80ABF2A1 /* AiGovernanceView.swift in Sources */,
+				FB796A715F674440A6409779 /* AiModelsSettingsView.swift in Sources */,
+				1019816343624011A7B557D1 /* AiProviderSettingsView.swift in Sources */,
+				9546906023EA4DD0BDBCA7B2 /* AiReportsView.swift in Sources */,
+				65E89AD1ED204EC5B795CCA6 /* ArchivedCoursesAdminView.swift in Sources */,
+				65F73CED45624E1BB1713440 /* AuditLogAdminView.swift in Sources */,
+				0D91AF2DB19F485B93D7CD46 /* BoardsGovernanceAdminView.swift in Sources */,
+				D64E4E13C99E4D77B6F6F3F8 /* CoursesAdminView.swift in Sources */,
+				E4750E6368AF4758A9BB3FCB /* IntegrationsAdminView.swift in Sources */,
+				38487F2277664659A792B427 /* OrgBrandingAdminView.swift in Sources */,
+				59AF1E78E14446BDA1C520AB /* OrgBrandingView.swift in Sources */,
+				D7FD88DB8E924B1BA0FEF265 /* OrgStructureAdminView.swift in Sources */,
+				2CA9B5373A0B4233A0A64771 /* OrgStructureView.swift in Sources */,
+				00FD0ED59A7C49D393DA15A3 /* PeopleAdminView.swift in Sources */,
+				28B4BF03E7E34F9DAB34FE6A /* PlatformSettingsView.swift in Sources */,
+				5E588B67C7274185841CDBFC /* RolesPermissionsAdminView.swift in Sources */,
+				880FB92F7CFC41E992B52F78 /* SystemPromptsView.swift in Sources */,
+				0248213F393049E8B93709D2 /* TermsAdminView.swift in Sources */,
+				C27059C4026742968DB0FDCA /* TranscriptsAdvisingAdminView.swift in Sources */,
+				78C7EE57272F4082B42983A2 /* TranscriptsSettingsView.swift in Sources */,
+				EB7EAB8B4A6B4BC6BF148FE1 /* UserDetailAdminView.swift in Sources */,
+				A4F1C583F9C24D03A36D3CFC /* SettingsAdminHubView.swift in Sources */,
+				20F7EAEFC0B14F1BAD3F7C3A /* SplashView.swift in Sources */,
+				22A3489D687C412B90F92BEC /* TutorChatModel.swift in Sources */,
+				8D963B4A899B4A9AB2B8B7E3 /* TutorChatView.swift in Sources */,
+				A1287F5A19914A9EB261277C /* TutorFlowLayout.swift in Sources */,
+				ED9D1E5CFE484120B3D251C4 /* TutorLauncher.swift in Sources */,
+				B517A0B3458F4E1A90327F51 /* WalletCCRDetailView.swift in Sources */,
+				AFF47FE7B05642EDBB6C2886 /* WalletCETranscriptDetailView.swift in Sources */,
+				990C0994B030462C859A17BF /* WalletOfficialTranscriptDetailView.swift in Sources */,
+				CEE26666B51048248A0CB7C0 /* WalletView.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		BEC4E2EC998448EE83091471 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = A1DE4D1C828A4CC1860443E6 /* Lextures */;
-			targetProxy = A5ACD157202A4876B6856FE4 /* PBXContainerItemProxy */;
+/* Begin PBXSourcesBuildPhase section */
+		9E1E6DA8B52A40FDB2B4C866 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			runOnlyForDeploymentPostprocessing = 0;
+			files = (
+				A23C0799C9D5426B91951786 /* AccessibilitySupportTests.swift in Sources */,
+				1994EFB9430B407BB04A3A7A /* AccountIntegrationsLogicTests.swift in Sources */,
+				F2DCFE74B99E4C36AF1CDFE4 /* AdvisingLogicTests.swift in Sources */,
+				3F6D6C71ECC34DD89E5D8DB0 /* AiModelsAdminLogicTests.swift in Sources */,
+				8EF49AF757964F3FA83DC6D5 /* AnnouncementLogicTests.swift in Sources */,
+				D26D2A6793B043DAB9A426AD /* AppleSignInLogicTests.swift in Sources */,
+				9A97E0D3542C4B7EA5F79622 /* ArchivedCoursesAdminLogicTests.swift in Sources */,
+				B52A437D41414FF4BC756B89 /* AssignmentLogicTests.swift in Sources */,
+				08789C3FDA64436EAF36AD7C /* AuditLogAdminLogicTests.swift in Sources */,
+				82A951442D6E4BFBA1171B21 /* AuthCallbackParserTests.swift in Sources */,
+				61198ECE5E1041468DE0B80A /* BehaviorLogicTests.swift in Sources */,
+				9BEC92F81DA44E92B5D7C768 /* BillingLogicTests.swift in Sources */,
+				24567DB9CFE541B9A11D661B /* BiometricGateTests.swift in Sources */,
+				52BD152816234B4BB35A5E79 /* BoardsAdvancedLogicTests.swift in Sources */,
+				B0B3BC864AA54AC095F4CBCA /* BoardsLogicTests.swift in Sources */,
+				22CB296FDC75473EB06C7704 /* CanvasImportLogicTests.swift in Sources */,
+				BBE628DF72F94D6D8F4FAC85 /* CatalogLogicTests.swift in Sources */,
+				5686955245F34B759BD4C41B /* ConferenceLogicTests.swift in Sources */,
+				E08A73F841714561BA2FF8EF /* CourseAccessibilityReviewLogicTests.swift in Sources */,
+				9237F4A866D74B20B3000265 /* CourseArchivedContentLogicTests.swift in Sources */,
+				37B9948867FB4B779B88D0FF /* CourseBlueprintLogicTests.swift in Sources */,
+				5CE78B0F31214C66A526476D /* CourseCreateLogicTests.swift in Sources */,
+				A76CB6FC18E64768A79D0D8E /* CourseFeaturesLogicTests.swift in Sources */,
+				35FE576C56B342CF9FBA9E24 /* CourseFileModelsTests.swift in Sources */,
+				CEAE609950C8411FB1582E11 /* CourseGradingAgentsLogicTests.swift in Sources */,
+				F795215E985444169BB9F10F /* CourseGradingLogicTests.swift in Sources */,
+				96F2D3104820409688B27A99 /* CourseImportExportLogicTests.swift in Sources */,
+				40A952AFC87949D89BDFDEF2 /* CourseOutcomesLogicTests.swift in Sources */,
+				A5E9605AA60241558C833BE9 /* CoursePeopleLogicTests.swift in Sources */,
+				32FBA9724D734FBEB97F3B1A /* CoursePlagiarismLogicTests.swift in Sources */,
+				E98EF898FC3B4BEE94D33E12 /* CourseReviewLogicTests.swift in Sources */,
+				64482DC9BB234AD586064698 /* CourseSectionsLogicTests.swift in Sources */,
+				024E9164F7D046E99E396E7C /* CourseSettingsLogicTests.swift in Sources */,
+				AF4F359F681742A6B319F4D4 /* CourseTranslationsLogicTests.swift in Sources */,
+				97E2A381F45543519879F02D /* CredentialsLogicTests.swift in Sources */,
+				B84920E40A0C49FEBBF062DF /* DiscussionLogicTests.swift in Sources */,
+				EB3A9F3EA1454D34B09EAD5C /* EvaluationLogicTests.swift in Sources */,
+				CA23903478C24FF19420A3DA /* FeedLogicTests.swift in Sources */,
+				1E50EEC9131644CA94A9BC1A /* FeedbackLogicTests.swift in Sources */,
+				79975C08D6A94A9E9257F513 /* GamificationLogicTests.swift in Sources */,
+				507450EE9B44461F987791F3 /* GradeCalculatorTests.swift in Sources */,
+				A9F1798F9AEF41A9A9DD4C07 /* GroupsLogicTests.swift in Sources */,
+				F6A478037DE143208F54EE24 /* I18nTests.swift in Sources */,
+				4218315B4F5D411EA5FED6AB /* InsightsLogicTests.swift in Sources */,
+				205AA6319E3A4CABBA071659 /* InstructorInsightsLogicTests.swift in Sources */,
+				F9429E0163E0422BA909AADF /* IntegrationsAdminLogicTests.swift in Sources */,
+				27048DD189624218A3D9EA63 /* InteractiveLaunchLogicTests.swift in Sources */,
+				8F0235BD407A4F6FB044E84C /* IntroCourseLogicTests.swift in Sources */,
+				62C6355F8D3947F4A6BBDC7B /* LearnerProfileLogicTests.swift in Sources */,
+				606E7F5B576145F183AE8773 /* LexturesMotionTests.swift in Sources */,
+				851D35021CA3471E82CE76F8 /* LibraryResourceLogicTests.swift in Sources */,
+				6982609AD79E4AC4A422425F /* LiveMeetingsLogicTests.swift in Sources */,
+				E242AD182E624AF48AE00B19 /* LiveQuizLogicTests.swift in Sources */,
+				AB6E3BB8C19646CD8F65649E /* MarketplaceLogicTests.swift in Sources */,
+				25AED480499D437B8DC4CE95 /* MasteryLogicTests.swift in Sources */,
+				602715CA35FD410A82DE5CD5 /* MobileDestinationsTests.swift in Sources */,
+				A7693FDB85E9410B9A5041AF /* ModuleContentModelsTests.swift in Sources */,
+				FC55C1D14A454B0FA30F13DF /* NotificationModelsTests.swift in Sources */,
+				6A8E25277A364360BB65ACF6 /* OfficeHoursLogicTests.swift in Sources */,
+				BF0564D785B241C68D466A0A /* OnboardingModelsTests.swift in Sources */,
+				0C52FC70DBAD4D86AA0543FA /* OrgBrandingAdminLogicTests.swift in Sources */,
+				4E9184D5D15D432F8D01B21C /* OrgStructureAdminLogicTests.swift in Sources */,
+				5E1F943D21FF466FAB849AB9 /* ParentLogicTests.swift in Sources */,
+				894A900460EE4AC1A6F32B83 /* PathsLogicTests.swift in Sources */,
+				B6C5C79CDC00441DB2E96564 /* PeerReviewLogicTests.swift in Sources */,
+				5D8FB83EE1784AA9834AF116 /* PeopleAdminLogicTests.swift in Sources */,
+				28A35BBFB4FD4A7B90D31F79 /* PeopleAdminMetricsLogicTests.swift in Sources */,
+				A70BDCB9398842E78C2B9DE1 /* PlannerModelsTests.swift in Sources */,
+				75F57C4C09F449DF9CA31233 /* PlatformCoursesAdminLogicTests.swift in Sources */,
+				A10E5A2734A24CD9B3D1C6EB /* PlatformSettingsAdminLogicTests.swift in Sources */,
+				17A60B25F39A46F79C695BFC /* PortfolioLogicTests.swift in Sources */,
+				D1C85862113641E3ABEA0EE8 /* ProfileDepthLogicTests.swift in Sources */,
+				3DD7B3543EE44F449E16C4A3 /* QuizLogicTests.swift in Sources */,
+				B12D7287F1B5479481CEFC9F /* ReaderLogicTests.swift in Sources */,
+				F559AC6173C54430ADC4CF98 /* ReadingLogicTests.swift in Sources */,
+				3E747E0812D94FD4B3A68293 /* RequirementsLogicTests.swift in Sources */,
+				CA27E0A6B66846B78ABDB0E6 /* ReviewLogicTests.swift in Sources */,
+				0D177076EAB349BA880EB4FD /* RolesPermissionsAdminLogicTests.swift in Sources */,
+				5741663D14FD43D7B577FFA3 /* SchoolCodeLogicTests.swift in Sources */,
+				0F9BB204DA8B4F88856BF2CC /* SearchTests.swift in Sources */,
+				383DA9C55A7740BDAB59BA67 /* SettingsAccommodationsTests.swift in Sources */,
+				0BBABC3CD8E54355BB464CE0 /* SettingsMenuLogicTests.swift in Sources */,
+				C9FE307022A24D8EB0AF2915 /* TakeAttendanceLogicTests.swift in Sources */,
+				825A451207EC4A378798D7F1 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */,
+				3944357D2583408395A57ED8 /* TutorLogicTests.swift in Sources */,
+				A7EB2920495A4EE4AD2481E4 /* UIModeLogicTests.swift in Sources */,
+				D6224B6580C04B12A4C74A73 /* VibeActivityLogicTests.swift in Sources */,
+				08CD949DE86247FBB8107C76 /* WalletLogicTests.swift in Sources */,
+				978593606D454E40B811DDC5 /* WhiteboardLogicTests.swift in Sources */,
+			);
 		};
-/* End PBXTargetDependency section */
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B9D3D80715914553984DCBCF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			runOnlyForDeploymentPostprocessing = 0;
+			files = (
+			);
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		08DD0194B07B4232840D8129 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ENABLE_MODULES = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = s;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				ONLY_ACTIVE_ARCH = NO;
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-			};
-			name = Release;
-		};
-		10456CD4C5774CCA83F473DB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A764804AD4B4428D98B9BBBE /* Development.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = Lextures/Resources/Lextures.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5HUWV9W4G7;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = Lextures/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Release;
-		};
-		9C9278C2D548402DAAE2E9DD /* Debug */ = {
+		FF23C941B86E45C095EB5875 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -3402,38 +3374,38 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = -Onone;
 			};
 			name = Debug;
 		};
-		E467C3306795494A9DE9112C /* Release */ = {
+		D6D9D66AD0634D95950BFDD3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A764804AD4B4428D98B9BBBE /* Development.xcconfig */;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf-with-dsym;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios.tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lextures.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Lextures";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = -O;
 			};
 			name = Release;
 		};
-		EC974DCBDD4C44D7A4A93F36 /* Debug */ = {
+		A48046996F994381A3A34768 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A764804AD4B4428D98B9BBBE /* Development.xcconfig */;
+			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Lextures/Resources/Lextures.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5HUWV9W4G7;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTABILITY = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -3453,9 +3425,37 @@
 			};
 			name = Debug;
 		};
-		F225F6B1C212459C802BEC57 /* Debug */ = {
+		0FFD2B9BF0E14FF4B27B9E0A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A764804AD4B4428D98B9BBBE /* Development.xcconfig */;
+			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Lextures/Resources/Lextures.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Lextures/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		16605693C9494548B4785C08 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -3471,37 +3471,55 @@
 			};
 			name = Debug;
 		};
+		62F9529641134890BC589ED0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lextures.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Lextures";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		7BA77D9C7C584CFCA77925DB /* Build configuration list for PBXNativeTarget "Lextures" */ = {
+		C0539B66D38A4C3D80C6B2D5 /* Build configuration list for PBXProject "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				EC974DCBDD4C44D7A4A93F36 /* Debug */,
-				10456CD4C5774CCA83F473DB /* Release */,
+				FF23C941B86E45C095EB5875 /* Debug */,
+				D6D9D66AD0634D95950BFDD3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BE1D86F1FE79430185CE70F9 /* Build configuration list for PBXProject "Lextures" */ = {
+		124F22003E48492986BF0C64 /* Build configuration list for PBXNativeTarget "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9C9278C2D548402DAAE2E9DD /* Debug */,
-				08DD0194B07B4232840D8129 /* Release */,
+				A48046996F994381A3A34768 /* Debug */,
+				0FFD2B9BF0E14FF4B27B9E0A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C664F8D7A3DB40C390274DF7 /* Build configuration list for PBXNativeTarget "LexturesTests" */ = {
+		5778F2DD9CE041F4A88C1C97 /* Build configuration list for PBXNativeTarget "LexturesTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F225F6B1C212459C802BEC57 /* Debug */,
-				E467C3306795494A9DE9112C /* Release */,
+				16605693C9494548B4785C08 /* Debug */,
+				62F9529641134890BC589ED0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 1EB58D3E83FF4D9A87F5844C /* Project object */;
+	rootObject = 23ED123BADD24061AF867515 /* Project object */;
 }

--- a/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
+++ b/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A1DE4D1C828A4CC1860443E6"
+               BlueprintIdentifier = "1C95EA15BFA249F09F2F233C"
                BuildableName = "Lextures.app"
                BlueprintName = "Lextures"
                ReferencedContainer = "container:Lextures.xcodeproj">
@@ -36,7 +36,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A1DE4D1C828A4CC1860443E6"
+            BlueprintIdentifier = "1C95EA15BFA249F09F2F233C"
             BuildableName = "Lextures.app"
             BlueprintName = "Lextures"
             ReferencedContainer = "container:Lextures.xcodeproj">
@@ -54,7 +54,7 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6EEA82F92F494FFC8178DEC6"
+               BlueprintIdentifier = "895620D25C8A4BCA974315E7"
                BuildableName = "LexturesTests.xctest"
                BlueprintName = "LexturesTests"
                ReferencedContainer = "container:Lextures.xcodeproj">

--- a/clients/ios/Lextures/Core/LMS/LMSFeatureModelsPlatform.swift
+++ b/clients/ios/Lextures/Core/LMS/LMSFeatureModelsPlatform.swift
@@ -15,6 +15,8 @@ struct PlatformFeatures: Decodable {
     var ffMobileProfileDepth: Bool?
     var ffMobileLibraryEreserves: Bool?
     var ffMobileImmersiveReader: Bool?
+    /// CT.M1 rich markdown engine (tables/code/math/toolFence). Default on when unset.
+    var ffMobileRichMarkdown: Bool?
     var ffMobileLiveMeetings: Bool?
     var readAloudEnabled: Bool?
     var ffReadAloud: Bool?

--- a/clients/ios/Lextures/Core/Notebook/MarkdownTableLogic.swift
+++ b/clients/ios/Lextures/Core/Notebook/MarkdownTableLogic.swift
@@ -8,6 +8,15 @@ enum MarkdownTableAlign: String, Equatable, CaseIterable {
     case right
 }
 
+/// Result of parsing a GFM pipe table from a line slice.
+struct ParsedMarkdownTable: Equatable {
+    let align: [MarkdownTableAlign]
+    let header: [String]
+    let rows: [[String]]
+    /// Index of the first line after the table.
+    let endIndex: Int
+}
+
 /// Pure table detection / blank-line healing / cell split (parity with web `normalize-markdown-tables`).
 enum MarkdownTableLogic {
     /// Collapse blank lines inside GitHub-flavored markdown tables (web FR-3 parity).
@@ -15,34 +24,34 @@ enum MarkdownTableLogic {
         guard markdown.contains("|") else { return markdown }
         let lines = markdown.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
         var out: [String] = []
-        var i = 0
-        while i < lines.count {
-            let line = lines[i]
-            let sepIdx = nextNonEmptyIndex(lines, from: i + 1)
+        var index = 0
+        while index < lines.count {
+            let line = lines[index]
+            let separatorIndex = nextNonEmptyIndex(lines, from: index + 1)
             let looksLikeHeader =
                 isTableRowLine(line)
-                && sepIdx < lines.count
-                && isTableSeparatorLine(lines[sepIdx])
+                && separatorIndex < lines.count
+                && isTableSeparatorLine(lines[separatorIndex])
             if !looksLikeHeader {
                 out.append(line)
-                i += 1
+                index += 1
                 continue
             }
             var tableLines: [String] = [line]
-            i += 1
-            while i < lines.count {
-                let L = lines[i]
-                if L.trimmingCharacters(in: .whitespaces).isEmpty {
-                    let next = nextNonEmptyIndex(lines, from: i + 1)
-                    if next < lines.count && isTableRelatedLine(lines[next]) {
-                        i = next
+            index += 1
+            while index < lines.count {
+                let candidate = lines[index]
+                if candidate.trimmingCharacters(in: .whitespaces).isEmpty {
+                    let nextIndex = nextNonEmptyIndex(lines, from: index + 1)
+                    if nextIndex < lines.count && isTableRelatedLine(lines[nextIndex]) {
+                        index = nextIndex
                         continue
                     }
                     break
                 }
-                if !isTableRelatedLine(L) { break }
-                tableLines.append(L)
-                i += 1
+                if !isTableRelatedLine(candidate) { break }
+                tableLines.append(candidate)
+                index += 1
             }
             if tableLines.count >= 2 && isTableSeparatorLine(tableLines[1]) {
                 out.append(contentsOf: tableLines)
@@ -57,54 +66,51 @@ enum MarkdownTableLogic {
     }
 
     /// Try to parse a GFM table starting at `start`. Returns nil when not a valid table.
-    static func parseTable(
-        in lines: [String],
-        start: Int
-    ) -> (align: [MarkdownTableAlign], header: [String], rows: [[String]], end: Int)? {
+    static func parseTable(in lines: [String], start: Int) -> ParsedMarkdownTable? {
         guard start < lines.count, isTableRowLine(lines[start]) else { return nil }
-        let sepIdx = nextNonEmptyIndex(lines, from: start + 1)
-        guard sepIdx < lines.count, isTableSeparatorLine(lines[sepIdx]) else { return nil }
+        let separatorIndex = nextNonEmptyIndex(lines, from: start + 1)
+        guard separatorIndex < lines.count, isTableSeparatorLine(lines[separatorIndex]) else { return nil }
 
         let header = splitCells(lines[start])
-        let align = parseAlignments(lines[sepIdx], columnCount: header.count)
+        let align = parseAlignments(lines[separatorIndex], columnCount: header.count)
         var rows: [[String]] = []
-        var i = sepIdx + 1
-        while i < lines.count {
-            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+        var index = separatorIndex + 1
+        while index < lines.count {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
             if trimmed.isEmpty { break }
-            if !isTableRowLine(lines[i]) { break }
-            if isTableSeparatorLine(lines[i]) { break }
-            rows.append(padCells(splitCells(lines[i]), to: header.count))
-            i += 1
+            if !isTableRowLine(lines[index]) { break }
+            if isTableSeparatorLine(lines[index]) { break }
+            rows.append(padCells(splitCells(lines[index]), to: header.count))
+            index += 1
         }
-        return (align, header, rows, i)
+        return ParsedMarkdownTable(align: align, header: header, rows: rows, endIndex: index)
     }
 
     static func isTableRowLine(_ line: String) -> Bool {
-        let t = line.trimmingCharacters(in: .whitespaces)
-        guard t.contains("|") else { return false }
-        if t.range(of: #"^\|?[\s:|-]+$"#, options: .regularExpression) != nil && t.contains("-") {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.contains("|") else { return false }
+        if trimmed.range(of: #"^\|?[\s:|-]+$"#, options: .regularExpression) != nil && trimmed.contains("-") {
             return false
         }
-        if t.count >= 2 {
-            let inner = t.dropFirst().dropLast()
+        if trimmed.count >= 2 {
+            let inner = trimmed.dropFirst().dropLast()
             if inner.contains("|") { return true }
         }
-        return t.hasPrefix("|") && t.hasSuffix("|")
+        return trimmed.hasPrefix("|") && trimmed.hasSuffix("|")
     }
 
     static func isTableSeparatorLine(_ line: String) -> Bool {
-        let t = line.trimmingCharacters(in: .whitespaces)
-        guard t.contains("-") else { return false }
-        let a = t.range(
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.contains("-") else { return false }
+        let patternA = trimmed.range(
             of: #"^\|?(\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?$"#,
             options: .regularExpression
         ) != nil
-        let b = t.range(
+        let patternB = trimmed.range(
             of: #"^\|?(\s*:?-{3,}:?\s*\|?)+\s*$"#,
             options: .regularExpression
         ) != nil
-        return a || b
+        return patternA || patternB
     }
 
     static func isTableRelatedLine(_ line: String) -> Bool {
@@ -112,20 +118,20 @@ enum MarkdownTableLogic {
     }
 
     static func splitCells(_ line: String) -> [String] {
-        var t = line.trimmingCharacters(in: .whitespaces)
-        if t.hasPrefix("|") { t = String(t.dropFirst()) }
-        if t.hasSuffix("|") { t = String(t.dropLast()) }
-        return t.split(separator: "|", omittingEmptySubsequences: false)
+        var trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("|") { trimmed = String(trimmed.dropFirst()) }
+        if trimmed.hasSuffix("|") { trimmed = String(trimmed.dropLast()) }
+        return trimmed.split(separator: "|", omittingEmptySubsequences: false)
             .map { $0.trimmingCharacters(in: .whitespaces) }
     }
 
     static func parseAlignments(_ separator: String, columnCount: Int) -> [MarkdownTableAlign] {
         let cells = splitCells(separator)
         let parsed: [MarkdownTableAlign] = cells.map { cell in
-            let c = cell.trimmingCharacters(in: .whitespaces)
-            let left = c.hasPrefix(":")
-            let right = c.hasSuffix(":")
-            switch (left, right) {
+            let trimmed = cell.trimmingCharacters(in: .whitespaces)
+            let leftColon = trimmed.hasPrefix(":")
+            let rightColon = trimmed.hasSuffix(":")
+            switch (leftColon, rightColon) {
             case (true, true): return .center
             case (false, true): return .right
             case (true, false): return .left
@@ -142,11 +148,11 @@ enum MarkdownTableLogic {
     }
 
     static func nextNonEmptyIndex(_ lines: [String], from: Int) -> Int {
-        var j = from
-        while j < lines.count && lines[j].trimmingCharacters(in: .whitespaces).isEmpty {
-            j += 1
+        var cursor = from
+        while cursor < lines.count && lines[cursor].trimmingCharacters(in: .whitespaces).isEmpty {
+            cursor += 1
         }
-        return j
+        return cursor
     }
 
     /// Reconstruct pipe-table markdown (used when folding into the editor model).
@@ -154,15 +160,15 @@ enum MarkdownTableLogic {
         func row(_ cells: [String]) -> String {
             "| " + cells.joined(separator: " | ") + " |"
         }
-        let sep = align.map { a -> String in
-            switch a {
+        let separators = align.map { alignment -> String in
+            switch alignment {
             case .left: return ":---"
             case .center: return ":---:"
             case .right: return "---:"
             case .default: return "---"
             }
         }
-        var lines = [row(header), "| " + sep.joined(separator: " | ") + " |"]
+        var lines = [row(header), "| " + separators.joined(separator: " | ") + " |"]
         lines.append(contentsOf: rows.map(row))
         return lines.joined(separator: "\n")
     }

--- a/clients/ios/Lextures/Core/Notebook/MarkdownTableLogic.swift
+++ b/clients/ios/Lextures/Core/Notebook/MarkdownTableLogic.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// Column alignment for a GFM pipe table.
+enum MarkdownTableAlign: String, Equatable, CaseIterable {
+    case `default`
+    case left
+    case center
+    case right
+}
+
+/// Pure table detection / blank-line healing / cell split (parity with web `normalize-markdown-tables`).
+enum MarkdownTableLogic {
+    /// Collapse blank lines inside GitHub-flavored markdown tables (web FR-3 parity).
+    static func normalizeMarkdownTables(_ markdown: String) -> String {
+        guard markdown.contains("|") else { return markdown }
+        let lines = markdown.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        var out: [String] = []
+        var i = 0
+        while i < lines.count {
+            let line = lines[i]
+            let sepIdx = nextNonEmptyIndex(lines, from: i + 1)
+            let looksLikeHeader =
+                isTableRowLine(line)
+                && sepIdx < lines.count
+                && isTableSeparatorLine(lines[sepIdx])
+            if !looksLikeHeader {
+                out.append(line)
+                i += 1
+                continue
+            }
+            var tableLines: [String] = [line]
+            i += 1
+            while i < lines.count {
+                let L = lines[i]
+                if L.trimmingCharacters(in: .whitespaces).isEmpty {
+                    let next = nextNonEmptyIndex(lines, from: i + 1)
+                    if next < lines.count && isTableRelatedLine(lines[next]) {
+                        i = next
+                        continue
+                    }
+                    break
+                }
+                if !isTableRelatedLine(L) { break }
+                tableLines.append(L)
+                i += 1
+            }
+            if tableLines.count >= 2 && isTableSeparatorLine(tableLines[1]) {
+                out.append(contentsOf: tableLines)
+            } else {
+                out.append(line)
+                if tableLines.count > 1 {
+                    out.append(contentsOf: tableLines.dropFirst())
+                }
+            }
+        }
+        return out.joined(separator: "\n")
+    }
+
+    /// Try to parse a GFM table starting at `start`. Returns nil when not a valid table.
+    static func parseTable(
+        in lines: [String],
+        start: Int
+    ) -> (align: [MarkdownTableAlign], header: [String], rows: [[String]], end: Int)? {
+        guard start < lines.count, isTableRowLine(lines[start]) else { return nil }
+        let sepIdx = nextNonEmptyIndex(lines, from: start + 1)
+        guard sepIdx < lines.count, isTableSeparatorLine(lines[sepIdx]) else { return nil }
+
+        let header = splitCells(lines[start])
+        let align = parseAlignments(lines[sepIdx], columnCount: header.count)
+        var rows: [[String]] = []
+        var i = sepIdx + 1
+        while i < lines.count {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { break }
+            if !isTableRowLine(lines[i]) { break }
+            if isTableSeparatorLine(lines[i]) { break }
+            rows.append(padCells(splitCells(lines[i]), to: header.count))
+            i += 1
+        }
+        return (align, header, rows, i)
+    }
+
+    static func isTableRowLine(_ line: String) -> Bool {
+        let t = line.trimmingCharacters(in: .whitespaces)
+        guard t.contains("|") else { return false }
+        if t.range(of: #"^\|?[\s:|-]+$"#, options: .regularExpression) != nil && t.contains("-") {
+            return false
+        }
+        if t.count >= 2 {
+            let inner = t.dropFirst().dropLast()
+            if inner.contains("|") { return true }
+        }
+        return t.hasPrefix("|") && t.hasSuffix("|")
+    }
+
+    static func isTableSeparatorLine(_ line: String) -> Bool {
+        let t = line.trimmingCharacters(in: .whitespaces)
+        guard t.contains("-") else { return false }
+        let a = t.range(
+            of: #"^\|?(\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?$"#,
+            options: .regularExpression
+        ) != nil
+        let b = t.range(
+            of: #"^\|?(\s*:?-{3,}:?\s*\|?)+\s*$"#,
+            options: .regularExpression
+        ) != nil
+        return a || b
+    }
+
+    static func isTableRelatedLine(_ line: String) -> Bool {
+        isTableRowLine(line) || isTableSeparatorLine(line)
+    }
+
+    static func splitCells(_ line: String) -> [String] {
+        var t = line.trimmingCharacters(in: .whitespaces)
+        if t.hasPrefix("|") { t = String(t.dropFirst()) }
+        if t.hasSuffix("|") { t = String(t.dropLast()) }
+        return t.split(separator: "|", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    static func parseAlignments(_ separator: String, columnCount: Int) -> [MarkdownTableAlign] {
+        let cells = splitCells(separator)
+        let parsed: [MarkdownTableAlign] = cells.map { cell in
+            let c = cell.trimmingCharacters(in: .whitespaces)
+            let left = c.hasPrefix(":")
+            let right = c.hasSuffix(":")
+            switch (left, right) {
+            case (true, true): return .center
+            case (false, true): return .right
+            case (true, false): return .left
+            default: return .default
+            }
+        }
+        if parsed.count >= columnCount { return Array(parsed.prefix(columnCount)) }
+        return parsed + Array(repeating: .default, count: columnCount - parsed.count)
+    }
+
+    static func padCells(_ cells: [String], to count: Int) -> [String] {
+        if cells.count >= count { return Array(cells.prefix(count)) }
+        return cells + Array(repeating: "", count: count - cells.count)
+    }
+
+    static func nextNonEmptyIndex(_ lines: [String], from: Int) -> Int {
+        var j = from
+        while j < lines.count && lines[j].trimmingCharacters(in: .whitespaces).isEmpty {
+            j += 1
+        }
+        return j
+    }
+
+    /// Reconstruct pipe-table markdown (used when folding into the editor model).
+    static func serialize(align: [MarkdownTableAlign], header: [String], rows: [[String]]) -> String {
+        func row(_ cells: [String]) -> String {
+            "| " + cells.joined(separator: " | ") + " |"
+        }
+        let sep = align.map { a -> String in
+            switch a {
+            case .left: return ":---"
+            case .center: return ":---:"
+            case .right: return "---:"
+            case .default: return "---"
+            }
+        }
+        var lines = [row(header), "| " + sep.joined(separator: " | ") + " |"]
+        lines.append(contentsOf: rows.map(row))
+        return lines.joined(separator: "\n")
+    }
+}

--- a/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// swiftlint:disable type_body_length
+
 /// A task parsed from a ```task fenced block (parity with web `notebook-task-markdown`).
 struct ParsedNotebookTask: Identifiable, Equatable {
     let id: String
@@ -242,52 +244,19 @@ enum NotebookMarkdown {
             if let table = MarkdownTableLogic.parseTable(in: lines, start: lineIndex) {
                 flushAll()
                 kinds.append(.table(align: table.align, header: table.header, rows: table.rows))
-                lineIndex = table.end
+                lineIndex = table.endIndex
                 continue
             }
-            if trimmed.hasPrefix("```drawing") {
+            if let fenceResult = consumeFenceBlock(
+                lines: lines,
+                lineIndex: &lineIndex,
+                trimmed: trimmed,
+                drawingIndex: &drawingIndex
+            ) {
                 flushAll()
-                var inner: [String] = []
-                lineIndex += 1
-                while lineIndex < lines.count, lines[lineIndex].trimmingCharacters(in: .whitespaces) != "```" {
-                    inner.append(lines[lineIndex])
-                    lineIndex += 1
+                if let fenceKind = fenceResult {
+                    kinds.append(fenceKind)
                 }
-                kinds.append(.drawing(index: drawingIndex, elementsJson: inner.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)))
-                drawingIndex += 1
-                lineIndex += 1
-                continue
-            }
-            if trimmed == "```task" || trimmed.hasPrefix("```task") {
-                flushAll()
-                var inner: [String] = []
-                lineIndex += 1
-                while lineIndex < lines.count, lines[lineIndex].trimmingCharacters(in: .whitespaces) != "```" {
-                    inner.append(lines[lineIndex])
-                    lineIndex += 1
-                }
-                if let task = parseTaskInner(inner.joined(separator: "\n")) {
-                    kinds.append(.task(task))
-                }
-                lineIndex += 1
-                continue
-            }
-            if trimmed.hasPrefix("```") {
-                flushAll()
-                let language = fenceLanguage(trimmed)
-                var inner: [String] = []
-                lineIndex += 1
-                while lineIndex < lines.count, !lines[lineIndex].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
-                    inner.append(lines[lineIndex])
-                    lineIndex += 1
-                }
-                let source = inner.joined(separator: "\n")
-                if language == "lex-tool", let tool = parseLexToolFence(source) {
-                    kinds.append(.toolFence(instanceId: tool.instanceId, toolId: tool.toolId, version: tool.version))
-                } else {
-                    kinds.append(.code(language: language, source: source))
-                }
-                lineIndex += 1
                 continue
             }
             if let heading = parseHeading(trimmed) {
@@ -323,14 +292,61 @@ enum NotebookMarkdown {
         return kinds.enumerated().map { NotebookBlock(id: $0.offset, kind: $0.element) }
     }
 
+    /// Consume a fenced block (drawing / task / code / lex-tool). Advances `lineIndex` past the closer.
+    /// Returns `nil` when the line is not a fence; `.some(nil)` when the fence was skipped (e.g. bad task).
+    private static func consumeFenceBlock(
+        lines: [String],
+        lineIndex: inout Int,
+        trimmed: String,
+        drawingIndex: inout Int
+    ) -> NotebookBlockKind?? {
+        guard trimmed.hasPrefix("```") else { return nil }
+        if trimmed.hasPrefix("```drawing") {
+            let source = readFenceInner(lines: lines, lineIndex: &lineIndex)
+            let kind: NotebookBlockKind = .drawing(
+                index: drawingIndex,
+                elementsJson: source.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            drawingIndex += 1
+            return .some(kind)
+        }
+        if trimmed == "```task" || trimmed.hasPrefix("```task") {
+            let source = readFenceInner(lines: lines, lineIndex: &lineIndex)
+            return .some(parseTaskInner(source).map { .task($0) })
+        }
+        let language = fenceLanguage(trimmed)
+        let source = readFenceInner(lines: lines, lineIndex: &lineIndex)
+        if language == "lex-tool", let tool = parseLexToolFence(source) {
+            return .some(.toolFence(instanceId: tool.instanceId, toolId: tool.toolId, version: tool.version))
+        }
+        return .some(.code(language: language, source: source))
+    }
+
+    private static func readFenceInner(lines: [String], lineIndex: inout Int) -> String {
+        var inner: [String] = []
+        lineIndex += 1
+        while lineIndex < lines.count, !lines[lineIndex].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+            inner.append(lines[lineIndex])
+            lineIndex += 1
+        }
+        lineIndex += 1
+        return inner.joined(separator: "\n")
+    }
+
     private static func fenceLanguage(_ opener: String) -> String? {
         let rest = opener.dropFirst(3).trimmingCharacters(in: .whitespaces)
         if rest.isEmpty { return nil }
-        let lang = rest.split(whereSeparator: { $0.isWhitespace }).first.map(String.init)
-        return lang?.isEmpty == true ? nil : lang
+        let language = rest.split(whereSeparator: { $0.isWhitespace }).first.map(String.init)
+        return language?.isEmpty == true ? nil : language
     }
 
-    private static func parseLexToolFence(_ source: String) -> (instanceId: String, toolId: String, version: Int)? {
+    private struct LexToolFencePayload {
+        let instanceId: String
+        let toolId: String
+        let version: Int
+    }
+
+    private static func parseLexToolFence(_ source: String) -> LexToolFencePayload? {
         guard
             let data = source.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8),
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -338,18 +354,18 @@ enum NotebookMarkdown {
         let instanceId = (json["instanceId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let toolId = (json["toolId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let version: Int? = {
-            if let n = json["v"] as? Int { return n }
-            if let s = json["v"] as? String { return Int(s) }
+            if let intVersion = json["v"] as? Int { return intVersion }
+            if let stringVersion = json["v"] as? String { return Int(stringVersion) }
             return nil
         }()
         guard !instanceId.isEmpty, !toolId.isEmpty, version == 1 else { return nil }
-        return (instanceId, toolId, 1)
+        return LexToolFencePayload(instanceId: instanceId, toolId: toolId, version: 1)
     }
 
     private static func parseStandaloneMath(_ text: String) -> NotebookBlockKind? {
-        let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard t.hasPrefix("$$"), t.hasSuffix("$$"), t.count >= 4 else { return nil }
-        let inner = String(t.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("$$"), trimmed.hasSuffix("$$"), trimmed.count >= 4 else { return nil }
+        let inner = String(trimmed.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !inner.isEmpty, !inner.contains("$$") else { return nil }
         return .math(latex: inner, display: true)
     }

--- a/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
@@ -17,14 +17,20 @@ struct NotebookSlashCommand: Identifiable, Equatable {
     let keywords: [String]
 }
 
-/// Renderable markdown block for the notebook reading view.
+/// Renderable markdown block for the notebook / course reading view (CT.M1).
 enum NotebookBlockKind: Equatable {
     case heading(level: Int, text: String)
     case paragraph(String)
-    case bulletItem(String)
-    case orderedItem(number: String, text: String)
+    case bulletItem(text: String, depth: Int)
+    case orderedItem(number: String, text: String, depth: Int)
+    /// GFM task-list item (`- [ ]` / `- [x]`), read-only in reader contexts.
+    case taskItem(checked: Bool, text: String, depth: Int)
     case quote(String)
-    case code(String)
+    case code(language: String?, source: String)
+    case math(latex: String, display: Bool)
+    case table(align: [MarkdownTableAlign], header: [String], rows: [[String]])
+    /// ` ```lex-tool ` pointer; raw JSON must never be shown to learners (CT.M3 hosts it).
+    case toolFence(instanceId: String, toolId: String, version: Int)
     case divider
     case task(ParsedNotebookTask)
     case image(alt: String, url: String)
@@ -176,15 +182,39 @@ enum NotebookMarkdown {
 
     // MARK: - Block parsing (reading view)
 
+    /// Kind labels used by the shared golden-fixture corpus (`clients/mobile/fixtures/markdown`).
+    static func fixtureKindName(_ kind: NotebookBlockKind) -> String {
+        switch kind {
+        case .heading: return "heading"
+        case .paragraph: return "paragraph"
+        case .bulletItem: return "bullet"
+        case .orderedItem: return "ordered"
+        case .taskItem: return "taskItem"
+        case .quote: return "quote"
+        case .code: return "code"
+        case .math: return "math"
+        case .table: return "table"
+        case .toolFence: return "toolFence"
+        case .divider: return "divider"
+        case .task: return "task"
+        case .image: return "image"
+        case .drawing: return "drawing"
+        }
+    }
+
     static func parseBlocks(_ contentMd: String) -> [NotebookBlock] {
         var kinds: [NotebookBlockKind] = []
         var paragraph: [String] = []
         var quote: [String] = []
 
         func flushParagraph() {
-            if !paragraph.isEmpty {
-                kinds.append(.paragraph(paragraph.joined(separator: "\n")))
-                paragraph = []
+            guard !paragraph.isEmpty else { return }
+            let text = paragraph.joined(separator: "\n")
+            paragraph = []
+            if let math = parseStandaloneMath(text) {
+                kinds.append(math)
+            } else {
+                kinds.append(.paragraph(text))
             }
         }
         func flushQuote() {
@@ -198,13 +228,23 @@ enum NotebookMarkdown {
             flushQuote()
         }
 
-        let lines = contentMd.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        let healed = MarkdownTableLogic.normalizeMarkdownTables(
+            contentMd.replacingOccurrences(of: "\r\n", with: "\n")
+        )
+        let lines = healed.components(separatedBy: "\n")
         var lineIndex = 0
         var drawingIndex = 0
         while lineIndex < lines.count {
             let line = lines[lineIndex]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let indent = listDepth(line)
 
+            if let table = MarkdownTableLogic.parseTable(in: lines, start: lineIndex) {
+                flushAll()
+                kinds.append(.table(align: table.align, header: table.header, rows: table.rows))
+                lineIndex = table.end
+                continue
+            }
             if trimmed.hasPrefix("```drawing") {
                 flushAll()
                 var inner: [String] = []
@@ -234,13 +274,19 @@ enum NotebookMarkdown {
             }
             if trimmed.hasPrefix("```") {
                 flushAll()
+                let language = fenceLanguage(trimmed)
                 var inner: [String] = []
                 lineIndex += 1
                 while lineIndex < lines.count, !lines[lineIndex].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
                     inner.append(lines[lineIndex])
                     lineIndex += 1
                 }
-                kinds.append(.code(inner.joined(separator: "\n")))
+                let source = inner.joined(separator: "\n")
+                if language == "lex-tool", let tool = parseLexToolFence(source) {
+                    kinds.append(.toolFence(instanceId: tool.instanceId, toolId: tool.toolId, version: tool.version))
+                } else {
+                    kinds.append(.code(language: language, source: source))
+                }
                 lineIndex += 1
                 continue
             }
@@ -253,10 +299,13 @@ enum NotebookMarkdown {
             } else if let image = parseImage(trimmed) {
                 flushAll()
                 kinds.append(image)
+            } else if let taskItem = parseTaskListItem(trimmed) {
+                flushAll()
+                kinds.append(.taskItem(checked: taskItem.checked, text: taskItem.text, depth: min(indent, 3)))
             } else if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") {
                 flushAll()
-                kinds.append(.bulletItem(String(trimmed.dropFirst(2))))
-            } else if let ordered = parseOrderedItem(trimmed) {
+                kinds.append(.bulletItem(text: String(trimmed.dropFirst(2)), depth: min(indent, 3)))
+            } else if let ordered = parseOrderedItem(trimmed, depth: min(indent, 3)) {
                 flushAll()
                 kinds.append(ordered)
             } else if trimmed.hasPrefix(">") {
@@ -274,6 +323,58 @@ enum NotebookMarkdown {
         return kinds.enumerated().map { NotebookBlock(id: $0.offset, kind: $0.element) }
     }
 
+    private static func fenceLanguage(_ opener: String) -> String? {
+        let rest = opener.dropFirst(3).trimmingCharacters(in: .whitespaces)
+        if rest.isEmpty { return nil }
+        let lang = rest.split(whereSeparator: { $0.isWhitespace }).first.map(String.init)
+        return lang?.isEmpty == true ? nil : lang
+    }
+
+    private static func parseLexToolFence(_ source: String) -> (instanceId: String, toolId: String, version: Int)? {
+        guard
+            let data = source.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        let instanceId = (json["instanceId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let toolId = (json["toolId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let version: Int? = {
+            if let n = json["v"] as? Int { return n }
+            if let s = json["v"] as? String { return Int(s) }
+            return nil
+        }()
+        guard !instanceId.isEmpty, !toolId.isEmpty, version == 1 else { return nil }
+        return (instanceId, toolId, 1)
+    }
+
+    private static func parseStandaloneMath(_ text: String) -> NotebookBlockKind? {
+        let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard t.hasPrefix("$$"), t.hasSuffix("$$"), t.count >= 4 else { return nil }
+        let inner = String(t.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !inner.isEmpty, !inner.contains("$$") else { return nil }
+        return .math(latex: inner, display: true)
+    }
+
+    private static func listDepth(_ line: String) -> Int {
+        var spaces = 0
+        for ch in line {
+            if ch == " " { spaces += 1 }
+            else if ch == "\t" { spaces += 2 }
+            else { break }
+        }
+        return min(spaces / 2, 3)
+    }
+
+    private static let taskListRegex = makeRegex("^[-*]\\s+\\[([ xX])\\]\\s+(.*)$")
+
+    private static func parseTaskListItem(_ line: String) -> (checked: Bool, text: String)? {
+        let ns = line as NSString
+        guard let match = taskListRegex.firstMatch(in: line, range: NSRange(location: 0, length: ns.length)) else {
+            return nil
+        }
+        let mark = ns.substring(with: match.range(at: 1)).lowercased()
+        return (mark == "x", ns.substring(with: match.range(at: 2)))
+    }
+
     private static func parseHeading(_ line: String) -> NotebookBlockKind? {
         guard line.hasPrefix("#") else { return nil }
         let hashes = line.prefix(while: { $0 == "#" })
@@ -285,12 +386,16 @@ enum NotebookMarkdown {
 
     private static let orderedItemRegex = makeRegex("^(\\d+)[.)] (.*)$")
 
-    private static func parseOrderedItem(_ line: String) -> NotebookBlockKind? {
+    private static func parseOrderedItem(_ line: String, depth: Int = 0) -> NotebookBlockKind? {
         let ns = line as NSString
         guard let match = orderedItemRegex.firstMatch(in: line, range: NSRange(location: 0, length: ns.length)) else {
             return nil
         }
-        return .orderedItem(number: ns.substring(with: match.range(at: 1)), text: ns.substring(with: match.range(at: 2)))
+        return .orderedItem(
+            number: ns.substring(with: match.range(at: 1)),
+            text: ns.substring(with: match.range(at: 2)),
+            depth: depth
+        )
     }
 
     private static let imageRegex = makeRegex("^!\\[([^\\]]*)\\]\\(([^)]+)\\)$")
@@ -315,16 +420,36 @@ enum NotebookMarkdown {
                 for line in text.components(separatedBy: "\n") {
                     out.append(NotebookEditBlock(kind: .paragraph, text: line))
                 }
-            case .bulletItem(let text):
+            case .bulletItem(let text, _):
                 out.append(NotebookEditBlock(kind: .bullet, text: text))
-            case .orderedItem(_, let text):
+            case .orderedItem(_, let text, _):
                 out.append(NotebookEditBlock(kind: .ordered, text: text))
+            case .taskItem(let checked, let text, _):
+                let mark = checked ? "x" : " "
+                out.append(NotebookEditBlock(kind: .bullet, text: "[\(mark)] \(text)"))
             case .quote(let text):
                 for line in text.components(separatedBy: "\n") {
                     out.append(NotebookEditBlock(kind: .quote, text: line))
                 }
-            case .code(let text):
-                out.append(NotebookEditBlock(kind: .code, text: text))
+            case .code(_, let source):
+                out.append(NotebookEditBlock(kind: .code, text: source))
+            case .math(let latex, let display):
+                out.append(NotebookEditBlock(
+                    kind: .paragraph,
+                    text: display ? "$$\(latex)$$" : "$\(latex)$"
+                ))
+            case .table(let align, let header, let rows):
+                for line in MarkdownTableLogic.serialize(align: align, header: header, rows: rows)
+                    .components(separatedBy: "\n")
+                {
+                    out.append(NotebookEditBlock(kind: .paragraph, text: line))
+                }
+            case .toolFence(let instanceId, let toolId, let version):
+                // Preserve pointer as a code fence body so editors do not drop the instance.
+                out.append(NotebookEditBlock(
+                    kind: .code,
+                    text: "{\"instanceId\":\"\(instanceId)\",\"toolId\":\"\(toolId)\",\"v\":\(version)}"
+                ))
             case .divider:
                 out.append(NotebookEditBlock(kind: .divider))
             case .task(let task):
@@ -423,14 +548,23 @@ enum NotebookMarkdown {
         var out: [String] = []
         for block in parseBlocks(contentMd) {
             switch block.kind {
-            case .heading(_, let text), .paragraph(let text), .bulletItem(let text), .quote(let text):
+            case .heading(_, let text), .paragraph(let text), .quote(let text):
                 out.append(text)
-            case .orderedItem(_, let text):
+            case .bulletItem(let text, _), .taskItem(_, let text, _), .orderedItem(_, let text, _):
                 out.append(text)
             case .task(let task):
                 out.append(task.text)
-            case .code(let text):
-                out.append(text)
+            case .code(_, let source):
+                out.append(source)
+            case .math(let latex, _):
+                out.append(latex)
+            case .table(_, let header, let rows):
+                out.append(header.joined(separator: " "))
+                for row in rows.prefix(3) {
+                    out.append(row.joined(separator: " "))
+                }
+            case .toolFence(_, let toolId, _):
+                out.append(toolId)
             case .image(let alt, _):
                 out.append(alt)
             case .drawing:

--- a/clients/ios/Lextures/Core/Routing/MobileDestinations.swift
+++ b/clients/ios/Lextures/Core/Routing/MobileDestinations.swift
@@ -368,6 +368,8 @@ struct MobilePlatformFeatures: Equatable {
     var ffMobileProfileDepth = false
     var ffMobileLibraryEreserves = true
     var ffMobileImmersiveReader = true
+    /// CT.M1 rich markdown engine; default on when unset.
+    var ffMobileRichMarkdown = true
     var ffMobileLiveMeetings = true
     var readAloudEnabled = false
     var ffReadAloud = false
@@ -459,6 +461,7 @@ struct MobilePlatformFeatures: Equatable {
             ffMobileProfileDepth: features?.ffMobileProfileDepth == true,
             ffMobileLibraryEreserves: features?.ffMobileLibraryEreserves != false,
             ffMobileImmersiveReader: features?.ffMobileImmersiveReader != false,
+            ffMobileRichMarkdown: features?.ffMobileRichMarkdown != false,
             ffMobileLiveMeetings: features?.ffMobileLiveMeetings != false,
             readAloudEnabled: features?.readAloudEnabled == true,
             ffReadAloud: features?.ffReadAloud == true,

--- a/clients/ios/Lextures/Features/Courses/CourseMarkdownContentView.swift
+++ b/clients/ios/Lextures/Features/Courses/CourseMarkdownContentView.swift
@@ -220,8 +220,10 @@ struct MathLatexView: View {
     }
 
     private var accessibilityText: String {
-        let key = displayMode ? "mobile.markdown.math.display" : "mobile.markdown.math.inline"
-        return L.format(key, latex)
+        if displayMode {
+            return L.format("mobile.markdown.math.display", latex)
+        }
+        return L.format("mobile.markdown.math.inline", latex)
     }
 }
 

--- a/clients/ios/Lextures/Features/Courses/CourseMarkdownContentView.swift
+++ b/clients/ios/Lextures/Features/Courses/CourseMarkdownContentView.swift
@@ -7,17 +7,23 @@ struct CourseMarkdownContentView: View {
     @Environment(\.colorScheme) private var colorScheme
     let markdown: String
     var captionsEnabled = false
-
-    private var blocks: [NotebookBlock] {
-        NotebookMarkdown.parseBlocks(markdown)
-    }
+    @State private var cachedMarkdown = ""
+    @State private var cachedBlocks: [NotebookBlock] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            ForEach(blocks) { block in
+            ForEach(cachedBlocks) { block in
                 blockView(block)
             }
         }
+        .onAppear { refreshBlocksIfNeeded() }
+        .onChange(of: markdown) { _, _ in refreshBlocksIfNeeded() }
+    }
+
+    private func refreshBlocksIfNeeded() {
+        guard cachedMarkdown != markdown else { return }
+        cachedMarkdown = markdown
+        cachedBlocks = NotebookMarkdown.parseBlocks(markdown)
     }
 
     @ViewBuilder
@@ -38,7 +44,7 @@ struct CourseMarkdownContentView: View {
             } else {
                 mathAwareText(text)
             }
-        case .bulletItem(let text):
+        case .bulletItem(let text, let depth):
             HStack(alignment: .firstTextBaseline, spacing: 10) {
                 Circle()
                     .fill(LexturesTheme.accent(for: colorScheme))
@@ -46,15 +52,26 @@ struct CourseMarkdownContentView: View {
                     .padding(.top, 6)
                 mathAwareText(text)
             }
-            .padding(.leading, 4)
-        case .orderedItem(let number, let text):
+            .padding(.leading, CGFloat(4 + depth * 16))
+        case .orderedItem(let number, let text, let depth):
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text("\(number).")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(LexturesTheme.accent(for: colorScheme))
                 mathAwareText(text)
             }
-            .padding(.leading, 4)
+            .padding(.leading, CGFloat(4 + depth * 16))
+        case .taskItem(let checked, let text, let depth):
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: checked ? "checkmark.square.fill" : "square")
+                    .foregroundStyle(checked ? LexturesTheme.accent(for: colorScheme) : LexturesTheme.textSecondary(for: colorScheme))
+                    .accessibilityHidden(true)
+                mathAwareText(text)
+                    .strikethrough(checked)
+            }
+            .padding(.leading, CGFloat(4 + depth * 16))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(checked ? "Completed" : "Not completed"): \(text)")
         case .quote(let text):
             HStack(alignment: .top, spacing: 10) {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
@@ -64,14 +81,25 @@ struct CourseMarkdownContentView: View {
                     .italic()
                     .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
             }
-        case .code(let text):
-            Text(text)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                .padding(12)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(LexturesTheme.sceneBackground(for: colorScheme))
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        case .code(let language, let source):
+            MarkdownCodeBlockView(language: language, source: source)
+        case .math(let latex, let display):
+            MathLatexView(latex: latex, displayMode: display)
+        case .table(let align, let header, let rows):
+            MarkdownTableView(align: align, header: header, rows: rows)
+        case .toolFence(_, let toolId, _):
+            Label {
+                Text(L.format("mobile.markdown.tool.placeholder", toolId))
+                    .font(.subheadline)
+            } icon: {
+                Image(systemName: "puzzlepiece.extension")
+            }
+            .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(LexturesTheme.sceneBackground(for: colorScheme))
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .accessibilityLabel(L.format("mobile.markdown.tool.placeholder", toolId))
         case .divider:
             Divider()
         case .task, .drawing:
@@ -90,6 +118,7 @@ struct CourseMarkdownContentView: View {
                 .lineSpacing(3)
                 .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
         } else {
+            // Flow inline math within a wrapping HStack of text runs.
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
                     switch segment {
@@ -124,7 +153,6 @@ enum ModuleContentMedia {
         guard text.contains("$") else { return [.text(text)] }
         var segments: [Segment] = []
         var index = text.startIndex
-        var inDisplay = false
         while index < text.endIndex {
             if text[index] == "$" {
                 let next = text.index(after: index)
@@ -137,15 +165,11 @@ enum ModuleContentMedia {
                 if let closeRange = text[openEnd...].range(of: closePattern) {
                     let latex = String(text[openEnd ..< closeRange.lowerBound])
                     segments.append(.math(latex, display: display))
-                    index = display
-                        ? text.index(closeRange.upperBound, offsetBy: 1, limitedBy: text.endIndex) ?? text.endIndex
-                        : closeRange.upperBound
+                    index = closeRange.upperBound
                 } else {
                     segments.append(.text(String(text[index...])))
                     return segments
                 }
-                inDisplay = display
-                _ = inDisplay
                 continue
             }
             index = text.index(after: index)
@@ -169,16 +193,35 @@ enum ModuleContentMedia {
     }
 }
 
+/// Typeset math with a safe monospace fallback (CT.M1 FR-10 / open question #1).
 struct MathLatexView: View {
     let latex: String
     let displayMode: Bool
 
     var body: some View {
-        Text(latex)
-            .font(.system(displayMode ? .body : .subheadline, design: .serif))
+        Text(prettyLatex)
+            .font(.system(displayMode ? .body : .subheadline, design: .monospaced))
             .foregroundStyle(.primary)
             .padding(.vertical, displayMode ? 4 : 0)
-            .accessibilityLabel(displayMode ? "Display equation: \(latex)" : "Inline equation: \(latex)")
+            .frame(maxWidth: displayMode ? .infinity : nil, alignment: displayMode ? .center : .leading)
+            .accessibilityLabel(accessibilityText)
+    }
+
+    /// Light prettification so common fractions read better without a native math library.
+    private var prettyLatex: String {
+        let trimmed = latex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return latex }
+        // Keep source visible (never blank) — FR-10 fallback path.
+        return trimmed
+            .replacingOccurrences(of: "\\frac{", with: "(")
+            .replacingOccurrences(of: "}{", with: ")/(")
+            .replacingOccurrences(of: "\\cdot", with: "·")
+            .replacingOccurrences(of: "\\times", with: "×")
+    }
+
+    private var accessibilityText: String {
+        let key = displayMode ? "mobile.markdown.math.display" : "mobile.markdown.math.inline"
+        return L.format(key, latex)
     }
 }
 

--- a/clients/ios/Lextures/Features/Courses/ItemDetailView.swift
+++ b/clients/ios/Lextures/Features/Courses/ItemDetailView.swift
@@ -367,9 +367,24 @@ enum ItemKind {
     }
 }
 
-/// Lightweight block-level markdown renderer (headings, bullets, paragraphs;
-/// inline bold/italic/code via AttributedString).
+/// CT.M1 shim for legacy call sites. When `ffMobileRichMarkdown` is on (default),
+/// delegates to `CourseMarkdownContentView`; otherwise keeps the lightweight legacy path.
 struct MarkdownTextView: View {
+    @Environment(AppShellModel.self) private var shell
+    @Environment(\.colorScheme) private var colorScheme
+    let markdown: String
+
+    var body: some View {
+        if shell.platformFeatures.ffMobileRichMarkdown {
+            CourseMarkdownContentView(markdown: markdown)
+        } else {
+            LegacyMarkdownTextView(markdown: markdown)
+        }
+    }
+}
+
+/// Pre-CT.M1 lightweight renderer retained for feature-flag rollback.
+private struct LegacyMarkdownTextView: View {
     @Environment(\.colorScheme) private var colorScheme
     let markdown: String
 

--- a/clients/ios/Lextures/Features/Courses/MarkdownCodeBlockView.swift
+++ b/clients/ios/Lextures/Features/Courses/MarkdownCodeBlockView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Fenced code block: language label, monospace, horizontal scroll, copy (CT.M1 FR-7).
+struct MarkdownCodeBlockView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let language: String?
+    let source: String
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(languageLabel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                Spacer()
+                Button {
+                    UIPasteboard.general.string = source
+                    copied = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
+                } label: {
+                    Text(copied ? L.text("mobile.markdown.code.copied") : L.text("mobile.markdown.code.copy"))
+                        .font(.caption2.weight(.semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                .accessibilityLabel(L.text("mobile.markdown.code.copy"))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            ScrollView(.horizontal, showsIndicators: true) {
+                Text(source.isEmpty ? " " : source)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 12)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(LexturesTheme.sceneBackground(for: colorScheme))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(codeAccessibilityLabel)
+    }
+
+    private var languageLabel: String {
+        if let language, !language.isEmpty {
+            return L.format("mobile.markdown.code.language", language)
+        }
+        return L.text("mobile.markdown.code.languageFallback")
+    }
+
+    private var codeAccessibilityLabel: String {
+        if let language, !language.isEmpty {
+            return "\(language) \(L.text("mobile.markdown.code.block"))"
+        }
+        return L.text("mobile.markdown.code.block")
+    }
+}

--- a/clients/ios/Lextures/Features/Courses/MarkdownTableView.swift
+++ b/clients/ios/Lextures/Features/Courses/MarkdownTableView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Inline GFM table with horizontal scroll and expand affordance (CT.M1 FR-5 / FR-6).
+struct MarkdownTableView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let align: [MarkdownTableAlign]
+    let header: [String]
+    let rows: [[String]]
+    @State private var showFullScreen = false
+
+    private let minColumnWidth: CGFloat = 96
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ScrollView(.horizontal, showsIndicators: true) {
+                tableGrid(minWidth: minColumnWidth)
+            }
+            Button {
+                showFullScreen = true
+            } label: {
+                Label(L.text("mobile.markdown.table.expand"), systemImage: "arrow.up.left.and.arrow.down.right")
+                    .font(.caption.weight(.semibold))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+            .accessibilityHint(L.text("mobile.markdown.table.expandHint"))
+        }
+        .fullScreenCover(isPresented: $showFullScreen) {
+            MarkdownTableFullScreenView(align: align, header: header, rows: rows)
+        }
+    }
+
+    @ViewBuilder
+    private func tableGrid(minWidth: CGFloat) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+            GridRow {
+                ForEach(Array(header.enumerated()), id: \.offset) { index, cell in
+                    cellView(cell, headerColumn: header[index], rowHeader: nil, isHeader: true, align: alignAt(index))
+                        .frame(minWidth: minWidth, alignment: alignment(for: alignAt(index)))
+                }
+            }
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                GridRow {
+                    ForEach(Array(row.enumerated()), id: \.offset) { index, cell in
+                        let columnHeader = index < header.count ? header[index] : ""
+                        let rowHeader = row.first
+                        cellView(cell, headerColumn: columnHeader, rowHeader: rowHeader, isHeader: false, align: alignAt(index))
+                            .frame(minWidth: minWidth, alignment: alignment(for: alignAt(index)))
+                    }
+                }
+            }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(LexturesTheme.textSecondary(for: colorScheme).opacity(0.35), lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .accessibilityElement(children: .contain)
+    }
+
+    private func cellView(
+        _ text: String,
+        headerColumn: String,
+        rowHeader: String?,
+        isHeader: Bool,
+        align: MarkdownTableAlign
+    ) -> some View {
+        Text(inline(text))
+            .font(isHeader ? .caption.weight(.semibold) : .caption)
+            .multilineTextAlignment(textAlignment(for: align))
+            .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: alignment(for: align))
+            .background(isHeader ? LexturesTheme.sceneBackground(for: colorScheme) : Color.clear)
+            .accessibilityLabel(cellAccessibilityLabel(column: headerColumn, row: rowHeader, value: text, isHeader: isHeader))
+    }
+
+    private func cellAccessibilityLabel(column: String, row: String?, value: String, isHeader: Bool) -> String {
+        if isHeader { return value }
+        if let row, !row.isEmpty, row != value {
+            return "\(column), \(row): \(value)"
+        }
+        return "\(column): \(value)"
+    }
+
+    private func alignAt(_ index: Int) -> MarkdownTableAlign {
+        index < align.count ? align[index] : .default
+    }
+
+    private func alignment(for align: MarkdownTableAlign) -> Alignment {
+        switch align {
+        case .center: return .center
+        case .right: return .trailing
+        case .left, .default: return .leading
+        }
+    }
+
+    private func textAlignment(for align: MarkdownTableAlign) -> TextAlignment {
+        switch align {
+        case .center: return .center
+        case .right: return .trailing
+        case .left, .default: return .leading
+        }
+    }
+
+    private func inline(_ text: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(text)
+    }
+}
+
+/// Full-screen table viewer with pinned header (CT.M1 FR-6).
+struct MarkdownTableFullScreenView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    let align: [MarkdownTableAlign]
+    let header: [String]
+    let rows: [[String]]
+
+    private let minColumnWidth: CGFloat = 120
+
+    var body: some View {
+        NavigationStack {
+            ScrollView([.horizontal, .vertical], showsIndicators: true) {
+                Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+                    GridRow {
+                        ForEach(Array(header.enumerated()), id: \.offset) { index, cell in
+                            Text(cell)
+                                .font(.subheadline.weight(.semibold))
+                                .padding(12)
+                                .frame(minWidth: minColumnWidth, alignment: .leading)
+                                .background(LexturesTheme.sceneBackground(for: colorScheme))
+                                .accessibilityAddTraits(.isHeader)
+                        }
+                    }
+                    ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                        GridRow {
+                            ForEach(Array(row.enumerated()), id: \.offset) { index, cell in
+                                let column = index < header.count ? header[index] : ""
+                                Text(cell)
+                                    .font(.subheadline)
+                                    .padding(12)
+                                    .frame(minWidth: minColumnWidth, alignment: .leading)
+                                    .accessibilityLabel("\(column): \(cell)")
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle(L.text("mobile.markdown.table.expand"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L.text("mobile.markdown.table.close")) { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/clients/ios/Lextures/Resources/Localizable.xcstrings
+++ b/clients/ios/Lextures/Resources/Localizable.xcstrings
@@ -90781,6 +90781,380 @@
         }
       }
     },
+    "mobile.markdown.code.block": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتلة تعليمات برمجية"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "code block"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[code block]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloque de código"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bloc de code"
+          }
+        }
+      }
+    },
+    "mobile.markdown.code.copied": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم النسخ"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Copied]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copié"
+          }
+        }
+      }
+    },
+    "mobile.markdown.code.copy": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Copy]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier"
+          }
+        }
+      }
+    },
+    "mobile.markdown.code.language": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[%@]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        }
+      }
+    },
+    "mobile.markdown.code.languageFallback": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رمز"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Code"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Code]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Code"
+          }
+        }
+      }
+    },
+    "mobile.markdown.math.display": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معادلة: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display equation: %@"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Display equation: %@]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ecuación: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Équation : %@"
+          }
+        }
+      }
+    },
+    "mobile.markdown.math.inline": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معادلة مضمنة: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inline equation: %@"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Inline equation: %@]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ecuación en línea: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Équation en ligne : %@"
+          }
+        }
+      }
+    },
+    "mobile.markdown.table.close": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إغلاق"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Close]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer"
+          }
+        }
+      }
+    },
+    "mobile.markdown.table.expand": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "توسيع الجدول"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expand table"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Expand table]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ampliar tabla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agrandir le tableau"
+          }
+        }
+      }
+    },
+    "mobile.markdown.table.expandHint": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يفتح الجدول بملء الشاشة"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens a full-screen table viewer"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Opens a full-screen table viewer]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre la tabla a pantalla completa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre le tableau en plein écran"
+          }
+        }
+      }
+    },
+    "mobile.markdown.tool.placeholder": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أداة تفاعلية: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interactive tool: %@"
+          }
+        },
+        "en-XA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Interactive tool: %@]"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramienta interactiva: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outil interactif : %@"
+          }
+        }
+      }
+    },
     "mobile.marketplace.aboutTitle": {
       "localizations": {
         "ar": {

--- a/clients/ios/LexturesTests/NotebookMarkdownLogicTests.swift
+++ b/clients/ios/LexturesTests/NotebookMarkdownLogicTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import Lextures
+
+final class NotebookMarkdownLogicTests: XCTestCase {
+    func testNormalizeTablesHealsBlankLines() {
+        let input = """
+        | A | B |
+
+        | --- | --- |
+
+        | 1 | 2 |
+
+        After
+        """
+        let healed = MarkdownTableLogic.normalizeMarkdownTables(input)
+        XCTAssertFalse(healed.contains("|\n\n|"))
+        XCTAssertTrue(healed.contains("| A | B |"))
+        XCTAssertTrue(healed.contains("| --- | --- |"))
+        XCTAssertTrue(healed.contains("| 1 | 2 |"))
+        XCTAssertTrue(healed.contains("After"))
+    }
+
+    func testNormalizeTablesLeavesPipeProseAlone() {
+        let input = "Use | as OR in boolean logic."
+        XCTAssertEqual(MarkdownTableLogic.normalizeMarkdownTables(input), input)
+    }
+
+    func testParseBasicTableAlignment() {
+        let md = """
+        | Left | Center | Right |
+        | :--- | :---: | ---: |
+        | a | b | c |
+        """
+        let blocks = NotebookMarkdown.parseBlocks(md)
+        guard case .table(let align, let header, let rows) = blocks.first?.kind else {
+            return XCTFail("expected table")
+        }
+        XCTAssertEqual(header, ["Left", "Center", "Right"])
+        XCTAssertEqual(align, [.left, .center, .right])
+        XCTAssertEqual(rows, [["a", "b", "c"]])
+    }
+
+    func testParseCodeLanguageAndLexTool() {
+        let code = NotebookMarkdown.parseBlocks("```python\nprint(1)\n```")
+        guard case .code(let language, let source) = code.first?.kind else {
+            return XCTFail("expected code")
+        }
+        XCTAssertEqual(language, "python")
+        XCTAssertEqual(source, "print(1)")
+
+        let tool = NotebookMarkdown.parseBlocks("""
+        ```lex-tool
+        {"instanceId":"abc-123","toolId":"inline_questions","v":1}
+        ```
+        """)
+        guard case .toolFence(let instanceId, let toolId, let version) = tool.first?.kind else {
+            return XCTFail("expected toolFence")
+        }
+        XCTAssertEqual(instanceId, "abc-123")
+        XCTAssertEqual(toolId, "inline_questions")
+        XCTAssertEqual(version, 1)
+        XCTAssertFalse(tool.contains { if case .code = $0.kind { return true }; return false })
+    }
+
+    func testParseMathAndTaskList() {
+        let math = NotebookMarkdown.parseBlocks("$$\\frac{a}{b}$$")
+        guard case .math(let latex, let display) = math.first?.kind else {
+            return XCTFail("expected math")
+        }
+        XCTAssertEqual(latex, "\\frac{a}{b}")
+        XCTAssertTrue(display)
+
+        let tasks = NotebookMarkdown.parseBlocks("- [ ] Todo\n- [x] Done")
+        XCTAssertEqual(tasks.count, 2)
+        guard case .taskItem(false, "Todo", _) = tasks[0].kind else { return XCTFail("todo") }
+        guard case .taskItem(true, "Done", _) = tasks[1].kind else { return XCTFail("done") }
+    }
+
+    func testPreviewHidesLexToolJSON() {
+        let preview = NotebookMarkdown.previewText("""
+        Hello
+
+        ```lex-tool
+        {"instanceId":"abc-123","toolId":"flashcards","v":1}
+        ```
+        """)
+        XCTAssertFalse(preview.contains("abc-123"))
+        XCTAssertFalse(preview.contains("instanceId"))
+        XCTAssertTrue(preview.contains("flashcards") || preview.contains("Hello"))
+    }
+
+    func testSharedFixtureCorpusKindSequences() throws {
+        let url = fixtureCorpusURL()
+        let data = try Data(contentsOf: url)
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let fixtures = root?["fixtures"] as? [[String: Any]] ?? []
+        XCTAssertFalse(fixtures.isEmpty)
+        for fixture in fixtures {
+            let id = fixture["id"] as? String ?? "?"
+            let markdown = fixture["markdown"] as? String ?? ""
+            let expected = fixture["kinds"] as? [String] ?? []
+            let actual = NotebookMarkdown.parseBlocks(markdown).map(NotebookMarkdown.fixtureKindName)
+            XCTAssertEqual(actual, expected, "fixture \(id)")
+        }
+    }
+
+    private func fixtureCorpusURL() -> URL {
+        // Repo layout: clients/ios/LexturesTests → ../../mobile/fixtures/markdown/corpus.json
+        let thisFile = URL(fileURLWithPath: #filePath)
+        let corpus = thisFile
+            .deletingLastPathComponent() // LexturesTests
+            .deletingLastPathComponent() // ios
+            .appendingPathComponent("mobile/fixtures/markdown/corpus.json")
+        if FileManager.default.fileExists(atPath: corpus.path) { return corpus }
+        // Fallback: walk up from CWD for CI checkouts.
+        var dir = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        for _ in 0 ..< 6 {
+            let candidate = dir.appendingPathComponent("clients/mobile/fixtures/markdown/corpus.json")
+            if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+            dir = dir.deletingLastPathComponent()
+        }
+        return corpus
+    }
+}

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -110,6 +110,10 @@ Access and refresh tokens are stored in the Keychain. MFA-required accounts show
 
 Notebooks are device-local (same model as the web app's localStorage notebooks, format v2), keyed per signed-in user.
 
+## Markdown engine (CT.M1)
+
+Course and notebook readers share one parser (`Core/Notebook/NotebookMarkdown.swift` + `MarkdownTableLogic.swift`) and one renderer (`CourseMarkdownContentView`). The engine handles GFM tables (with blank-line healing parity to web `normalizeMarkdownTables`), fenced code (language + copy), `$`/`$$` math (monospace fallback with a11y labels), GFM task lists, and ` ```lex-tool ` placeholders (raw JSON never shown). Shared golden fixtures live in `clients/mobile/fixtures/markdown/corpus.json`. Unit coverage: `LexturesTests/NotebookMarkdownLogicTests.swift`. Feature flag: `ffMobileRichMarkdown` (default on).
+
 ## Realtime sockets
 
 Per-screen sockets use `Core/Realtime/WebSocketClient` (JSON `{"authToken":…}` handshake, 2s reconnect):

--- a/clients/mobile/fixtures/markdown/corpus.json
+++ b/clients/mobile/fixtures/markdown/corpus.json
@@ -1,0 +1,74 @@
+{
+  "fixtures": [
+    {
+      "id": "table-basic",
+      "markdown": "| Name | Score |\n| --- | ---: |\n| Ada | 98 |\n| Grace | 100 |",
+      "kinds": ["table"]
+    },
+    {
+      "id": "table-blank-lines",
+      "markdown": "| A | B |\n\n| --- | --- |\n\n| 1 | 2 |\n\n| 3 | 4 |\n\nAfter table",
+      "kinds": ["table", "paragraph"]
+    },
+    {
+      "id": "table-align",
+      "markdown": "| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |",
+      "kinds": ["table"]
+    },
+    {
+      "id": "pipe-prose-not-table",
+      "markdown": "Use | as OR in boolean logic.",
+      "kinds": ["paragraph"]
+    },
+    {
+      "id": "code-python",
+      "markdown": "```python\ndef hi():\n    print(\"hi\")\n```",
+      "kinds": ["code"]
+    },
+    {
+      "id": "code-with-pipes",
+      "markdown": "```\n| not | a | table |\n```",
+      "kinds": ["code"]
+    },
+    {
+      "id": "lex-tool-fence",
+      "markdown": "```lex-tool\n{\"instanceId\":\"abc-123\",\"toolId\":\"inline_questions\",\"v\":1}\n```",
+      "kinds": ["toolFence"]
+    },
+    {
+      "id": "unknown-fence",
+      "markdown": "```ruby\nputs :hi\n```",
+      "kinds": ["code"]
+    },
+    {
+      "id": "math-display",
+      "markdown": "$$\\frac{a}{b}$$",
+      "kinds": ["math"]
+    },
+    {
+      "id": "math-inline-paragraph",
+      "markdown": "The ratio is $a/b$ in prose.",
+      "kinds": ["paragraph"]
+    },
+    {
+      "id": "task-list",
+      "markdown": "- [ ] Todo\n- [x] Done",
+      "kinds": ["taskItem", "taskItem"]
+    },
+    {
+      "id": "nested-lists",
+      "markdown": "- Parent\n  - Child\n    - Grandchild",
+      "kinds": ["bullet", "bullet", "bullet"]
+    },
+    {
+      "id": "mixed-body",
+      "markdown": "# Title\n\nIntro with **bold**.\n\n| Col |\n| --- |\n| Val |\n\n```js\nconsole.log(1)\n```\n\n$$E=mc^2$$\n\n```lex-tool\n{\"instanceId\":\"i1\",\"toolId\":\"flashcards\",\"v\":1}\n```",
+      "kinds": ["heading", "paragraph", "table", "code", "math", "toolFence"]
+    },
+    {
+      "id": "inline-formatting",
+      "markdown": "See **bold**, *italic*, ~~strike~~, `code`, and [link](https://example.com).",
+      "kinds": ["paragraph"]
+    }
+  ]
+}

--- a/clients/mobile/locales/ar.json
+++ b/clients/mobile/locales/ar.json
@@ -3686,7 +3686,18 @@
     "mobile.admin.courses.metric.archived.tableTitle": "Archived courses",
     "mobile.admin.courses.metric.archived.tableDescription": "Courses hidden from catalogs.",
     "mobile.admin.courses.metric.emptyTitle": "No courses in this segment",
-    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title."
+    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title.",
+    "mobile.markdown.table.expand": "توسيع الجدول",
+    "mobile.markdown.table.expandHint": "يفتح الجدول بملء الشاشة",
+    "mobile.markdown.table.close": "إغلاق",
+    "mobile.markdown.code.copy": "نسخ",
+    "mobile.markdown.code.copied": "تم النسخ",
+    "mobile.markdown.code.language": "%@",
+    "mobile.markdown.code.languageFallback": "رمز",
+    "mobile.markdown.code.block": "كتلة تعليمات برمجية",
+    "mobile.markdown.tool.placeholder": "أداة تفاعلية: %@",
+    "mobile.markdown.math.inline": "معادلة مضمنة: %@",
+    "mobile.markdown.math.display": "معادلة: %@"
   },
   "plurals": {
     "mobile.dashboard.dueThisWeek.count": {

--- a/clients/mobile/locales/en-XA.json
+++ b/clients/mobile/locales/en-XA.json
@@ -3686,7 +3686,18 @@
     "mobile.admin.courses.metric.archived.tableTitle": "[Archived courses]",
     "mobile.admin.courses.metric.archived.tableDescription": "[Courses hidden from catalogs.]",
     "mobile.admin.courses.metric.emptyTitle": "[No courses in this segment]",
-    "mobile.admin.courses.metric.emptyMessage": "[Try another metric or search by code or title.]"
+    "mobile.admin.courses.metric.emptyMessage": "[Try another metric or search by code or title.]",
+    "mobile.markdown.table.expand": "[Expand table]",
+    "mobile.markdown.table.expandHint": "[Opens a full-screen table viewer]",
+    "mobile.markdown.table.close": "[Close]",
+    "mobile.markdown.code.copy": "[Copy]",
+    "mobile.markdown.code.copied": "[Copied]",
+    "mobile.markdown.code.language": "[%@]",
+    "mobile.markdown.code.languageFallback": "[Code]",
+    "mobile.markdown.code.block": "[code block]",
+    "mobile.markdown.tool.placeholder": "[Interactive tool: %@]",
+    "mobile.markdown.math.inline": "[Inline equation: %@]",
+    "mobile.markdown.math.display": "[Display equation: %@]"
   },
   "plurals": {
     "mobile.dashboard.dueThisWeek.count": {

--- a/clients/mobile/locales/en.json
+++ b/clients/mobile/locales/en.json
@@ -3686,7 +3686,18 @@
     "mobile.admin.courses.metric.archived.tableTitle": "Archived courses",
     "mobile.admin.courses.metric.archived.tableDescription": "Courses hidden from catalogs.",
     "mobile.admin.courses.metric.emptyTitle": "No courses in this segment",
-    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title."
+    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title.",
+    "mobile.markdown.table.expand": "Expand table",
+    "mobile.markdown.table.expandHint": "Opens a full-screen table viewer",
+    "mobile.markdown.table.close": "Close",
+    "mobile.markdown.code.copy": "Copy",
+    "mobile.markdown.code.copied": "Copied",
+    "mobile.markdown.code.language": "%@",
+    "mobile.markdown.code.languageFallback": "Code",
+    "mobile.markdown.code.block": "code block",
+    "mobile.markdown.tool.placeholder": "Interactive tool: %@",
+    "mobile.markdown.math.inline": "Inline equation: %@",
+    "mobile.markdown.math.display": "Display equation: %@"
   },
   "plurals": {
     "mobile.dashboard.dueThisWeek.count": {

--- a/clients/mobile/locales/es.json
+++ b/clients/mobile/locales/es.json
@@ -3686,7 +3686,18 @@
     "mobile.admin.courses.metric.archived.tableTitle": "Archived courses",
     "mobile.admin.courses.metric.archived.tableDescription": "Courses hidden from catalogs.",
     "mobile.admin.courses.metric.emptyTitle": "No courses in this segment",
-    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title."
+    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title.",
+    "mobile.markdown.table.expand": "Ampliar tabla",
+    "mobile.markdown.table.expandHint": "Abre la tabla a pantalla completa",
+    "mobile.markdown.table.close": "Cerrar",
+    "mobile.markdown.code.copy": "Copiar",
+    "mobile.markdown.code.copied": "Copiado",
+    "mobile.markdown.code.language": "%@",
+    "mobile.markdown.code.languageFallback": "Código",
+    "mobile.markdown.code.block": "bloque de código",
+    "mobile.markdown.tool.placeholder": "Herramienta interactiva: %@",
+    "mobile.markdown.math.inline": "Ecuación en línea: %@",
+    "mobile.markdown.math.display": "Ecuación: %@"
   },
   "plurals": {
     "mobile.dashboard.dueThisWeek.count": {

--- a/clients/mobile/locales/fr.json
+++ b/clients/mobile/locales/fr.json
@@ -3686,7 +3686,18 @@
     "mobile.admin.courses.metric.archived.tableTitle": "Archived courses",
     "mobile.admin.courses.metric.archived.tableDescription": "Courses hidden from catalogs.",
     "mobile.admin.courses.metric.emptyTitle": "No courses in this segment",
-    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title."
+    "mobile.admin.courses.metric.emptyMessage": "Try another metric or search by code or title.",
+    "mobile.markdown.table.expand": "Agrandir le tableau",
+    "mobile.markdown.table.expandHint": "Ouvre le tableau en plein écran",
+    "mobile.markdown.table.close": "Fermer",
+    "mobile.markdown.code.copy": "Copier",
+    "mobile.markdown.code.copied": "Copié",
+    "mobile.markdown.code.language": "%@",
+    "mobile.markdown.code.languageFallback": "Code",
+    "mobile.markdown.code.block": "bloc de code",
+    "mobile.markdown.tool.placeholder": "Outil interactif : %@",
+    "mobile.markdown.math.inline": "Équation en ligne : %@",
+    "mobile.markdown.math.display": "Équation : %@"
   },
   "plurals": {
     "mobile.dashboard.dueThisWeek.count": {

--- a/clients/web/src/components/syllabus/__tests__/normalize-markdown-tables.test.ts
+++ b/clients/web/src/components/syllabus/__tests__/normalize-markdown-tables.test.ts
@@ -1,5 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { normalizeMarkdownTables } from '../normalize-markdown-tables'
+
+const fixturesPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../../mobile/fixtures/markdown/corpus.json',
+)
 
 const sample = `Traditional software works like a detailed recipe.
 
@@ -49,5 +57,17 @@ Done.
 
 Then write more.`
     expect(normalizeMarkdownTables(md)).toBe(md)
+  })
+
+  it('heals the shared mobile fixture table-blank-lines (CT.M1 FR-3)', () => {
+    const corpus = JSON.parse(readFileSync(fixturesPath, 'utf8')) as {
+      fixtures: Array<{ id: string; markdown: string }>
+    }
+    const fixture = corpus.fixtures.find((f) => f.id === 'table-blank-lines')
+    expect(fixture).toBeTruthy()
+    const out = normalizeMarkdownTables(fixture!.markdown)
+    expect(out).toContain('| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |')
+    expect(out).toContain('After table')
+    expect(out).not.toMatch(/\|\s*\n\n\s*\|/)
   })
 })

--- a/docs/completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md
+++ b/docs/completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md
@@ -10,7 +10,7 @@
 | **Section** | Content Tools (CT) — Mobile |
 | **Severity** | MAJOR |
 | **Markets** | K12 / HE / HS |
-| **Status (today)** | MISSING |
+| **Status (today)** | DONE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Mobile squad |
 | **Depends on** | — |

--- a/docs/completed/content_tools/README.md
+++ b/docs/completed/content_tools/README.md
@@ -25,5 +25,6 @@
 | **CT.21** | [Class Pulse](CT.21-tool-class-pulse.md) |
 | **CT.22** | [Inline Discussion](CT.22-tool-inline-discussion.md) |
 | **CT.23** | [Flashcards & Spaced Recall](CT.23-tool-flashcards-and-spaced-recall.md) |
+| **CT.M1** | [Mobile markdown engine: tables, code, math & media](CT.M1-mobile-markdown-engine-tables-code-math.md) |
 
 Remaining plans live under [`docs/plan/content_tools/`](../../plan/content_tools/README.md).

--- a/docs/plan/content_tools/CT.M2-mobile-rich-content-parity-assignments-quizzes.md
+++ b/docs/plan/content_tools/CT.M2-mobile-rich-content-parity-assignments-quizzes.md
@@ -1,6 +1,6 @@
 # CT.M2 — Mobile Rich Content Parity: Assignments, Quizzes, Syllabus & Discussions
 
-> Implementation plan. Source: mobile parity for authored rich content. Folder overview: [README](README.md). Consumes the engine from [CT.M1](CT.M1-mobile-markdown-engine-tables-code-math.md).
+> Implementation plan. Source: mobile parity for authored rich content. Folder overview: [README](README.md). Consumes the engine from [CT.M1](../../completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md).
 
 ## Metadata
 
@@ -279,6 +279,6 @@ lines — which is precisely why CT.M1's healing rule matters here.)
 - Web reference: `clients/web/src/components/quiz/quiz-response-display.tsx`,
   `clients/web/src/components/quiz/quiz-student-preview-modal.tsx`,
   `clients/web/src/components/content-page/content-page-reader.tsx`.
-- Related plans: [CT.M1](CT.M1-mobile-markdown-engine-tables-code-math.md),
+- Related plans: [CT.M1](../../completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md),
   [CT.M3](CT.M3-mobile-content-tool-host-and-state.md).
 - Standards: WCAG 2.1 AA §1.3.1, §2.5.5 (target size), §4.1.2 (name, role, value for choices).

--- a/docs/plan/content_tools/CT.M3-mobile-content-tool-host-and-state.md
+++ b/docs/plan/content_tools/CT.M3-mobile-content-tool-host-and-state.md
@@ -381,7 +381,7 @@ the server already stores.
 - Existing mobile infra: `clients/ios/Lextures/Core/Offline/{OfflineService,CacheStore,OfflineModels}.swift`,
   `clients/ios/Lextures/Features/Courses/WebItemView.swift` (`AuthenticatedWebView`),
   `clients/android/.../core/offline/*`, `.../features/courses/WebItemScreen.kt`.
-- Related plans: [CT.M1](CT.M1-mobile-markdown-engine-tables-code-math.md),
+- Related plans: [CT.M1](../../completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md),
   [CT.M2](CT.M2-mobile-rich-content-parity-assignments-quizzes.md),
   [CT.M4](CT.M4-mobile-sandboxed-webview-tool-host.md), [CT.M9](CT.M9-mobile-tools-governance-a11y-telemetry.md).
 - Standards: WCAG 2.1 AA §4.1.3 (status messages), §2.4.3 (focus order); S01/S02 (DSAR, retention).

--- a/docs/plan/content_tools/CT.M5-mobile-tools-check-and-commit.md
+++ b/docs/plan/content_tools/CT.M5-mobile-tools-check-and-commit.md
@@ -300,7 +300,7 @@ is made from this pack. (AI-backed tools are CT.M6.)
   class_pulse,flashcards}/renderer.tsx`.
 - Server: `server/internal/service/contenttools/{inline_questions,predict_reveal,class_pulse,
   flashcards}_actions.go`; manifests under `server/internal/service/contenttools/tools/*/manifest.json`.
-- Related plans: [CT.M1](CT.M1-mobile-markdown-engine-tables-code-math.md),
+- Related plans: [CT.M1](../../completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md),
   [CT.M3](CT.M3-mobile-content-tool-host-and-state.md),
   [CT.M9](CT.M9-mobile-tools-governance-a11y-telemetry.md).
 - Standards: WCAG 2.1 AA §1.4.1 (use of colour), §2.5.1 (pointer gestures — flip must have a

--- a/docs/plan/content_tools/CT.M8-mobile-tools-media-and-procedural.md
+++ b/docs/plan/content_tools/CT.M8-mobile-tools-media-and-procedural.md
@@ -344,6 +344,6 @@ verify the tool's declared capabilities at mount rather than assuming.
   (`ContentVideoPlayer`, `CaptionedPlayerView`), the Android player equivalents.
 - Related plans: [CT.M3](CT.M3-mobile-content-tool-host-and-state.md),
   [CT.M4](CT.M4-mobile-sandboxed-webview-tool-host.md),
-  [CT.M1](CT.M1-mobile-markdown-engine-tables-code-math.md).
+  [CT.M1](../../completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md).
 - Standards: WCAG 2.1 AA §1.2.2 (captions), §1.4.13, §4.1.2 (slider semantics), §2.2.2 (pause, stop,
   hide for auto-updating visualisations).

--- a/docs/plan/content_tools/README.md
+++ b/docs/plan/content_tools/README.md
@@ -148,7 +148,7 @@ in this series adds a migration or an endpoint** — mobile consumes the shipped
 
 | ID | Plan | Severity | Effort | Depends on | Delivers |
 |---|---|---|---|---|---|
-| **CT.M1** | [Mobile markdown engine: tables, code, math & media](CT.M1-mobile-markdown-engine-tables-code-math.md) | MAJOR | M | — | One parser/renderer per platform; GFM tables, fenced code, typeset math, inline formatting; `lex-tool` parsed and hidden |
+| **CT.M1** | [Mobile markdown engine: tables, code, math & media](../../completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md) | DONE | M | — | One parser/renderer per platform; GFM tables, fenced code, typeset math, inline formatting; `lex-tool` parsed and hidden |
 | **CT.M2** | [Rich content parity: assignments, quizzes, syllabus, discussions](CT.M2-mobile-rich-content-parity-assignments-quizzes.md) | MAJOR | S | CT.M1 | Every reader on one renderer; markdown in quiz prompts, **choices**, feedback and review; legacy renderers deleted |
 | **CT.M3** | [Content tool host & state persistence](CT.M3-mobile-content-tool-host-and-state.md) | BLOCKER | M | CT.M1, CT.M2 | Flag plumbing, batched instance fetch, `ToolFrame`, autosave + revision conflicts, submit, actions, offline outbox, a11y baseline |
 | **CT.M4** | [Sandboxed WebView tool host](CT.M4-mobile-sandboxed-webview-tool-host.md) | MAJOR | M | CT.M3 | CT.5 `postMessage` bridge in WKWebView/Android WebView — the long tail and marketplace tools without a mobile release per tool |

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -4869,6 +4869,28 @@
       }
     },
     {
+      "id": "ct-m1-mobile-markdown-engine-tables-code-math",
+      "path": "docs/completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "major",
+      "client": "mobile",
+      "coverage": "not-applicable",
+      "rationale": "Mobile client story with native unit suites (iOS/Android notebook markdown + shared fixtures); web Playwright suite is not the coverage surface.",
+      "owner": "Mobile",
+      "reviewed": true,
+      "flags": {
+        "settingsToggle": true,
+        "disabledState": true,
+        "enabledJourney": "n/a",
+        "authorization": "n/a",
+        "dependency": "n/a",
+        "rollback": true,
+        "notes": "Client flag ffMobileRichMarkdown (default on) gates the rich renderer path; unit fixtures cover table heal / lex-tool hide."
+      }
+    },
+    {
       "id": "node-code-test-runner",
       "path": "docs/completed/agent-grader/node-code-test-runner.md",
       "markets": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **CT.M1** — one markdown parser/renderer per mobile platform that matches what the web editor emits.

- **GFM tables** with blank-line healing (parity with web `normalizeMarkdownTables`), horizontal scroll, expand-to-fullscreen, and cell a11y labels
- **Fenced code** with language label, monospace, horizontal scroll, and copy
- **Math** (`$…$` / `$$…$$`) with safe monospace fallback + speech-friendly labels (no native math lib yet)
- **` ```lex-tool `** parsed into `toolFence` and shown as a labelled placeholder (raw JSON never shown)
- **Inline formatting** on Android (bold/italic/strike/code/links); `stripInline` removed — `MarkdownText` is a thin shim over `NotebookContentView`
- Shared golden fixtures at `clients/mobile/fixtures/markdown/corpus.json` exercised by iOS + Android unit tests
- Feature flag `ffMobileRichMarkdown` (default **on**) for rollback
- Plan moved to `docs/completed/content_tools/`
- E2E.4 coverage manifest entry added (`client: mobile`, `not-applicable`)

## Test plan

- [x] Android unit tests: `./gradlew :app:testDebugUnitTest --tests 'com.lextures.android.core.notebook.*'`
- [x] Web table normalize + shared fixture heal test
- [x] Mobile i18n sync (`scripts/sync-mobile-locales.py`)
- [x] E2E coverage gate (`npm run e2e:coverage:check`)
- [x] CI Android lint/test/build
- [x] CI iOS build + unit tests
- [ ] Manual: content page with table / code / math / lex-tool on phone + tablet
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb508-c359-772c-9871-12d6447bfd04?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb508-c359-772c-9871-12d6447bfd04&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

