### PR TITLE
feat(ct.m2): mobile rich content parity for assignments & quizzes

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -38,6 +38,9 @@ jobs:
       - name: I18n artifacts
         run: ../../scripts/check-mobile-i18n.sh
 
+      - name: Single markdown renderer gate (CT.M2)
+        run: ../../scripts/check-mobile-markdown-renderer.sh
+
       - name: Lint, test, and build
         run: ./gradlew lint test assembleDebug --build-cache --parallel
 

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -54,6 +54,9 @@ jobs:
       - name: I18n artifacts
         run: ../../scripts/check-mobile-i18n.sh
 
+      - name: Single markdown renderer gate (CT.M2)
+        run: ../../scripts/check-mobile-markdown-renderer.sh
+
       - name: Select iOS Simulator
         id: sim
         run: |

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -84,9 +84,9 @@ Access and refresh tokens are stored in EncryptedSharedPreferences. MFA-required
 
 Notebooks are device-local (same model as the web app's localStorage notebooks, format v2), keyed per signed-in user.
 
-## Markdown engine (CT.M1)
+## Markdown engine (CT.M1 / CT.M2)
 
-Course and notebook readers share one parser (`core/notebook/NotebookMarkdown.kt` + `MarkdownTableLogic.kt`) and one renderer (`NotebookContentView` plus `features/courses/markdown/*`). The engine handles GFM tables (blank-line healing parity to web `normalizeMarkdownTables`), fenced code (language + copy), `$`/`$$` math (monospace fallback with a11y labels), GFM task lists, inline formatting (bold/italic/strike/code/links — `stripInline` removed), and ` ```lex-tool ` placeholders. Shared golden fixtures: `clients/mobile/fixtures/markdown/corpus.json`. Unit coverage: `app/src/test/kotlin/.../core/notebook/*Test.kt`. Feature flag: `ffMobileRichMarkdown` (default on). Legacy `MarkdownText` is a thin shim over `NotebookContentView` for CT.M2 migration.
+Course and notebook readers share one parser (`core/notebook/NotebookMarkdown.kt` + `MarkdownTableLogic.kt`) and **one** renderer (`NotebookContentView` plus `features/courses/markdown/*`). Assignments, quizzes (prompt/choices/review), syllabus, item detail, boards, portfolio, tutor, discussions, feed, and grade feedback all use that renderer. Pass `compact = true` in chat/cards/list rows; pass `suppressAffordances = true` during lockdown quizzes so copy/table-expand/link taps stay closed. The legacy `MarkdownText` shim is deleted — CI enforces this via `scripts/check-mobile-markdown-renderer.sh`. Shared golden fixtures: `clients/mobile/fixtures/markdown/corpus.json`. Unit coverage: `app/src/test/kotlin/.../core/notebook/*Test.kt`, `.../markdown/MarkdownRenderStyleTest.kt`. Feature flag: `ffMobileRichMarkdown` (default on).
 
 ## Realtime sockets
 

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/accessibility/AccessibilitySupport.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/accessibility/AccessibilitySupport.kt
@@ -1,5 +1,7 @@
 package com.lextures.android.core.accessibility
 
+import com.lextures.android.core.notebook.NotebookBlock
+import com.lextures.android.core.notebook.NotebookMarkdown
 import kotlin.math.pow
 
 /** Pure helpers shared by read-aloud, contrast checks, and tests. */
@@ -42,25 +44,69 @@ object AccessibilitySupport {
         return sentences
     }
 
+    /**
+     * Plain-text projection for read-aloud (CT.M2 FR-12 / AC-10).
+     * Uses the shared block parser so tables/code/math linearise without pipe/fence markup.
+     */
     fun plainTextFromMarkdown(markdown: String): String {
-        var text = markdown
+        val parts = mutableListOf<String>()
+        for (block in NotebookMarkdown.parseBlocks(markdown)) {
+            when (block) {
+                is NotebookBlock.Heading -> appendStripped(block.text, parts)
+                is NotebookBlock.Paragraph -> appendStripped(block.text, parts)
+                is NotebookBlock.Quote -> appendStripped(block.text, parts)
+                is NotebookBlock.BulletItem -> appendStripped(block.text, parts)
+                is NotebookBlock.OrderedItem -> appendStripped(block.text, parts)
+                is NotebookBlock.TaskItem -> appendStripped(block.text, parts)
+                is NotebookBlock.TaskBlock -> appendStripped(block.task.text, parts)
+                is NotebookBlock.Code -> {
+                    val trimmed = block.text.trim()
+                    if (trimmed.isNotEmpty()) parts.add(trimmed)
+                }
+                is NotebookBlock.Math -> {
+                    val trimmed = block.latex.trim()
+                    if (trimmed.isNotEmpty()) parts.add(trimmed)
+                }
+                is NotebookBlock.Table -> {
+                    val headerLine = block.header.map(::stripInlineMarkdown).filter { it.isNotEmpty() }.joinToString(", ")
+                    if (headerLine.isNotEmpty()) parts.add(headerLine)
+                    for (row in block.rows) {
+                        val rowLine = row.map(::stripInlineMarkdown).filter { it.isNotEmpty() }.joinToString(", ")
+                        if (rowLine.isNotEmpty()) parts.add(rowLine)
+                    }
+                }
+                is NotebookBlock.ToolFence -> if (block.toolId.isNotEmpty()) parts.add(block.toolId)
+                is NotebookBlock.Image -> if (block.alt.isNotEmpty()) parts.add(block.alt)
+                is NotebookBlock.Drawing -> parts.add("Drawing")
+                NotebookBlock.Divider -> Unit
+            }
+        }
+        return parts.joinToString(" ").replace(Regex("\\s+"), " ").trim()
+    }
+
+    fun stripInlineMarkdown(text: String): String {
+        var line = text
         val replacements = listOf(
             Regex("!\\[[^\\]]*]\\([^)]*\\)") to "",
             Regex("\\[([^\\]]+)]\\([^)]*\\)") to "$1",
-            Regex("`{1,3}[^`]+`{1,3}") to "",
-            Regex("^#{1,6}\\s+", RegexOption.MULTILINE) to "",
-            Regex("^>\\s?", RegexOption.MULTILINE) to "",
-            Regex("^[-*+]\\s+", RegexOption.MULTILINE) to "",
-            Regex("^\\d+\\.\\s+", RegexOption.MULTILINE) to "",
+            Regex("`([^`]+)`") to "$1",
             Regex("\\*\\*([^*]+)\\*\\*") to "$1",
             Regex("\\*([^*]+)\\*") to "$1",
             Regex("__([^_]+)__") to "$1",
             Regex("_([^_]+)_") to "$1",
+            Regex("~~([^~]+)~~") to "$1",
+            Regex("\\$\\$([^$]+)\\$\\$") to "$1",
+            Regex("\\$([^$]+)\\$") to "$1",
         )
         for ((pattern, replacement) in replacements) {
-            text = pattern.replace(text, replacement)
+            line = pattern.replace(line, replacement)
         }
-        return text.replace(Regex("\\s+"), " ").trim()
+        return line.trim()
+    }
+
+    private fun appendStripped(text: String, parts: MutableList<String>) {
+        val stripped = stripInlineMarkdown(text)
+        if (stripped.isNotEmpty()) parts.add(stripped)
     }
 
     private fun relativeLuminance(color: ColorComponents): Double {

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/assignments/AssignmentDetailScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/assignments/AssignmentDetailScreen.kt
@@ -80,7 +80,7 @@ import com.lextures.android.core.lms.SubmitAssignmentTextRequest
 import com.lextures.android.core.offline.OfflineService
 import com.lextures.android.features.courses.detailRows
 import com.lextures.android.features.courses.ItemKind
-import com.lextures.android.features.courses.MarkdownText
+import com.lextures.android.features.notebooks.NotebookContentView
 import com.lextures.android.features.reader.ImmersiveReaderPreferencesSheet
 import com.lextures.android.features.reader.ReaderToolbarOrLegacy
 import com.lextures.android.features.reader.rememberImmersiveReaderState
@@ -408,7 +408,7 @@ fun AssignmentDetailScreen(
                             onOpenPreferences = readerState.onShowPreferences,
                             ttsSpeed = readerState.store.row.ttsSpeed.toFloat(),
                         )
-                        MarkdownText(markdown)
+                        NotebookContentView(markdown = markdown)
                     }
                 }
             }

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/boards/BoardPostCard.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/boards/BoardPostCard.kt
@@ -66,7 +66,7 @@ import com.lextures.android.core.lms.BoardReactionMode
 import com.lextures.android.core.lms.BoardSection
 import com.lextures.android.core.lms.BoardsLogic
 import com.lextures.android.core.lms.WhiteboardRenderer
-import com.lextures.android.features.courses.MarkdownText
+import com.lextures.android.features.notebooks.NotebookContentView
 import com.lextures.android.features.home.LmsCard
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 
@@ -221,7 +221,7 @@ fun BoardPostCard(
         when (known) {
             BoardContentType.Text -> {
                 val plain = BoardsLogic.bodyPlainText(post)
-                if (plain.isNotBlank()) MarkdownText(plain)
+                if (plain.isNotBlank()) NotebookContentView(markdown = plain, compact = true)
             }
             BoardContentType.Image -> MediaBlock(
                 post = post,

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/CourseSections.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/CourseSections.kt
@@ -92,6 +92,7 @@ import com.lextures.android.features.home.LmsEmptyState
 import com.lextures.android.features.home.LmsErrorBanner
 import com.lextures.android.features.home.LmsProgressRing
 import com.lextures.android.features.home.LmsSkeletonList
+import com.lextures.android.features.notebooks.NotebookContentView
 import kotlinx.coroutines.launch
 
 // region Syllabus ("Overview")
@@ -140,7 +141,7 @@ fun CourseSyllabusSection(
                                 color = textPrimary(),
                             )
                         }
-                        MarkdownText(section.markdown)
+                        NotebookContentView(markdown = section.markdown)
                     }
                 }
                 LmsDates.parse(payload.updatedAt)?.let {

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/ItemDetailScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/ItemDetailScreen.kt
@@ -257,7 +257,7 @@ fun ItemDetailScreen(
                             onOpenPreferences = readerState.onShowPreferences,
                             ttsSpeed = readerState.store.row.ttsSpeed.toFloat(),
                         )
-                        MarkdownText(markdown)
+                        NotebookContentView(markdown = markdown)
                     }
                 }
             }
@@ -407,21 +407,6 @@ private fun lateLabel(policy: String, penalty: Int?): String = when (policy) {
 
 private fun titlecase(raw: String): String =
     raw.replace('_', ' ').replaceFirstChar { it.uppercase() }
-
-/**
- * CT.M1 shim: legacy call sites keep `MarkdownText(...)` while the rich engine
- * (`NotebookContentView`) renders tables/code/math/inline formatting.
- * `stripInline` is deleted — formatting is no longer stripped (FR-8).
- */
-@Composable
-fun MarkdownText(markdown: String, modifier: Modifier = Modifier) {
-    NotebookContentView(
-        markdown = markdown,
-        onToggleTask = {},
-        onEditTaskDue = {},
-        modifier = modifier,
-    )
-}
 
 /** Student view of their own submission status and released grade. */
 @Composable

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownCodeBlock.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownCodeBlock.kt
@@ -47,6 +47,7 @@ fun MarkdownCodeBlock(
     source: String,
     language: String?,
     modifier: Modifier = Modifier,
+    suppressCopy: Boolean = false,
 ) {
     val context = LocalContext.current
     var copied by remember { mutableStateOf(false) }
@@ -83,23 +84,25 @@ fun MarkdownCodeBlock(
                 color = textSecondary(),
                 modifier = Modifier.padding(start = 4.dp),
             )
-            TextButton(
-                onClick = {
-                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                    clipboard.setPrimaryClip(ClipData.newPlainText("code", source))
-                    copied = true
-                    Toast.makeText(
-                        context,
-                        context.getString(R.string.mobile_markdown_code_copied),
-                        Toast.LENGTH_SHORT,
-                    ).show()
-                },
-            ) {
-                Text(
-                    text = if (copied) L.text(R.string.mobile_markdown_code_copied) else L.text(R.string.mobile_markdown_code_copy),
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
+            if (MarkdownRenderStyle.allowsAffordances(suppressCopy)) {
+                TextButton(
+                    onClick = {
+                        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                        clipboard.setPrimaryClip(ClipData.newPlainText("code", source))
+                        copied = true
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.mobile_markdown_code_copied),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    },
+                ) {
+                    Text(
+                        text = if (copied) L.text(R.string.mobile_markdown_code_copied) else L.text(R.string.mobile_markdown_code_copy),
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
             }
         }
         Row(

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownRenderStyle.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownRenderStyle.kt
@@ -1,0 +1,32 @@
+package com.lextures.android.features.courses.markdown
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.lextures.android.core.accessibility.AccessibilitySupport
+
+/** Spacing and typography tokens for the shared markdown renderer (CT.M2 FR-11 / FR-13). */
+object MarkdownRenderStyle {
+    fun blockSpacing(compact: Boolean): Dp = if (compact) 6.dp else 12.dp
+
+    fun headingSize(level: Int, compact: Boolean): Int =
+        when {
+            compact && level == 1 -> 18
+            compact && level == 2 -> 16
+            compact -> 15
+            level == 1 -> 24
+            level == 2 -> 19
+            else -> 16
+        }
+
+    fun headingTopPadding(level: Int, compact: Boolean): Dp =
+        when {
+            compact && level == 1 -> 2.dp
+            compact -> 0.dp
+            level == 1 -> 6.dp
+            else -> 2.dp
+        }
+
+    fun allowsAffordances(suppressAffordances: Boolean): Boolean = !suppressAffordances
+
+    fun plainLabel(text: String): String = AccessibilitySupport.plainTextFromMarkdown(text)
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownTable.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/courses/markdown/MarkdownTable.kt
@@ -46,6 +46,7 @@ fun MarkdownTable(
     header: List<String>,
     rows: List<List<String>>,
     modifier: Modifier = Modifier,
+    suppressExpand: Boolean = false,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -53,16 +54,18 @@ fun MarkdownTable(
         Row(modifier = Modifier.horizontalScroll(rememberScrollState())) {
             TableGrid(align = align, header = header, rows = rows, minCellWidth = 96)
         }
-        TextButton(onClick = { expanded = true }) {
-            Text(
-                text = L.text(R.string.mobile_markdown_table_expand),
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-            )
+        if (MarkdownRenderStyle.allowsAffordances(suppressExpand)) {
+            TextButton(onClick = { expanded = true }) {
+                Text(
+                    text = L.text(R.string.mobile_markdown_table_expand),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
         }
     }
 
-    if (expanded) {
+    if (expanded && MarkdownRenderStyle.allowsAffordances(suppressExpand)) {
         Dialog(
             onDismissRequest = { expanded = false },
             properties = DialogProperties(usePlatformDefaultWidth = false),

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/discussions/DiscussionsScreens.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/discussions/DiscussionsScreens.kt
@@ -63,6 +63,7 @@ import com.lextures.android.features.home.LmsEmptyState
 import com.lextures.android.features.home.LmsErrorBanner
 import com.lextures.android.features.home.LmsSegmentedChips
 import com.lextures.android.features.home.LmsSkeletonList
+import com.lextures.android.features.notebooks.NotebookContentView
 import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encodeToString
@@ -371,7 +372,7 @@ fun DiscussionThreadScreen(
                                 onOpenPreferences = readerState.onShowPreferences,
                                 ttsSpeed = readerState.store.row.ttsSpeed.toFloat(),
                             )
-                            Text(detail.bodyPlainText, color = textPrimary())
+                            NotebookContentView(markdown = detail.bodyPlainText, compact = true)
                         }
                     }
                 }
@@ -411,7 +412,7 @@ fun DiscussionThreadScreen(
                                 onOpenPreferences = readerState.onShowPreferences,
                                 ttsSpeed = readerState.store.row.ttsSpeed.toFloat(),
                             )
-                            Text(post.bodyPlainText, color = textPrimary())
+                            NotebookContentView(markdown = post.bodyPlainText, compact = true)
                             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                                 TextButton(onClick = {
                                     scope.launch {

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/feed/FeedScreens.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/feed/FeedScreens.kt
@@ -66,6 +66,7 @@ import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsEmptyState
 import com.lextures.android.features.home.LmsErrorBanner
 import com.lextures.android.features.home.LmsSkeletonList
+import com.lextures.android.features.notebooks.NotebookContentView
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -523,7 +524,7 @@ private fun FeedMessageBubble(
                 )
             }
             if (text.isNotEmpty()) {
-                Text(text, color = textPrimary())
+                NotebookContentView(markdown = text, compact = true)
             }
             imagePath?.let { path -> FeedImage(path = path, accessToken = accessToken) }
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/grades/GradeFeedbackScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/grades/GradeFeedbackScreen.kt
@@ -61,6 +61,7 @@ import com.lextures.android.core.lms.SubmissionGrade
 import com.lextures.android.features.files.AnnotatedFilePreviewScreen
 import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsEmptyState
+import com.lextures.android.features.notebooks.NotebookContentView
 
 /** Full student feedback: rubric, comments, annotated file, a/v playback (M6.1). */
 @Composable
@@ -270,13 +271,13 @@ private fun RubricCriterionRow(criterion: RubricCriterion, score: Double?) {
             )
         }
         criterion.description?.takeIf { it.isNotBlank() }?.let {
-            Text(it, fontSize = 12.sp, color = textSecondary())
+            NotebookContentView(markdown = it, compact = true)
         }
         if (score != null) {
             matchedLevel(criterion, score)?.let { level ->
                 Text(level.label, fontSize = 12.sp, fontWeight = FontWeight.Medium)
                 level.description?.takeIf { it.isNotBlank() }?.let { note ->
-                    Text(note, fontSize = 12.sp, color = textSecondary())
+                    NotebookContentView(markdown = note, compact = true)
                 }
             }
         }
@@ -288,7 +289,7 @@ private fun FeedbackCommentCard(title: String, body: String) {
     LmsCard {
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             Text(title, style = LexturesType.display(16, FontWeight.Bold))
-            Text(body, fontSize = 14.sp)
+            NotebookContentView(markdown = body, compact = true)
         }
     }
 }
@@ -303,7 +304,7 @@ private fun CommentsSection(comments: List<GradeComment>) {
                     comment.displayName?.takeIf { it.isNotBlank() }?.let {
                         Text(it, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
                     }
-                    Text(comment.body, fontSize = 14.sp)
+                    NotebookContentView(markdown = comment.body, compact = true)
                 }
             }
         }

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookContentView.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookContentView.kt
@@ -64,6 +64,7 @@ import com.lextures.android.core.notebook.ParsedNotebookTask
 import com.lextures.android.core.routing.ContentLinkRouter
 import com.lextures.android.features.courses.markdown.MarkdownCodeBlock
 import com.lextures.android.features.courses.markdown.MarkdownMath
+import com.lextures.android.features.courses.markdown.MarkdownRenderStyle
 import com.lextures.android.features.courses.markdown.MarkdownTable
 import com.lextures.android.features.courses.markdown.MarkdownToolPlaceholder
 import com.lextures.android.features.reader.CaptionedPlayer
@@ -74,27 +75,35 @@ import java.time.Instant
 /**
  * Rendered reading view for a notebook page: headings, lists, quotes, code,
  * and interactive task checkboxes (parity with the web notebook editor output).
+ *
+ * CT.M2: single renderer for all reading surfaces. `compact` caps spacing/heading sizes;
+ * `suppressAffordances` hides copy/expand/link escapes during lockdown quizzes.
  */
 @Composable
 fun NotebookContentView(
     markdown: String,
-    onToggleTask: (ParsedNotebookTask) -> Unit,
-    onEditTaskDue: (ParsedNotebookTask) -> Unit,
+    onToggleTask: (ParsedNotebookTask) -> Unit = {},
+    onEditTaskDue: (ParsedNotebookTask) -> Unit = {},
     modifier: Modifier = Modifier,
     accessToken: String? = null,
     captionsEnabled: Boolean = false,
     onEditDrawing: ((index: Int, elementsJson: String) -> Unit)? = null,
+    compact: Boolean = false,
+    suppressAffordances: Boolean = false,
 ) {
     // Memoised once per markdown body (CT.M1 NFR).
     val blocks = remember(markdown) { NotebookMarkdown.parseBlocks(markdown) }
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(MarkdownRenderStyle.blockSpacing(compact)),
+    ) {
         blocks.forEach { block ->
             when (block) {
                 is NotebookBlock.Heading -> Text(
-                    text = inlineMarkdown(block.text),
-                    style = LexturesType.display(if (block.level == 1) 24 else if (block.level == 2) 19 else 16),
+                    text = inlineMarkdown(block.text, suppressLinks = suppressAffordances),
+                    style = LexturesType.display(MarkdownRenderStyle.headingSize(block.level, compact)),
                     color = textPrimary(),
-                    modifier = Modifier.padding(top = if (block.level == 1) 6.dp else 2.dp),
+                    modifier = Modifier.padding(top = MarkdownRenderStyle.headingTopPadding(block.level, compact)),
                 )
 
                 is NotebookBlock.Paragraph -> {
@@ -104,7 +113,7 @@ fun NotebookContentView(
                             CaptionedPlayer(url = videoUrl, accessToken = accessToken)
                         videoUrl != null && accessToken != null ->
                             ContentVideoPlayer(url = videoUrl, accessToken = accessToken)
-                        else -> MathAwareParagraph(text = block.text)
+                        else -> MathAwareParagraph(text = block.text, suppressLinks = suppressAffordances, compact = compact)
                     }
                 }
 
@@ -119,7 +128,7 @@ fun NotebookContentView(
                             .clip(CircleShape)
                             .background(accentColor()),
                     )
-                    MathAwareParagraph(text = block.text)
+                    MathAwareParagraph(text = block.text, suppressLinks = suppressAffordances, compact = compact)
                 }
 
                 is NotebookBlock.OrderedItem -> Row(
@@ -132,7 +141,7 @@ fun NotebookContentView(
                         fontWeight = FontWeight.SemiBold,
                         color = accentColor(),
                     )
-                    MathAwareParagraph(text = block.text)
+                    MathAwareParagraph(text = block.text, suppressLinks = suppressAffordances, compact = compact)
                 }
 
                 is NotebookBlock.TaskItem -> Row(
@@ -146,7 +155,7 @@ fun NotebookContentView(
                         modifier = Modifier.size(18.dp),
                     )
                     Text(
-                        text = inlineMarkdown(block.text),
+                        text = inlineMarkdown(block.text, suppressLinks = suppressAffordances),
                         fontSize = 14.sp,
                         color = if (block.checked) textSecondary() else textPrimary(),
                         textDecoration = if (block.checked) TextDecoration.LineThrough else TextDecoration.None,
@@ -165,14 +174,18 @@ fun NotebookContentView(
                             .background(LexturesColors.BrandAmber),
                     )
                     Text(
-                        text = inlineMarkdown(block.text),
+                        text = inlineMarkdown(block.text, suppressLinks = suppressAffordances),
                         fontSize = 14.sp,
                         fontStyle = FontStyle.Italic,
                         color = textSecondary(),
                     )
                 }
 
-                is NotebookBlock.Code -> MarkdownCodeBlock(source = block.text, language = block.language)
+                is NotebookBlock.Code -> MarkdownCodeBlock(
+                    source = block.text,
+                    language = block.language,
+                    suppressCopy = suppressAffordances,
+                )
 
                 is NotebookBlock.Math -> MarkdownMath(latex = block.latex, display = block.display)
 
@@ -180,6 +193,7 @@ fun NotebookContentView(
                     align = block.align,
                     header = block.header,
                     rows = block.rows,
+                    suppressExpand = suppressAffordances,
                 )
 
                 is NotebookBlock.ToolFence -> MarkdownToolPlaceholder(toolId = block.toolId)
@@ -214,24 +228,30 @@ fun NotebookContentView(
 }
 
 @Composable
-private fun MathAwareParagraph(text: String) {
+private fun MathAwareParagraph(
+    text: String,
+    suppressLinks: Boolean = false,
+    compact: Boolean = false,
+) {
     val segments = remember(text) { mathSegments(text) }
+    val lineHeight = if (compact) 18.sp else 21.sp
+    val gap = if (compact) 4.dp else 6.dp
     if (segments.size == 1 && segments[0] is MathSegment.Text) {
         Text(
-            text = inlineMarkdown((segments[0] as MathSegment.Text).value),
+            text = inlineMarkdown((segments[0] as MathSegment.Text).value, suppressLinks = suppressLinks),
             fontSize = 14.sp,
-            lineHeight = 21.sp,
+            lineHeight = lineHeight,
             color = textPrimary(),
         )
         return
     }
-    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(gap)) {
         segments.forEach { segment ->
             when (segment) {
                 is MathSegment.Text -> Text(
-                    text = inlineMarkdown(segment.value),
+                    text = inlineMarkdown(segment.value, suppressLinks = suppressLinks),
                     fontSize = 14.sp,
-                    lineHeight = 21.sp,
+                    lineHeight = lineHeight,
                     color = textPrimary(),
                 )
                 is MathSegment.Math -> MarkdownMath(latex = segment.latex, display = segment.display)
@@ -405,7 +425,7 @@ private fun isPastDue(dueAt: String): Boolean =
 private val linkRegex = Regex("""\[([^\]]+)]\(([^)]+)\)""")
 
 /** Inline markdown: **bold**, *italic*, ~~strike~~, `code`, [text](url). */
-fun inlineMarkdown(raw: String): AnnotatedString = buildAnnotatedString {
+fun inlineMarkdown(raw: String, suppressLinks: Boolean = false): AnnotatedString = buildAnnotatedString {
     var i = 0
     while (i < raw.length) {
         when {
@@ -458,20 +478,24 @@ fun inlineMarkdown(raw: String): AnnotatedString = buildAnnotatedString {
                 if (match != null && ContentLinkRouter.isAllowedHref(match.groupValues[2])) {
                     val label = match.groupValues[1]
                     val href = match.groupValues[2]
-                    val linkStyle = SpanStyle(
-                        color = LexturesColors.Primary,
-                        textDecoration = TextDecoration.Underline,
-                    )
-                    if (ContentLinkRouter.isExternalHref(href)) {
-                        withLink(LinkAnnotation.Url(href)) {
+                    if (suppressLinks) {
+                        append(label)
+                    } else {
+                        val linkStyle = SpanStyle(
+                            color = LexturesColors.Primary,
+                            textDecoration = TextDecoration.Underline,
+                        )
+                        if (ContentLinkRouter.isExternalHref(href)) {
+                            withLink(LinkAnnotation.Url(href)) {
+                                pushStyle(linkStyle)
+                                append(label)
+                                pop()
+                            }
+                        } else {
                             pushStyle(linkStyle)
                             append(label)
                             pop()
                         }
-                    } else {
-                        pushStyle(linkStyle)
-                        append(label)
-                        pop()
                     }
                     i = match.range.last + 1
                 } else {

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/portfolio/ArtifactDetailScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/portfolio/ArtifactDetailScreen.kt
@@ -35,7 +35,7 @@ import com.lextures.android.core.lms.FilePreviewTarget
 import com.lextures.android.core.lms.LmsApi
 import com.lextures.android.core.lms.PortfolioArtifact
 import com.lextures.android.core.lms.PortfolioLogic
-import com.lextures.android.features.courses.MarkdownText
+import com.lextures.android.features.notebooks.NotebookContentView
 import com.lextures.android.features.files.FilePreviewScreen
 import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsErrorBanner
@@ -161,7 +161,7 @@ fun ArtifactDetailScreen(
 
         if (PortfolioLogic.isContentPage(current) && current.textContent.isNotBlank()) {
             LmsCard {
-                MarkdownText(current.textContent)
+                NotebookContentView(markdown = current.textContent)
             }
         }
 

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/quiz/QuizIntroScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/quiz/QuizIntroScreen.kt
@@ -51,6 +51,7 @@ import com.lextures.android.core.offline.OfflineService
 import com.lextures.android.features.courses.RowHeader
 import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsErrorBanner
+import com.lextures.android.features.notebooks.NotebookContentView
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -148,7 +149,7 @@ fun QuizIntroScreen(
                 val markdown = detail?.markdown ?: quiz?.markdown
                 if (!markdown.isNullOrBlank()) {
                     LmsCard {
-                        Text(markdown)
+                        NotebookContentView(markdown = markdown)
                     }
                 }
                 val timeLimit = detail?.timeLimitMinutes ?: quiz?.timeLimitMinutes
@@ -520,6 +521,8 @@ fun QuizTakerScreen(
                                     accessToken = token,
                                 )
                             },
+                            suppressAffordances = serverLockdown ||
+                                QuizLogic.requiresDeviceLockdown(lockdownMode = start.lockdownMode),
                         )
                     }
                     Row(

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/quiz/QuizQuestion.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/quiz/QuizQuestion.kt
@@ -1,10 +1,12 @@
 package com.lextures.android.features.quiz
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -15,6 +17,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.lextures.android.core.design.AuthPrimaryButton
@@ -26,7 +32,10 @@ import com.lextures.android.core.lms.QuizQuestionKind
 import com.lextures.android.core.lms.QuizResultsResponse
 import com.lextures.android.core.lms.QuizSaveState
 import com.lextures.android.features.courses.RowHeader
+import com.lextures.android.features.courses.markdown.MarkdownRenderStyle
 import com.lextures.android.features.home.LmsCard
+import com.lextures.android.features.notebooks.NotebookContentView
+import com.lextures.android.features.notebooks.inlineMarkdown
 
 @Composable
 fun QuizQuestionContent(
@@ -36,10 +45,14 @@ fun QuizQuestionContent(
     onChange: (QuizAnswerState) -> Unit,
     codeRunContext: CodeQuestionRunContext? = null,
     modifier: Modifier = Modifier,
+    suppressAffordances: Boolean = false,
 ) {
     val kind = QuizQuestionKind.from(question.questionType)
     LmsCard(modifier = modifier.padding(vertical = 8.dp)) {
-        Text(question.prompt, fontWeight = FontWeight.Medium)
+        NotebookContentView(
+            markdown = question.prompt,
+            suppressAffordances = suppressAffordances,
+        )
         when (saveState) {
             QuizSaveState.Saved -> Text(quizSavedLabel())
             QuizSaveState.Failed -> Text(quizSaveFailedLabel(), color = LexturesColors.Coral)
@@ -52,16 +65,12 @@ fun QuizQuestionContent(
         } else when (kind) {
             QuizQuestionKind.MultipleChoice, QuizQuestionKind.TrueFalse -> {
                 QuizLogic.visibleChoices(question).forEachIndexed { index, choice ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        RadioButton(
-                            selected = answer.choice == index,
-                            onClick = { onChange(answer.copy(choice = index)) },
-                        )
-                        Text(choice)
-                    }
+                    QuizChoiceRow(
+                        label = choice,
+                        selected = answer.choice == index,
+                        suppressLinks = suppressAffordances,
+                        onClick = { onChange(answer.copy(choice = index)) },
+                    )
                 }
             }
             QuizQuestionKind.Numeric, QuizQuestionKind.Formula, QuizQuestionKind.ShortAnswer,
@@ -83,11 +92,20 @@ fun QuizQuestionContent(
                 }
                 items.forEachIndexed { index, item ->
                     Row(
-                        Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp)
+                            .heightIn(min = 48.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text("${index + 1}. $item")
+                        Text("${index + 1}.", fontWeight = FontWeight.SemiBold)
+                        Text(
+                            text = inlineMarkdown(item, suppressLinks = suppressAffordances),
+                            modifier = Modifier.semantics {
+                                contentDescription = MarkdownRenderStyle.plainLabel(item)
+                            },
+                        )
                     }
                 }
             }
@@ -103,24 +121,53 @@ fun QuizQuestionContent(
                 val pairs = QuizLogic.matchingPairs(question)
                 val rights = QuizLogic.sortedRightOptions(pairs)
                 pairs.forEach { pair ->
-                    Text(pair.left, fontWeight = FontWeight.Medium)
+                    Text(
+                        text = inlineMarkdown(pair.left, suppressLinks = suppressAffordances),
+                        fontWeight = FontWeight.Medium,
+                        modifier = Modifier.semantics {
+                            contentDescription = MarkdownRenderStyle.plainLabel(pair.left)
+                        },
+                    )
                     rights.forEach { right ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            RadioButton(
-                                selected = answer.matching?.get(pair.leftId) == right,
-                                onClick = {
-                                    val map = (answer.matching ?: emptyMap()).toMutableMap()
-                                    map[pair.leftId] = right
-                                    onChange(answer.copy(matching = map))
-                                },
-                            )
-                            Text(right)
-                        }
+                        QuizChoiceRow(
+                            label = right,
+                            selected = answer.matching?.get(pair.leftId) == right,
+                            suppressLinks = suppressAffordances,
+                            onClick = {
+                                val map = (answer.matching ?: emptyMap()).toMutableMap()
+                                map[pair.leftId] = right
+                                onChange(answer.copy(matching = map))
+                            },
+                        )
                     }
                 }
             }
             else -> Text(quizOpenOnWebLabel())
         }
+    }
+}
+
+@Composable
+private fun QuizChoiceRow(
+    label: String,
+    selected: Boolean,
+    suppressLinks: Boolean,
+    onClick: () -> Unit,
+) {
+    val plain = MarkdownRenderStyle.plainLabel(label)
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) {
+                role = Role.RadioButton
+                contentDescription = plain
+            },
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Text(text = inlineMarkdown(label, suppressLinks = suppressLinks))
     }
 }
 
@@ -150,7 +197,9 @@ fun QuizResultsScreen(
             results.questions.orEmpty().forEach { question ->
                 LmsCard {
                     Text(quizQuestionNumberLabel(question.questionIndex + 1))
-                    question.promptSnapshot?.let { Text(it) }
+                    question.promptSnapshot?.let {
+                        NotebookContentView(markdown = it, compact = true)
+                    }
                     question.pointsAwarded?.let {
                         Text("$it / ${question.maxPoints} pts")
                     }

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/review/ReviewSessionScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/review/ReviewSessionScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,9 +50,12 @@ import com.lextures.android.core.lms.SrsGrade
 import com.lextures.android.core.lms.SrsReviewSubmitBody
 import com.lextures.android.core.notebook.NotebookStore
 import com.lextures.android.core.offline.OfflineService
+import com.lextures.android.features.courses.markdown.MarkdownRenderStyle
 import com.lextures.android.features.home.HomeShellState
 import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsErrorBanner
+import com.lextures.android.features.notebooks.NotebookContentView
+import com.lextures.android.features.notebooks.inlineMarkdown
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -180,18 +185,33 @@ fun ReviewSessionScreen(
                             fontWeight = FontWeight.SemiBold,
                             color = textSecondary(),
                         )
-                        Text(item.stem, color = textPrimary())
+                        NotebookContentView(markdown = item.stem)
                         val quizQuestion = ReviewLogic.toQuizQuestion(item)
                         if (quizQuestion != null && !revealed) {
                             when (QuizQuestionKind.from(item.questionType)) {
                                 QuizQuestionKind.MultipleChoice, QuizQuestionKind.TrueFalse -> {
                                     QuizLogic.visibleChoices(quizQuestion).forEach { choice ->
-                                        Text("• $choice", color = textPrimary())
+                                        Text(
+                                            text = inlineMarkdown(choice),
+                                            color = textPrimary(),
+                                            modifier = Modifier.semantics {
+                                                contentDescription = MarkdownRenderStyle.plainLabel(choice)
+                                            },
+                                        )
                                     }
                                 }
                                 QuizQuestionKind.Ordering -> {
                                     QuizLogic.orderingItems(quizQuestion).forEachIndexed { index, label ->
-                                        Text("${index + 1}. $label", color = textPrimary())
+                                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                            Text("${index + 1}.", color = textPrimary())
+                                            Text(
+                                                text = inlineMarkdown(label),
+                                                color = textPrimary(),
+                                                modifier = Modifier.semantics {
+                                                    contentDescription = MarkdownRenderStyle.plainLabel(label)
+                                                },
+                                            )
+                                        }
                                     }
                                 }
                                 else -> Unit
@@ -215,7 +235,7 @@ fun ReviewSessionScreen(
                             )
                             Text(ReviewLogic.formatAnswerPreview(item.correctAnswer), color = textPrimary())
                             item.explanation?.takeIf { it.isNotBlank() }?.let {
-                                Text(it, fontSize = 12.sp, color = textSecondary())
+                                NotebookContentView(markdown = it, compact = true)
                             }
                         }
                     }

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/tutor/TutorChatScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/tutor/TutorChatScreen.kt
@@ -501,8 +501,7 @@ private fun TutorMessageBubble(message: TutorDisplayMessage) {
             } else {
                 NotebookContentView(
                     markdown = message.content,
-                    onToggleTask = {},
-                    onEditTaskDue = {},
+                    compact = true,
                 )
                 message.citations.forEach { citation ->
                     Text(

--- a/clients/android/app/src/test/kotlin/com/lextures/android/core/accessibility/AccessibilitySupportTest.kt
+++ b/clients/android/app/src/test/kotlin/com/lextures/android/core/accessibility/AccessibilitySupportTest.kt
@@ -22,6 +22,28 @@ class AccessibilitySupportTest {
     }
 
     @Test
+    fun plainTextFromMarkdown_linearisesTablesWithoutPipes() {
+        val plain = AccessibilitySupport.plainTextFromMarkdown(
+            """
+            | Week | Topic |
+            | --- | --- |
+            | 1 | Intro |
+            | 2 | Labs |
+            """.trimIndent(),
+        )
+        assertFalse(plain.contains("|"))
+        assertTrue(plain.contains("Week"))
+        assertTrue(plain.contains("Intro"))
+    }
+
+    @Test
+    fun plainTextFromMarkdown_speaksCodeWithoutFences() {
+        val plain = AccessibilitySupport.plainTextFromMarkdown("```python\nprint(1)\n```")
+        assertFalse(plain.contains("```"))
+        assertTrue(plain.contains("print(1)"))
+    }
+
+    @Test
     fun contrastRatio_meetsWcagAAForBrandText() {
         assertTrue(primaryTextContrastMeetsAA)
         val ratio = AccessibilitySupport.contrastRatio(

--- a/clients/android/app/src/test/kotlin/com/lextures/android/features/courses/markdown/MarkdownRenderStyleTest.kt
+++ b/clients/android/app/src/test/kotlin/com/lextures/android/features/courses/markdown/MarkdownRenderStyleTest.kt
@@ -1,0 +1,39 @@
+package com.lextures.android.features.courses.markdown
+
+import com.lextures.android.features.notebooks.inlineMarkdown
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownRenderStyleTest {
+    @Test
+    fun compactSpacingIsTighterThanDefault() {
+        assertTrue(MarkdownRenderStyle.blockSpacing(true) < MarkdownRenderStyle.blockSpacing(false))
+        assertTrue(MarkdownRenderStyle.headingSize(1, true) < MarkdownRenderStyle.headingSize(1, false))
+    }
+
+    @Test
+    fun lockdownSuppressesAffordances() {
+        assertTrue(MarkdownRenderStyle.allowsAffordances(false))
+        assertFalse(MarkdownRenderStyle.allowsAffordances(true))
+    }
+
+    @Test
+    fun inlineMarkdownKeepsFormattingAndCanSuppressLinks() {
+        val withLink = inlineMarkdown("See [docs](https://example.com) and **bold**")
+        assertTrue(withLink.text.contains("docs"))
+        assertTrue(withLink.text.contains("bold"))
+
+        val suppressed = inlineMarkdown("See [docs](https://example.com)", suppressLinks = true)
+        assertEquals("See docs", suppressed.text)
+    }
+
+    @Test
+    fun plainLabelMergesChoiceText() {
+        val label = MarkdownRenderStyle.plainLabel("Use `print()` and **bold**")
+        assertEquals("Use print() and bold", label)
+        assertFalse(label.contains("`"))
+        assertFalse(label.contains("**"))
+    }
+}

--- a/clients/ios/Lextures.xcodeproj/project.pbxproj
+++ b/clients/ios/Lextures.xcodeproj/project.pbxproj
@@ -7,1309 +7,1317 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6ED369A7EE154CDCBE032887 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC21ED0D16140FA8E128181 /* AppDelegate.swift */; };
-		15E1F90879A9406FBBBA92F6 /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB3CC07877B4410A1AA5030 /* LexturesApp.swift */; };
-		20454A04869B4B678FA6157E /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F09135218740BEA6B986E5 /* RootView.swift */; };
-		F4F1D79C0F53493EBAF31CCA /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2391332DEEEF49AB92138DD9 /* AccessibilityPreferences.swift */; };
-		A3D8BE5BBE4E4EC6922FB9AE /* AccessibilitySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D877139FEBC4481391B5DD95 /* AccessibilitySupport.swift */; };
-		DC933262AF1C4EE78BDDD135 /* DictationField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9F43CFA29B464B8321DE60 /* DictationField.swift */; };
-		6A559EEE76EA40B0B5E919D7 /* ReadAloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C08405046034F249A8E4203 /* ReadAloud.swift */; };
-		1F84B57453EC443DBD850C7C /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236584CA08EB4D21A75CB359 /* AuthAPI.swift */; };
-		625DE845245045A9B259C8F2 /* AuthCallbackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A6C2CF29B94FD8ACF73AA1 /* AuthCallbackParser.swift */; };
-		751CB6CA908C42AAA8A799EA /* AuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB15491376F47848D44B281 /* AuthConstants.swift */; };
-		9B9E21406160409F8D81FB5F /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7BD34CEB384CB3B4A718A6 /* AuthSession.swift */; };
-		6123B63B7BBD44C0B9A5EEF9 /* BiometricGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7552797A53BB4FCE9FE53E6D /* BiometricGate.swift */; };
-		AC0EE35E21034BB5BAAD78AC /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C1ED70666464594D7B357 /* KeychainStore.swift */; };
-		BE6ED0BBA1EB4014BEA5B85C /* SessionsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0B98E8DFAD4FD4870B4B32 /* SessionsAPI.swift */; };
-		41A7DB60D97B43A5ACCDA312 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCECD071C74C40B592761510 /* AppConfiguration.swift */; };
-		7C05A81CDD024AF5B53CF947 /* EnvironmentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706824795CA64D6CA900F6FD /* EnvironmentStore.swift */; };
-		DBA2446EE0D343D08044259A /* SchoolCodeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72B5AE8D40842608ED2A93B /* SchoolCodeLogic.swift */; };
-		30F64C0A143A46F59F00F5A1 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9E89A08F9048A498A3C2C9 /* AuthFieldRepresentable.swift */; };
-		45145825BFEA43AC83DDBDD5 /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E602BC87C274EB8BF6D2F82 /* BrandLogoView.swift */; };
-		D7AA30F9E7B44FBF9D2327B8 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A4411A8DB948DBBC52AB07 /* Haptics.swift */; };
-		62107BFEAA9B4D66973F2017 /* LexturesMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217B50509F7E4605A3AEA934 /* LexturesMotion.swift */; };
-		49400339D9134FFFA49CE52A /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C13D65F0331422587A7251A /* LexturesTheme.swift */; };
-		B22762E1FBD14F85A0D0C148 /* LexturesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39991ABDC8984C10936F533E /* LexturesType.swift */; };
-		5FAA6C38FD1C480DAEE2D729 /* ProfileAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788BE3FA0266441F8EE51DDA /* ProfileAvatarView.swift */; };
-		F3CDAC973F184CF48652D5D9 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118A196BFF72440985648417 /* SyncStatusView.swift */; };
-		38B668077E8B49F5ACB6FFE0 /* ThemePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F9FFA509F042BA997FB0AD /* ThemePreference.swift */; };
-		5A9724DB099341E79DA96A47 /* UIMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A831877A709428DACAE01AA /* UIMode.swift */; };
-		0E6CE5FAF63D463BAE988E9D /* UnsavedChangesBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31131F38DD8C4F71AB103C65 /* UnsavedChangesBanner.swift */; };
-		88CA2A3A7A47431DA028824C /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122671E8CAD442C99A656D34 /* DateFormatting.swift */; };
-		5286BF63D688419CB52D762D /* LocaleAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820F8FD64D9F4831BF993A8D /* LocaleAPI.swift */; };
-		AA7440F0963E49EABD664063 /* LocalePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CA37F7628145F8A5485536 /* LocalePreferences.swift */; };
-		5864916C8AA948DA91B23021 /* Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEABF3ECB7BD4EE28923328C /* Localized.swift */; };
-		A77698B1846F4D6E9EFA6BAC /* AccountAccommodationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876822D3381A4D0EB3AD2B13 /* AccountAccommodationModels.swift */; };
-		47C0179CEEAB4D6F999ECF72 /* AccountIntegrationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DC0271021341C49AEE4143 /* AccountIntegrationsLogic.swift */; };
-		DD92909F887D4008BD46B6FE /* AdvisingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E4F4CDA774754BBF2B46E /* AdvisingLogic.swift */; };
-		C81BC21475CA478EA4075B85 /* AiModelsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C94283167EE41B58D02C513 /* AiModelsAdminLogic.swift */; };
-		A6C6FCAC87AB4EE381972F02 /* AnnouncementLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26AB3D0F63B4B1484296E98 /* AnnouncementLogic.swift */; };
-		DD96F4097EF446199697B80D /* ArchivedCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9200E6719844BDFA2739BCD /* ArchivedCoursesAdminLogic.swift */; };
-		1A31F1D6D90C4955BD1F573A /* AssignmentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413FF3F2B574D8BA4A8641A /* AssignmentLogic.swift */; };
-		30E996A34E254F359D5524D5 /* AuditLogAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA16EC96F3B47B7BB83472D /* AuditLogAdminLogic.swift */; };
-		584C5965CF674DBABA550E10 /* BehaviorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8218A5DA074493A9E0C1A59 /* BehaviorLogic.swift */; };
-		80CC735067BD4E049A911122 /* BillingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE3BC019E0A410DA462E0C9 /* BillingLogic.swift */; };
-		D2DA16D6D49B4DD9BBC1742D /* BoardRealtimeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9483963ED37B434EAC4A7F8C /* BoardRealtimeLogic.swift */; };
-		F0BD139076674FDC9CBEB5EB /* BoardsAdvancedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1216ABCEF6C4A5092B7575B /* BoardsAdvancedLogic.swift */; };
-		EEC299626D5E41C8BE6863AA /* BoardsGovernanceAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425CCC3EE56D42899515B90B /* BoardsGovernanceAdminLogic.swift */; };
-		B1626F1EDB1940F6B09877D4 /* BoardsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654A68FBFF004593A6234FEA /* BoardsLogic.swift */; };
-		64577D94F29F41D69F3429FB /* CanvasImportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAD098C5D86467195AAEFB2 /* CanvasImportLogic.swift */; };
-		1F2F3185DD6743408FDD59E7 /* CanvasImportObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2BC38FEABA48CFBA00F250 /* CanvasImportObservability.swift */; };
-		AF97D393CA304376A3EBECFA /* CatalogLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1B4CAE70324A789B0B2A32 /* CatalogLogic.swift */; };
-		1CBD8E88A0E746268004C5A7 /* ConferenceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902B8828157D4900A862C29C /* ConferenceLogic.swift */; };
-		04B226DB102E4A8D8F8940D4 /* CourseAccessibilityReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30416340D9054E0B99CD6FC9 /* CourseAccessibilityReviewLogic.swift */; };
-		51951A19C75B49CFB079BAC2 /* CourseArchivedContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94EF43760CF14277B04B2E26 /* CourseArchivedContentLogic.swift */; };
-		2EE334A9DD8843D7B8FED259 /* CourseBlueprintLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F96BF5345940B29F034AE7 /* CourseBlueprintLogic.swift */; };
-		58251CFEB17E4330BC32050D /* CourseCreateDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82679475DB4F44808D9B2A80 /* CourseCreateDraftStore.swift */; };
-		E0BF1ACE45BE4777989D0FDC /* CourseCreateLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010D8A6487C848EA8815BE13 /* CourseCreateLogic.swift */; };
-		B25B4B8A5947421BBC083268 /* CourseCreateObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA41BD3596684A6B9A402E7E /* CourseCreateObservability.swift */; };
-		79F9D65C98C945F28936F111 /* CourseFeaturesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECCB1A1680B415D932DA179 /* CourseFeaturesLogic.swift */; };
-		9832E919FE9E433DB05F6712 /* CourseFileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F1D7AAFF3346ECAB215A9A /* CourseFileLogic.swift */; };
-		851C32BA90434973909B7C7C /* CourseGradingAgentsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA328ED019264948840DC527 /* CourseGradingAgentsLogic.swift */; };
-		2C7F8DB9A7C74FC09536B274 /* CourseGradingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D4CE8302454BA09CB5BC24 /* CourseGradingLogic.swift */; };
-		17B40FA2B7084F90BA44AA56 /* CourseHeroImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E508006F4842A58668DB57 /* CourseHeroImage.swift */; };
-		1BCCDB4F8B184F498D1BA398 /* CourseImportExportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC62A6B2B27441E5B7915806 /* CourseImportExportLogic.swift */; };
-		B6AC338EF20A481080AAEC66 /* CourseOutcomesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8EA99BDF0A4AF6ACD0C05B /* CourseOutcomesLogic.swift */; };
-		044E734121B04AD4AF133F21 /* CoursePeopleLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B286388C9EC40C887371ED5 /* CoursePeopleLogic.swift */; };
-		E0034CBC4A4A44AA9ACA8F84 /* CoursePeopleObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89062806BF744D468AA7DFD1 /* CoursePeopleObservability.swift */; };
-		5604F5CF805A4EACA96AD8E6 /* CoursePlagiarismLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8877458D0E44F6DB649AF12 /* CoursePlagiarismLogic.swift */; };
-		964A3784221D48699021420C /* CourseReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E7C1D0E02D41ADBF4D5464 /* CourseReviewLogic.swift */; };
-		34AE4236646B4DFA92E7EE27 /* CourseSectionsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA37BA46DFF4A6392FE691F /* CourseSectionsLogic.swift */; };
-		57A71865D4EE48F7946F95E9 /* CourseSettingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4323122721FF43A98CBA77DD /* CourseSettingsLogic.swift */; };
-		56A36D1DABC144AE8BA8EDC2 /* CourseTranslationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39DD7B13CC04A99B5EEF892 /* CourseTranslationsLogic.swift */; };
-		D13E48A8AE0A44568B32D385 /* CredentialsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3388A3D4894C97907F21A6 /* CredentialsLogic.swift */; };
-		31449678DAE74DD994F3444C /* CurrencyExponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19865D60BF49490CA83E3FC8 /* CurrencyExponent.swift */; };
-		98F5A359170E43508EBC1010 /* DiscussionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821E07F7B3BD4516933FD25F /* DiscussionLogic.swift */; };
-		5B293A532CB94B5C8CAC371D /* EvaluationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5F20597F4246188C41BC16 /* EvaluationLogic.swift */; };
-		D7E0841ECCFC4A3395EC04C0 /* FeedbackLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802E14FA9C1E486E8320D4C9 /* FeedbackLogic.swift */; };
-		7F239EB29E674FEF9874B4A7 /* FileDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB1D45B7CFF4C63AE669D1A /* FileDownloadManager.swift */; };
-		AFF61B9106234F7D83EBC362 /* GamificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88B6AF6F97C420CA3528020 /* GamificationLogic.swift */; };
-		4091BD957DE54482B0A0C8C4 /* GradeCalculator+MyGrades.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4EAB0E8322489395633B7F /* GradeCalculator+MyGrades.swift */; };
-		A408256D4D144E1B95481536 /* GradeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3A0A78C0E24855A2FC15B9 /* GradeCalculator.swift */; };
-		B7EF464315D54771870EB1A1 /* GroupsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3D19836EB74186A1414C77 /* GroupsLogic.swift */; };
-		0369207C3D5E44EBA0BEB2C4 /* InsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21D78D26D264655AB76C425 /* InsightsLogic.swift */; };
-		002905AB12F64D788195ADD0 /* InstructorInsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A150CD947F4E56BFF48EAD /* InstructorInsightsLogic.swift */; };
-		FB2CC0967E66475D95256EBA /* IntegrationsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C016EA4D3A0B472CB5D1125D /* IntegrationsAdminLogic.swift */; };
-		B8320F5DF6B9400F8A47EE47 /* InteractiveLaunchLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A43C87E3984E9097D25841 /* InteractiveLaunchLogic.swift */; };
-		75511354CC734D89A7A9C046 /* IntroCourseLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919E594A7B8D4B6F98B0B1F7 /* IntroCourseLogic.swift */; };
-		9FE504583E704A828E3CBBDC /* IntroCourseObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6542DA2E77D24963B76CF7C2 /* IntroCourseObservability.swift */; };
-		DD52F82C382945D2988DB8E3 /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966CD203A95F4B3B819D5965 /* LMSAPI.swift */; };
-		FC08960D992547B69F6FB9EA /* LMSAPIAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CDA1E5F1194D00ACE24EB7 /* LMSAPIAccountIntegrations.swift */; };
-		2A82B52122014896A389E3CB /* LMSAPIAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97217C9DC56846FA9D63293B /* LMSAPIAdmin.swift */; };
-		D5EA0BE7DFD747188BC89A0D /* LMSAPIAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56A544993F04A8CBB03CEDD /* LMSAPIAdvising.swift */; };
-		FCA20985E69A47AB8768D75D /* LMSAPIAnnouncements.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150DCF9F7224315B7B30C60 /* LMSAPIAnnouncements.swift */; };
-		CD3E2665C37C4A2CBEB05C30 /* LMSAPIAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9127F532CB4C378571046A /* LMSAPIAuditLog.swift */; };
-		5FB0E4CE699F408D908CD65B /* LMSAPIBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B851C9FA0E4125AC76F48A /* LMSAPIBehavior.swift */; };
-		DE38858E481D4A97B0078961 /* LMSAPIBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A904A5B0DB4B3098645E2A /* LMSAPIBilling.swift */; };
-		9E8BDF3EE56A4D038A7EC6CA /* LMSAPIBoardAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994BBFFE141A485DA43BC060 /* LMSAPIBoardAccess.swift */; };
-		77BE2015AE5E4F1EADDE9A8B /* LMSAPIBoardAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71BA7EC2E36488D9549FC98 /* LMSAPIBoardAnalytics.swift */; };
-		BD3D62016549414B9854CC64 /* LMSAPIBoardEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801E18789F664D0DA7B9F036 /* LMSAPIBoardEngagement.swift */; };
-		9DFF1DA4BB314351964D9086 /* LMSAPIBoardExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A55EC392CA1443EB6FD698D /* LMSAPIBoardExport.swift */; };
-		2BE5A0593D3A48EBB96A507C /* LMSAPIBoardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF09D800BBA244ADB1F89793 /* LMSAPIBoardLayout.swift */; };
-		D47A6CCBA23D418F9A53E695 /* LMSAPIBoardModeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C464E7B7706B46A6A1EC6B2F /* LMSAPIBoardModeration.swift */; };
-		163081DACD874AFC9CEBB4CB /* LMSAPIBoardPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86242101E8CC4D4D9DB48D1E /* LMSAPIBoardPosts.swift */; };
-		3F3F700D8EBD494F860E258F /* LMSAPIBoardTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02AE223E87C46CA849E4F4A /* LMSAPIBoardTemplates.swift */; };
-		3CAF4BC52EE14E59AA9AA375 /* LMSAPIBoards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9B571E7F1E4C1D8B0B8EB3 /* LMSAPIBoards.swift */; };
-		1EC0B2C122144589AD10A89D /* LMSAPICanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8955E4A2CB0471DB37AB7E1 /* LMSAPICanvasImport.swift */; };
-		AAF254745FA145C4978E8767 /* LMSAPICatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A728634557104CC48E4FA9FA /* LMSAPICatalog.swift */; };
-		1074AE412E3D45479E3FC24B /* LMSAPICourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3060A84315140D48D885600 /* LMSAPICourseAccessibility.swift */; };
-		B402E25ADDA4412DA067751D /* LMSAPICourseArchivedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB86D9F3B774232B8B64374 /* LMSAPICourseArchivedContent.swift */; };
-		05224A5A9E0D4046809E2B0D /* LMSAPICourseBlueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7649122040475593E51536 /* LMSAPICourseBlueprint.swift */; };
-		1357C78D319D4F308D52A8F8 /* LMSAPICourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F838E38FD3314A86A61313B3 /* LMSAPICourseCreate.swift */; };
-		BC762DECD0C844329C7F10F9 /* LMSAPICourseFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02159D88D4604E099DC45F01 /* LMSAPICourseFeatures.swift */; };
-		67538CE802674998AE77B463 /* LMSAPICourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C84ED01FAFE4F6A866A68EF /* LMSAPICourseGrading.swift */; };
-		A2BF109AE8C949C6937E69CD /* LMSAPICourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38FAB25C7DD43B284D8EFCD /* LMSAPICourseGradingAgents.swift */; };
-		8B8F3F12483D438983936BB7 /* LMSAPICourseImportExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD72034B7394CDDB3C71596 /* LMSAPICourseImportExport.swift */; };
-		4E904AB3021B4420B0C06A3B /* LMSAPICoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B5DBDBE0EA4FD6811B8A9C /* LMSAPICoursePlagiarism.swift */; };
-		48823DAE80D24C32B3F4873D /* LMSAPICourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5ECA1E769A42E8AB9D07AC /* LMSAPICourseReviews.swift */; };
-		B2295608748A41B7AC205BCC /* LMSAPICourseSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668A5BEF50304DEEB227C929 /* LMSAPICourseSections.swift */; };
-		70BE875893DA41728EF11CF0 /* LMSAPICourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF1717F955345CEB67D4387 /* LMSAPICourseSettings.swift */; };
-		574940E35AB04C66B966557F /* LMSAPICourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E5D70AB65A4BD0842B8517 /* LMSAPICourseTranslations.swift */; };
-		031BF94EDA8941B58ED65CFB /* LMSAPICredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A29CB1E340146B2AB9FC2E4 /* LMSAPICredentials.swift */; };
-		80612637EAEF448CA0384CBC /* LMSAPIDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068520BD32F0465EBD006759 /* LMSAPIDiscussions.swift */; };
-		B6494DA38A7547888D36551B /* LMSAPIEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3131373FEB59466C8AB0AC7C /* LMSAPIEportfolio.swift */; };
-		9B69CCFEB0034CFEA7F815A6 /* LMSAPIEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306DA47EB9F146349ADE21A8 /* LMSAPIEvaluations.swift */; };
-		5D61EF685351448BA9E2CEE8 /* LMSAPIFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5CE9C20A164A57A2912047 /* LMSAPIFeatures.swift */; };
-		E9B249DC0717464180E51A62 /* LMSAPIFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2D7AF6A7E74E419C4E3E6D /* LMSAPIFeed.swift */; };
-		0CDB3FDC6C064673A5C9FADC /* LMSAPIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D110AD56244378A93E0E15 /* LMSAPIFeedback.swift */; };
-		59E4A13C071A48CAAE16D8E1 /* LMSAPIGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894E2AD904124DDDB1BD3CBF /* LMSAPIGamification.swift */; };
-		0F52C3C798F4427B81D6C8A6 /* LMSAPIGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF12B79BA4A4F999CA668DF /* LMSAPIGroups.swift */; };
-		E5C077722D6940F78A4293E7 /* LMSAPIInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA3D5D9FD24A8B9B2EFDDF /* LMSAPIInsights.swift */; };
-		7DD3C39B0D0D4D5CAB137BFE /* LMSAPIInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BDAE0779984913A3A462B8 /* LMSAPIInstructorInsights.swift */; };
-		99DB368B3BC14B77AED0EA42 /* LMSAPIIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A92F7A21E3452886DEB48E /* LMSAPIIntroCourse.swift */; };
-		983CDB5358764FD6989EE994 /* LMSAPILearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4A56A3B3B84A10991DAF47 /* LMSAPILearnerProfile.swift */; };
-		1F65E5A34F584D36BC87EF70 /* LMSAPILiveQuiz.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDD6A07DA3446248362F3D7 /* LMSAPILiveQuiz.swift */; };
-		6D88B5874E204CF3A2E31F39 /* LMSAPIMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4288167DEBBD4889AE882767 /* LMSAPIMarketplace.swift */; };
-		D6CC17B5DA7540AFB7D53BBD /* LMSAPIMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FE81C12C6F499187483CE8 /* LMSAPIMastery.swift */; };
-		25BED0BFCE244FDDB113467B /* LMSAPIMobileWave.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD07E78BFB04381B3637B0E /* LMSAPIMobileWave.swift */; };
-		0107441311A1498BA49C74AD /* LMSAPIOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C746D09F7AED46FC9EFF8F3A /* LMSAPIOutcomes.swift */; };
-		8A9259E216124941B7AAA60B /* LMSAPIParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813EBA9635704CB7AA3ED889 /* LMSAPIParent.swift */; };
-		B89E19B30F1A4B31A8FF9534 /* LMSAPIPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9675FBC57BC64C3F9111FD59 /* LMSAPIPaths.swift */; };
-		B9641A3904A14311B0ACECCD /* LMSAPIPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33223C7241234E22923DE250 /* LMSAPIPeerReview.swift */; };
-		F80F0668233D435AA9111D91 /* LMSAPIProctoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F5E609206F4CC4A2CF95E1 /* LMSAPIProctoring.swift */; };
-		4E0F55A6CE1947508C936550 /* LMSAPIQuizCodeRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FE06D846ED40A58DCE2230 /* LMSAPIQuizCodeRun.swift */; };
-		F658066BAB224F77B2EE617C /* LMSAPIReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8906D74CFF4701B255EAF4 /* LMSAPIReader.swift */; };
-		07D34EE7807A46B59DEBC009 /* LMSAPIReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A0B299B0D94ADC97F88528 /* LMSAPIReading.swift */; };
-		F4F7980EFE93464DA5512090 /* LMSAPIReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B8FDE10B9B4CEC8A5C6F5E /* LMSAPIReview.swift */; };
-		4FC4D8989506445D8A22D96B /* LMSAPITutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86ED0FB8585D46868F83CB1F /* LMSAPITutor.swift */; };
-		07E475945B75494B86C0EDD3 /* LMSAPIWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207E7D9985164CD29E02D922 /* LMSAPIWallet.swift */; };
-		6BFE443C16D44678883081EF /* LMSAPIWhiteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D9DD802E174B83AE982827 /* LMSAPIWhiteboard.swift */; };
-		4D015EF64B97490DAB901F99 /* LMSBoardAdvancedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F968115560419084BFD1DA /* LMSBoardAdvancedModels.swift */; };
-		73A688D46E3E48FCA0EE3FBD /* LMSBoardModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904B49C91AD649B8ACE9FF53 /* LMSBoardModels.swift */; };
-		57B5A846FD164DA1854CD044 /* LMSFeatureModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F30BB03583A40CBACF8BAC7 /* LMSFeatureModels.swift */; };
-		955A8DFB29674447B8015D2A /* LMSFeatureModelsAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5AFDFFD4954154AA08B6F0 /* LMSFeatureModelsAccountIntegrations.swift */; };
-		EC4CFF3700DC422A8E2DFFD7 /* LMSFeatureModelsAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80B84481BE743C8815CE2A1 /* LMSFeatureModelsAdvising.swift */; };
-		13161AA1ADBC4A6685BE7F95 /* LMSFeatureModelsAiAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EEC8D940813443B82EF99FB /* LMSFeatureModelsAiAdmin.swift */; };
-		6975DE522A664A1EB37B7F4C /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A3ACCAF55B4CB3BC634A50 /* LMSFeatureModelsArchivedCoursesAdmin.swift */; };
-		BEA8298EE5BE471F8CF2C10B /* LMSFeatureModelsAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE63E84856084D178F811FA9 /* LMSFeatureModelsAuditLog.swift */; };
-		B8AAEFE9A7EF494AA858B3C7 /* LMSFeatureModelsBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C177FF51E7499F98FEB135 /* LMSFeatureModelsBehavior.swift */; };
-		18B2F850A925428E8F668D01 /* LMSFeatureModelsBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8F213D1EFE4B02BE3EA0DC /* LMSFeatureModelsBilling.swift */; };
-		65B52B889BD547BC9A4643DC /* LMSFeatureModelsCanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189CE9ECC48A43A2934C6332 /* LMSFeatureModelsCanvasImport.swift */; };
-		E042CA4A3D2F4EC6A718B836 /* LMSFeatureModelsCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60FFEEF85CA49868E48854D /* LMSFeatureModelsCatalog.swift */; };
-		11725BAAC0164B4F934DDEEE /* LMSFeatureModelsCourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D140A0009994251829A8550 /* LMSFeatureModelsCourseAccessibility.swift */; };
-		D6C37562AEBD4CEA8739A1DE /* LMSFeatureModelsCourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8FE4612AF54B47AFEA77FC /* LMSFeatureModelsCourseCreate.swift */; };
-		930D5585356C42E6B1E714D3 /* LMSFeatureModelsCourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024FE8FC67C4411EA992E641 /* LMSFeatureModelsCourseGrading.swift */; };
-		625835250AA44CAB8BD357AF /* LMSFeatureModelsCourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2290E19122C4493AE1EBD28 /* LMSFeatureModelsCourseGradingAgents.swift */; };
-		C0681F597D194C86A516158D /* LMSFeatureModelsCourseOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55830F753A0046C981B6A5A6 /* LMSFeatureModelsCourseOutcomes.swift */; };
-		E33E8694BA8747CF9DA48BD7 /* LMSFeatureModelsCoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293E953D73FB46039E06FEA4 /* LMSFeatureModelsCoursePlagiarism.swift */; };
-		76595C5CC6AA4AD09A6DCD57 /* LMSFeatureModelsCourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB7B6D7573A436D9EE6C0BD /* LMSFeatureModelsCourseReviews.swift */; };
-		95816DE8A5154BAAB8FC9CFA /* LMSFeatureModelsCourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C78CFD171E4C50B5AC21BB /* LMSFeatureModelsCourseSettings.swift */; };
-		8E74170077DB4DE9808236D9 /* LMSFeatureModelsCourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6602EEA446149C0BF76FD4F /* LMSFeatureModelsCourseTranslations.swift */; };
-		8944F1C9147041929F16AB50 /* LMSFeatureModelsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215E096BEF9B47F68FB552A7 /* LMSFeatureModelsCredentials.swift */; };
-		B39FDDFD04C94707ABD777F0 /* LMSFeatureModelsDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448F3041DA3349A4B85A5849 /* LMSFeatureModelsDiscussions.swift */; };
-		9F23BC5B6D4740F1B1A95C87 /* LMSFeatureModelsEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F09DF8AF0BD45B195F3B93C /* LMSFeatureModelsEportfolio.swift */; };
-		D3D780D070DF42ACAA1FFF82 /* LMSFeatureModelsEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1655E9A8D3C4BF089B81C17 /* LMSFeatureModelsEvaluations.swift */; };
-		4DB2AB512BDB4A53AEE8BB95 /* LMSFeatureModelsFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7D2B5DFB6D4597B12EC5CC /* LMSFeatureModelsFeed.swift */; };
-		742C8A710730478F9387553E /* LMSFeatureModelsFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750096FF04F847F08FA588EE /* LMSFeatureModelsFeedback.swift */; };
-		29886400FBD04A58B95CC0B2 /* LMSFeatureModelsGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888D7AF98DAE4275B6026F44 /* LMSFeatureModelsGamification.swift */; };
-		8385C939AD84420C94FF12E3 /* LMSFeatureModelsGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DB93BEB74C4BDBA17AC808 /* LMSFeatureModelsGroups.swift */; };
-		FD948DD685444BF9BCF318B5 /* LMSFeatureModelsInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BD6CA3F08E413693067FCE /* LMSFeatureModelsInsights.swift */; };
-		6D88CE52C986453A8BF5B0C6 /* LMSFeatureModelsInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03308D4ECF2B43DB882A33FF /* LMSFeatureModelsInstructorInsights.swift */; };
-		093D43FBB19545D2AC4E75BD /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023909062EED4A2B9B375E4A /* LMSFeatureModelsIntegrationsAdmin.swift */; };
-		6894134B17314822902FFAF9 /* LMSFeatureModelsIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE321A529D7B4A4DA1F2EDB3 /* LMSFeatureModelsIntroCourse.swift */; };
-		179BA98C79DC4A5E95C34E79 /* LMSFeatureModelsLearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734204250DE94773B2699164 /* LMSFeatureModelsLearnerProfile.swift */; };
-		AA25A097B4D54E04ADEC2434 /* LMSFeatureModelsLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B548F6309447C3A3FBFF17 /* LMSFeatureModelsLive.swift */; };
-		0C741C7AE32844099FB1FBB5 /* LMSFeatureModelsMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD04098A231494CA3F09F78 /* LMSFeatureModelsMarketplace.swift */; };
-		0BB69957873C40A780B86B3F /* LMSFeatureModelsMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DDFFC0D69A491D9DA742FA /* LMSFeatureModelsMastery.swift */; };
-		4A098125BC2C473F9073B74E /* LMSFeatureModelsMobile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAE21F884C8447AA61BF858 /* LMSFeatureModelsMobile.swift */; };
-		494414593D924216A78D4AD8 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E0AB224456451DBA4E7994 /* LMSFeatureModelsOrgBrandingAdmin.swift */; };
-		34EE6AF8F3554C1CAC6172B3 /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C43119FFBC54D04B7C27FD9 /* LMSFeatureModelsOrgStructureAdmin.swift */; };
-		6ACCA3B209314501B5AA46CD /* LMSFeatureModelsParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550DB0C297164ED9880A4FD7 /* LMSFeatureModelsParent.swift */; };
-		FA454F66A1264FBEA9C2B06A /* LMSFeatureModelsPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4790175587647C88099ADD4 /* LMSFeatureModelsPaths.swift */; };
-		4610A27CBA494A13930F773F /* LMSFeatureModelsPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F3143CD283049999A70EE00 /* LMSFeatureModelsPeerReview.swift */; };
-		6DF84F2D562042BE961B6EDD /* LMSFeatureModelsPeopleAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B0D6B8EA2C4B84993EA288 /* LMSFeatureModelsPeopleAdmin.swift */; };
-		93D366EE1FF142819422301B /* LMSFeatureModelsPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CCABD2171944B38CFFE643 /* LMSFeatureModelsPlatform.swift */; };
-		29396971F24F4367A238A82D /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DD0143BF514EB898AEEFAD /* LMSFeatureModelsPlatformCoursesAdmin.swift */; };
-		9A52A294619B4BA18EC8E197 /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F009617AFF417CABF397AE /* LMSFeatureModelsPlatformSettingsAdmin.swift */; };
-		7029802B224848E9A126865B /* LMSFeatureModelsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4643CE61530B4FD8971104A2 /* LMSFeatureModelsReader.swift */; };
-		44F05A1005114E37884E5375 /* LMSFeatureModelsReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F39CB0482F4A64913BB349 /* LMSFeatureModelsReading.swift */; };
-		2C5D91394CC1432A9C1C7AEB /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E609EA910A5A463B99D7C222 /* LMSFeatureModelsRolesPermissionsAdmin.swift */; };
-		61D3278D97E84FC39DF35584 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9F3F51E5A245A1A459EF71 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */; };
-		F50DD76D2D8A4868B51A8C3E /* LMSFeatureModelsTutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E589186B3024558AE276C41 /* LMSFeatureModelsTutor.swift */; };
-		C6F366B4969647F4AEFCC95E /* LMSFeatureModelsWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB025E305E73486AB634D170 /* LMSFeatureModelsWallet.swift */; };
-		B718690ECB8C4105B00637EF /* LMSInteractiveModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3AEDE2A3A24B1FB83AD8CD /* LMSInteractiveModels.swift */; };
-		628623E4AE6B4DA19322109F /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C17447C206F491F86B62429 /* LMSModels.swift */; };
-		82B05DA5BBF04F6CA95B08A3 /* LearnerProfileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2DA8F783004A75B61C861E /* LearnerProfileLogic.swift */; };
-		5A300C2DE1AB4D8BAB2ABA39 /* LibraryResourceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B520F7E9737D4C78B5511ADA /* LibraryResourceLogic.swift */; };
-		9DBAA00087EE44908764E3A5 /* LiveGameLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37D57FE7FD94B599A7462C4 /* LiveGameLogic.swift */; };
-		D507791B8EAB4DC28817850A /* LiveMeetingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1968A81A18024476BACDA0C8 /* LiveMeetingsLogic.swift */; };
-		A3584F94A1494D57BCCBD4CF /* LiveQuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2A21241F6A48D79A316B25 /* LiveQuizLogic.swift */; };
-		D7807865C9EA4116A413AE18 /* MarketplaceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B6B3C5A0A44CF0BE0695FC /* MarketplaceLogic.swift */; };
-		AD5D29047CA546C58B133BCC /* MasteryLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D94CAC8ADF4E77ADBCE34B /* MasteryLogic.swift */; };
-		3CD94916407742879D20E044 /* ModuleContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76986149DC3348B4AB702714 /* ModuleContentLogic.swift */; };
-		5D01EB754B7645A6A12F9E6A /* ModuleLastVisited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11775417D81E4E9BAE6C9E95 /* ModuleLastVisited.swift */; };
-		345219F117C0489D85F68966 /* NotificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EA30C7BA6041EF97247A7D /* NotificationLogic.swift */; };
-		C02086BBF39A4D788E013067 /* OfficeHoursLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6855BB77F7A14D1EB6FC6F9B /* OfficeHoursLogic.swift */; };
-		597F6B4BE5874F68868530FA /* OnboardingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F81340A6FCF4880BBBA4791 /* OnboardingModels.swift */; };
-		D73F09E1288A4DDF9D908386 /* OrgBrandingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86594C5CEF924F1DB75AEC45 /* OrgBrandingAdminLogic.swift */; };
-		0BB946A1AB534B6085F62EED /* OrgStructureAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF8F46759714555BDFE85ED /* OrgStructureAdminLogic.swift */; };
-		53E1827781ED439DAE9BF12A /* ParentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E007BE645CB04728BEFB4B4B /* ParentLogic.swift */; };
-		EFD3A6E385E44BF5977B429F /* PathsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07AEF18A77544789FA89FEA /* PathsLogic.swift */; };
-		E4CE1F7DE7F544EB823E2729 /* PeerReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFB99E8194E4D8D91176740 /* PeerReviewLogic.swift */; };
-		BE55CC8650BC46489079B9B4 /* PeopleAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26155397F5234AE695039840 /* PeopleAdminLogic.swift */; };
-		D7784F2CEA6F4CBC924DA81D /* PlannerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25AC1FC6EA5428E8B72D682 /* PlannerLogic.swift */; };
-		5D1D2935B55E48899286F045 /* PlannerSnapshotCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5790510331EE4827B84DE958 /* PlannerSnapshotCoding.swift */; };
-		7C17718ECC9E4DE98F4CF7E1 /* PlatformCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D87AB33B084FB29D7A6D57 /* PlatformCoursesAdminLogic.swift */; };
-		12A7174B46624AB19D10DEA1 /* PlatformSettingsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F21F0185187479A99043D89 /* PlatformSettingsAdminLogic.swift */; };
-		6E4BFD606DEF461492C0CC34 /* PortfolioLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56248BCF827943AC98A609E6 /* PortfolioLogic.swift */; };
-		A9348C0F85494A02A4D7CE38 /* ProfileDepthLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7979B9805F94AC3BA42C0A2 /* ProfileDepthLogic.swift */; };
-		31B51BA5175E4674B9955071 /* ProfileDepthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182B9799F5841BDA349CFB7 /* ProfileDepthModels.swift */; };
-		6F6A3A5298B6448F8C99A3E7 /* QuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9C4896A7134E4EBBB34EB7 /* QuizLogic.swift */; };
-		3D4B2B612A2C4206A769AACC /* ReadingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C014105AAF843E483AA944A /* ReadingLogic.swift */; };
-		FF885585D39642C0B45C160C /* RequirementsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F385DEC274498C97903AA4 /* RequirementsLogic.swift */; };
-		F9C7058850944E8F95807196 /* ReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92202601E40437985EDDDBD /* ReviewModels.swift */; };
-		D1EE55FB461F463DAB742BBC /* RolesPermissionsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1B974B7FBA4A0B829A0604 /* RolesPermissionsAdminLogic.swift */; };
-		A1FBE83DFE4149CEB92B8765 /* SettingsMenuLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B5ECA2A97A41E096C017B9 /* SettingsMenuLogic.swift */; };
-		B2E07FFB481C4A5BBE6EF8E0 /* TakeAttendanceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A6BA560C44113A46D4988 /* TakeAttendanceLogic.swift */; };
-		C7567ACBBD6F4EECACCE2E4E /* TranscriptsAdvisingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922C235D780B473CBC59D7F5 /* TranscriptsAdvisingAdminLogic.swift */; };
-		232E17A4D7494AE1B6B77E79 /* TutorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89473B285B5E49A0A79308DC /* TutorLogic.swift */; };
-		C044F6B123904CB2A77EB75A /* TutorStreamClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2751D8B98E43CD9F62F7AD /* TutorStreamClient.swift */; };
-		36B0A7F4F4B44BC2A74438AA /* VibeActivityLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25FA4F8614F4D7D9EEED7D3 /* VibeActivityLogic.swift */; };
-		F27F3356FE4F482D8BDBE836 /* WalletLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C019B8498C499AAE46FEF3 /* WalletLogic.swift */; };
-		768E9C7C01454C198C99336C /* WhiteboardLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A531E690F2CE4FEB86896985 /* WhiteboardLogic.swift */; };
-		A066A4DDEEE34F5495CD715F /* WhiteboardRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2B972D59944A22A14CD382 /* WhiteboardRenderer.swift */; };
-		81164CE867B049079A45A29D /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9539914B91EA4AC0A10CD744 /* APIClient.swift */; };
-		FF6ADB7EFBA647D89ACCDB96 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C60DD35D434947B391DCCB /* APIError.swift */; };
-		18883053C2CF44569CD0FF76 /* NetworkAuthContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F886051A547F6B9915B17 /* NetworkAuthContext.swift */; };
-		648C39D5C7FE43B8B1F16146 /* NetworkBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034243060A9D460D8829F84B /* NetworkBootstrap.swift */; };
-		10385B466EC84FDBA0825283 /* MarkdownTableLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D674B0C9ED146939FC329F3 /* MarkdownTableLogic.swift */; };
-		EC8703EC21534F22B998CF6D /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83042AE2827442483E3E27C /* NotebookDrawing.swift */; };
-		ACEE34B68C1745D38686B7EC /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB326385E92C4DA1B823A4F4 /* NotebookMarkdown.swift */; };
-		508C1E9687124A349438D5EE /* NotebookSlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0190BC6FDADE41CCB994CF1F /* NotebookSlashCommands.swift */; };
-		B4D601C0AC7741FAB409722A /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD6D10890F84565933F42DB /* NotebookStore.swift */; };
-		98EF53753BB04B84A456942D /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC8BA6757C24485B7248CA1 /* NotebookSync.swift */; };
-		3172F3227AF54990B74FB813 /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6CC2ED061F4414B31ABB71 /* NotebookTree.swift */; };
-		681E8B1C40D540969DF80B6F /* CacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D48D6ED18E84162ADDD9DFD /* CacheStore.swift */; };
-		E71CF5810718438B94805D18 /* DownloadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08584DB395634C77BC5D895C /* DownloadStore.swift */; };
-		5954DCD025F74B1DAB907502 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CF0C8E08904DE4BA967198 /* NetworkMonitor.swift */; };
-		64342B0D4ADB4EA7913D491D /* OfflineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1594BFF9A242A9A66BDC90 /* OfflineModels.swift */; };
-		6CE5D9B0001044E7A96C0C1C /* OfflineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5662A6252F164C63B7CDBA00 /* OfflineService.swift */; };
-		DE91392DAAF24F848649990B /* OutboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748936187DFB496C964B1168 /* OutboxStore.swift */; };
-		167A204A3A04495A94282ECB /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01174D0301DC49278345703C /* SyncEngine.swift */; };
-		D77CDD1A60F04BDA84A8AC2A /* PushManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2AD54DF35243D08D0884D7 /* PushManager.swift */; };
-		65C54D08FE8A45C7BB5AFF62 /* RealtimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F8C9E8AEC94C8CB4048E6F /* RealtimeManager.swift */; };
-		BADCC8AA27914AD39AD39E8D /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF143DA58EC349B88DE918D5 /* WebSocketClient.swift */; };
-		CF4AB5B897894BD1BE2F2648 /* ContentLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1E5E66145E42A1971D08A6 /* ContentLinkRouter.swift */; };
-		7BE976C048F842CE82F153A5 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD1758A01574A04BD37420F /* DeepLinkRouter.swift */; };
-		567EA4491007481BA5DF9EEE /* MobileDestinations.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3755F559B9448F87A2512D /* MobileDestinations.swift */; };
-		1ED73BFD03AD49F7966024C1 /* MobileIaPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CF4329D62D43529C92A419 /* MobileIaPreferences.swift */; };
-		D492EBF9575B43CCB7D00891 /* MobileProfileDepthPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129D441D1F9D47469C14936A /* MobileProfileDepthPreferences.swift */; };
-		583F78BCFE074771AFB8CA3A /* SearchActionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AB82BC37F649188244C769 /* SearchActionRegistry.swift */; };
-		406EC6322EBB4CA38E0EF6A1 /* SearchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB95D2CEDEF34154B27C0629 /* SearchModels.swift */; };
-		74B0E82EE4094B42B32DEB3A /* SearchPathNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10471B9CC0341E191FCC111 /* SearchPathNavigator.swift */; };
-		4BC8D3E45C984AEF8E9EA992 /* SearchRecentsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C50C881A26455F812729AB /* SearchRecentsStore.swift */; };
-		25C1DAC6628B40E4B7BB1764 /* CodeEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3EC0B819B54DD1A3035E15 /* CodeEditor.swift */; };
-		4F3D564DFDAA45D485DC08BC /* AdvisingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20692C98F7CF4C5E9E630940 /* AdvisingView.swift */; };
-		2B5AC6605D1C41C197E6144E /* AssignmentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E0B6EB1F464ADEABF0BBEE /* AssignmentDetailView.swift */; };
-		44288896B6304DC8833C55B1 /* AssignmentDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB370489A524C4494940128 /* AssignmentDraftStore.swift */; };
-		0C506D3676A448019F3501F8 /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0253694A82134E3AAEB30D97 /* AttachmentUploader.swift */; };
-		9E093827852844E099424DD5 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969DA09CDDFD40049CE615D0 /* AppleSignInController.swift */; };
-		E71DA52069B94A41A248DC44 /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9B1359A4404825AE15F3A3 /* AuthFlowView.swift */; };
-		3A41AC17DEE546AE8292162B /* GetStartedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42150EF643F4D7D9FFFFAE0 /* GetStartedView.swift */; };
-		9B69C172AE4C4CBB98B3D3AA /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10532DC1D669434B82A731A2 /* LoginView.swift */; };
-		0DDB95AAB94640099A401E97 /* MFAChallengeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FE0D2585394BF187ECA1B7 /* MFAChallengeView.swift */; };
-		7D119A5127964CCD8B9A239D /* MfaPasskeyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D04881B017D42D59271A7FF /* MfaPasskeyController.swift */; };
-		22DDAE6A06A24FDAAFE0A0D3 /* SSOAuthController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F813600B54249D3B9938C60 /* SSOAuthController.swift */; };
-		A6BDD382DFCB4C6CBFC6AEBD /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64116C457D144592923CE953 /* SignupView.swift */; };
-		CD9CF44DD51A41D4BB5EE71E /* BehaviorRosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6A680715844859B5AB1482 /* BehaviorRosterView.swift */; };
-		7ED3B55E2F194A148E68FB20 /* HallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F834E7C7E2B4F83977CD393 /* HallPassView.swift */; };
-		EAF60A9E783D4A6AA27B1BA4 /* MyHallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589449D3174C412290E4395C /* MyHallPassView.swift */; };
-		90DB3F5A985C452CA2BEFF3E /* BillingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D5E89F64034E519A897B39 /* BillingView.swift */; };
-		2CFDE3DCAFD943DFA374506A /* CheckoutReturnHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002621179B3240B88E42D3BE /* CheckoutReturnHandler.swift */; };
-		07AC8CA9D7B745DF959322CF /* PurchaseFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBA28AFA45B4196BA532489 /* PurchaseFlow.swift */; };
-		7DFC6F1AB6804EB0B9AD139D /* BoardAnalyticsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA12F2E861645A1980CF97B /* BoardAnalyticsSheet.swift */; };
-		3087F31746B0445F88163E16 /* BoardComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8924613254124B5AA8FD0491 /* BoardComposerView.swift */; };
-		513201C8086B4D4ABAB2D2B6 /* BoardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03216D95DEEE443283E5957E /* BoardDetailView.swift */; };
-		112B5FC6A26A4C239DEA5E68 /* BoardEngagementEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337088D4F5644F398827A1F8 /* BoardEngagementEnvironment.swift */; };
-		B628B4D06766416D85DB280C /* BoardExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF51B8DD3EC1499B9B67BB98 /* BoardExportSheet.swift */; };
-		9350312EFD914AA18023A16A /* BoardModerationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83131615195A4ACC8EE64E7D /* BoardModerationSettings.swift */; };
-		E34650CFE1F245C7A1D446E0 /* BoardPostCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259DF311E035446E813AA4DB /* BoardPostCard.swift */; };
-		9CBB67B45CD6442AAF18BEA6 /* BoardPresentModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B34D6497C14CAC8663E762 /* BoardPresentModeView.swift */; };
-		462A976E735E43448BB18912 /* BoardSaveAsTemplateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B437E7FBB6B460F8178C628 /* BoardSaveAsTemplateSheet.swift */; };
-		4467D7B9B3724D79AE2541D8 /* BoardShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E9D9B7CC2408C88DC216F /* BoardShareSheet.swift */; };
-		F0DBF31E806B493FBE728A77 /* BoardSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B45A1B0F53148FEACFB6231 /* BoardSocket.swift */; };
-		CE9000050C4C46DD86BD15AD /* BoardSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51EF4DBC774C6DBD841565 /* BoardSurface.swift */; };
-		522B18E83695425299B42E93 /* BoardSyncStatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886E207B6264422F8B23AB06 /* BoardSyncStatusChip.swift */; };
-		55419C0568874D84A05F9222 /* BoardTemplatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3143CE3BEC4D3FB873211C /* BoardTemplatePickerView.swift */; };
-		DA3CB0D8439B43F9B04AAFC1 /* BoardsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490CFC138B7B46DDABD858C5 /* BoardsListView.swift */; };
-		B1C0367397C4440ABD4A3FF1 /* CardArrangeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D68ECFF7B644E71BC47AE87 /* CardArrangeMenu.swift */; };
-		E632825BF32E431EAB2DC308 /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC767DDD02B4309BF4ADDC0 /* CommentSheet.swift */; };
-		C33E125522F6463B8588D9DC /* GradeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED68C4F898B4AA492F84347 /* GradeSheet.swift */; };
-		E9500E279FD84474B49E2767 /* CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370BAE4B96A34903AB73ED0C /* CanvasLayout.swift */; };
-		F097D9E47BBD48E4B2995514 /* ColumnsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BA4EA8C1154A7EA1731CD8 /* ColumnsLayout.swift */; };
-		9D718AC9F4EA40A6B67DBBFC /* MapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780DA182FF4043B38696D36C /* MapLayout.swift */; };
-		35B8C5A588124A2495CEF149 /* TimelineLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CB8C1BE7504CD9B7CEEAC6 /* TimelineLayout.swift */; };
-		C4FB2773115A4272B35A725D /* WallLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDCF46AF3E4B0DA1A173DB /* WallLayout.swift */; };
-		B22FFB3070274427A9BA052C /* ModerationQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611830A137CA49C1959CDE8F /* ModerationQueueView.swift */; };
-		5DDFD0CD90AA4D949D3F81A6 /* BoardPublicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F852E57D2D14F8A95455DBE /* BoardPublicView.swift */; };
-		2CBEB5B6A97E4AD49B8E9B90 /* ReactionControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6055DB2C26AB4129A22E0F29 /* ReactionControl.swift */; };
-		7E6946757D0347E1A59361C3 /* ReportDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8288AA0576624915998DFB6D /* ReportDialog.swift */; };
-		ACDCFD35679449A495D39680 /* CatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133747F8014442AEB513EB08 /* CatalogView.swift */; };
-		CF786EBFF6C5411A86A78307 /* CourseLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DF8A394EE945B8B60D579F /* CourseLandingView.swift */; };
-		3762E2C6D0CA48B7A02CD6BA /* ReviewComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AB0F11CDF54868BE71CFF3 /* ReviewComposer.swift */; };
-		68FC92E933224C5AB8D3C8A7 /* ContentPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847219C1BF3A490581AAEF0D /* ContentPageView.swift */; };
-		086E2770AE5E4D4AA34E78AF /* CourseAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB770D3718FF4A90B5384778 /* CourseAttendanceView.swift */; };
-		C9E28C386F1E45C4980FBFBE /* CourseBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87682C9CFE11404282D85EDA /* CourseBanner.swift */; };
-		83260790D9E748C38AC0A640 /* CourseDestinationPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6439F689A7D84336B9539BD9 /* CourseDestinationPlaceholder.swift */; };
-		4DD69D0912AF47218F88D530 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0365B3EC4674A04B2BDFDFB /* CourseDetailView.swift */; };
-		853F5994106A4F3AB990ECC8 /* CourseGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8263EB4500D544EE8D550D89 /* CourseGradesView.swift */; };
-		24C3085C652641CD947EC5CC /* CourseLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCD2C6E51C24F738ED8C250 /* CourseLibraryView.swift */; };
-		49E8E80342304542BED428A5 /* CourseMarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A025369C914A4C87867124F5 /* CourseMarkdownContentView.swift */; };
-		800AC77153994AE1AB074F25 /* CoursePeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B6AC4FDA634026875BA2D4 /* CoursePeopleView.swift */; };
-		6460CCE4EDF641E9AB43BC36 /* CourseStructureSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DE8049A8EC481999C88093 /* CourseStructureSocket.swift */; };
-		43420264D4024516951C37A9 /* CourseSyllabusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7557B966F73F4899BC996BB4 /* CourseSyllabusView.swift */; };
-		6F2FA487AD9A474FBA27747A /* CourseWorkspaceNav.swift in Sources */ = {isa = PBXBuildFile; fileRef = A564BD3178B141A79D7DADA8 /* CourseWorkspaceNav.swift */; };
-		03AA2BD5DC0843E29F26566D /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40536B390EA3411BA49279F6 /* CoursesListView.swift */; };
-		16ACA5E324634EBD9F5D8FEC /* CanvasImportComingSoonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35EB05D53C374ABEB6EA3DD0 /* CanvasImportComingSoonView.swift */; };
-		E33361292D104B2FBC9EBD97 /* CanvasImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F823AB9D514792B470A794 /* CanvasImportView.swift */; };
-		9F2FF5D8602D49BB9EF3AAB4 /* CourseCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCB46E9122846B5904855D6 /* CourseCreateView.swift */; };
-		EF354F667A754B4CB3B2E808 /* ItemDetailRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F747815F954B388C7CD9D6 /* ItemDetailRows.swift */; };
-		59B70927C9A94595AF643F78 /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77028F77277348C399FE5293 /* ItemDetailView.swift */; };
-		DCEC40B738504791ACDF80AA /* LaunchContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6F3A0A6E144C2E9E1DA262 /* LaunchContainerView.swift */; };
-		3E6A765D21D14E129AB3740E /* LibraryResourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E68A635B7041AE8657D5F3 /* LibraryResourceView.swift */; };
-		068C3531D6A04E219A9A8DE0 /* MarkdownCodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CAC416D8494E778F4B9787 /* MarkdownCodeBlockView.swift */; };
-		916DEA86CCB2455EB02B79C2 /* MarkdownTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E00898CE0B5A4D8F832F234E /* MarkdownTableView.swift */; };
-		7E62025B1F4348478529176A /* ModuleItemRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659D85899B3942718E0FCEF8 /* ModuleItemRouteView.swift */; };
-		4BE9EB7CC590462388982E9D /* ModuleListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7F68903B0466686850D5D /* ModuleListView.swift */; };
-		69207C1393864BDCAE39E998 /* RequirementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0F193562AA48EA9D3B5751 /* RequirementsView.swift */; };
-		7821EF2DCC1D4F36A7BDDCF0 /* CourseAccessibilityReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E895804DE50A41ED8B232135 /* CourseAccessibilityReviewView.swift */; };
-		30464CEA6CC54B44A858A09C /* CourseArchivedContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267410C1A41D49FF99FBB5C7 /* CourseArchivedContentView.swift */; };
-		26EE54861D354BF990E116DF /* CourseBlueprintSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBAB76F491F4138AED91A60 /* CourseBlueprintSettingsView.swift */; };
-		5AA3C4A008D749E688257943 /* CourseCrossListingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84EB24717C41269F150D07 /* CourseCrossListingView.swift */; };
-		5AB361DED5A14AB09E19E088 /* CourseFeaturesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02BDC83DB8485CBCE81507 /* CourseFeaturesSettingsView.swift */; };
-		8B2102DFDD9C498D8547CBFB /* CourseGeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB6A4245D294042A00AA6A4 /* CourseGeneralSettingsView.swift */; };
-		E7025A24B32745AEA3557CC6 /* CourseGradingAgentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5349888EC0114570ACD831E4 /* CourseGradingAgentsView.swift */; };
-		6D313D94411C4894945CF1D9 /* CourseGradingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF72CCCF474E3AAA676528 /* CourseGradingSettingsView.swift */; };
-		509D8DAA646A45E284DCCC7B /* CourseHeroImageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA41E9040649456DB33BC162 /* CourseHeroImageEditor.swift */; };
-		E1BAD5B13167480E9754514E /* CourseImportExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA181A953E14C468095768C /* CourseImportExportView.swift */; };
-		C6B6CAB5BF834B7C87C57651 /* CourseMarketplaceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3AA0F3A6F4471AA1C6E35 /* CourseMarketplaceSettingsView.swift */; };
-		8A9ACCD6B4C54455887861BB /* CourseOutcomesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC1C07012AA400FB90CD1B1 /* CourseOutcomesSettingsView.swift */; };
-		5C6F24975F844463975AB0EF /* CoursePlagiarismSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2225D9D07D9C459196127219 /* CoursePlagiarismSettingsView.swift */; };
-		15846C31C0F34E3997155B24 /* CourseSectionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE94582729E48E39E56B2E9 /* CourseSectionsSettingsView.swift */; };
-		05DDF2F21D4247DA95411261 /* CourseSettingsHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713566F955A64593962A78CF /* CourseSettingsHostView.swift */; };
-		717C57DFB68848F9BDABD762 /* CourseTranslationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA5BBF44C9844CEA26C3C6A /* CourseTranslationsSettingsView.swift */; };
-		DE2BB701059B41B2B66D9BF9 /* TakeAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F287EF609D48A587AE804D /* TakeAttendanceView.swift */; };
-		7E0CB8C2CDAB46E79723EE12 /* VibeActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8937A1E1F8C542699D4EFCE3 /* VibeActivityView.swift */; };
-		09E2975018AA4483B41E86CA /* WebItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D25A64C53F44E8A3DCA18F /* WebItemView.swift */; };
-		402D0BB774624382981F9F26 /* CredentialDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FF896DFF2C4573B7293396 /* CredentialDetailView.swift */; };
-		78BA3A76893147B4A5737ABB /* CredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1B0BC5160C4FAF85C3E3A9 /* CredentialsView.swift */; };
-		3CF154ACD0AF4C26850C3895 /* DashboardCoursesCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFFCC5A901E49019C8EBA1D /* DashboardCoursesCarousel.swift */; };
-		078F8DA5217C45208D255A55 /* DashboardHeroPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DC62FD64AE4B6D8014259E /* DashboardHeroPanel.swift */; };
-		5C0F730A8CCC4506A5496BBC /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBAFCBF1764488498252FCB /* DashboardView.swift */; };
-		1D5E3116179641499E19A849 /* LiveMeetingsRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A1E7EAE66744EC93DF87FF /* LiveMeetingsRail.swift */; };
-		651F92E886654DF18ABF24B3 /* CourseDiscussionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F065BDB057427B997809FB /* CourseDiscussionsSection.swift */; };
-		8DC2AFB29CB44E3CB810C74D /* DiscussionThreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E79761A651C453CAD0276FA /* DiscussionThreadView.swift */; };
-		2F9DC1F6EE32484CBBABCC71 /* DiscussionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4292E5B6E44215941C86AE /* DiscussionsListView.swift */; };
-		566E104CBB1D406C922336C0 /* PostComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B640B95186493C897B723A /* PostComposerView.swift */; };
-		3298E94176FD4C4FBDF2852A /* CourseEvaluationsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1435004D17D84682BA71973A /* CourseEvaluationsSection.swift */; };
-		20D72CFD7A78479C8F207651 /* EvaluationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF3D50943E74F2FB0FA5844 /* EvaluationFormView.swift */; };
-		DE82C7D29D4741279DAA8153 /* EvaluationResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C00764961C47D08D3E81CA /* EvaluationResultsView.swift */; };
-		B100473493A545AC974176CD /* CourseFeedSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9C93B850C1470B8EDD80F4 /* CourseFeedSection.swift */; };
-		3FA12DC95AA74C2C9EC4BCAC /* FeedChannelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7EDA538039A4B58AFB7F963 /* FeedChannelView.swift */; };
-		F47EF201B61B48F7BACDBD03 /* FeedChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E2315E98DE4E0595C568E0 /* FeedChannelsView.swift */; };
-		DDEBC7E31C0045D68325CD41 /* FeedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767D634EA7C54421A5B762FC /* FeedLogic.swift */; };
-		DCB152BA4C474975930194DA /* FeedSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657339EC3D474DAAA0A66C9F /* FeedSocket.swift */; };
-		5F44382D41CB4D548EAB9004 /* ShareFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67E5F19F42C4743B164654A /* ShareFeedbackView.swift */; };
-		7426989562E9444DB451C246 /* CourseFilesSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C3F47E3007496C8003BA97 /* CourseFilesSocket.swift */; };
-		F61A96F44BC7447D9A85ACF5 /* CourseFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA60D42F624F89B59C7A13 /* CourseFilesView.swift */; };
-		27250EF2EC844ECFB41A423E /* FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12EC7DB66414805BFD47BEE /* FilePreviewView.swift */; };
-		22C990D73BB54604A866A4B6 /* MarkupOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50423B031C594FD081D8F3D3 /* MarkupOverlayView.swift */; };
-		426C6FBF61FE47208BF75BF1 /* GamificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2B964842AE422AB1F8FE31 /* GamificationView.swift */; };
-		66B9B406167D4F02B7E088F1 /* GradeFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58E798DDE14728B7048B49 /* GradeFeedbackView.swift */; };
-		03E52BCDB01948F1A6CD0C84 /* WhatIfController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98606023BD664072A84363A2 /* WhatIfController.swift */; };
-		F96BE9C647734EDAAF73934C /* GradingBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F830C796E96842FC902C5B4A /* GradingBacklogView.swift */; };
-		1350A36283514ED3AE5B98B6 /* SpeedGraderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3539CFC6934AD2BB2F4EAE /* SpeedGraderView.swift */; };
-		7A61CF28A0C5485EA1F34718 /* CollabDocView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC7E1DD087A4E1489ADF74E /* CollabDocView.swift */; };
-		0FCDDDBD482C46DDA0461CC1 /* CourseCollabDocsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2AC07D555534757A7A76999 /* CourseCollabDocsSection.swift */; };
-		15D8976AFB32451EB3D4CCDA /* CourseGroupsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A28AD16498A4136A77E5F6C /* CourseGroupsSection.swift */; };
-		B4EB528F99D34C3F83091138 /* GroupSpaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E086F925E3C94E3DBF6D5B8D /* GroupSpaceView.swift */; };
-		0ED62D425A4E451FBF6E7E0A /* AnnouncementComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C5179B7C504B4C9F06FE64 /* AnnouncementComposerView.swift */; };
-		A54A6D3D36D04795AD7F553D /* AnnouncementsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B357B269DD46DB9FB3C801 /* AnnouncementsViews.swift */; };
-		9AB309A4D92B488DA1EB2DAC /* BroadcastComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9961BE2DA57F4F4ABD8656AB /* BroadcastComposerView.swift */; };
-		283F45906F944EAE81A97E84 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DB00E3B5884F338081EA9C /* MainTabView.swift */; };
-		A169C2814F1A42D8A7284907 /* MoreHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903A8BB06DD34793B5FC272B /* MoreHubView.swift */; };
-		D64647424591472CB12CC11B /* ShellHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6A66930C9247509F766F7F /* ShellHeaderBar.swift */; };
-		1EFCE70315F94C0C92EEF4E4 /* TeachHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7ADBFE36AA24EB7B0908D7B /* TeachHubView.swift */; };
-		8DC73E8306284B74A24AB14A /* UniversalSearchPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4502383E9D304013A8EAB757 /* UniversalSearchPlaceholder.swift */; };
-		B97CB5F54C204F83A2274DA9 /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396EAFDB8CD498F95D9E93A /* ComposeMessageView.swift */; };
-		C4B4AFAF23E444D684C74E7F /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B52603AD774852A54614C5 /* InboxView.swift */; };
-		6BA3AA98591D46448467F24F /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8B2EA90F7F474F93CF162D /* MessageDetailView.swift */; };
-		7C69AE1F574F4047A3EF86DC /* DashboardInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06853E09C60842B0B32A7B61 /* DashboardInsightsSection.swift */; };
-		241714943727494EBFB5FF96 /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080ADF9D3C34BBC9A31EA9B /* InsightsView.swift */; };
-		740A06DFD62F4D29B36AFC9C /* AtRiskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8792C700AE49F4B0D8146F /* AtRiskListView.swift */; };
-		73C6E16C6E484470B9E7B784 /* CourseInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBD4F4A79CB4E4DBF2EE5F3 /* CourseInsightsSection.swift */; };
-		7A0C884A584B4D2FB584B571 /* StudentProgressDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE1EBB432794F2DA01BFC0D /* StudentProgressDetailView.swift */; };
-		606693184E4E4BA39AABB2BE /* WhatsWorkingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A903C2817C74B468239F028 /* WhatsWorkingView.swift */; };
-		5D2F4FB5C52F4FA595A14104 /* IntroCelebrationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E418402F1C0442649025F56A /* IntroCelebrationPresenter.swift */; };
-		EF16E79934FD4222BF0282C4 /* IntroCompletionCelebrationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E155C5C5BB47D28E97E754 /* IntroCompletionCelebrationSheet.swift */; };
-		B7F02A7A8E994A0F9731E277 /* IntroCourseEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE4282C6A94244BFF19D3C /* IntroCourseEntryCard.swift */; };
-		88956425ADC64D098DB484A6 /* IntroCourseProgressRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4180F25AFDF1407D98915D1C /* IntroCourseProgressRail.swift */; };
-		36D53233307941019D2C7BFC /* LearnerProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B80C1444C6A48B6A39E2FF2 /* LearnerProfileView.swift */; };
-		B3F5555053E046309DAEC51E /* LibraryBrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89023B353D84747859B117E /* LibraryBrowseView.swift */; };
-		E5BF3CA3C75442C0915A16B5 /* MeetingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9229467C210C4301B2D98D60 /* MeetingDetailView.swift */; };
-		24CEFEFAC27D484D8CA4488A /* MeetingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1302D78379A34ED49391CD74 /* MeetingListView.swift */; };
-		50524B78462E46138E798C76 /* WhiteboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EEEB959E8549A182B2DE40 /* WhiteboardView.swift */; };
-		31A43E223AE64CF7B317B52D /* LiveGameSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6C74B0C8A24ADFA92DCB62 /* LiveGameSocket.swift */; };
-		54A3749733E34452AABF49F0 /* LiveQuizHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9691EB7FB06A4E5DAF1ACA40 /* LiveQuizHubView.swift */; };
-		C3713CE5BCD84D13A708233F /* LiveQuizPlaySurfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65BBF0633EB45F0820C1161 /* LiveQuizPlaySurfaces.swift */; };
-		576FE9B632694797BF162106 /* LiveQuizPlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FBF86F867A46CCACACAEFB /* LiveQuizPlayView.swift */; };
-		013DB38E476047E5B10E42C4 /* MarketplaceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB840DC10A7340F085F9F10A /* MarketplaceDetailView.swift */; };
-		FD825CB92D9F4E53B6C36931 /* MarketplaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B11BF2897F4875B7A42317 /* MarketplaceView.swift */; };
-		0F0885C1A7A442658E9C26BB /* MyPurchasesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2B0D06CC104264A7571102 /* MyPurchasesView.swift */; };
-		8879708009664DF28200AABA /* CourseMasterySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E773ADF53394F77BEAFB505 /* CourseMasterySection.swift */; };
-		48BF5A9124F8434C87C1624B /* ReportCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2313BB40BCC74375989C45AC /* ReportCardListView.swift */; };
-		86BB5688245243B0BA1DE5E6 /* CourseDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62345060129B4913870E54C1 /* CourseDrawer.swift */; };
-		983B748754844B6F8577C6EB /* DrawerScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0688DB90454A19A18E8185 /* DrawerScaffold.swift */; };
-		B381D36A6BA443FAB2EF7852 /* DrawerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4638969A0A9A4BC3AFD33B5F /* DrawerToolbar.swift */; };
-		3A5938FDCD9243E9A370FB22 /* GlobalDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0276213236EA41DD87B05021 /* GlobalDrawer.swift */; };
-		6E60D3E912F14800A3BFDBEC /* NotebookDrawingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5685788C03E1478E8174A5CB /* NotebookDrawingViews.swift */; };
-		3C32289AF75C4E309711EA94 /* NotebookEditorSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E52B98F8D184587BFDA269B /* NotebookEditorSupportViews.swift */; };
-		FA31A98E26824E12877C62B9 /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5408DF2B2B44228B3BEC80B /* NotebookEditorView.swift */; };
-		C442C7E0CC254DD5975BAE3E /* NotebookPagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAFF705789F14DA1A6B7774C /* NotebookPagesView.swift */; };
-		2A0A014EBAF04CEA98BD74EE /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43F54B92C1F4A8FB207FE48 /* NotebooksListView.swift */; };
-		5DD96E804585487A93D22342 /* BookingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBBE5F676024C5A8546BD9E /* BookingSheet.swift */; };
-		23392DD7C8324AEBAA7FCBCA /* MyBookingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809FB33A0AD94818A168A9FA /* MyBookingsView.swift */; };
-		8BFEB92094DD4A6CAD797E5A /* OfficeHoursView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6402F22622804592B0BD16AF /* OfficeHoursView.swift */; };
-		7D513B71CE1D44A4B1949DF0 /* DiagnosticView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21416CD8DFA947858881FB67 /* DiagnosticView.swift */; };
-		260854A2B9AE45B0A1C9FC0C /* OnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B8423CB03A421DB125FA7E /* OnboardingFlowView.swift */; };
-		BCB3CC5EF20E4AAC9FF804CF /* ConferenceBookingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7495B658AA314BECB39FA0BC /* ConferenceBookingView.swift */; };
-		2F406664162147C2BD5E3C8E /* MyConferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D4BF14581E46E1877105A7 /* MyConferencesView.swift */; };
-		168A2E2592844CF78FEBB370 /* ParentAttendanceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1BEB9B7C19486C90AF60B6 /* ParentAttendanceDetailView.swift */; };
-		8826351567BC4109BDF7381B /* ParentDashboardSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E88D3509D4581AD3B0D49 /* ParentDashboardSections.swift */; };
-		AF30AF67DF5446A98623E2CB /* ParentDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E0738CB7DD4EDAAF0B898E /* ParentDashboardView.swift */; };
-		785871EE701340E2B507B3DF /* ParentGradesDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC689423511413EBBF6A2F0 /* ParentGradesDetailView.swift */; };
-		0BD013A4452946769F5F4A6F /* ParentNotificationPrefsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9913DD13854F259223B9CB /* ParentNotificationPrefsView.swift */; };
-		004B2E95410C4CE693140269 /* DashboardStudySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DDD4F6F0DF44B790377108 /* DashboardStudySection.swift */; };
-		5889497F36044AA98D79B813 /* MyPathsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519A867DDBC343C2BD999131 /* MyPathsView.swift */; };
-		3A24DF561FD049CE89E0824C /* PathLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFABD1859A945CFB9EE0177 /* PathLandingView.swift */; };
-		B9FCFF1F9A0F4A4B9557491E /* PathRunnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C84307E2BC94C6FA15D3BDE /* PathRunnerView.swift */; };
-		9A195E6758A34DDF8BA6D4EA /* PathsCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB94EA892F64D8D9B8737C2 /* PathsCatalogView.swift */; };
-		2464507F608B4D9F86E0A739 /* PeerReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2AD1BAB40F4D73A5DD2DBE /* PeerReviewDetailView.swift */; };
-		F62CC3ECE02147AF98727689 /* PeerReviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3BBE2A5AFB4B66ABFEA6C5 /* PeerReviewListView.swift */; };
-		FB2A2F3E3B674353B9C1ABAB /* ReviewsReceivedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144BCB7F170F41D9B763AE01 /* ReviewsReceivedView.swift */; };
-		110B95E7D06F41D98EEE593C /* RubricScorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62C5B28B5F148DAB9EAC51C /* RubricScorerView.swift */; };
-		93C936E6351E42909BEFFF64 /* CalendarSubscribeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60236CCDF7AA48738D0D49FB /* CalendarSubscribeSheet.swift */; };
-		271722C4C86E428FA661E784 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3F8A9FCD1249E79F8CC819 /* CalendarView.swift */; };
-		1629C666F31944FFAC72E301 /* ConferenceReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C606E34F9144B64A777B6FC /* ConferenceReminderScheduler.swift */; };
-		489FCA1B438644B3965E6729 /* DueReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD1CE39301A41058120A843 /* DueReminderScheduler.swift */; };
-		BBB85B31F17F444AA4F67A07 /* OfficeHoursReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427B5B7A544441FF83DAB84F /* OfficeHoursReminderScheduler.swift */; };
-		6FCF7610FB9B4724A89499D1 /* PlannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35482D532A2149B080CD6765 /* PlannerModel.swift */; };
-		38A42102E27A4C2483A4337C /* PlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADAEEFB6B414AA287062F8B /* PlannerView.swift */; };
-		B53D8D2674ED4316A7691858 /* TodosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C7B900B7ED4925A1869D55 /* TodosView.swift */; };
-		658C1E186EA74FAEAA965EE8 /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35BC5FD1AF146CBAF2065AB /* ArtifactDetailView.swift */; };
-		1CE32F92A4DD4B6797B7BB87 /* ArtifactEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E149F4B7DA48DD9F801DD0 /* ArtifactEditorView.swift */; };
-		912AC1F1D73A4DA3BFCE09C5 /* PortfolioArtifactUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5004097E1B874DDB93242DA0 /* PortfolioArtifactUploader.swift */; };
-		50C833577E5147D79BAFD02E /* PortfolioDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A30B10FF37F4C73B99B56B6 /* PortfolioDetailView.swift */; };
-		3F563D375D0842BC8CF659C8 /* PortfolioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1211C341964513B98889F4 /* PortfolioView.swift */; };
-		988D1AE76D7449ABBE80B402 /* AiAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849FD0BE416241E8A1617D59 /* AiAdminEntryCard.swift */; };
-		D5B2C7631A3C41D2B3CE4699 /* ArchivedCoursesAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F339E576E4464982A315D3 /* ArchivedCoursesAdminEntryCard.swift */; };
-		18E7D3CBDC874492BE473861 /* BiometricLockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269BBDA8E3F84DEA9DEA260D /* BiometricLockView.swift */; };
-		65BA9A19ECD34E46B75F0388 /* DeviceSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72BD8DB3522843548EDB368A /* DeviceSessionsView.swift */; };
-		A461B3DDA25A400B8E47CF0A /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D7198549954D4CA1AC7026 /* EditProfileView.swift */; };
-		EE46711E174C4CF8A90DAD74 /* IntegrationsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF071116BC2F446789DB95AC /* IntegrationsAdminEntryCard.swift */; };
-		A058ED27325C4EDF80191061 /* IntegrationsEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF54036E6B3426390D72262 /* IntegrationsEntryCard.swift */; };
-		232A98A3944642D0B5191DDF /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E6FEAC28BF4ECBB2548552 /* IntegrationsView.swift */; };
-		AE8F3E64ECA24E65A0F62C42 /* LearnerProfileEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292E60D74B50449DBF81B8D6 /* LearnerProfileEntryCard.swift */; };
-		DD2BB5D7D51B43E1AD072233 /* MyAccommodationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612542398DB34253A6686424 /* MyAccommodationsView.swift */; };
-		5C31A7F145FC463D9F6F5200 /* NotificationPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BBC380C7B14E1C97904F62 /* NotificationPreferencesView.swift */; };
-		6490751995BB44478A5830CC /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366826087F904BB7BC321C08 /* NotificationsView.swift */; };
-		D7521F8FD5314D019530DEC1 /* OrgBrandingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CEB80575D4484FBEFD5CC5 /* OrgBrandingAdminEntryCard.swift */; };
-		43BDD65562BA4828A30FDE61 /* OrgStructureAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283D9CE400334AC49AFD50AC /* OrgStructureAdminEntryCard.swift */; };
-		C1DA398745A3417792CDA221 /* PeopleAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE73F8C7ED4996B392B117 /* PeopleAdminEntryCard.swift */; };
-		51A96095D86A48D99E716480 /* PlatformSettingsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918C26A90C7045FD93FF96C1 /* PlatformSettingsAdminEntryCard.swift */; };
-		1B5CD9DECC884CD2AFFF2EA5 /* ProfileDepthCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E99FC07CB54E0C96EA10BD /* ProfileDepthCards.swift */; };
-		DBD0B30AA580420AA2E283B0 /* ProfilePersonalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCFBF1C1FCF47BB84AEAF38 /* ProfilePersonalDetailsView.swift */; };
-		5698DCD9EA9B44068CDDB85D /* ProfileSecurityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12BAF195789448DB078C7CF /* ProfileSecurityCard.swift */; };
-		981C208401B74B6C9998AB92 /* ProfileSettingsCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = E057149B676F46098DDDBD1A /* ProfileSettingsCards.swift */; };
-		81DEECEC9D914F06AE2B5B2F /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F1FD9E84874180BAD8D5DC /* ProfileView.swift */; };
-		8206C4C37F2949B4B3302494 /* ProfileViewSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BF6067904E4A2087EC27CE /* ProfileViewSections.swift */; };
-		209D699F24D347E39DA62895 /* ResearchStudiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53305DC75B204D9C81F3585B /* ResearchStudiesView.swift */; };
-		63622B33B9F34BF7973C9FF7 /* RolesPermissionsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4320E0C0E24EB9BE1B7F58 /* RolesPermissionsAdminEntryCard.swift */; };
-		F2F2C8589D5C4364A43B4E4E /* SettingsAdminHubEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E6AEEF26D44D3EA65A25A0 /* SettingsAdminHubEntryCard.swift */; };
-		5AED2A42200C417D901A3AAA /* ShareFeedbackEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67308866EF5479FA01FC732 /* ShareFeedbackEntryCard.swift */; };
-		B5CCD9D022344044B331EA01 /* TranscriptsAdvisingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD739C270344ADEB1A3142D /* TranscriptsAdvisingAdminEntryCard.swift */; };
-		1A87D70734574A048A8DC349 /* CodeQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BCD90D8A8E4EF4AFB9D583 /* CodeQuestionView.swift */; };
-		E17908C4CA6446149BE0EC97 /* LockdownController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633C85BCCB7941E5BD24D270 /* LockdownController.swift */; };
-		E04539B73C8E44DE96E3C469 /* QuizIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC57DD00547498A8F4FB307 /* QuizIntroView.swift */; };
-		FA7CC2716D954890A3F5890C /* QuizQuestionViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9DCCE9B89246218C4CE8EF /* QuizQuestionViews.swift */; };
-		1FD2CDA0ADAB418B997BA63D /* QuizResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34504285543C4C9A8CD6F5EA /* QuizResultsView.swift */; };
-		A6ED01A672094CE3B09AA985 /* QuizTakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B81ADC20ABF47A3AD5C31F4 /* QuizTakerView.swift */; };
-		0BA36578549C4277A43ECCCD /* CaptionedPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EC5757A7B946098AC5B893 /* CaptionedPlayerView.swift */; };
-		E1F0BF5110DB4C24A97D4986 /* ContentTranslationControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAACDFB103B9456BBC73750E /* ContentTranslationControls.swift */; };
-		6747A8A5EFF84C2D9C98F46D /* ImmersiveReaderCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49467C0BBC9C415780029214 /* ImmersiveReaderCapabilities.swift */; };
-		8CD1372F58304586963CF984 /* ReaderLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990F430024144399B37A91A2 /* ReaderLogic.swift */; };
-		588A85CFE0F0414794AFB234 /* ReaderToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F495ED7A44B4C73968DA21E /* ReaderToolbar.swift */; };
-		42A1556AAD4B4AD1BC0042AB /* ReadingPreferencesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDA47FBE9DE454C9CD75E5D /* ReadingPreferencesSheet.swift */; };
-		D288A4AEBF374F039E752C9A /* ReadingPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AB029FB1A444B3BEA5D695 /* ReadingPreferencesStore.swift */; };
-		FB5C34E084D24E9594C76212 /* LeveledLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56111FF37D29429987AB0096 /* LeveledLibraryView.swift */; };
-		8D420F0E8EED450E856C6A86 /* LogReadingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A83C44B84487CB01EFF3C /* LogReadingSheet.swift */; };
-		775B51A27C5345ABBB0D23EF /* ReadingDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5A6D6A50874B1FAB312EE8 /* ReadingDashboardView.swift */; };
-		1ED91D14ABB64871BA5D370B /* ReviewHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBB673CA4DB420BA37B9208 /* ReviewHomeView.swift */; };
-		11AC31C299564C5FBE87051E /* ReviewReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6440ADA1E9544ECBF69F85E /* ReviewReminderScheduler.swift */; };
-		FA96F45D033F489AB83FDE81 /* ReviewSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31DE89C777B4A51887F141C /* ReviewSessionView.swift */; };
-		F709C02F211E476BB1FF7DDA /* UniversalSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A178AEF05541188021889B /* UniversalSearchView.swift */; };
-		A89A4C91638E4106A0EE487A /* AdminMetricCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97B6F26B6DC4092BAB78F26 /* AdminMetricCards.swift */; };
-		5FAB919A843A440E82EE8D04 /* AdvisingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36A44F66604F3C843C50D9 /* AdvisingSettingsView.swift */; };
-		F2214A1D92FC45BB9CE2ADD2 /* AiAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9843014D154611A7BFD0C9 /* AiAdminHubView.swift */; };
-		50367A9E1471406B80ABF2A1 /* AiGovernanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A56979663249C4AFE83221 /* AiGovernanceView.swift */; };
-		FB796A715F674440A6409779 /* AiModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889FAFAF774142C2BA86329C /* AiModelsSettingsView.swift */; };
-		1019816343624011A7B557D1 /* AiProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C29C92B3B24E5C86725EE7 /* AiProviderSettingsView.swift */; };
-		9546906023EA4DD0BDBCA7B2 /* AiReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA28E77314484396AB0AE64A /* AiReportsView.swift */; };
-		65E89AD1ED204EC5B795CCA6 /* ArchivedCoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4355CA566304FBAAB98D098 /* ArchivedCoursesAdminView.swift */; };
-		65F73CED45624E1BB1713440 /* AuditLogAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942584F491914827B95F3282 /* AuditLogAdminView.swift */; };
-		0D91AF2DB19F485B93D7CD46 /* BoardsGovernanceAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88724DBA10A14C4BB795E26F /* BoardsGovernanceAdminView.swift */; };
-		D64E4E13C99E4D77B6F6F3F8 /* CoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914CCB5EAAF34214B8885432 /* CoursesAdminView.swift */; };
-		E4750E6368AF4758A9BB3FCB /* IntegrationsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BFDD3B36BC48A8B13DE360 /* IntegrationsAdminView.swift */; };
-		38487F2277664659A792B427 /* OrgBrandingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E256FCB9F14A47B25202B5 /* OrgBrandingAdminView.swift */; };
-		59AF1E78E14446BDA1C520AB /* OrgBrandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B6653C12AF4B4395D2650A /* OrgBrandingView.swift */; };
-		D7FD88DB8E924B1BA0FEF265 /* OrgStructureAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3124434EF14E0F9A93AF28 /* OrgStructureAdminView.swift */; };
-		2CA9B5373A0B4233A0A64771 /* OrgStructureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12EEAD3B385B4D19A7EE0841 /* OrgStructureView.swift */; };
-		00FD0ED59A7C49D393DA15A3 /* PeopleAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EF610BF1484F9AADE2AA95 /* PeopleAdminView.swift */; };
-		28B4BF03E7E34F9DAB34FE6A /* PlatformSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A03C39AFE47918DBCC377 /* PlatformSettingsView.swift */; };
-		5E588B67C7274185841CDBFC /* RolesPermissionsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67E4C60CD8D4042A5591FEE /* RolesPermissionsAdminView.swift */; };
-		880FB92F7CFC41E992B52F78 /* SystemPromptsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2FA99DD121458D8201C26C /* SystemPromptsView.swift */; };
-		0248213F393049E8B93709D2 /* TermsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AF5D02D2464887B58449B2 /* TermsAdminView.swift */; };
-		C27059C4026742968DB0FDCA /* TranscriptsAdvisingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5AD5CA80204A4D9F4EDB14 /* TranscriptsAdvisingAdminView.swift */; };
-		78C7EE57272F4082B42983A2 /* TranscriptsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B3CD2CBADB4D5CB7B5CD36 /* TranscriptsSettingsView.swift */; };
-		EB7EAB8B4A6B4BC6BF148FE1 /* UserDetailAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9240550142D1439DB32F9DDA /* UserDetailAdminView.swift */; };
-		A4F1C583F9C24D03A36D3CFC /* SettingsAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC90322BE577468290B4551A /* SettingsAdminHubView.swift */; };
-		20F7EAEFC0B14F1BAD3F7C3A /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C311030F725471CBF67D6F8 /* SplashView.swift */; };
-		22A3489D687C412B90F92BEC /* TutorChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871BFA5C95E049CBAFEC0731 /* TutorChatModel.swift */; };
-		8D963B4A899B4A9AB2B8B7E3 /* TutorChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9452C8D2829F4FB6B21CAB26 /* TutorChatView.swift */; };
-		A1287F5A19914A9EB261277C /* TutorFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAB6ED9091E4B3E94718267 /* TutorFlowLayout.swift */; };
-		ED9D1E5CFE484120B3D251C4 /* TutorLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66A524C7AAC4FB2B017F128 /* TutorLauncher.swift */; };
-		B517A0B3458F4E1A90327F51 /* WalletCCRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F9005EEE2744EBB7D096EC /* WalletCCRDetailView.swift */; };
-		AFF47FE7B05642EDBB6C2886 /* WalletCETranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF4CF0A377A4ED5B3DC1AA0 /* WalletCETranscriptDetailView.swift */; };
-		990C0994B030462C859A17BF /* WalletOfficialTranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AACA18723DA4543805BE85B /* WalletOfficialTranscriptDetailView.swift */; };
-		CEE26666B51048248A0CB7C0 /* WalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F06C20D3B941B69051DDA0 /* WalletView.swift */; };
-		A23C0799C9D5426B91951786 /* AccessibilitySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373523C32EB949A5B9CAA82A /* AccessibilitySupportTests.swift */; };
-		1994EFB9430B407BB04A3A7A /* AccountIntegrationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A13B3495F1F4A4F819B53AF /* AccountIntegrationsLogicTests.swift */; };
-		F2DCFE74B99E4C36AF1CDFE4 /* AdvisingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865591C44DA943BAAF006BA8 /* AdvisingLogicTests.swift */; };
-		3F6D6C71ECC34DD89E5D8DB0 /* AiModelsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCE179E631F4F1587E17C1A /* AiModelsAdminLogicTests.swift */; };
-		8EF49AF757964F3FA83DC6D5 /* AnnouncementLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FF81B2344C47318DA46DEA /* AnnouncementLogicTests.swift */; };
-		D26D2A6793B043DAB9A426AD /* AppleSignInLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B763FBAF0F348CEA7B7F700 /* AppleSignInLogicTests.swift */; };
-		9A97E0D3542C4B7EA5F79622 /* ArchivedCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B046C3491242F78AFC62B5 /* ArchivedCoursesAdminLogicTests.swift */; };
-		B52A437D41414FF4BC756B89 /* AssignmentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBA7D88E4324BAA8C417F29 /* AssignmentLogicTests.swift */; };
-		08789C3FDA64436EAF36AD7C /* AuditLogAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D03F861BB2F42CFA59E0822 /* AuditLogAdminLogicTests.swift */; };
-		82A951442D6E4BFBA1171B21 /* AuthCallbackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBC569F456A4BD3B900F0B4 /* AuthCallbackParserTests.swift */; };
-		61198ECE5E1041468DE0B80A /* BehaviorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F482AACC614C47BB93AC3A /* BehaviorLogicTests.swift */; };
-		9BEC92F81DA44E92B5D7C768 /* BillingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFB9831EC6A4D94810B09A2 /* BillingLogicTests.swift */; };
-		24567DB9CFE541B9A11D661B /* BiometricGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E50B8DE72E4B06BF467B31 /* BiometricGateTests.swift */; };
-		52BD152816234B4BB35A5E79 /* BoardsAdvancedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF89736CCA439C94F43B27 /* BoardsAdvancedLogicTests.swift */; };
-		B0B3BC864AA54AC095F4CBCA /* BoardsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F97E50BCA747C9BD1D9FA2 /* BoardsLogicTests.swift */; };
-		22CB296FDC75473EB06C7704 /* CanvasImportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FC3FBB11F247FBA7765A55 /* CanvasImportLogicTests.swift */; };
-		BBE628DF72F94D6D8F4FAC85 /* CatalogLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805240352A4542E6B904D4AC /* CatalogLogicTests.swift */; };
-		5686955245F34B759BD4C41B /* ConferenceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E480CDFCB0E5428393B4648B /* ConferenceLogicTests.swift */; };
-		E08A73F841714561BA2FF8EF /* CourseAccessibilityReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21EB256086B4484BE067D42 /* CourseAccessibilityReviewLogicTests.swift */; };
-		9237F4A866D74B20B3000265 /* CourseArchivedContentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550DA196AE6B43B6B903B0FA /* CourseArchivedContentLogicTests.swift */; };
-		37B9948867FB4B779B88D0FF /* CourseBlueprintLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86F2841498A4C32AA7093AA /* CourseBlueprintLogicTests.swift */; };
-		5CE78B0F31214C66A526476D /* CourseCreateLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1F7E879D54243A4DA10E1 /* CourseCreateLogicTests.swift */; };
-		A76CB6FC18E64768A79D0D8E /* CourseFeaturesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E7A2D79A0A47F1ABD4C3AC /* CourseFeaturesLogicTests.swift */; };
-		35FE576C56B342CF9FBA9E24 /* CourseFileModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16533B0965BB4F4DA160F03E /* CourseFileModelsTests.swift */; };
-		CEAE609950C8411FB1582E11 /* CourseGradingAgentsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 566A8F4AA7BB49848E5D5552 /* CourseGradingAgentsLogicTests.swift */; };
-		F795215E985444169BB9F10F /* CourseGradingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF4C3297E884354ADDEDFC6 /* CourseGradingLogicTests.swift */; };
-		96F2D3104820409688B27A99 /* CourseImportExportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A6BF2D82C24B07A02D4F16 /* CourseImportExportLogicTests.swift */; };
-		40A952AFC87949D89BDFDEF2 /* CourseOutcomesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FD447ED651463297DB49D6 /* CourseOutcomesLogicTests.swift */; };
-		A5E9605AA60241558C833BE9 /* CoursePeopleLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19A901DA16C44A98BCFC878 /* CoursePeopleLogicTests.swift */; };
-		32FBA9724D734FBEB97F3B1A /* CoursePlagiarismLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E96F164ACF476A90625A44 /* CoursePlagiarismLogicTests.swift */; };
-		E98EF898FC3B4BEE94D33E12 /* CourseReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FC803557FA400798E517D6 /* CourseReviewLogicTests.swift */; };
-		64482DC9BB234AD586064698 /* CourseSectionsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DCDA7BE5F4D968FD8C654 /* CourseSectionsLogicTests.swift */; };
-		024E9164F7D046E99E396E7C /* CourseSettingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDD54F128A34514B52E92C3 /* CourseSettingsLogicTests.swift */; };
-		AF4F359F681742A6B319F4D4 /* CourseTranslationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9DE4A71F4B41C1A155FAA9 /* CourseTranslationsLogicTests.swift */; };
-		97E2A381F45543519879F02D /* CredentialsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C40E4D7ACF46108CCE6999 /* CredentialsLogicTests.swift */; };
-		B84920E40A0C49FEBBF062DF /* DiscussionLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0EF8D14F18747E4B15D7672 /* DiscussionLogicTests.swift */; };
-		EB3A9F3EA1454D34B09EAD5C /* EvaluationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B5F96B46D4D66AB310255 /* EvaluationLogicTests.swift */; };
-		CA23903478C24FF19420A3DA /* FeedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43ECD1F3A5847A08AA8D7AE /* FeedLogicTests.swift */; };
-		1E50EEC9131644CA94A9BC1A /* FeedbackLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EDCFA8D4C441EC8D01E20E /* FeedbackLogicTests.swift */; };
-		79975C08D6A94A9E9257F513 /* GamificationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB4F84C218644FC898D5E1A5 /* GamificationLogicTests.swift */; };
-		507450EE9B44461F987791F3 /* GradeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A73FC830CB4D27A8DD4B25 /* GradeCalculatorTests.swift */; };
-		A9F1798F9AEF41A9A9DD4C07 /* GroupsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70912832963940B79AFA8373 /* GroupsLogicTests.swift */; };
-		F6A478037DE143208F54EE24 /* I18nTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DF14D128D64FE3913D78F3 /* I18nTests.swift */; };
-		4218315B4F5D411EA5FED6AB /* InsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0686994B5D846CF87F347DF /* InsightsLogicTests.swift */; };
-		205AA6319E3A4CABBA071659 /* InstructorInsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF2B2D6C6B44BC2866C2D93 /* InstructorInsightsLogicTests.swift */; };
-		F9429E0163E0422BA909AADF /* IntegrationsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF38019511514A39A5938F26 /* IntegrationsAdminLogicTests.swift */; };
-		27048DD189624218A3D9EA63 /* InteractiveLaunchLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD8FA95ACA24505AAD62EE7 /* InteractiveLaunchLogicTests.swift */; };
-		8F0235BD407A4F6FB044E84C /* IntroCourseLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F44242ADD2F4D4384FB8217 /* IntroCourseLogicTests.swift */; };
-		62C6355F8D3947F4A6BBDC7B /* LearnerProfileLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74498D27D0A423F9F710088 /* LearnerProfileLogicTests.swift */; };
-		606E7F5B576145F183AE8773 /* LexturesMotionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D31802C470C412595FA718E /* LexturesMotionTests.swift */; };
-		851D35021CA3471E82CE76F8 /* LibraryResourceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF702B17A3744F4AE9A21DB /* LibraryResourceLogicTests.swift */; };
-		6982609AD79E4AC4A422425F /* LiveMeetingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14872F45A72248E591C80A5C /* LiveMeetingsLogicTests.swift */; };
-		E242AD182E624AF48AE00B19 /* LiveQuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B152116F1844EA939CD2B0 /* LiveQuizLogicTests.swift */; };
-		AB6E3BB8C19646CD8F65649E /* MarketplaceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAEFB24E3C34525BC2F040B /* MarketplaceLogicTests.swift */; };
-		25AED480499D437B8DC4CE95 /* MasteryLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E6ECF6C15C455F86415C69 /* MasteryLogicTests.swift */; };
-		602715CA35FD410A82DE5CD5 /* MobileDestinationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D65C9AD65F4155AC1B2C74 /* MobileDestinationsTests.swift */; };
-		A7693FDB85E9410B9A5041AF /* ModuleContentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D553BFCCA75D4ADDB8E03FDA /* ModuleContentModelsTests.swift */; };
-		FC55C1D14A454B0FA30F13DF /* NotificationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8A5CE055EE4CBB875FFC50 /* NotificationModelsTests.swift */; };
-		6A8E25277A364360BB65ACF6 /* OfficeHoursLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6453702A8CC84167A99D06FC /* OfficeHoursLogicTests.swift */; };
-		BF0564D785B241C68D466A0A /* OnboardingModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A17E2E10AB14AF1A4BC0A20 /* OnboardingModelsTests.swift */; };
-		0C52FC70DBAD4D86AA0543FA /* OrgBrandingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C6AF633234B11B05AC8B3 /* OrgBrandingAdminLogicTests.swift */; };
-		4E9184D5D15D432F8D01B21C /* OrgStructureAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3030AF2E57974257827BCD97 /* OrgStructureAdminLogicTests.swift */; };
-		5E1F943D21FF466FAB849AB9 /* ParentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114DE315F90F46428790C499 /* ParentLogicTests.swift */; };
-		894A900460EE4AC1A6F32B83 /* PathsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B278631504942649E2B10A7 /* PathsLogicTests.swift */; };
-		B6C5C79CDC00441DB2E96564 /* PeerReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE0AAD7BE7F4DE4A0E2E97E /* PeerReviewLogicTests.swift */; };
-		5D8FB83EE1784AA9834AF116 /* PeopleAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E780269A3774488C96081F4D /* PeopleAdminLogicTests.swift */; };
-		28A35BBFB4FD4A7B90D31F79 /* PeopleAdminMetricsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1122C950BA74EC3B0F4C4BA /* PeopleAdminMetricsLogicTests.swift */; };
-		A70BDCB9398842E78C2B9DE1 /* PlannerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201E3DED9B6B4C7D9E3CDBA1 /* PlannerModelsTests.swift */; };
-		75F57C4C09F449DF9CA31233 /* PlatformCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADE113A4F7D4363B71AAB5D /* PlatformCoursesAdminLogicTests.swift */; };
-		A10E5A2734A24CD9B3D1C6EB /* PlatformSettingsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E20A89C03B34AE681FE9B7C /* PlatformSettingsAdminLogicTests.swift */; };
-		17A60B25F39A46F79C695BFC /* PortfolioLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFD385E20E4874B208B6E8 /* PortfolioLogicTests.swift */; };
-		D1C85862113641E3ABEA0EE8 /* ProfileDepthLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED465D36A86D429D8D927E4D /* ProfileDepthLogicTests.swift */; };
-		3DD7B3543EE44F449E16C4A3 /* QuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF03A123F79457888EEB315 /* QuizLogicTests.swift */; };
-		B12D7287F1B5479481CEFC9F /* ReaderLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CEBA182BF44B2BE3FCADD /* ReaderLogicTests.swift */; };
-		F559AC6173C54430ADC4CF98 /* ReadingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82D214349F34003A916A5BD /* ReadingLogicTests.swift */; };
-		3E747E0812D94FD4B3A68293 /* RequirementsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583B845B981A489A80BD757D /* RequirementsLogicTests.swift */; };
-		CA27E0A6B66846B78ABDB0E6 /* ReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164416E4C983431883516796 /* ReviewLogicTests.swift */; };
-		0D177076EAB349BA880EB4FD /* RolesPermissionsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C08E0BEB834A3EB334C08A /* RolesPermissionsAdminLogicTests.swift */; };
-		5741663D14FD43D7B577FFA3 /* SchoolCodeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232FFCED0306441FA66F4EB3 /* SchoolCodeLogicTests.swift */; };
-		0F9BB204DA8B4F88856BF2CC /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B291A3D998D4494EB5BF4F69 /* SearchTests.swift */; };
-		383DA9C55A7740BDAB59BA67 /* SettingsAccommodationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB038F7ADFA40A0958FCA12 /* SettingsAccommodationsTests.swift */; };
-		0BBABC3CD8E54355BB464CE0 /* SettingsMenuLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C23C8D85854FB8A73C1AE1 /* SettingsMenuLogicTests.swift */; };
-		C9FE307022A24D8EB0AF2915 /* TakeAttendanceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D33288F5C5A4CC4967D0503 /* TakeAttendanceLogicTests.swift */; };
-		825A451207EC4A378798D7F1 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1410FB35F44CC4B312DD2A /* TranscriptsAdvisingAdminLogicTests.swift */; };
-		3944357D2583408395A57ED8 /* TutorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BC8DA818EC4DBEB21CB6A3 /* TutorLogicTests.swift */; };
-		A7EB2920495A4EE4AD2481E4 /* UIModeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D38DC81AAE47D78174340E /* UIModeLogicTests.swift */; };
-		D6224B6580C04B12A4C74A73 /* VibeActivityLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DECA44A9D514EB9B68544FB /* VibeActivityLogicTests.swift */; };
-		08CD949DE86247FBB8107C76 /* WalletLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04481C8E09DD46DB93EA9D47 /* WalletLogicTests.swift */; };
-		978593606D454E40B811DDC5 /* WhiteboardLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2F1DCD549844B092CD0466 /* WhiteboardLogicTests.swift */; };
-		40E58270E8384B91A6D7D8D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F1D492B110A3479A86B62F45 /* Assets.xcassets */; };
-		86440F50A4684F768EF22A0B /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 6678AEC9159340A695FD20AD /* Localizable.xcstrings */; };
+		240E725891A946D08885C587 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DEFBE299634A468607326D /* AppDelegate.swift */; };
+		D3158A6047094E109678C04E /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67025CF88B846CAACE2DA27 /* LexturesApp.swift */; };
+		BF3767E999414BCB8FE7FF06 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB9F41D2A524DEF9846DACA /* RootView.swift */; };
+		239510D3B95E407F93FA9377 /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BA05FDEBB64BAF93BE2F13 /* AccessibilityPreferences.swift */; };
+		9D48DC10D5FA4DA1924942E9 /* AccessibilitySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF91E36EF4544195BBD02326 /* AccessibilitySupport.swift */; };
+		7FDD14D2965F46C2981D6162 /* DictationField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0069CCE81BA14890AC1EAC3B /* DictationField.swift */; };
+		228C93C1C1C7461AA010DC6E /* ReadAloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A3F5F78EAD4A4DA36C2B0C /* ReadAloud.swift */; };
+		A34CD14DAEF84B6689A26A5A /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754D0E92FDE34E7E8AB24CB5 /* AuthAPI.swift */; };
+		65D5352C4B094F5FBC5A7C4B /* AuthCallbackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A1B1EBE2104C3BA7F2ABDC /* AuthCallbackParser.swift */; };
+		E3BDDFD9E8C64AEFA657B749 /* AuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E568CA21DD5463582E682BF /* AuthConstants.swift */; };
+		CB59C836C8504AB2AE2A0002 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE836A40074D413B863331C4 /* AuthSession.swift */; };
+		7B7067F5422C4FD583B92F95 /* BiometricGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88441ABD3AF4EA18B9D7919 /* BiometricGate.swift */; };
+		3D15EB78AC1D4176AFEC622D /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E844AA4E55E44D0A44667CE /* KeychainStore.swift */; };
+		FC12D9DAB2C54204BFF9DC79 /* SessionsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EB9537C0C44179B8F67001 /* SessionsAPI.swift */; };
+		CF9E1E4B7DC645C6A42DF6B1 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5814B80506574CC7A0273C68 /* AppConfiguration.swift */; };
+		FDBFBF4C39494C95B24424E0 /* EnvironmentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185C4FF6313D4A0A87BAF184 /* EnvironmentStore.swift */; };
+		0987ED60211E4CF599A232E0 /* SchoolCodeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E3EE98E2A744009E08B8C6 /* SchoolCodeLogic.swift */; };
+		97B3815945CF446ABAC90677 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1391CC0E37F48CCB9C631A4 /* AuthFieldRepresentable.swift */; };
+		5D9A051F49AC4502B87507ED /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9230D0D6774D73B2D53DEF /* BrandLogoView.swift */; };
+		6F57AEBC0E6B4A03A4EB7CD1 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F148F9731962426CA4DF6261 /* Haptics.swift */; };
+		4EF2E72697034CF6ACDBEF99 /* LexturesMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E31C9A4AEC4493B8884AEC /* LexturesMotion.swift */; };
+		FE63A2E93C7947E78877C089 /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F01FCEF2ED44219E53DD2B /* LexturesTheme.swift */; };
+		9DCB53369DF3421884130349 /* LexturesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0427B681B0B450F9B6F3CD0 /* LexturesType.swift */; };
+		897D94C1E6D34B3691F44149 /* ProfileAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BEFC9869AF45FBB5984148 /* ProfileAvatarView.swift */; };
+		E9941B1ED1E04E2E9A0CF097 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B58E98D00DD4DC7936D761A /* SyncStatusView.swift */; };
+		2FBA46C749524801A4C5D6BE /* ThemePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB4278C38914F3BA5A8C451 /* ThemePreference.swift */; };
+		E5066CDBEAAA40C6907AAE2A /* UIMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40A0E47E5164CF1B895B900 /* UIMode.swift */; };
+		085A467A10964B5ABCD3D5D5 /* UnsavedChangesBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E74364021942FA9B9032BF /* UnsavedChangesBanner.swift */; };
+		794A20EE490942E3971E963F /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E645CC9EAC4B068156F427 /* DateFormatting.swift */; };
+		8493FDD3C7264C6B817772A3 /* LocaleAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E08FB6345A44C42B2D45068 /* LocaleAPI.swift */; };
+		D41ABE75085944DF83CD69B2 /* LocalePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1643642F69411C88E9EAAA /* LocalePreferences.swift */; };
+		21D09E098F224E98A9D6393F /* Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00A1733168246CB972CC87A /* Localized.swift */; };
+		8E1F4288320B4463B790DC9C /* AccountAccommodationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68F93E592FB4648929B0871 /* AccountAccommodationModels.swift */; };
+		BD7530F8E3C84B0CA9DE4347 /* AccountIntegrationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8DE74B587434CB984788154 /* AccountIntegrationsLogic.swift */; };
+		9968113BCCE1445BA7389CBF /* AdvisingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE5A93F036646F4A0316BF8 /* AdvisingLogic.swift */; };
+		ACA42359AF0D40BAA8188BB3 /* AiModelsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7FEBC30EB6460BB11D890A /* AiModelsAdminLogic.swift */; };
+		1FF219B9AE854AE09E8D98A3 /* AnnouncementLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B873466B0F9844E38FBD2EEB /* AnnouncementLogic.swift */; };
+		B27A1C6E5EDE4D02B3C05788 /* ArchivedCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0BB372CDF64D93A5EEE8BB /* ArchivedCoursesAdminLogic.swift */; };
+		BA633B46A19041ADB11491DD /* AssignmentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B01C8A31794FEDB5CA0C3C /* AssignmentLogic.swift */; };
+		83D707BF5EE04D4C9BE9FF8A /* AuditLogAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ADFCEC7474296A587ABB7 /* AuditLogAdminLogic.swift */; };
+		A6084BED41FB411CAD04CF80 /* BehaviorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C627F927094E7DB6B60B7C /* BehaviorLogic.swift */; };
+		8BBACF5962DB4B83BD07E163 /* BillingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF856F8981D4DBFBDCC78B7 /* BillingLogic.swift */; };
+		462799CE7D3A483A9ACC482D /* BoardRealtimeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA5BC461B394AC9811974BB /* BoardRealtimeLogic.swift */; };
+		A19F9E1736274C0186C44B25 /* BoardsAdvancedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61598E2C8FD4D32AA09F946 /* BoardsAdvancedLogic.swift */; };
+		5D32434460034544A6E21E37 /* BoardsGovernanceAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A418E83F8A8F43E8B4DC3105 /* BoardsGovernanceAdminLogic.swift */; };
+		76AEDBEE89D1496DBA2C246E /* BoardsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8632D3336742959B406677 /* BoardsLogic.swift */; };
+		36BE2AC2689A4D14963FC35E /* CanvasImportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F2525060E34C70BCB38510 /* CanvasImportLogic.swift */; };
+		4DB09BEB18624C8DAC03A00B /* CanvasImportObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF05BCBA4D84824A04B9796 /* CanvasImportObservability.swift */; };
+		49C8456D791647B897FC0F9D /* CatalogLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBCF0D5A1DA4969968D0D41 /* CatalogLogic.swift */; };
+		08C2762C6232453F8FC0120E /* ConferenceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3E03A9F1A2490DB6A15B8B /* ConferenceLogic.swift */; };
+		0D15085F7C96411B89E7D8F4 /* CourseAccessibilityReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752DEF0373E54AEF83685C57 /* CourseAccessibilityReviewLogic.swift */; };
+		78A919BC931D42CC8A8C53F4 /* CourseArchivedContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D70879399D4C2887045226 /* CourseArchivedContentLogic.swift */; };
+		2A4F4D22793843BE9F3BF0D3 /* CourseBlueprintLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150AD95FB44A4599B3FDADDC /* CourseBlueprintLogic.swift */; };
+		385DE05194384AF39E76E34B /* CourseCreateDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21312747EECB49078649F0D5 /* CourseCreateDraftStore.swift */; };
+		13062509014549A0A9B3519A /* CourseCreateLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B052C0DDDC34A22B89918ED /* CourseCreateLogic.swift */; };
+		6DA4BEC68E49448CAE3D8DB5 /* CourseCreateObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02E84D076E4C5B976D43FA /* CourseCreateObservability.swift */; };
+		EA485314F84640689A386903 /* CourseFeaturesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A64839A40BB48829B81C012 /* CourseFeaturesLogic.swift */; };
+		FE18E33BDD52412D930A5631 /* CourseFileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAE591DAB9E4F139DEFFE39 /* CourseFileLogic.swift */; };
+		53EA8774096F4C72A463E81D /* CourseGradingAgentsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C801B83CE74B5E8A7D2523 /* CourseGradingAgentsLogic.swift */; };
+		2CF45ACA7FB948F6A7F97BFF /* CourseGradingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB034F1229147CA87AC6AEE /* CourseGradingLogic.swift */; };
+		79DA50595F224D1690B730CD /* CourseHeroImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E228B612E4F19B1399BD7 /* CourseHeroImage.swift */; };
+		9963B524737F4357AEB2A067 /* CourseImportExportLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E04650D5824DDA840FA21B /* CourseImportExportLogic.swift */; };
+		688FBFFBD7764BC69D763B49 /* CourseOutcomesLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F5328B34D4699983E7BF5 /* CourseOutcomesLogic.swift */; };
+		110C4453D25C4FBEAC6707CC /* CoursePeopleLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7CD0F2D33447528D1C23CA /* CoursePeopleLogic.swift */; };
+		C411FF02FF234B308DA47F86 /* CoursePeopleObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A175A4F351E24D06B14450BD /* CoursePeopleObservability.swift */; };
+		309E6CC1F9984ED1942BFEAC /* CoursePlagiarismLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A8FA6D8AB44BB795EC8499 /* CoursePlagiarismLogic.swift */; };
+		601A00C9DCCF491A99EA6312 /* CourseReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3651540DE6426CBA163F6A /* CourseReviewLogic.swift */; };
+		C9811D8C71C84F0AB7030690 /* CourseSectionsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FBFA97169645C6BAF9D202 /* CourseSectionsLogic.swift */; };
+		660B923CF33A4629A2A42483 /* CourseSettingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDFCAFCA054246B428D8D6 /* CourseSettingsLogic.swift */; };
+		B472932012434DBEB45BEE69 /* CourseTranslationsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9A809DC9D44A81876C84D6 /* CourseTranslationsLogic.swift */; };
+		69A3BABA9AC84CBF8310E63D /* CredentialsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED7960BED804EBAB21DB624 /* CredentialsLogic.swift */; };
+		9B96254C9DC64382B3589B67 /* CurrencyExponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBA158B2F624AC98BE02A3D /* CurrencyExponent.swift */; };
+		784F2D0EF9D347C883890507 /* DiscussionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09D6EDF371C48098874B22C /* DiscussionLogic.swift */; };
+		4C29F2616BAD4AC2A1A17FB8 /* EvaluationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A4DAAD9D8E4E4EA7299202 /* EvaluationLogic.swift */; };
+		D11F63DD27814C158A3D57E7 /* FeedbackLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C78219C42C422EA2F7E48C /* FeedbackLogic.swift */; };
+		982EDF1CACF74079A2320F04 /* FileDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D80581D2F94A02BAAED322 /* FileDownloadManager.swift */; };
+		54659AF589E54284BF7D2172 /* GamificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D368F3EC634E2585AAA222 /* GamificationLogic.swift */; };
+		75727BAE71F0499E9C6738C4 /* GradeCalculator+MyGrades.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213653C2BDE4591B0CCA138 /* GradeCalculator+MyGrades.swift */; };
+		C8D6494A7A00465D8ADBB657 /* GradeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F05C3B54914F429882583C /* GradeCalculator.swift */; };
+		D42731304DEE497A8FD005F2 /* GroupsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19320D4F624D4E81A07DB852 /* GroupsLogic.swift */; };
+		22486BC798FE40CBB8BA3C05 /* InsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47D6DDC0A834B6396610973 /* InsightsLogic.swift */; };
+		4994A5BB02CA4090AC139ECF /* InstructorInsightsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB97F9F93694C9793C63614 /* InstructorInsightsLogic.swift */; };
+		8DE068765D6D45AF90A28759 /* IntegrationsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B8A1A6109E4556B2336DD9 /* IntegrationsAdminLogic.swift */; };
+		30996B616F334582BBF67A11 /* InteractiveLaunchLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7E41797A5E4EFE90B176B8 /* InteractiveLaunchLogic.swift */; };
+		F0BFAAFDB1B24A429598422F /* IntroCourseLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8786D1D4285415199C49EDE /* IntroCourseLogic.swift */; };
+		5EBEA5A2224247EBA6B4CCFB /* IntroCourseObservability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98B884A3B324822AB0ABE8A /* IntroCourseObservability.swift */; };
+		93E22620D60849E8BB78AC16 /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93BD7724C24E4C9B96FF02C2 /* LMSAPI.swift */; };
+		49891A28140145539FAB5438 /* LMSAPIAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696AAE4C18A5412193D9FA8C /* LMSAPIAccountIntegrations.swift */; };
+		E6F8820247D840C9B04BBF08 /* LMSAPIAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07DE5F1155441E49DEA50FB /* LMSAPIAdmin.swift */; };
+		9D6DD08B63B240E897A574FD /* LMSAPIAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDA23E010114F39BF8B899B /* LMSAPIAdvising.swift */; };
+		16B72527F6284ED6AA2DA90A /* LMSAPIAnnouncements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7538ABD46EAF4599B2C42CE2 /* LMSAPIAnnouncements.swift */; };
+		87980E620BFC4D4D99BB1A23 /* LMSAPIAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116C05C9CA2840DCA1A2C4CB /* LMSAPIAuditLog.swift */; };
+		31EF66E980E34557BEBF50F0 /* LMSAPIBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E18FC25D3574725B9548ECC /* LMSAPIBehavior.swift */; };
+		D2CBE14D6986402B82413AD5 /* LMSAPIBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754564AA344740C1AA7A6323 /* LMSAPIBilling.swift */; };
+		65DB95BBC6F443AEA17F8161 /* LMSAPIBoardAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FCF3B0FA264A869E9F6542 /* LMSAPIBoardAccess.swift */; };
+		4F2DA25C7BD3488BB56FADDA /* LMSAPIBoardAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486137AACE1A4826A2C71E49 /* LMSAPIBoardAnalytics.swift */; };
+		C4D5FB5D70B441CAB9640EEC /* LMSAPIBoardEngagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D57FD88E4421DB1887176 /* LMSAPIBoardEngagement.swift */; };
+		0182BBA1A620401E985103C0 /* LMSAPIBoardExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A356D13BF3A43AA987E66CF /* LMSAPIBoardExport.swift */; };
+		29321170955D4397823E154D /* LMSAPIBoardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE2C7EECD8341B99934ABB6 /* LMSAPIBoardLayout.swift */; };
+		5C346123E2FE47579E8B5812 /* LMSAPIBoardModeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30035C0884734E0482DA7934 /* LMSAPIBoardModeration.swift */; };
+		CF133D650FBA43DEB9578313 /* LMSAPIBoardPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B7A32365D24C0880F6F284 /* LMSAPIBoardPosts.swift */; };
+		DF86EB0188B04C01AE4F102E /* LMSAPIBoardTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D118B2EB3134D42A3B2CB7B /* LMSAPIBoardTemplates.swift */; };
+		71BA6FFC84B04878BA370CFF /* LMSAPIBoards.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FA21ABFBC4611B3BE640C /* LMSAPIBoards.swift */; };
+		23316F07C97E46FD9BED6F2B /* LMSAPICanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042BC610AE594924AEB29479 /* LMSAPICanvasImport.swift */; };
+		836A5167E555477ABFE70785 /* LMSAPICatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783765A9C2054F2CB418A46D /* LMSAPICatalog.swift */; };
+		73C7958E365E459FBBC2B05E /* LMSAPICourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA53D0293F9E4CDF93F367BB /* LMSAPICourseAccessibility.swift */; };
+		03A9650885DA4A9E8ECAB91E /* LMSAPICourseArchivedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC41C117EA1B4D258C520BCA /* LMSAPICourseArchivedContent.swift */; };
+		ABEB447BF62D484ABE5B2646 /* LMSAPICourseBlueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2599FFE0DE6845D6B74944FF /* LMSAPICourseBlueprint.swift */; };
+		C405BF5605AC48F7A19B8385 /* LMSAPICourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB2C99B7D8840068A3D4076 /* LMSAPICourseCreate.swift */; };
+		7DC57A3FC93745239F87E19C /* LMSAPICourseFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E5D01EE7AB43168D2679A3 /* LMSAPICourseFeatures.swift */; };
+		3210B7B6C8B94FC1BC33ED09 /* LMSAPICourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70B259D43F4D448CFBAAB8 /* LMSAPICourseGrading.swift */; };
+		75D7908CA5484BD4936E722D /* LMSAPICourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F34E4E4941749D4877040E7 /* LMSAPICourseGradingAgents.swift */; };
+		81383CFB926A43A491D73398 /* LMSAPICourseImportExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C276309B00E2443A93D953C2 /* LMSAPICourseImportExport.swift */; };
+		BBE1349E588D468AB05182E9 /* LMSAPICoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2E90CB7F4245A4B43AF026 /* LMSAPICoursePlagiarism.swift */; };
+		D85EDDE499C04996ADC6E33C /* LMSAPICourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC70C9A48C94BF4B4C3BB1E /* LMSAPICourseReviews.swift */; };
+		3AB1AE726AAE46F9811119E0 /* LMSAPICourseSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA80816617A14D78B9FE54BF /* LMSAPICourseSections.swift */; };
+		463E6EFB171F4B218A4AFED2 /* LMSAPICourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FF1AF25FF04DD6AB70FB57 /* LMSAPICourseSettings.swift */; };
+		FF4F21F99FB84DFC88B54C0C /* LMSAPICourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2574DCE83C460EA90E3F85 /* LMSAPICourseTranslations.swift */; };
+		35ACD26635664FB5B9B83089 /* LMSAPICredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ACD5D8E10340B9B9697ECC /* LMSAPICredentials.swift */; };
+		3DB5BFD37E344C81BEF726D3 /* LMSAPIDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E21E540FBF84BFC8F4E2D9A /* LMSAPIDiscussions.swift */; };
+		6297C32CEBB2437DB2ABD155 /* LMSAPIEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474A042D5DE49069BED4533 /* LMSAPIEportfolio.swift */; };
+		347BDAC60A034CDE8296AB0B /* LMSAPIEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00767DB4B92F4E0DA05BD38C /* LMSAPIEvaluations.swift */; };
+		C15B30F14F6340179249738E /* LMSAPIFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA1EFB4E5A246FDB803C2DF /* LMSAPIFeatures.swift */; };
+		A72A4A03D5DB4CCB8C2EF62A /* LMSAPIFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75B89DB41E547AA84F61487 /* LMSAPIFeed.swift */; };
+		F699FFC6DB87461EBA53FE2F /* LMSAPIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BD38517A854ABB84951E98 /* LMSAPIFeedback.swift */; };
+		E1AB8D7FCD35477CB3F02623 /* LMSAPIGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2D858067A24BD0B0F3C5AF /* LMSAPIGamification.swift */; };
+		AC1E863CA56F45A4B39E3196 /* LMSAPIGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = F081D2E7003B4AE0B9D681CE /* LMSAPIGroups.swift */; };
+		813D82FE3E9949D094F6077B /* LMSAPIInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6635E0AC104977B2C9A88B /* LMSAPIInsights.swift */; };
+		0F878E226FBD4B09AB3C0C32 /* LMSAPIInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD9D91E638A4A639AB1CD7C /* LMSAPIInstructorInsights.swift */; };
+		F82E2C8F45A64A4DB9ADBB27 /* LMSAPIIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28C4D21531D4A33A1865EAC /* LMSAPIIntroCourse.swift */; };
+		0BE802E7DBD945A8BD3C69B4 /* LMSAPILearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7789C8CFDE394EBEBE23881B /* LMSAPILearnerProfile.swift */; };
+		A55978E50E784669915A8229 /* LMSAPILiveQuiz.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB1209784D4AAA9985A44E /* LMSAPILiveQuiz.swift */; };
+		EEB27A5AB5794497B0D2E450 /* LMSAPIMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B32DB5484C1481CA15B2324 /* LMSAPIMarketplace.swift */; };
+		62F975D1A171433FB02FB693 /* LMSAPIMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0133E4DAF845C28F931794 /* LMSAPIMastery.swift */; };
+		EF57F32C16B249A59C1B0A9D /* LMSAPIMobileWave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B1DBF812454BF49DC9A309 /* LMSAPIMobileWave.swift */; };
+		B86CE3E6E2C1410B95DED754 /* LMSAPIOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021B46FAE5F947198127DF0E /* LMSAPIOutcomes.swift */; };
+		82349E2D374E44EFA6384DA2 /* LMSAPIParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967D00F11FE3420E968C119E /* LMSAPIParent.swift */; };
+		934754F3673844D6ADC73E1D /* LMSAPIPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8B663C1A1B4962B2E66A73 /* LMSAPIPaths.swift */; };
+		4E2653C7721C4ADE90E0E38D /* LMSAPIPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05120AC28E87464DB043E631 /* LMSAPIPeerReview.swift */; };
+		C12F6B8702F94423B7D9D528 /* LMSAPIProctoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23C258FCE4EA4550A8DF0FB2 /* LMSAPIProctoring.swift */; };
+		82FD2057433749D0A0BA95B0 /* LMSAPIQuizCodeRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAAE1D0F18446B0AFCD4F20 /* LMSAPIQuizCodeRun.swift */; };
+		834205D9CAA34D1986FB6277 /* LMSAPIReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CE7B57D3C74A39947F0288 /* LMSAPIReader.swift */; };
+		11EBA0BF7102475DB405CADA /* LMSAPIReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0586DF49BB4BEBAAC22DF6 /* LMSAPIReading.swift */; };
+		841FB2BB9D5D4B15B8FD87BB /* LMSAPIReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B43740C05F4E4FAFCF4552 /* LMSAPIReview.swift */; };
+		245688C1364C4EA5915DDDFA /* LMSAPITutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7D36BC426C4CFB90398EC9 /* LMSAPITutor.swift */; };
+		18372484FB8941A5AC4249AF /* LMSAPIWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EE42BE8C4F457081935252 /* LMSAPIWallet.swift */; };
+		0DB86C83EC9E46D29A07C87E /* LMSAPIWhiteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA8395926874179BC6133B6 /* LMSAPIWhiteboard.swift */; };
+		E7CE05F426644DA5897B0E5D /* LMSBoardAdvancedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD727138615C4BB58E5AD531 /* LMSBoardAdvancedModels.swift */; };
+		8B0972CBF2D04A14B368D108 /* LMSBoardModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A22BBC906A4965AD20E9FB /* LMSBoardModels.swift */; };
+		E8D24D84CE224F8DBD5E2411 /* LMSFeatureModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1246E4FB56BA4A8EAC0C4755 /* LMSFeatureModels.swift */; };
+		CBE4A8B6A18C4E9A907101DF /* LMSFeatureModelsAccountIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01BB4CF617C4AE697326AD2 /* LMSFeatureModelsAccountIntegrations.swift */; };
+		C3842CD715564231AA759EA7 /* LMSFeatureModelsAdvising.swift in Sources */ = {isa = PBXBuildFile; fileRef = A191660A8AAC4367BBC6DBC0 /* LMSFeatureModelsAdvising.swift */; };
+		5FB62DC30515458A8BA807A9 /* LMSFeatureModelsAiAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A051C237A05542B78195DF54 /* LMSFeatureModelsAiAdmin.swift */; };
+		69ED71C918DB4FD5A77936E0 /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9495FEEA294923AEA5BF53 /* LMSFeatureModelsArchivedCoursesAdmin.swift */; };
+		34DE4A2CA55647E681ED10D9 /* LMSFeatureModelsAuditLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A0E5C89ED548A199704515 /* LMSFeatureModelsAuditLog.swift */; };
+		2CE8557F96544087B915939D /* LMSFeatureModelsBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E58DD379584EC9897EBA81 /* LMSFeatureModelsBehavior.swift */; };
+		DF305854A9B3465F809033B7 /* LMSFeatureModelsBilling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C298A33135644A24AFBCB734 /* LMSFeatureModelsBilling.swift */; };
+		E9FE5598C89943DD9564C85E /* LMSFeatureModelsCanvasImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8C6B060664460BDBC632C /* LMSFeatureModelsCanvasImport.swift */; };
+		1CE59956AA99451EBA69F703 /* LMSFeatureModelsCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A51DF333A470280FD211F /* LMSFeatureModelsCatalog.swift */; };
+		CEEB499363AA47B9BD4DB1D9 /* LMSFeatureModelsCourseAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43569D183CA24C02982D1D9B /* LMSFeatureModelsCourseAccessibility.swift */; };
+		C13E314EE9914A0F88C5EA25 /* LMSFeatureModelsCourseCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF0237DC5854F459C5FE8E6 /* LMSFeatureModelsCourseCreate.swift */; };
+		3723D36E9F334F7C9BC86A1A /* LMSFeatureModelsCourseGrading.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BC6C3FE403447E84BC459A /* LMSFeatureModelsCourseGrading.swift */; };
+		E2FB2FC6C5EF473997A646FB /* LMSFeatureModelsCourseGradingAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536DE680136F4CDCA73A7D4B /* LMSFeatureModelsCourseGradingAgents.swift */; };
+		324EA67076A64B6F847BFDAD /* LMSFeatureModelsCourseOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5B6BE5CE3C47CAB01E3445 /* LMSFeatureModelsCourseOutcomes.swift */; };
+		4143DD46081F4792B24016AE /* LMSFeatureModelsCoursePlagiarism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237CEC1FDEA14D838F468EAD /* LMSFeatureModelsCoursePlagiarism.swift */; };
+		7D5E8019C8AC43C89611D31C /* LMSFeatureModelsCourseReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DA2A4D1562445E95C7AC68 /* LMSFeatureModelsCourseReviews.swift */; };
+		6B41FF45F003438C9CD7DD64 /* LMSFeatureModelsCourseSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D34C1A41442759A10378F /* LMSFeatureModelsCourseSettings.swift */; };
+		B2686988F6F04B4090F49237 /* LMSFeatureModelsCourseTranslations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01AC1FB62E24D11838EAA39 /* LMSFeatureModelsCourseTranslations.swift */; };
+		BD946DC38EDA47218847A225 /* LMSFeatureModelsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99859DB50F94DCDAFFBC162 /* LMSFeatureModelsCredentials.swift */; };
+		01C1E9640176491D835C99C1 /* LMSFeatureModelsDiscussions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D707EDA39BF4C7695FEDF02 /* LMSFeatureModelsDiscussions.swift */; };
+		9DFB3E79F732439E8CEA473B /* LMSFeatureModelsEportfolio.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CD4CE25EE24E1DAC99E738 /* LMSFeatureModelsEportfolio.swift */; };
+		4F0E3F4A2DBD4EDEBBD59026 /* LMSFeatureModelsEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D715C2FF7ABC4967AD788A5D /* LMSFeatureModelsEvaluations.swift */; };
+		F75567D364554666A851761D /* LMSFeatureModelsFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B72EDBB99BD488F849B8502 /* LMSFeatureModelsFeed.swift */; };
+		63C47F3B9CD1428199B41F6E /* LMSFeatureModelsFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B56FCCE1A1B495BBB800C3A /* LMSFeatureModelsFeedback.swift */; };
+		46C8C80B8CAE4E6D80D77E1C /* LMSFeatureModelsGamification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0530E77E12B74004BCD92E74 /* LMSFeatureModelsGamification.swift */; };
+		4EE4790234B34E709A12C77B /* LMSFeatureModelsGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE08986FF7C4EBD9546D49D /* LMSFeatureModelsGroups.swift */; };
+		16EAC80ADB914C2BBBE28DD1 /* LMSFeatureModelsInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF4F0AA6B9864CE6BDA4C4F4 /* LMSFeatureModelsInsights.swift */; };
+		8AE4B56B0ABE4960945A8F41 /* LMSFeatureModelsInstructorInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1AFD8ED73440A580259DF3 /* LMSFeatureModelsInstructorInsights.swift */; };
+		2FBB27D77EC1440E9353D36C /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACB3E9F0C42444F83FFEC13 /* LMSFeatureModelsIntegrationsAdmin.swift */; };
+		0AADB5D519824BC0BF643547 /* LMSFeatureModelsIntroCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2BA536957A4BB589B41FB9 /* LMSFeatureModelsIntroCourse.swift */; };
+		7757E1B6A0134FE1B4CAEBE9 /* LMSFeatureModelsLearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CA540852D447A9A5EB534E /* LMSFeatureModelsLearnerProfile.swift */; };
+		992A92D738DB4C51B68C38D6 /* LMSFeatureModelsLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D7E2DC15CD47ABB396D038 /* LMSFeatureModelsLive.swift */; };
+		75A8782B2CE547C187F90CE1 /* LMSFeatureModelsMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB72B8AA5B8D4BF283C4812C /* LMSFeatureModelsMarketplace.swift */; };
+		66CA3D0F2644484ABE36714B /* LMSFeatureModelsMastery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4285A765335C47D98D5AA5F8 /* LMSFeatureModelsMastery.swift */; };
+		0AEC11C76D7E4ED5ACD4800D /* LMSFeatureModelsMobile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EAF3DF3E19B47EAA6306310 /* LMSFeatureModelsMobile.swift */; };
+		0365606EC80F49BDA720B9D5 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3E507D2F554E4F8547C016 /* LMSFeatureModelsOrgBrandingAdmin.swift */; };
+		B1DA7F3B2426465F8B2B697A /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F484F5C857C41B8B8D83F3B /* LMSFeatureModelsOrgStructureAdmin.swift */; };
+		765D7205C018448BA5CB7585 /* LMSFeatureModelsParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16C35E71B2B44079C194684 /* LMSFeatureModelsParent.swift */; };
+		7DEFB3C3FA03419AB8D62785 /* LMSFeatureModelsPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2118B981A084588B17EA862 /* LMSFeatureModelsPaths.swift */; };
+		C46E9A6897934C81868C79D2 /* LMSFeatureModelsPeerReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEB85F2108F4CDA89C97B20 /* LMSFeatureModelsPeerReview.swift */; };
+		A0A38195FBB343559254C7E3 /* LMSFeatureModelsPeopleAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD23228423D425187827C43 /* LMSFeatureModelsPeopleAdmin.swift */; };
+		DE1F5BF161664686B3F986CE /* LMSFeatureModelsPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3687F3FFC80047629DB76329 /* LMSFeatureModelsPlatform.swift */; };
+		D1E6B8660F554214A2CCA006 /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F153827ABE574FB28D26FDD5 /* LMSFeatureModelsPlatformCoursesAdmin.swift */; };
+		F93B651870E641088106001D /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9082A0730B411CBEADB9D7 /* LMSFeatureModelsPlatformSettingsAdmin.swift */; };
+		BC64E58484E34804A6EBD122 /* LMSFeatureModelsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD7A193F6B842AB9AD0E084 /* LMSFeatureModelsReader.swift */; };
+		60F6CA9A2A6B4A63802523D6 /* LMSFeatureModelsReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = F493EF6C307441C187C07C95 /* LMSFeatureModelsReading.swift */; };
+		6EBF6EB0F7FD4DAEA1094256 /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8595E8DCA0142C78593020D /* LMSFeatureModelsRolesPermissionsAdmin.swift */; };
+		6AAA48A92983410998A01C76 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C2F7DAE4904509A7C51AB2 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */; };
+		2BC58B9A6B41442FA1D76296 /* LMSFeatureModelsTutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B390B819E404BAC9BD710C6 /* LMSFeatureModelsTutor.swift */; };
+		9744687130044CC9B39025DF /* LMSFeatureModelsWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83EF63F17104ADBBC135CAE /* LMSFeatureModelsWallet.swift */; };
+		58BC60765C004E76B3925EBD /* LMSInteractiveModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83103D7B44E2473A8E083B12 /* LMSInteractiveModels.swift */; };
+		9B03252B96D34568B7F8EA2D /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41EC1D1D81843C3AE5D6B7C /* LMSModels.swift */; };
+		54E3BBADE6FA4124AB0FD16D /* LearnerProfileLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F662D40CBC435EA8AB4575 /* LearnerProfileLogic.swift */; };
+		516AA3B61F134041A0DD7696 /* LibraryResourceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5888F7E8AE85481493777E03 /* LibraryResourceLogic.swift */; };
+		DB662E4E91804D5397835186 /* LiveGameLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A00E00E7074ED386216A18 /* LiveGameLogic.swift */; };
+		566B2B6782DE4B3A87939F9C /* LiveMeetingsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978D91FEAC854AC1A7DEE81E /* LiveMeetingsLogic.swift */; };
+		4480C1BCB27349A6909200C0 /* LiveQuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC24E5FF6DF4E1594203298 /* LiveQuizLogic.swift */; };
+		B8928C79D1314D3CB0C7E4C9 /* MarketplaceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 324AA97B736A47DEABAEF8B5 /* MarketplaceLogic.swift */; };
+		886E7AA8383A49DC83C1FB78 /* MasteryLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F243E67246474E0E9E9700B4 /* MasteryLogic.swift */; };
+		96E667E07D0F42619D9D2A39 /* ModuleContentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C3277E87654FFBB9E8B608 /* ModuleContentLogic.swift */; };
+		C33B651F4BEE4AFD9BA6A113 /* ModuleLastVisited.swift in Sources */ = {isa = PBXBuildFile; fileRef = A312A18DBBA04A82928F7F31 /* ModuleLastVisited.swift */; };
+		226EF0559B1049D6B8EA3B6E /* NotificationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691310D5834D4D85AA80D7EC /* NotificationLogic.swift */; };
+		AD853B2E98F4469B8C1B2403 /* OfficeHoursLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2DCD08A7254E47904BA8B6 /* OfficeHoursLogic.swift */; };
+		113C2860AB3F4A9AB10F1938 /* OnboardingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3437C6C5E5403389A1408B /* OnboardingModels.swift */; };
+		8F54752BD35B491DA6372FFC /* OrgBrandingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0E3748F97D4C1195784DDD /* OrgBrandingAdminLogic.swift */; };
+		F941BCE5E5414D33B51230B7 /* OrgStructureAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D346F3E4DB4208BE31F01C /* OrgStructureAdminLogic.swift */; };
+		1F74D8F205524A75A1148215 /* ParentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA5EC88D6A54B4AA3A4C0D1 /* ParentLogic.swift */; };
+		293022E9ED5F4F6BAD2BD92D /* PathsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F358BC135D3048869EFE35DA /* PathsLogic.swift */; };
+		FC8F1D359C80452E8055B706 /* PeerReviewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A28AEE5FE14AAC93E51F53 /* PeerReviewLogic.swift */; };
+		999FF64D4B5F49D6BE039FE9 /* PeopleAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE82C0E43BD4BB798193FAC /* PeopleAdminLogic.swift */; };
+		3747DCA0E57E442DB26F1B10 /* PlannerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3F76CDFC704620898EB820 /* PlannerLogic.swift */; };
+		8DF70E53F83A4E2DA95E89EA /* PlannerSnapshotCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2A976460E4A0AB1FD5C20 /* PlannerSnapshotCoding.swift */; };
+		6D797CF5C2B442A9A790A7B8 /* PlatformCoursesAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0239F95B6144258A56BF208 /* PlatformCoursesAdminLogic.swift */; };
+		64E2F9497D42489385339C34 /* PlatformSettingsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F42C914017E4A18955B7847 /* PlatformSettingsAdminLogic.swift */; };
+		DA1D085747E14E45A307FA26 /* PortfolioLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D0756CA8CA470BBF27C53D /* PortfolioLogic.swift */; };
+		6106DFE4AC1B414E9E69D471 /* ProfileDepthLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF820D89BD44A048BF21491 /* ProfileDepthLogic.swift */; };
+		58BFF00FEA8F4652B49830BE /* ProfileDepthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E6C53BD425423D97C894BA /* ProfileDepthModels.swift */; };
+		66894447C75F4399AD5FCBF9 /* QuizLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1195F59ED53A48938097273C /* QuizLogic.swift */; };
+		48517E55EB974BEB9602811F /* ReadingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51DD3FFD2C24B4A8734F6EE /* ReadingLogic.swift */; };
+		83D46D16BDE844E3973F8031 /* RequirementsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95053CA3B524D51B57E496E /* RequirementsLogic.swift */; };
+		E28FE2DE3F72446AB723CAD4 /* ReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC0C94610224F1E8DA306D3 /* ReviewModels.swift */; };
+		6A311B5B4C0D47838C805FC9 /* RolesPermissionsAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD5F8EC05E43BDBA7F30C9 /* RolesPermissionsAdminLogic.swift */; };
+		F0053352FC944B5B9198349A /* SettingsMenuLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F67A970A474EBEAFFDB391 /* SettingsMenuLogic.swift */; };
+		4ECB87923FCA4E06B317FA12 /* TakeAttendanceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D73263ACDD3471B8D3DEB09 /* TakeAttendanceLogic.swift */; };
+		38CD2DA112D84039BE13872C /* TranscriptsAdvisingAdminLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259D4E20FEE14AF788D4414A /* TranscriptsAdvisingAdminLogic.swift */; };
+		100E500E47654B8E9D58D1BA /* TutorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A990FFE37A8546BA870D0F0F /* TutorLogic.swift */; };
+		7073B7DC74AC4786922C5A88 /* TutorStreamClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 769106ABCAAB4179B02463AB /* TutorStreamClient.swift */; };
+		8EA2B955CD3E49F0B814E6EB /* VibeActivityLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC94FFFF90F4F1B8917156C /* VibeActivityLogic.swift */; };
+		5B3924782AD4464380B2586C /* WalletLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D2D4BE9BCE435285FF58B2 /* WalletLogic.swift */; };
+		A8BFC3095651449F93DC57DC /* WhiteboardLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DF4ED214C142B28F0F7C6C /* WhiteboardLogic.swift */; };
+		ECAF8370AF32489CBBB9690A /* WhiteboardRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1C407BBDF4740977C3248 /* WhiteboardRenderer.swift */; };
+		57133A9F3CA54981B73A4429 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83BBBE62917426DAE86975C /* APIClient.swift */; };
+		1DA6D34F38B34B929EA3A4F5 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F257901D5014000A8EBE90D /* APIError.swift */; };
+		8F7AA6EF876C45FBA23429D7 /* NetworkAuthContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68B209FB8AF410DBD34F031 /* NetworkAuthContext.swift */; };
+		240DB855C922497C97B8EBBE /* NetworkBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D572BD0B890840029E117FF8 /* NetworkBootstrap.swift */; };
+		4207EB18545E4118B229DC7A /* MarkdownTableLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2249CF0A07C46B8BFA8BB20 /* MarkdownTableLogic.swift */; };
+		5C28EEC9903F456FB74CCA22 /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FD3EEDE8744FF7B0AFC538 /* NotebookDrawing.swift */; };
+		A85FE91D01F5467D86B9BF74 /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CE9866F2DB4E23BF1F8012 /* NotebookMarkdown.swift */; };
+		F3263F6085144AE8B6E39956 /* NotebookSlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80E77440983473EA95A4FB8 /* NotebookSlashCommands.swift */; };
+		DE7D12C90D5F4915B518228C /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6637E78D17B64DA29CCAB464 /* NotebookStore.swift */; };
+		E63F7DCEA58948D18358F541 /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960144A5952D4276A7C05E82 /* NotebookSync.swift */; };
+		30FC256EFC0A4C67B8C9898E /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9948647BA7401E9F6F93A3 /* NotebookTree.swift */; };
+		E9FC59A699384BB4B53A104A /* CacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29345BCE6B754740843A8BB1 /* CacheStore.swift */; };
+		6ED2AA50E9104B3796009C02 /* DownloadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DA5F6B6B2B4706823CC528 /* DownloadStore.swift */; };
+		B3204D72A8CF487EB32BBDCF /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D2A5D9447C40FCA57D17F8 /* NetworkMonitor.swift */; };
+		DE20FADBCB6145598DCE6369 /* OfflineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6931A626E6DE4BFD97A330D0 /* OfflineModels.swift */; };
+		CD937E856ABA41FBAA28CF11 /* OfflineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D1233CE30E43268AFFBED0 /* OfflineService.swift */; };
+		0B0A7BE81FAF426593571257 /* OutboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F409CE2BF8B4D93B26107EF /* OutboxStore.swift */; };
+		ED3273E559024ED3AF29401B /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DEEE2246B84A8291FF4E39 /* SyncEngine.swift */; };
+		C004C571DCA647FAB2422719 /* PushManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2CBA2BC92149079B34E5B4 /* PushManager.swift */; };
+		E49CE5F07BA44823B7A607AC /* RealtimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628EE4A22DBC40ADBF48A1FD /* RealtimeManager.swift */; };
+		E7DA1291B82F4787A193E475 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9D774CB8BA476E96510260 /* WebSocketClient.swift */; };
+		BDEC9A2C593442108AAC86AA /* ContentLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AD86FA9B7E444D85BE565C /* ContentLinkRouter.swift */; };
+		EC52B2E9900C4798AC33C2E8 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB7098E697E48EF95C80DAB /* DeepLinkRouter.swift */; };
+		08460599AB95423A832FF804 /* MobileDestinations.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD45A9FF969B4384BA86BC18 /* MobileDestinations.swift */; };
+		1F572F4ACC5C4E2B94139944 /* MobileIaPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677639FB1EC34FE4AE969527 /* MobileIaPreferences.swift */; };
+		16DB0460AAFB4F54A7A202F4 /* MobileProfileDepthPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DAC2367DC547DD8374E611 /* MobileProfileDepthPreferences.swift */; };
+		A25D499594014184AF31C9A5 /* SearchActionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F61AC93CAF44F8BB058BF9 /* SearchActionRegistry.swift */; };
+		91EE4551F6854DDDB913DB66 /* SearchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE97A944286469AB5BCD6EA /* SearchModels.swift */; };
+		76905E28FB2144DE911C42A4 /* SearchPathNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467E4692126D4E1FBF694D3F /* SearchPathNavigator.swift */; };
+		6214C6A27B964B9E8EAC9F89 /* SearchRecentsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722AE47C26754F9FB7BC7FE7 /* SearchRecentsStore.swift */; };
+		A6EE2A3D824341B487A1C244 /* CodeEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154A15FAD34D4A58B24EE09B /* CodeEditor.swift */; };
+		962AAE04805E4891B9E03C61 /* AdvisingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5530E9E13A8848E09D6085D7 /* AdvisingView.swift */; };
+		506F118453554CDB9C4B0B3A /* AssignmentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBD1F0BA9AE4F6683F4F7A3 /* AssignmentDetailView.swift */; };
+		FCD3EBD366FF45099486D63D /* AssignmentDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222A43CE1EE64C479E56D313 /* AssignmentDraftStore.swift */; };
+		12DF11AD3F7242768F33B2B6 /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953BC13048144DD7BB15E059 /* AttachmentUploader.swift */; };
+		2F2E132CE72C4567BE0726BD /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3CF162C00F4464BF4C159A /* AppleSignInController.swift */; };
+		D732685C0FF0488BBAA22982 /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76335E8AFED64A7183393292 /* AuthFlowView.swift */; };
+		6ED640DD957543A4B99A7A7D /* GetStartedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125355EB6974E71A3CA2EC1 /* GetStartedView.swift */; };
+		D92F4EA291BE409F9437894D /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56BEBB06CE44FBAB66FDE47 /* LoginView.swift */; };
+		FEF892DF287A43FEA76DB673 /* MFAChallengeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E7CA262752498EBC9F37C4 /* MFAChallengeView.swift */; };
+		0C438CB84F7C4745A2173C55 /* MfaPasskeyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC2FB7498CB41128E31F74C /* MfaPasskeyController.swift */; };
+		B5FB4F9C3EBD40689AD7D2C4 /* SSOAuthController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48D2A7865F843E9AE3D5A11 /* SSOAuthController.swift */; };
+		BEAB9B110A7C4F4C86512B73 /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E8D15FB6C14BD091BD0120 /* SignupView.swift */; };
+		32E42FD57CDD4F7FA04D067E /* BehaviorRosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56CD26A604DD442983974886 /* BehaviorRosterView.swift */; };
+		7F4DC548B19A44CF976A2382 /* HallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBAB05AF3BE4315AF713859 /* HallPassView.swift */; };
+		8210AE54E6404D42BDD72612 /* MyHallPassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6778CFE234463994858F9B /* MyHallPassView.swift */; };
+		8BEBC50CA2D94EB283B57E00 /* BillingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CD7D697B764F92BF51A7AA /* BillingView.swift */; };
+		5DA781C1560E43C59BB181B7 /* CheckoutReturnHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECF122BCB5B49188C076AE4 /* CheckoutReturnHandler.swift */; };
+		F8184F209BE44FB98AD75351 /* PurchaseFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528A15350CAA4ECB8BF82EBD /* PurchaseFlow.swift */; };
+		44C6DEB1E13C418FB2B4B741 /* BoardAnalyticsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E02556B74F24A17BA8376FD /* BoardAnalyticsSheet.swift */; };
+		E442ECB676D24A8AA8999603 /* BoardComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC42D146F16B4BDAA812C3EF /* BoardComposerView.swift */; };
+		6A23CC2CB34F4B3CBF53151A /* BoardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02484C6E8F31475FB95C2B07 /* BoardDetailView.swift */; };
+		2BDA6EE9C1914949AF185F06 /* BoardEngagementEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78EAA9448BD040DAB66EF2A0 /* BoardEngagementEnvironment.swift */; };
+		4ABF4AD4F6414BD587FC9BD9 /* BoardExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0FE6FD029F4E009765A1B0 /* BoardExportSheet.swift */; };
+		B8014C6F26404C1ABA54B98A /* BoardModerationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B87ED193FE417396EB2B4E /* BoardModerationSettings.swift */; };
+		F3374E3122724407AE1831A0 /* BoardPostCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5059595D0E24E059420088C /* BoardPostCard.swift */; };
+		EC846646414D4294AE2C7F30 /* BoardPresentModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E996C23C6F942F1878DFFFB /* BoardPresentModeView.swift */; };
+		7B7CDBEA9C244789A77F4E3E /* BoardSaveAsTemplateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BF473B64E846569C3A5978 /* BoardSaveAsTemplateSheet.swift */; };
+		C1AA183B64CA4D568D35D3EF /* BoardShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1080FED284840089F65DDE5 /* BoardShareSheet.swift */; };
+		6D5C9E70F3AB49D18718B941 /* BoardSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9942E130569A4AB48B2A051E /* BoardSocket.swift */; };
+		19A59B1D142B49E5BF348176 /* BoardSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462B3468F5514FA7BBBF3277 /* BoardSurface.swift */; };
+		BCFE3FDF7C9D4F8D95D844C9 /* BoardSyncStatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791BDC8ACF6D435EAB32CB67 /* BoardSyncStatusChip.swift */; };
+		1500C44153F64F46BA19FEDE /* BoardTemplatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E582767F06462184FEADE6 /* BoardTemplatePickerView.swift */; };
+		D9A3B0E1CCF54F389CD76AE0 /* BoardsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FC6C0DCE1B4091B988ED17 /* BoardsListView.swift */; };
+		88F3DF69B1624E3CA3FD9DFB /* CardArrangeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5831E2E338A043009714F4CA /* CardArrangeMenu.swift */; };
+		2D070B2A301444FF9F81D8DE /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55759ED87B334852AA3741F6 /* CommentSheet.swift */; };
+		2ECDD0555E6E4CE3A8A7B431 /* GradeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3891A2BEEA8A4B12A04001EC /* GradeSheet.swift */; };
+		A8AF49F2654C4782A91B097C /* CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA492F2BE1548339ADEA334 /* CanvasLayout.swift */; };
+		B1DA0AE34E8948A9A34EB674 /* ColumnsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6749D8AD1CC84795999E67B0 /* ColumnsLayout.swift */; };
+		38E2D8D116B54D3F88483BE8 /* MapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EA2749A48844A58A8DF179 /* MapLayout.swift */; };
+		5C2CD71B7A444B4EB9CBE622 /* TimelineLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CDC3E525A84E28AAC2BFBA /* TimelineLayout.swift */; };
+		0478D5C26401485C9A2B466E /* WallLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622A895CD460490799FB6A37 /* WallLayout.swift */; };
+		7FA1D5569FE8478ABFE88B8F /* ModerationQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B35607BAD254091AA44612B /* ModerationQueueView.swift */; };
+		3A50627DBB5B4A19B671B4B3 /* BoardPublicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CEB85CCEAB433394A7F47B /* BoardPublicView.swift */; };
+		65EC8B13D15B4D2B96E59EA4 /* ReactionControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21EA6406ED74F73879793F0 /* ReactionControl.swift */; };
+		10E4F32A4A9242A5A73A1925 /* ReportDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4559488E1B46FBBA32F113 /* ReportDialog.swift */; };
+		6B661E3E666B48F88DCE5603 /* CatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8461C5082547B3986EB882 /* CatalogView.swift */; };
+		E6293FFB9D94420AA03C70B6 /* CourseLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E5CD08014E4CCA97CD4DF8 /* CourseLandingView.swift */; };
+		DA9186FA5F724E1596DE3289 /* ReviewComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D7698E4A49453A81518DD7 /* ReviewComposer.swift */; };
+		95C4FED9BC85471B8C4B228A /* ContentPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2A9F83441479BA727CC45 /* ContentPageView.swift */; };
+		6ACAFC4A055D44D4961384D1 /* CourseAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80C96F7C5154E88AAC91702 /* CourseAttendanceView.swift */; };
+		A55BFC1B5155444E965DFB29 /* CourseBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E481996B2340459B264B04 /* CourseBanner.swift */; };
+		6F7CFC38EAB844AFA156D9A1 /* CourseDestinationPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19004FBF9EF9417AB20D14FB /* CourseDestinationPlaceholder.swift */; };
+		DD9A0C83F05E468F9BF5A80F /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D042B2C9BB492BBECBFB64 /* CourseDetailView.swift */; };
+		8DC0B320947C4B87A6B1552F /* CourseGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDC409C63F44BC0BAE119BA /* CourseGradesView.swift */; };
+		71C7B5CE78344BD4A8A7DF83 /* CourseLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A294251A80649ECACA3255E /* CourseLibraryView.swift */; };
+		1DBFF471525B40B49FD04BC6 /* CourseMarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3698C94ECDF54D808F2E6A38 /* CourseMarkdownContentView.swift */; };
+		ADB207B1CDA446F38AE15A03 /* CoursePeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C664531BA882440EB0BF2C57 /* CoursePeopleView.swift */; };
+		FA51F10B12C54219AA1E340E /* CourseStructureSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CB7C7379E8462D8EB901E6 /* CourseStructureSocket.swift */; };
+		B35F4473DC82444F9894D7B1 /* CourseSyllabusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179AF25F442A4BA1A8C5B84A /* CourseSyllabusView.swift */; };
+		83710C4019E642D19616CC1F /* CourseWorkspaceNav.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD90B7194D54297A97E2D15 /* CourseWorkspaceNav.swift */; };
+		A140069F4BE9482386F0326C /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0968A034C0FD4A7BA32085DE /* CoursesListView.swift */; };
+		FABDFE1B10C24681A491EE9C /* CanvasImportComingSoonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD6433A5A6745859F26D7E2 /* CanvasImportComingSoonView.swift */; };
+		074A6C21C2384BE89EEA579C /* CanvasImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79A38EF73D849B89A24DB63 /* CanvasImportView.swift */; };
+		00F69700725A40AB9E788676 /* CourseCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B4F1E4C99949DCB57815D2 /* CourseCreateView.swift */; };
+		E08082B023EB45019F6A65BD /* InlineMarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ECB4A39A1747C8BBAC7CCE /* InlineMarkdownText.swift */; };
+		BC6EA35F8FFB45219353899B /* ItemDetailRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48213DEC0E36407FA056F408 /* ItemDetailRows.swift */; };
+		86DD243A03AB41BFAA0043F9 /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7697EDBBD47B4C94B5C48B6D /* ItemDetailView.swift */; };
+		BA1CCA84DD474F1FA3B6F11F /* LaunchContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52F523B506E47DD9A87703A /* LaunchContainerView.swift */; };
+		E63BC5C8B8CF4270ADFF79AA /* LibraryResourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB3F7D10F824E8CAF96F9A0 /* LibraryResourceView.swift */; };
+		E736CBCD3B144852A9714FCF /* MarkdownCodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8351F282776A40C095C1EA50 /* MarkdownCodeBlockView.swift */; };
+		FDB100E93E9942A2A744701C /* MarkdownRenderStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9DABD8D7824346841D6AD8 /* MarkdownRenderStyle.swift */; };
+		3530A1790E3B465BA5C255E0 /* MarkdownTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164872C278714902AEE2DB47 /* MarkdownTableView.swift */; };
+		78F21148716D4FDCA5D867DC /* ModuleItemRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5BE60BCECC4042B0C27709 /* ModuleItemRouteView.swift */; };
+		D1B0205939D647B887577239 /* ModuleListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CCB948B3AD4913A67A0BA0 /* ModuleListView.swift */; };
+		1CFCB09E8128482A8D29C675 /* RequirementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB09A194C034B7BA76B7284 /* RequirementsView.swift */; };
+		DAF121923DF8456388604A78 /* CourseAccessibilityReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF070004C4CA433E8F0F74A7 /* CourseAccessibilityReviewView.swift */; };
+		F458E8B903514623A9796AB5 /* CourseArchivedContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832248171BB1497E8A935DB6 /* CourseArchivedContentView.swift */; };
+		B7267D8EF6684472A2568BD7 /* CourseBlueprintSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF044088FCA451EA8388263 /* CourseBlueprintSettingsView.swift */; };
+		01B444792F274BD5A8C03389 /* CourseCrossListingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869F283288214F60917D5FE2 /* CourseCrossListingView.swift */; };
+		D0DB5D7329D9462BA89B3886 /* CourseFeaturesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119EC8AFB9F42ADA2BBE773 /* CourseFeaturesSettingsView.swift */; };
+		5CA59FC4749C4B8783B32EAF /* CourseGeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E583694E9B463B9829B3CA /* CourseGeneralSettingsView.swift */; };
+		38CDFDDD198444F7B965E076 /* CourseGradingAgentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B013FC2F99764401B0DE38C6 /* CourseGradingAgentsView.swift */; };
+		EE60AB03848A41A7BABB6BA4 /* CourseGradingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61142908EABC4D26A5A04DE1 /* CourseGradingSettingsView.swift */; };
+		44834B1BD5F044B0965F161E /* CourseHeroImageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA480BF4B3144A949E93817E /* CourseHeroImageEditor.swift */; };
+		14AB4B00A96E435D9E8D72F3 /* CourseImportExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689FDA3F9E714CAF9E30C243 /* CourseImportExportView.swift */; };
+		30570D437C9F482F9061E426 /* CourseMarketplaceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527F305D833141F0B9A7F432 /* CourseMarketplaceSettingsView.swift */; };
+		2E0EA4B077894D279ADDEA2D /* CourseOutcomesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53520527C1094B3D9051FA7A /* CourseOutcomesSettingsView.swift */; };
+		6F89BBA520FC42C99E5754EE /* CoursePlagiarismSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6289444D5E1340958D35A588 /* CoursePlagiarismSettingsView.swift */; };
+		38FC70DC9501453DB9EAF5B6 /* CourseSectionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE01EA5982740088E1C66E7 /* CourseSectionsSettingsView.swift */; };
+		23078AF7C7B4495BB15EDA93 /* CourseSettingsHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D1490287164C789D58C042 /* CourseSettingsHostView.swift */; };
+		34C4D843CA64495FBAFC9060 /* CourseTranslationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE3DE7CE7F8448E9FAECE4B /* CourseTranslationsSettingsView.swift */; };
+		02FBBACE4E5F4B068231651B /* TakeAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6945859664455189D2B8E3 /* TakeAttendanceView.swift */; };
+		715F2DD426814864A39A79D4 /* VibeActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D45AA78BA294951896232EF /* VibeActivityView.swift */; };
+		B380509EE6BD4726A0BD70AA /* WebItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF30B7FBA3CB4F8A87934ABB /* WebItemView.swift */; };
+		B0CADD61C68041C9B8B30DF7 /* CredentialDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0515955E570A4924AD25F62A /* CredentialDetailView.swift */; };
+		7B7BDE6F40DE4FAD94975F7C /* CredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C045D69C75EE4D01B6900402 /* CredentialsView.swift */; };
+		4470D49B89A146B4B656D74D /* DashboardCoursesCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9BED0E045041E0B67D3E7C /* DashboardCoursesCarousel.swift */; };
+		CFF920103B414BF08BB4B508 /* DashboardHeroPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E8F9F4B1E74EA89D9CE097 /* DashboardHeroPanel.swift */; };
+		CC144EE80A654553BC154DA8 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C8650B918048FFB715D157 /* DashboardView.swift */; };
+		429EE63084EC44F29DB30CAB /* LiveMeetingsRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024F7FE6C92F47189E4D0743 /* LiveMeetingsRail.swift */; };
+		E92D89082F1D41EAA1C98233 /* CourseDiscussionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71AA5BA948D94095BB9C37FF /* CourseDiscussionsSection.swift */; };
+		02495A339C6F41D2BA1EFAA5 /* DiscussionThreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0941978D71174F0689587DB0 /* DiscussionThreadView.swift */; };
+		E331288A0F674EEA94B24A3E /* DiscussionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318FF7C7D24A4ECDA8227DAE /* DiscussionsListView.swift */; };
+		D0E82E8FC22B442B941693A0 /* PostComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE854695ECBA4204AB0DE576 /* PostComposerView.swift */; };
+		5BA81EB8CDA24A7EBE984486 /* CourseEvaluationsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2327B1074F4A668A9C4BA8 /* CourseEvaluationsSection.swift */; };
+		994D4272D09A4266B81C10E2 /* EvaluationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50788B3B53CB42BE8F185D0D /* EvaluationFormView.swift */; };
+		3750DD3F1BCB4B0199594517 /* EvaluationResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB68CA9959D24657B8E7127E /* EvaluationResultsView.swift */; };
+		29242711A5FC47B694263955 /* CourseFeedSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A491D3423B534C4EBD81B475 /* CourseFeedSection.swift */; };
+		5E0B56C819FC40499848E34D /* FeedChannelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8536659166D649D3BDCCC5A5 /* FeedChannelView.swift */; };
+		D80E0F81FBFD45BF8EF8A9B9 /* FeedChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6883D3DA4F2343F1A3EA9A79 /* FeedChannelsView.swift */; };
+		F1A4B1B5F5DC4291B37A14F8 /* FeedLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFBD986DC7D49509FF77E4E /* FeedLogic.swift */; };
+		A3731DB6E85E4FAE82310A82 /* FeedSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EACB47FAA72484787927D72 /* FeedSocket.swift */; };
+		D4777BE989634FE19684A17F /* ShareFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD0948FFE1148BBBBBE2D6C /* ShareFeedbackView.swift */; };
+		80ADB85FC1A8409BA6F57698 /* CourseFilesSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18097E976BCB4C65A606B828 /* CourseFilesSocket.swift */; };
+		946FDBDCD2914D88821BFC89 /* CourseFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBDEFECB96647F69BE549DA /* CourseFilesView.swift */; };
+		98E2D68BCA964AE0AFBD4616 /* FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5969A54F304BF391B96B52 /* FilePreviewView.swift */; };
+		F711F2F8D1F2444D8F0059F0 /* MarkupOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57EE20D3C8244BF97EE2AA7 /* MarkupOverlayView.swift */; };
+		A6406B6A53A14BECAEFE6BE0 /* GamificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD564B829F54B788712FD2D /* GamificationView.swift */; };
+		8ACF1E26FFC7451E8ED323DE /* GradeFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC43B7F26C946E48F8732A9 /* GradeFeedbackView.swift */; };
+		4C1FAB2031E94160AEF0F39A /* WhatIfController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4707DC82B2524CD3BAEEF06F /* WhatIfController.swift */; };
+		B109E49708B346F8AE19D0DF /* GradingBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F41DCE71464DB59B5C6663 /* GradingBacklogView.swift */; };
+		36268A9B409440A2991B997E /* SpeedGraderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E6EC53A9394379A90D21E2 /* SpeedGraderView.swift */; };
+		54A37B117E42410D92826745 /* CollabDocView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CF978646344FCFA4454830 /* CollabDocView.swift */; };
+		9A1F9515EBB24991992B4E20 /* CourseCollabDocsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0EAE54E8B14774BF07E17D /* CourseCollabDocsSection.swift */; };
+		46AA01AD5D1640469E8357F4 /* CourseGroupsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ED2FABE3594F74881ED2B8 /* CourseGroupsSection.swift */; };
+		4F24ADE138A44690B717B9AF /* GroupSpaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980E64BF62DC4188B34C56BA /* GroupSpaceView.swift */; };
+		59CDBAED2BA84E2489149137 /* AnnouncementComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C177A84D04E4331844EEBAE /* AnnouncementComposerView.swift */; };
+		15581A68133149139B6B6063 /* AnnouncementsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A10F1D947447B5956D48C3 /* AnnouncementsViews.swift */; };
+		BBC7C359B9754362ABCC094E /* BroadcastComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0A9806AF8440C4A8C8CDF7 /* BroadcastComposerView.swift */; };
+		74120AB8F1214541A94A002F /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28100343CFDF4AF59C86A6FC /* MainTabView.swift */; };
+		A38F8CF989CF483B8C742305 /* MoreHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64A1F8CCF9EE4EDA8B5CFF59 /* MoreHubView.swift */; };
+		A375E55BAA2A4A85BFF6DA0E /* ShellHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB6923BCC1D4805AEFF8239 /* ShellHeaderBar.swift */; };
+		91A4B4AF5ECB458591DED7FE /* TeachHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0CCD64E62341E68686CFE0 /* TeachHubView.swift */; };
+		01C2021DA8724C4F8B4489FA /* UniversalSearchPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA66206BD0147519D6AC6FA /* UniversalSearchPlaceholder.swift */; };
+		D03EDFA65CB94AD49A23D07C /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D1228B44564E0E8DB04060 /* ComposeMessageView.swift */; };
+		B7317102138D45648DE78440 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D3A231947E4B708305CB2E /* InboxView.swift */; };
+		DB9E6921DF2D4ECE9DD3131A /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FE86CAD8E4067A5F844B7 /* MessageDetailView.swift */; };
+		AA4CC32004DB48CEBE2ADD44 /* DashboardInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531503917D1E4CE6A75ADE5E /* DashboardInsightsSection.swift */; };
+		AC5DEED5C2134E8EA30F97A6 /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD21BB758214149B940C422 /* InsightsView.swift */; };
+		745E4A013F3F4DBCAE694434 /* AtRiskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7672FF915C65418797A16566 /* AtRiskListView.swift */; };
+		B72C210EF12B46FE8255BDAC /* CourseInsightsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C541977EC6B04FB6A37B1F29 /* CourseInsightsSection.swift */; };
+		055C2D867C904934B52F3E69 /* StudentProgressDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D26361290F44B185668F88 /* StudentProgressDetailView.swift */; };
+		74D6E4758A6B4F2DBFB8FF70 /* WhatsWorkingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7B30875E8E4ECDA36E6EAC /* WhatsWorkingView.swift */; };
+		FA4D50265A784D8FABF995F8 /* IntroCelebrationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A2632F4E6146C0888CDCAA /* IntroCelebrationPresenter.swift */; };
+		7AFFC51DBBCF4C1A92C3F8FD /* IntroCompletionCelebrationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048EC217A0B74F2B9BB4EAE2 /* IntroCompletionCelebrationSheet.swift */; };
+		A2EF87A864774480A56DDB30 /* IntroCourseEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C781C8F72BA844A88D7DFD34 /* IntroCourseEntryCard.swift */; };
+		FA8524D1DAFA4A1AB3505A11 /* IntroCourseProgressRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3D3F2BF2B4C4AB6AD00BB /* IntroCourseProgressRail.swift */; };
+		07B3A259F1494F5E9F9BC6D2 /* LearnerProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E385C465842945319D3820E6 /* LearnerProfileView.swift */; };
+		3750F0C2E07147D4B6270002 /* LibraryBrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D02627FB9C849F79EC5C993 /* LibraryBrowseView.swift */; };
+		2ADF58AB69E7437F8715D93F /* MeetingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE11AD774E754CB0B4F41F9C /* MeetingDetailView.swift */; };
+		BD12AE60FB6045C083DD2CD5 /* MeetingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B9189B2A6C4365BDFA77EA /* MeetingListView.swift */; };
+		BF6C6F1D5AAD49DBA79A7D77 /* WhiteboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2019900D80C9473CB449F94E /* WhiteboardView.swift */; };
+		2D00E33E6CF54F61A901E1AC /* LiveGameSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA09F23627DF4281A4F5A604 /* LiveGameSocket.swift */; };
+		D96DF573596B41388A8C8CA9 /* LiveQuizHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81513A4BA1FB4B33B26A4904 /* LiveQuizHubView.swift */; };
+		4C0FA75A018448B6844536AA /* LiveQuizPlaySurfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF86A09506C49D0ACF4694E /* LiveQuizPlaySurfaces.swift */; };
+		5E29E0AB8B17400FB0DDD8D7 /* LiveQuizPlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B579284FCBF34783ACA74A29 /* LiveQuizPlayView.swift */; };
+		D870E7A5D79547E988417CF7 /* MarketplaceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0D94941BE3495F961A91A1 /* MarketplaceDetailView.swift */; };
+		0AD8C4F49F5849AC888C86DF /* MarketplaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6331924043854C3CBF0A9E5F /* MarketplaceView.swift */; };
+		16DEB596B0494E5C8F122577 /* MyPurchasesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959FB9FC548444E39D3552DF /* MyPurchasesView.swift */; };
+		2B7A05CE6FDE41788801778C /* CourseMasterySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E203D2C754954BB8A2E97859 /* CourseMasterySection.swift */; };
+		D8A97A50811C4BCD93CDCDA5 /* ReportCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA42760F06B46B68A649C76 /* ReportCardListView.swift */; };
+		A27F0E4449CE474AAA9174A0 /* CourseDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A58E25472CC4432FA317805B /* CourseDrawer.swift */; };
+		60A013C7F62D4BB7BB038A90 /* DrawerScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1446CD993A4484B907BEBB4 /* DrawerScaffold.swift */; };
+		1F4B76F746B94060B2A5CDD1 /* DrawerToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C986E9B6854FC7AD29E25A /* DrawerToolbar.swift */; };
+		A139A816FD314BD3A5043667 /* GlobalDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC556A9FC50D4E8588B82D1E /* GlobalDrawer.swift */; };
+		2B5EC07E690943609A5C616B /* NotebookDrawingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98011A2A19A74B2DA36D628F /* NotebookDrawingViews.swift */; };
+		BBE29386B2B4402A9941F7D9 /* NotebookEditorSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BB10FDBC994065AADF8481 /* NotebookEditorSupportViews.swift */; };
+		CA70EF63897F49B786B225CA /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5A3677FC5A4F328B8BDB0B /* NotebookEditorView.swift */; };
+		19E93DB8211E400688115BEA /* NotebookPagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F23E48BCE4A7490880B6D9E8 /* NotebookPagesView.swift */; };
+		9A147E80CBC44402B0130242 /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F35E579A8D541FFA66061EF /* NotebooksListView.swift */; };
+		B2A7C2F7696F44D9B504C32C /* BookingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A432E81BD5D8424F97BBEE18 /* BookingSheet.swift */; };
+		8F8141BD6FA54CC3B2F9134B /* MyBookingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2504E439EB4BC3B0F5AC9D /* MyBookingsView.swift */; };
+		E5E05D80234E4F20891D8E4B /* OfficeHoursView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00DF85D5B624D7CB6A004AC /* OfficeHoursView.swift */; };
+		9A83BDA7F65F4830990E28D1 /* DiagnosticView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F8216A97C24D3EA7598AB2 /* DiagnosticView.swift */; };
+		7FF900EF4CEB473CA26E50E0 /* OnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774B6FA5FF744EF485F0E850 /* OnboardingFlowView.swift */; };
+		B4BA69CEA39F41498E73A9DB /* ConferenceBookingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385A78C7174346588920560C /* ConferenceBookingView.swift */; };
+		F50D333188834A1F97F2EF83 /* MyConferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B1D976EE245B68D041D72 /* MyConferencesView.swift */; };
+		541666AE1C7D4EEAA5429BD6 /* ParentAttendanceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94092F15E26460C816BE4D3 /* ParentAttendanceDetailView.swift */; };
+		781B8CD946FA42EDB9EC487C /* ParentDashboardSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FBDF00E06B4425BB6598B8C /* ParentDashboardSections.swift */; };
+		D5BA0C24AEB94A79AF7DAD1B /* ParentDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18358A0EE94FBD9DCB1140 /* ParentDashboardView.swift */; };
+		68746262C0C14747ACC5E4FE /* ParentGradesDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF80C29CDF4624A491DAF9 /* ParentGradesDetailView.swift */; };
+		D27FC3C1650B4D2AAD3E230A /* ParentNotificationPrefsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEF5E4F7B904C2888E1D8D6 /* ParentNotificationPrefsView.swift */; };
+		55F12AC896D249D4A2251BFC /* DashboardStudySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0261A469004ADFB46BA3B2 /* DashboardStudySection.swift */; };
+		8FA67D0A5FED4611B2E5BFF4 /* MyPathsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD12D72F206465DB20F7D92 /* MyPathsView.swift */; };
+		A5238D23338D4929AF95DBFA /* PathLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD05A1B6F44A0C874FA1A7 /* PathLandingView.swift */; };
+		7AFB454C765A4532B6109E88 /* PathRunnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB651E4D0105497FB87FC85D /* PathRunnerView.swift */; };
+		72861B8A8A9E45EBB7C628FA /* PathsCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DD7963C4FB4AF99D362C5D /* PathsCatalogView.swift */; };
+		50B051D0E6EF4F18BFC52BFB /* PeerReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4728726CE7444DAC53AE44 /* PeerReviewDetailView.swift */; };
+		32B112939A2D4A489AD3E86B /* PeerReviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97464A6F695B4C1D829E0A31 /* PeerReviewListView.swift */; };
+		BEE087DF4C394B4E819F6717 /* ReviewsReceivedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348865567B2E49AE8BC76B2B /* ReviewsReceivedView.swift */; };
+		7B1294501E8B4C8DB62A2E31 /* RubricScorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1FE883E9294779A42DF919 /* RubricScorerView.swift */; };
+		3F4C647187A848AE87F2AC69 /* CalendarSubscribeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4906C7481D4846209825317F /* CalendarSubscribeSheet.swift */; };
+		429BCEDAFD7F4D0C9C41FCBB /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63D10FFB5994D85916B3452 /* CalendarView.swift */; };
+		B86B1B2AF4B443D0A4DD113B /* ConferenceReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2C9AD63AE64C28A581941C /* ConferenceReminderScheduler.swift */; };
+		482290ADF9CB4F1A9FA0C3AE /* DueReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9458F0AE1943F5ABED08F8 /* DueReminderScheduler.swift */; };
+		9FEFD60A895E4E44AF52FC80 /* OfficeHoursReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8234B2B85127411A9170A3B4 /* OfficeHoursReminderScheduler.swift */; };
+		6235F0C5CBB54BDA965DD437 /* PlannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA88792E76548ECB5F42F63 /* PlannerModel.swift */; };
+		1C9E6551E0E64368BA9A4D6E /* PlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5DB43679D4F0883B914C9 /* PlannerView.swift */; };
+		4898E73B3D9C4C46AFD959FF /* TodosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB75241F3C54D6BAF22C7C5 /* TodosView.swift */; };
+		9A6CA6BE6BAF4314957B71AD /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70B61AEC9A84C17B965B80C /* ArtifactDetailView.swift */; };
+		2FAC9721ADA74435BECEE7FC /* ArtifactEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56725B79B7C4322A19637D3 /* ArtifactEditorView.swift */; };
+		B27F3BFCA52E4D1187C4FF7B /* PortfolioArtifactUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99F8E9BBDA442DAA6DE27D9 /* PortfolioArtifactUploader.swift */; };
+		0D96BC8D62B645949D97CC57 /* PortfolioDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B914CD8D81974975B0B22EF2 /* PortfolioDetailView.swift */; };
+		8341D1F8E54E4269B367A930 /* PortfolioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DEBFEC34B6F41FB97FC6F29 /* PortfolioView.swift */; };
+		F3B6BD11E6794E459EE723B9 /* AiAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592539EF2B3D4074804061C6 /* AiAdminEntryCard.swift */; };
+		156A40230FC94EF7B063C3A9 /* ArchivedCoursesAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D9881CB51A4181AB4D16D0 /* ArchivedCoursesAdminEntryCard.swift */; };
+		03CE9CB6CF1B41D7A0AC9DE8 /* BiometricLockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A64092496C4AD2B8F25D58 /* BiometricLockView.swift */; };
+		5FE93E88622040D6A23C4A8B /* DeviceSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E507504BBD476CA403DD67 /* DeviceSessionsView.swift */; };
+		1B6D93F7DC3A4ADAA1703D91 /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68599A8761C649ABBB52D83B /* EditProfileView.swift */; };
+		4E2BEF195A7540FCBCBBF523 /* IntegrationsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBEEB71BD314400A927650F /* IntegrationsAdminEntryCard.swift */; };
+		17699894CF734423B1810202 /* IntegrationsEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E5C27923924FD0A90C01B9 /* IntegrationsEntryCard.swift */; };
+		F72E0A5059D449DFAD5A4CE3 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4BE77EF7674E1E9E3757D2 /* IntegrationsView.swift */; };
+		C32EFCEB65F342B1BD901EC9 /* LearnerProfileEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04F9D5BE5EF4D878ACE1733 /* LearnerProfileEntryCard.swift */; };
+		45D0B94381C54DD9A46B980C /* MyAccommodationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AE110FA35341549393278C /* MyAccommodationsView.swift */; };
+		F8A8CA34DD5248E198ADEDE1 /* NotificationPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641868BD33C04BE9AF3E8954 /* NotificationPreferencesView.swift */; };
+		0935B7CEF8A14D9F8C0342C7 /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EA9BD24D0C4E8DB20249B6 /* NotificationsView.swift */; };
+		74E2107E87FC4613905F4BBB /* OrgBrandingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC2145244F94724B67473A5 /* OrgBrandingAdminEntryCard.swift */; };
+		9D3C641B6E06434F9A489533 /* OrgStructureAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D034344ED842FE8B459C23 /* OrgStructureAdminEntryCard.swift */; };
+		C25D7F0B62C04EAA8F510D80 /* PeopleAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89848B70521648509950383E /* PeopleAdminEntryCard.swift */; };
+		73D070D590B54C59BA6D89F4 /* PlatformSettingsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229CE427FD1A4EF28A143AFE /* PlatformSettingsAdminEntryCard.swift */; };
+		7C6879BE72D64794A3A4370C /* ProfileDepthCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040626B6A7374B009C3BD9E3 /* ProfileDepthCards.swift */; };
+		D8592ED7E4B140B2825D9BEC /* ProfilePersonalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3477F16CDB66413397751CCB /* ProfilePersonalDetailsView.swift */; };
+		50879B7AF9CF4BCB9C720100 /* ProfileSecurityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883E4F888A014172A4ACD859 /* ProfileSecurityCard.swift */; };
+		1208ABCC1A064031A6748CC6 /* ProfileSettingsCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8809936E57384A37BBA2F68F /* ProfileSettingsCards.swift */; };
+		A0EE8A9FCDEA4755AC6AD5A9 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309494895CAB4416BC2569D5 /* ProfileView.swift */; };
+		8655EDCE0C1846C7855C55C0 /* ProfileViewSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223A451AED7B4DF08DF67712 /* ProfileViewSections.swift */; };
+		0F7BBEE32D964C7F8EEDEA18 /* ResearchStudiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AED4420C17745ADB291B9B8 /* ResearchStudiesView.swift */; };
+		310279C1035A4E7DAA8A4DC6 /* RolesPermissionsAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346A50DE69D841D19BD94AB8 /* RolesPermissionsAdminEntryCard.swift */; };
+		6C4F19F1954243F0826A96E2 /* SettingsAdminHubEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1150E53D840E3B21131A5 /* SettingsAdminHubEntryCard.swift */; };
+		18250A1593BE4CB1991A68D8 /* ShareFeedbackEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B39FAB37194467A12B0D1B /* ShareFeedbackEntryCard.swift */; };
+		CACA2DD9E49346AEA08893A4 /* TranscriptsAdvisingAdminEntryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694198A11E7247BEAB1CFE82 /* TranscriptsAdvisingAdminEntryCard.swift */; };
+		302A06DBACF7406DAFD4A0E9 /* CodeQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD71CD636D5942858C5CD40D /* CodeQuestionView.swift */; };
+		4F9DAEEDB26541AABC17C6CE /* LockdownController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBCAEDFDB0B4FE9A86D39FE /* LockdownController.swift */; };
+		B748606474484111B73691B2 /* QuizIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C82DEEFB314FE3B1262BB5 /* QuizIntroView.swift */; };
+		596EE131CF8D47E7A9311A5E /* QuizQuestionViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6765D118B5E24C9F9BE2CBDE /* QuizQuestionViews.swift */; };
+		473462BCE7684B44B380A32F /* QuizResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02C95A7DCC443B2BF852B70 /* QuizResultsView.swift */; };
+		88FD7F199B27482CACFC5D59 /* QuizTakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7EE232B3A749DDB1F48C02 /* QuizTakerView.swift */; };
+		5AA6AEA33B1E409AB6888F0D /* CaptionedPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5691E7CBA8204B74BF155205 /* CaptionedPlayerView.swift */; };
+		7CBE738084DA452B8FAFB32B /* ContentTranslationControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE44AC00C29F4222A81865E6 /* ContentTranslationControls.swift */; };
+		D8E45C0A2E884945B4A1AA41 /* ImmersiveReaderCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD37D28F45B2488BA3BFDAD0 /* ImmersiveReaderCapabilities.swift */; };
+		FFD93AA9D5124D20A7F3484D /* ReaderLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF2041EABAF44E589DA9C66 /* ReaderLogic.swift */; };
+		90AC42CD64A048F0BFFB6BA4 /* ReaderToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1CA05D397847C18530E5FC /* ReaderToolbar.swift */; };
+		C4CE1383CBB64D8FA63EBF2A /* ReadingPreferencesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D555BC7606A84D7484F73373 /* ReadingPreferencesSheet.swift */; };
+		97BC3EDD867D418E9EC69204 /* ReadingPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3C4F7284FF450D85F2EC20 /* ReadingPreferencesStore.swift */; };
+		33883F4C4CA64C1EB3E340AB /* LeveledLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB809EFFFB04243A54BEFB5 /* LeveledLibraryView.swift */; };
+		B54D947779A240E6AA303510 /* LogReadingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8A987C0A714FDEB2297C6A /* LogReadingSheet.swift */; };
+		CC512AC43B434B9A922BB0AC /* ReadingDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD831BE987D4190BCF6851C /* ReadingDashboardView.swift */; };
+		7EF4EC3EF7644B63B8D12684 /* ReviewHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60C3CA6A5BE45BFB0D1BCC0 /* ReviewHomeView.swift */; };
+		68DC76A3A65C4EDE938E3446 /* ReviewReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46422DFEFDB340AC9BCEFBDA /* ReviewReminderScheduler.swift */; };
+		945C1A9C455643069DF05690 /* ReviewSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97400E67C60C4E2192CC0D59 /* ReviewSessionView.swift */; };
+		4DAAEC930A39445F9B51D291 /* UniversalSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8B565C9B67483486E952FE /* UniversalSearchView.swift */; };
+		D90135D7FD1B4A04BC9294AA /* AdminMetricCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F39278CAC240B7B0EF370C /* AdminMetricCards.swift */; };
+		FD17B0656CDE4AB08E8673B5 /* AdvisingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466D182804AB4200BC2B51AC /* AdvisingSettingsView.swift */; };
+		BA35B15C5E0A41EF8FD2E6D5 /* AiAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D757F646B1574C6C9D533E3E /* AiAdminHubView.swift */; };
+		576E6A5DEEBF42B5AADB411B /* AiGovernanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09FDB3EC56C46ACBA943EB8 /* AiGovernanceView.swift */; };
+		4111A83ADCAC413689A3E0A5 /* AiModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B06D5DC1FD14C06B7AFA51D /* AiModelsSettingsView.swift */; };
+		BE519708C3C243EE9C2EBA7D /* AiProviderSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2300CD6C3A8E4E10939991A8 /* AiProviderSettingsView.swift */; };
+		6AA80F451C054584A8DE520B /* AiReportsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE1042D83B4C0BA7ED4338 /* AiReportsView.swift */; };
+		9B229FD9B1224282B9AA85A8 /* ArchivedCoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D53F974E0C14CB28AA79912 /* ArchivedCoursesAdminView.swift */; };
+		2D49A7B336A74EE0A11D13DC /* AuditLogAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AE7753E97A49B49B6FD4DB /* AuditLogAdminView.swift */; };
+		A0A10166BBC44489B7AB0F81 /* BoardsGovernanceAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA4720B61B84CD5813CC3CE /* BoardsGovernanceAdminView.swift */; };
+		C4C3441D100F43F39882BF04 /* CoursesAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3766C479F4F9CA634923F /* CoursesAdminView.swift */; };
+		24156EB0BE74406F92C4FF99 /* IntegrationsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96506190CC5A4108B2477B94 /* IntegrationsAdminView.swift */; };
+		F881C5FA406E4711A0FB30BE /* OrgBrandingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B57D0B310A40D49231F4EC /* OrgBrandingAdminView.swift */; };
+		4AB9E3A8C59F4F89A903F617 /* OrgBrandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530384910C664DFC8EE07B36 /* OrgBrandingView.swift */; };
+		588328F541FA475FACB717B7 /* OrgStructureAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CE3A3E34D04EC8B5962871 /* OrgStructureAdminView.swift */; };
+		EE768E0C0828429C8D916854 /* OrgStructureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7DA1CF78814F369E0C8B70 /* OrgStructureView.swift */; };
+		43064F63BF904BA990B88E23 /* PeopleAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D314EF2EE8456F80C84955 /* PeopleAdminView.swift */; };
+		94EBD100C5D04CE8BBD552EB /* PlatformSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C89EEE709B84652A6258FAA /* PlatformSettingsView.swift */; };
+		748C8C9178184C2CA3DD46D5 /* RolesPermissionsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880351C617DA4F71A53CF111 /* RolesPermissionsAdminView.swift */; };
+		64966FD197AA44D9A6F60CE9 /* SystemPromptsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB13261BF35E47EB8D1AF53B /* SystemPromptsView.swift */; };
+		AA8D98D4A34944CC87EB9922 /* TermsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA372629F404455AA0D9CB3 /* TermsAdminView.swift */; };
+		C6666DFD63064A7E9849784B /* TranscriptsAdvisingAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56161BC8160D47CC9E032B96 /* TranscriptsAdvisingAdminView.swift */; };
+		DA7784D0FDB741498D67B357 /* TranscriptsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F0283432F14B4389A33A17 /* TranscriptsSettingsView.swift */; };
+		F5DF3579B496478C8C58850A /* UserDetailAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DF455833C46BDADCD8939 /* UserDetailAdminView.swift */; };
+		CB990445D4064516976730CD /* SettingsAdminHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBA2CA382684EE780FCDEC8 /* SettingsAdminHubView.swift */; };
+		BD27BE34B7054ADE84D4808F /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBFB03D4B1B44B69F7A8928 /* SplashView.swift */; };
+		886FBEC3140242A1BA44825E /* TutorChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5052260E3DE1456BBA59B151 /* TutorChatModel.swift */; };
+		8A10CFB4C61E44BE835BFF10 /* TutorChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3223D2B42D3A4F13B49D7F42 /* TutorChatView.swift */; };
+		32DC0B8667B541929156076E /* TutorFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346A67698B641D7B2D4A441 /* TutorFlowLayout.swift */; };
+		AABE9F5B4EE042D0B602FD28 /* TutorLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D315B2782FB43308BEF661D /* TutorLauncher.swift */; };
+		E44E98544E5D44798AE35167 /* WalletCCRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07BCE656BB942D48E005C49 /* WalletCCRDetailView.swift */; };
+		FB5AEC562CA14B04A563CC3F /* WalletCETranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B9B807BBC44CDDB7803DA5 /* WalletCETranscriptDetailView.swift */; };
+		C8F94F30867A46D0861FE535 /* WalletOfficialTranscriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC36E8FB3D78445B83CA8A83 /* WalletOfficialTranscriptDetailView.swift */; };
+		1B0E9238582A467987E23888 /* WalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877ECF71BA4E4ACCBC6DC624 /* WalletView.swift */; };
+		57A97D7429D64E39A3579A72 /* AccessibilitySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815F27882B8346A1B4F004B0 /* AccessibilitySupportTests.swift */; };
+		5120B88C62194109BDA91E66 /* AccountIntegrationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211609286B984816ADBA3FDE /* AccountIntegrationsLogicTests.swift */; };
+		530BCEC8DCDB438D8982765E /* AdvisingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82954E2C195A4EDB952EB64D /* AdvisingLogicTests.swift */; };
+		CE7B6A467D0A40B49A3046FE /* AiModelsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73A837B515E4758915D8F04 /* AiModelsAdminLogicTests.swift */; };
+		277DA9184D854CAAB92D91BE /* AnnouncementLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FB17ABC18C40C69D14A910 /* AnnouncementLogicTests.swift */; };
+		002B53E3646445088F1F012E /* AppleSignInLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B23AAB14FB4FA6893C0FD6 /* AppleSignInLogicTests.swift */; };
+		F88378C305294860A839D6D1 /* ArchivedCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A207247ECB734CE5A3D0AB73 /* ArchivedCoursesAdminLogicTests.swift */; };
+		26C3F6B141584EAA81BCAD41 /* AssignmentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACC207BF99E4112B1FD91A0 /* AssignmentLogicTests.swift */; };
+		395F9B7ED8954949AD9FF536 /* AuditLogAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89591167FA446A1BDE86825 /* AuditLogAdminLogicTests.swift */; };
+		93AA2ACE3B0E436F9366D9A9 /* AuthCallbackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5456F54003A8489AA404FA8B /* AuthCallbackParserTests.swift */; };
+		3AE68EBB7DAB4FBFA2CD4C3C /* BehaviorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABAF7EAA4A241BA8367C47A /* BehaviorLogicTests.swift */; };
+		0046F0DD46804DD2BCC3C17F /* BillingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5EABE108A8425AA97D31B3 /* BillingLogicTests.swift */; };
+		94DDF97828D147469EB851B1 /* BiometricGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B63CC51235F434EB769FDEB /* BiometricGateTests.swift */; };
+		809175F2CCAC40438E08DD31 /* BoardsAdvancedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4965C41B0F214A6D86E4B7C0 /* BoardsAdvancedLogicTests.swift */; };
+		383266D98F4F4120B60B7726 /* BoardsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A4218E42AA4F65B693267C /* BoardsLogicTests.swift */; };
+		8B664563762B460AB4572916 /* CanvasImportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D60A5AB27874900A0FD5525 /* CanvasImportLogicTests.swift */; };
+		F09E461DAA2E45978262D4A4 /* CatalogLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C444EF6A33C848D39DA1435C /* CatalogLogicTests.swift */; };
+		368798378CD84E039799EAEA /* ConferenceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5FF78599A14807B12C1BD8 /* ConferenceLogicTests.swift */; };
+		EF9D6FE117584AE0A6E1E479 /* CourseAccessibilityReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB956A60F93C4587A5625D65 /* CourseAccessibilityReviewLogicTests.swift */; };
+		47D96D3C23E84F1E8B3439EC /* CourseArchivedContentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BB058D250E49AABEE076F0 /* CourseArchivedContentLogicTests.swift */; };
+		58A90479BDCD42E5B86E1593 /* CourseBlueprintLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E82EC8C0914BDBA08B66F3 /* CourseBlueprintLogicTests.swift */; };
+		4EEE681736574464AB0D44A6 /* CourseCreateLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1022F9279574366AE68F41B /* CourseCreateLogicTests.swift */; };
+		3ED806CD70334015B26BB8CA /* CourseFeaturesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418F98B49DF342B98B12D211 /* CourseFeaturesLogicTests.swift */; };
+		0C3D47AEF68D451081B866D9 /* CourseFileModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C279F5C871240AFB016A16D /* CourseFileModelsTests.swift */; };
+		2BF298D68F034BCBA88676CF /* CourseGradingAgentsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C468A9C56F4A3DB68E4C74 /* CourseGradingAgentsLogicTests.swift */; };
+		5EB0CB4685294FD985610BD7 /* CourseGradingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB43C658100448CB1D7112D /* CourseGradingLogicTests.swift */; };
+		28096A60B53B4DC48D902404 /* CourseImportExportLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3484ACD97D4FAD938D2786 /* CourseImportExportLogicTests.swift */; };
+		9661B34023F3417A9289E9DA /* CourseOutcomesLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F28C8F488E84B1F9301B9DD /* CourseOutcomesLogicTests.swift */; };
+		EB9C414783E24AE3938FEE83 /* CoursePeopleLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423B19795811473F88990190 /* CoursePeopleLogicTests.swift */; };
+		803355198DE84312B00EEF6B /* CoursePlagiarismLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9AF7175F8483AA685642A /* CoursePlagiarismLogicTests.swift */; };
+		8408F1012BB1432EB56C470B /* CourseReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35969042DB74D4C80609F6E /* CourseReviewLogicTests.swift */; };
+		D532541CEF9548C2B34F7535 /* CourseSectionsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B6E5F701DD4593807504CA /* CourseSectionsLogicTests.swift */; };
+		5689EDC948304F298739625D /* CourseSettingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77F6F32A9AD4658B757BDCE /* CourseSettingsLogicTests.swift */; };
+		EF9846D4464740F380C37A87 /* CourseTranslationsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF121729CFF497A8601372F /* CourseTranslationsLogicTests.swift */; };
+		7529AA44DAFB43E99ADECA6D /* CredentialsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1CE4EFA0C9449A86F10FB8 /* CredentialsLogicTests.swift */; };
+		B2DBE14BE7F64544966082B7 /* DiscussionLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2899FEBD1E794778A9838B0B /* DiscussionLogicTests.swift */; };
+		A1D5C56A8E344EAFBACC7C35 /* EvaluationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32217947DFAA418A8AA53BE8 /* EvaluationLogicTests.swift */; };
+		D7901A53D7884F90B1A51037 /* FeedLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281C5308887B40D98502BD04 /* FeedLogicTests.swift */; };
+		1F8366B441054C13B54E758A /* FeedbackLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B74676C4A864FCDB403C2F6 /* FeedbackLogicTests.swift */; };
+		27A854C542464A4BA0F79ED8 /* GamificationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B011D700883A4C529F40ADF9 /* GamificationLogicTests.swift */; };
+		777EFEB4E8B944F386678D3E /* GradeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E915F121E2453E9C9DC166 /* GradeCalculatorTests.swift */; };
+		BCBFFF3641164CE494E83790 /* GroupsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCD0C7EE0AD43FC8CD9466F /* GroupsLogicTests.swift */; };
+		73F8B712205046ED8D7F2F84 /* I18nTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E57C4D83B5E46B989095E89 /* I18nTests.swift */; };
+		F169B4F28EA24B019CE5DFDA /* InsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7E5AECE51C4710BBBD0A6F /* InsightsLogicTests.swift */; };
+		545D648D1A1745D899C3E8F2 /* InstructorInsightsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2705D55089B644FBB61D7361 /* InstructorInsightsLogicTests.swift */; };
+		067B2BAE409C4159A355BEA5 /* IntegrationsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E236964F7A21442F920436C6 /* IntegrationsAdminLogicTests.swift */; };
+		AA03DB3FA49B49FE8D2ADA0E /* InteractiveLaunchLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BD8ADF66B443EB991623CF /* InteractiveLaunchLogicTests.swift */; };
+		B32463EFC6094592BEE07740 /* IntroCourseLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA84104BB084D00AD4D18FE /* IntroCourseLogicTests.swift */; };
+		AD0F9DB79E9244BF909AABBF /* LearnerProfileLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98DD42CB96146EE8615D9D6 /* LearnerProfileLogicTests.swift */; };
+		6B59078A87D64B57ACC8757A /* LexturesMotionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8427BEB6D23449D59B66DFE0 /* LexturesMotionTests.swift */; };
+		E628602F8B35472D8DF7B1EA /* LibraryResourceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A897A2A9FCCE46A1BDCDC9F9 /* LibraryResourceLogicTests.swift */; };
+		9CEBF3BE9511495D949ADD0A /* LiveMeetingsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F746768C374CA8ACF3248B /* LiveMeetingsLogicTests.swift */; };
+		06C3CEF59C1C4CE290B7C342 /* LiveQuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1B2FC2F7D8458FB146B015 /* LiveQuizLogicTests.swift */; };
+		93039533CCFD4DA19D4E6EFF /* MarkdownRenderStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF46B174E3E4263B24534FA /* MarkdownRenderStyleTests.swift */; };
+		09929548D33445B29B9C439E /* MarketplaceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854AF3D78B6847E89C04E6A9 /* MarketplaceLogicTests.swift */; };
+		0C24F3E25B7D45F79A4F0B7D /* MasteryLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60E8779468140FFA8CF464E /* MasteryLogicTests.swift */; };
+		C195101C016C479F81CE9EDA /* MobileDestinationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE38C4AC86E47F9A5F25151 /* MobileDestinationsTests.swift */; };
+		E4ABE07F1C394EF98D2C9717 /* ModuleContentModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04636BF487D0472FB8E01182 /* ModuleContentModelsTests.swift */; };
+		AE0327D9102F4CC58008B6BB /* NotebookMarkdownLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2780E67E0D841BA89E1090A /* NotebookMarkdownLogicTests.swift */; };
+		6BD36E65FE764C50861C2505 /* NotificationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90152F97EB3408FB6F4FB13 /* NotificationModelsTests.swift */; };
+		F0AF9957D9064367A34028B9 /* OfficeHoursLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F882C9109483EB074B02D /* OfficeHoursLogicTests.swift */; };
+		B4DB643004924B3B8652780F /* OnboardingModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5CB4AF6B8A4E28AA2B4F07 /* OnboardingModelsTests.swift */; };
+		B0C2AA0267EF4141A7F1CDB0 /* OrgBrandingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A19AEF84EE24A5C8BAC4FEE /* OrgBrandingAdminLogicTests.swift */; };
+		066465F02A3E44B9A7E5B80D /* OrgStructureAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5132581B344AB09F8BBD7F /* OrgStructureAdminLogicTests.swift */; };
+		BF0628E37D384A7FBD883B3D /* ParentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4D3FEAFE024D28B778DBB7 /* ParentLogicTests.swift */; };
+		5F2F1EB90880426887D4538C /* PathsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEE6D9F178F48C0A5DB001C /* PathsLogicTests.swift */; };
+		03036CF1FCC04A03B6BE4623 /* PeerReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F2EB641A944265A21C4740 /* PeerReviewLogicTests.swift */; };
+		407F6D81F5B74C21A199BAC7 /* PeopleAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8EC4B829AB41B494992851 /* PeopleAdminLogicTests.swift */; };
+		1E788BCE8D7C46578ACF6F90 /* PeopleAdminMetricsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA6C3C79A9D43F8B386B7DA /* PeopleAdminMetricsLogicTests.swift */; };
+		5F2E636E72714BAF97C3BE3D /* PlannerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC921554B784491AE7C4E2B /* PlannerModelsTests.swift */; };
+		2B34BF9141B548E0AF398995 /* PlatformCoursesAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BB7C512915458A972CCC94 /* PlatformCoursesAdminLogicTests.swift */; };
+		2D9C6408AF88442F8FEF8EEA /* PlatformSettingsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFD56443D14E499E544953 /* PlatformSettingsAdminLogicTests.swift */; };
+		8B803539203D41C5BB05FF18 /* PortfolioLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB9B0121EB44D98E4F6BCF /* PortfolioLogicTests.swift */; };
+		242B8D51724945219BF5C15E /* ProfileDepthLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1780BBBEDBA4E2DA5DFE1A3 /* ProfileDepthLogicTests.swift */; };
+		A64A85A6032A46ABB86F7659 /* QuizLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA865D11B13B40FCB4AE5E04 /* QuizLogicTests.swift */; };
+		258A6F160B0642E0A992971E /* ReaderLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313BD35E54704F289EAC7634 /* ReaderLogicTests.swift */; };
+		36B7D7960FFC4EADA9F2A077 /* ReadingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27985FD43E004432B9B0179B /* ReadingLogicTests.swift */; };
+		CC5EA2607D504120AB18646C /* RequirementsLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E75E8B939F44588B464D97D /* RequirementsLogicTests.swift */; };
+		930EAC750D6B421EAF7DDFEC /* ReviewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16CB5D88367423FBB8154EB /* ReviewLogicTests.swift */; };
+		B48907B2DDFF45A4809AF6D0 /* RolesPermissionsAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A8A29291324150B8F23295 /* RolesPermissionsAdminLogicTests.swift */; };
+		C664F3DD33B14077B246EBFC /* SchoolCodeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E283BC2A4784BFD804126CE /* SchoolCodeLogicTests.swift */; };
+		DD7DB2BFF30F4823AF4C3896 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094E01AE9B3E4FF597751CD5 /* SearchTests.swift */; };
+		49F1811D65E843018ADB7D17 /* SettingsAccommodationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2CA6FD42FF42908E6CD759 /* SettingsAccommodationsTests.swift */; };
+		CD90F2D580BF42C78050252F /* SettingsMenuLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0970B656B1D4C0E867AF200 /* SettingsMenuLogicTests.swift */; };
+		922365EE47B64847AB3FBFC3 /* TakeAttendanceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19847C3754F4543A31DB248 /* TakeAttendanceLogicTests.swift */; };
+		6591684EC46A43A98EE07406 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9EF064E0A040799E8BF24C /* TranscriptsAdvisingAdminLogicTests.swift */; };
+		BB0F590A59E64399AE8CBB1B /* TutorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7757B1CEF39247E4846E6D3F /* TutorLogicTests.swift */; };
+		F44134C31B564701BB2AE1A9 /* UIModeLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F6C5016CE5F482EBA739D42 /* UIModeLogicTests.swift */; };
+		AE4DCED03D3546DC844254BA /* VibeActivityLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFB97285A334898B4D61F22 /* VibeActivityLogicTests.swift */; };
+		E3AF358694E74BFB8578CF29 /* WalletLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF1C9ACB37C4AF8B0B3D88B /* WalletLogicTests.swift */; };
+		0686C91BC3DF4BD5B3015C21 /* WhiteboardLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68884487729C49D5A7060152 /* WhiteboardLogicTests.swift */; };
+		D3122341196441F4963C7B28 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98AE7CC27C32455DBCB6B543 /* Assets.xcassets */; };
+		19B9233A70F1444A911CB5C9 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 5F90D85ED7EC4470B135AD34 /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		45A94E45545C4385825A8FAB /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		15F81775D0274CCC924659BA /* LexturesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LexturesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BCC21ED0D16140FA8E128181 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		2DB3CC07877B4410A1AA5030 /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
-		46F09135218740BEA6B986E5 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		2391332DEEEF49AB92138DD9 /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
-		D877139FEBC4481391B5DD95 /* AccessibilitySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupport.swift; sourceTree = "<group>"; };
-		7F9F43CFA29B464B8321DE60 /* DictationField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationField.swift; sourceTree = "<group>"; };
-		0C08405046034F249A8E4203 /* ReadAloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAloud.swift; sourceTree = "<group>"; };
-		236584CA08EB4D21A75CB359 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
-		42A6C2CF29B94FD8ACF73AA1 /* AuthCallbackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParser.swift; sourceTree = "<group>"; };
-		7CB15491376F47848D44B281 /* AuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConstants.swift; sourceTree = "<group>"; };
-		2B7BD34CEB384CB3B4A718A6 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
-		7552797A53BB4FCE9FE53E6D /* BiometricGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGate.swift; sourceTree = "<group>"; };
-		0E8C1ED70666464594D7B357 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
-		EC0B98E8DFAD4FD4870B4B32 /* SessionsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsAPI.swift; sourceTree = "<group>"; };
-		DCECD071C74C40B592761510 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
-		706824795CA64D6CA900F6FD /* EnvironmentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentStore.swift; sourceTree = "<group>"; };
-		A72B5AE8D40842608ED2A93B /* SchoolCodeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogic.swift; sourceTree = "<group>"; };
-		3D9E89A08F9048A498A3C2C9 /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
-		1E602BC87C274EB8BF6D2F82 /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
-		94A4411A8DB948DBBC52AB07 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
-		217B50509F7E4605A3AEA934 /* LexturesMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotion.swift; sourceTree = "<group>"; };
-		8C13D65F0331422587A7251A /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
-		39991ABDC8984C10936F533E /* LexturesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesType.swift; sourceTree = "<group>"; };
-		788BE3FA0266441F8EE51DDA /* ProfileAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAvatarView.swift; sourceTree = "<group>"; };
-		118A196BFF72440985648417 /* SyncStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusView.swift; sourceTree = "<group>"; };
-		C3F9FFA509F042BA997FB0AD /* ThemePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePreference.swift; sourceTree = "<group>"; };
-		1A831877A709428DACAE01AA /* UIMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIMode.swift; sourceTree = "<group>"; };
-		31131F38DD8C4F71AB103C65 /* UnsavedChangesBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsavedChangesBanner.swift; sourceTree = "<group>"; };
-		122671E8CAD442C99A656D34 /* DateFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
-		820F8FD64D9F4831BF993A8D /* LocaleAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleAPI.swift; sourceTree = "<group>"; };
-		33CA37F7628145F8A5485536 /* LocalePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalePreferences.swift; sourceTree = "<group>"; };
-		BEABF3ECB7BD4EE28923328C /* Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localized.swift; sourceTree = "<group>"; };
-		876822D3381A4D0EB3AD2B13 /* AccountAccommodationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAccommodationModels.swift; sourceTree = "<group>"; };
-		46DC0271021341C49AEE4143 /* AccountIntegrationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogic.swift; sourceTree = "<group>"; };
-		D12E4F4CDA774754BBF2B46E /* AdvisingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogic.swift; sourceTree = "<group>"; };
-		0C94283167EE41B58D02C513 /* AiModelsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogic.swift; sourceTree = "<group>"; };
-		E26AB3D0F63B4B1484296E98 /* AnnouncementLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogic.swift; sourceTree = "<group>"; };
-		D9200E6719844BDFA2739BCD /* ArchivedCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogic.swift; sourceTree = "<group>"; };
-		F413FF3F2B574D8BA4A8641A /* AssignmentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogic.swift; sourceTree = "<group>"; };
-		6DA16EC96F3B47B7BB83472D /* AuditLogAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogic.swift; sourceTree = "<group>"; };
-		A8218A5DA074493A9E0C1A59 /* BehaviorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogic.swift; sourceTree = "<group>"; };
-		9FE3BC019E0A410DA462E0C9 /* BillingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogic.swift; sourceTree = "<group>"; };
-		9483963ED37B434EAC4A7F8C /* BoardRealtimeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardRealtimeLogic.swift; sourceTree = "<group>"; };
-		F1216ABCEF6C4A5092B7575B /* BoardsAdvancedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogic.swift; sourceTree = "<group>"; };
-		425CCC3EE56D42899515B90B /* BoardsGovernanceAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminLogic.swift; sourceTree = "<group>"; };
-		654A68FBFF004593A6234FEA /* BoardsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogic.swift; sourceTree = "<group>"; };
-		1AAD098C5D86467195AAEFB2 /* CanvasImportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogic.swift; sourceTree = "<group>"; };
-		9E2BC38FEABA48CFBA00F250 /* CanvasImportObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportObservability.swift; sourceTree = "<group>"; };
-		DA1B4CAE70324A789B0B2A32 /* CatalogLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogic.swift; sourceTree = "<group>"; };
-		902B8828157D4900A862C29C /* ConferenceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogic.swift; sourceTree = "<group>"; };
-		30416340D9054E0B99CD6FC9 /* CourseAccessibilityReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogic.swift; sourceTree = "<group>"; };
-		94EF43760CF14277B04B2E26 /* CourseArchivedContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogic.swift; sourceTree = "<group>"; };
-		20F96BF5345940B29F034AE7 /* CourseBlueprintLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogic.swift; sourceTree = "<group>"; };
-		82679475DB4F44808D9B2A80 /* CourseCreateDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateDraftStore.swift; sourceTree = "<group>"; };
-		010D8A6487C848EA8815BE13 /* CourseCreateLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogic.swift; sourceTree = "<group>"; };
-		CA41BD3596684A6B9A402E7E /* CourseCreateObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateObservability.swift; sourceTree = "<group>"; };
-		FECCB1A1680B415D932DA179 /* CourseFeaturesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogic.swift; sourceTree = "<group>"; };
-		90F1D7AAFF3346ECAB215A9A /* CourseFileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileLogic.swift; sourceTree = "<group>"; };
-		CA328ED019264948840DC527 /* CourseGradingAgentsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogic.swift; sourceTree = "<group>"; };
-		D8D4CE8302454BA09CB5BC24 /* CourseGradingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogic.swift; sourceTree = "<group>"; };
-		75E508006F4842A58668DB57 /* CourseHeroImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImage.swift; sourceTree = "<group>"; };
-		CC62A6B2B27441E5B7915806 /* CourseImportExportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogic.swift; sourceTree = "<group>"; };
-		0C8EA99BDF0A4AF6ACD0C05B /* CourseOutcomesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogic.swift; sourceTree = "<group>"; };
-		1B286388C9EC40C887371ED5 /* CoursePeopleLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogic.swift; sourceTree = "<group>"; };
-		89062806BF744D468AA7DFD1 /* CoursePeopleObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleObservability.swift; sourceTree = "<group>"; };
-		F8877458D0E44F6DB649AF12 /* CoursePlagiarismLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogic.swift; sourceTree = "<group>"; };
-		35E7C1D0E02D41ADBF4D5464 /* CourseReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogic.swift; sourceTree = "<group>"; };
-		CBA37BA46DFF4A6392FE691F /* CourseSectionsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogic.swift; sourceTree = "<group>"; };
-		4323122721FF43A98CBA77DD /* CourseSettingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogic.swift; sourceTree = "<group>"; };
-		D39DD7B13CC04A99B5EEF892 /* CourseTranslationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogic.swift; sourceTree = "<group>"; };
-		EA3388A3D4894C97907F21A6 /* CredentialsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogic.swift; sourceTree = "<group>"; };
-		19865D60BF49490CA83E3FC8 /* CurrencyExponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExponent.swift; sourceTree = "<group>"; };
-		821E07F7B3BD4516933FD25F /* DiscussionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogic.swift; sourceTree = "<group>"; };
-		5A5F20597F4246188C41BC16 /* EvaluationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogic.swift; sourceTree = "<group>"; };
-		802E14FA9C1E486E8320D4C9 /* FeedbackLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogic.swift; sourceTree = "<group>"; };
-		7DB1D45B7CFF4C63AE669D1A /* FileDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadManager.swift; sourceTree = "<group>"; };
-		D88B6AF6F97C420CA3528020 /* GamificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogic.swift; sourceTree = "<group>"; };
-		7E4EAB0E8322489395633B7F /* GradeCalculator+MyGrades.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GradeCalculator+MyGrades.swift"; sourceTree = "<group>"; };
-		9A3A0A78C0E24855A2FC15B9 /* GradeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculator.swift; sourceTree = "<group>"; };
-		2F3D19836EB74186A1414C77 /* GroupsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogic.swift; sourceTree = "<group>"; };
-		E21D78D26D264655AB76C425 /* InsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogic.swift; sourceTree = "<group>"; };
-		36A150CD947F4E56BFF48EAD /* InstructorInsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogic.swift; sourceTree = "<group>"; };
-		C016EA4D3A0B472CB5D1125D /* IntegrationsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogic.swift; sourceTree = "<group>"; };
-		92A43C87E3984E9097D25841 /* InteractiveLaunchLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogic.swift; sourceTree = "<group>"; };
-		919E594A7B8D4B6F98B0B1F7 /* IntroCourseLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogic.swift; sourceTree = "<group>"; };
-		6542DA2E77D24963B76CF7C2 /* IntroCourseObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseObservability.swift; sourceTree = "<group>"; };
-		966CD203A95F4B3B819D5965 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
-		60CDA1E5F1194D00ACE24EB7 /* LMSAPIAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAccountIntegrations.swift; sourceTree = "<group>"; };
-		97217C9DC56846FA9D63293B /* LMSAPIAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdmin.swift; sourceTree = "<group>"; };
-		E56A544993F04A8CBB03CEDD /* LMSAPIAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdvising.swift; sourceTree = "<group>"; };
-		A150DCF9F7224315B7B30C60 /* LMSAPIAnnouncements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAnnouncements.swift; sourceTree = "<group>"; };
-		7F9127F532CB4C378571046A /* LMSAPIAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAuditLog.swift; sourceTree = "<group>"; };
-		D5B851C9FA0E4125AC76F48A /* LMSAPIBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBehavior.swift; sourceTree = "<group>"; };
-		46A904A5B0DB4B3098645E2A /* LMSAPIBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBilling.swift; sourceTree = "<group>"; };
-		994BBFFE141A485DA43BC060 /* LMSAPIBoardAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAccess.swift; sourceTree = "<group>"; };
-		C71BA7EC2E36488D9549FC98 /* LMSAPIBoardAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAnalytics.swift; sourceTree = "<group>"; };
-		801E18789F664D0DA7B9F036 /* LMSAPIBoardEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardEngagement.swift; sourceTree = "<group>"; };
-		9A55EC392CA1443EB6FD698D /* LMSAPIBoardExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardExport.swift; sourceTree = "<group>"; };
-		EF09D800BBA244ADB1F89793 /* LMSAPIBoardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardLayout.swift; sourceTree = "<group>"; };
-		C464E7B7706B46A6A1EC6B2F /* LMSAPIBoardModeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardModeration.swift; sourceTree = "<group>"; };
-		86242101E8CC4D4D9DB48D1E /* LMSAPIBoardPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardPosts.swift; sourceTree = "<group>"; };
-		E02AE223E87C46CA849E4F4A /* LMSAPIBoardTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardTemplates.swift; sourceTree = "<group>"; };
-		7E9B571E7F1E4C1D8B0B8EB3 /* LMSAPIBoards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoards.swift; sourceTree = "<group>"; };
-		D8955E4A2CB0471DB37AB7E1 /* LMSAPICanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICanvasImport.swift; sourceTree = "<group>"; };
-		A728634557104CC48E4FA9FA /* LMSAPICatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICatalog.swift; sourceTree = "<group>"; };
-		E3060A84315140D48D885600 /* LMSAPICourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseAccessibility.swift; sourceTree = "<group>"; };
-		5AB86D9F3B774232B8B64374 /* LMSAPICourseArchivedContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseArchivedContent.swift; sourceTree = "<group>"; };
-		7A7649122040475593E51536 /* LMSAPICourseBlueprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseBlueprint.swift; sourceTree = "<group>"; };
-		F838E38FD3314A86A61313B3 /* LMSAPICourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseCreate.swift; sourceTree = "<group>"; };
-		02159D88D4604E099DC45F01 /* LMSAPICourseFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseFeatures.swift; sourceTree = "<group>"; };
-		1C84ED01FAFE4F6A866A68EF /* LMSAPICourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGrading.swift; sourceTree = "<group>"; };
-		E38FAB25C7DD43B284D8EFCD /* LMSAPICourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGradingAgents.swift; sourceTree = "<group>"; };
-		8AD72034B7394CDDB3C71596 /* LMSAPICourseImportExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseImportExport.swift; sourceTree = "<group>"; };
-		E4B5DBDBE0EA4FD6811B8A9C /* LMSAPICoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICoursePlagiarism.swift; sourceTree = "<group>"; };
-		9C5ECA1E769A42E8AB9D07AC /* LMSAPICourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseReviews.swift; sourceTree = "<group>"; };
-		668A5BEF50304DEEB227C929 /* LMSAPICourseSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSections.swift; sourceTree = "<group>"; };
-		7BF1717F955345CEB67D4387 /* LMSAPICourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSettings.swift; sourceTree = "<group>"; };
-		99E5D70AB65A4BD0842B8517 /* LMSAPICourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseTranslations.swift; sourceTree = "<group>"; };
-		4A29CB1E340146B2AB9FC2E4 /* LMSAPICredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICredentials.swift; sourceTree = "<group>"; };
-		068520BD32F0465EBD006759 /* LMSAPIDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIDiscussions.swift; sourceTree = "<group>"; };
-		3131373FEB59466C8AB0AC7C /* LMSAPIEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEportfolio.swift; sourceTree = "<group>"; };
-		306DA47EB9F146349ADE21A8 /* LMSAPIEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEvaluations.swift; sourceTree = "<group>"; };
-		9A5CE9C20A164A57A2912047 /* LMSAPIFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeatures.swift; sourceTree = "<group>"; };
-		5E2D7AF6A7E74E419C4E3E6D /* LMSAPIFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeed.swift; sourceTree = "<group>"; };
-		99D110AD56244378A93E0E15 /* LMSAPIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeedback.swift; sourceTree = "<group>"; };
-		894E2AD904124DDDB1BD3CBF /* LMSAPIGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGamification.swift; sourceTree = "<group>"; };
-		0AF12B79BA4A4F999CA668DF /* LMSAPIGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGroups.swift; sourceTree = "<group>"; };
-		9BAA3D5D9FD24A8B9B2EFDDF /* LMSAPIInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInsights.swift; sourceTree = "<group>"; };
-		80BDAE0779984913A3A462B8 /* LMSAPIInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInstructorInsights.swift; sourceTree = "<group>"; };
-		35A92F7A21E3452886DEB48E /* LMSAPIIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIIntroCourse.swift; sourceTree = "<group>"; };
-		9E4A56A3B3B84A10991DAF47 /* LMSAPILearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILearnerProfile.swift; sourceTree = "<group>"; };
-		2CDD6A07DA3446248362F3D7 /* LMSAPILiveQuiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILiveQuiz.swift; sourceTree = "<group>"; };
-		4288167DEBBD4889AE882767 /* LMSAPIMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMarketplace.swift; sourceTree = "<group>"; };
-		08FE81C12C6F499187483CE8 /* LMSAPIMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMastery.swift; sourceTree = "<group>"; };
-		AAD07E78BFB04381B3637B0E /* LMSAPIMobileWave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMobileWave.swift; sourceTree = "<group>"; };
-		C746D09F7AED46FC9EFF8F3A /* LMSAPIOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIOutcomes.swift; sourceTree = "<group>"; };
-		813EBA9635704CB7AA3ED889 /* LMSAPIParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIParent.swift; sourceTree = "<group>"; };
-		9675FBC57BC64C3F9111FD59 /* LMSAPIPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPaths.swift; sourceTree = "<group>"; };
-		33223C7241234E22923DE250 /* LMSAPIPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPeerReview.swift; sourceTree = "<group>"; };
-		64F5E609206F4CC4A2CF95E1 /* LMSAPIProctoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIProctoring.swift; sourceTree = "<group>"; };
-		48FE06D846ED40A58DCE2230 /* LMSAPIQuizCodeRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIQuizCodeRun.swift; sourceTree = "<group>"; };
-		DF8906D74CFF4701B255EAF4 /* LMSAPIReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReader.swift; sourceTree = "<group>"; };
-		10A0B299B0D94ADC97F88528 /* LMSAPIReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReading.swift; sourceTree = "<group>"; };
-		60B8FDE10B9B4CEC8A5C6F5E /* LMSAPIReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReview.swift; sourceTree = "<group>"; };
-		86ED0FB8585D46868F83CB1F /* LMSAPITutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPITutor.swift; sourceTree = "<group>"; };
-		207E7D9985164CD29E02D922 /* LMSAPIWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWallet.swift; sourceTree = "<group>"; };
-		C6D9DD802E174B83AE982827 /* LMSAPIWhiteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWhiteboard.swift; sourceTree = "<group>"; };
-		F7F968115560419084BFD1DA /* LMSBoardAdvancedModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardAdvancedModels.swift; sourceTree = "<group>"; };
-		904B49C91AD649B8ACE9FF53 /* LMSBoardModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardModels.swift; sourceTree = "<group>"; };
-		2F30BB03583A40CBACF8BAC7 /* LMSFeatureModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModels.swift; sourceTree = "<group>"; };
-		5D5AFDFFD4954154AA08B6F0 /* LMSFeatureModelsAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAccountIntegrations.swift; sourceTree = "<group>"; };
-		D80B84481BE743C8815CE2A1 /* LMSFeatureModelsAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAdvising.swift; sourceTree = "<group>"; };
-		3EEC8D940813443B82EF99FB /* LMSFeatureModelsAiAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAiAdmin.swift; sourceTree = "<group>"; };
-		B1A3ACCAF55B4CB3BC634A50 /* LMSFeatureModelsArchivedCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsArchivedCoursesAdmin.swift; sourceTree = "<group>"; };
-		DE63E84856084D178F811FA9 /* LMSFeatureModelsAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAuditLog.swift; sourceTree = "<group>"; };
-		A9C177FF51E7499F98FEB135 /* LMSFeatureModelsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBehavior.swift; sourceTree = "<group>"; };
-		1C8F213D1EFE4B02BE3EA0DC /* LMSFeatureModelsBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBilling.swift; sourceTree = "<group>"; };
-		189CE9ECC48A43A2934C6332 /* LMSFeatureModelsCanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCanvasImport.swift; sourceTree = "<group>"; };
-		E60FFEEF85CA49868E48854D /* LMSFeatureModelsCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCatalog.swift; sourceTree = "<group>"; };
-		5D140A0009994251829A8550 /* LMSFeatureModelsCourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseAccessibility.swift; sourceTree = "<group>"; };
-		DD8FE4612AF54B47AFEA77FC /* LMSFeatureModelsCourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseCreate.swift; sourceTree = "<group>"; };
-		024FE8FC67C4411EA992E641 /* LMSFeatureModelsCourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGrading.swift; sourceTree = "<group>"; };
-		D2290E19122C4493AE1EBD28 /* LMSFeatureModelsCourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGradingAgents.swift; sourceTree = "<group>"; };
-		55830F753A0046C981B6A5A6 /* LMSFeatureModelsCourseOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseOutcomes.swift; sourceTree = "<group>"; };
-		293E953D73FB46039E06FEA4 /* LMSFeatureModelsCoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCoursePlagiarism.swift; sourceTree = "<group>"; };
-		7CB7B6D7573A436D9EE6C0BD /* LMSFeatureModelsCourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseReviews.swift; sourceTree = "<group>"; };
-		32C78CFD171E4C50B5AC21BB /* LMSFeatureModelsCourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseSettings.swift; sourceTree = "<group>"; };
-		A6602EEA446149C0BF76FD4F /* LMSFeatureModelsCourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseTranslations.swift; sourceTree = "<group>"; };
-		215E096BEF9B47F68FB552A7 /* LMSFeatureModelsCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCredentials.swift; sourceTree = "<group>"; };
-		448F3041DA3349A4B85A5849 /* LMSFeatureModelsDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsDiscussions.swift; sourceTree = "<group>"; };
-		8F09DF8AF0BD45B195F3B93C /* LMSFeatureModelsEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEportfolio.swift; sourceTree = "<group>"; };
-		C1655E9A8D3C4BF089B81C17 /* LMSFeatureModelsEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEvaluations.swift; sourceTree = "<group>"; };
-		4B7D2B5DFB6D4597B12EC5CC /* LMSFeatureModelsFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeed.swift; sourceTree = "<group>"; };
-		750096FF04F847F08FA588EE /* LMSFeatureModelsFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeedback.swift; sourceTree = "<group>"; };
-		888D7AF98DAE4275B6026F44 /* LMSFeatureModelsGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGamification.swift; sourceTree = "<group>"; };
-		08DB93BEB74C4BDBA17AC808 /* LMSFeatureModelsGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGroups.swift; sourceTree = "<group>"; };
-		C0BD6CA3F08E413693067FCE /* LMSFeatureModelsInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInsights.swift; sourceTree = "<group>"; };
-		03308D4ECF2B43DB882A33FF /* LMSFeatureModelsInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInstructorInsights.swift; sourceTree = "<group>"; };
-		023909062EED4A2B9B375E4A /* LMSFeatureModelsIntegrationsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntegrationsAdmin.swift; sourceTree = "<group>"; };
-		CE321A529D7B4A4DA1F2EDB3 /* LMSFeatureModelsIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntroCourse.swift; sourceTree = "<group>"; };
-		734204250DE94773B2699164 /* LMSFeatureModelsLearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLearnerProfile.swift; sourceTree = "<group>"; };
-		98B548F6309447C3A3FBFF17 /* LMSFeatureModelsLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLive.swift; sourceTree = "<group>"; };
-		0CD04098A231494CA3F09F78 /* LMSFeatureModelsMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMarketplace.swift; sourceTree = "<group>"; };
-		39DDFFC0D69A491D9DA742FA /* LMSFeatureModelsMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMastery.swift; sourceTree = "<group>"; };
-		5CAE21F884C8447AA61BF858 /* LMSFeatureModelsMobile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMobile.swift; sourceTree = "<group>"; };
-		B1E0AB224456451DBA4E7994 /* LMSFeatureModelsOrgBrandingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgBrandingAdmin.swift; sourceTree = "<group>"; };
-		2C43119FFBC54D04B7C27FD9 /* LMSFeatureModelsOrgStructureAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgStructureAdmin.swift; sourceTree = "<group>"; };
-		550DB0C297164ED9880A4FD7 /* LMSFeatureModelsParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsParent.swift; sourceTree = "<group>"; };
-		F4790175587647C88099ADD4 /* LMSFeatureModelsPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPaths.swift; sourceTree = "<group>"; };
-		0F3143CD283049999A70EE00 /* LMSFeatureModelsPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeerReview.swift; sourceTree = "<group>"; };
-		72B0D6B8EA2C4B84993EA288 /* LMSFeatureModelsPeopleAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeopleAdmin.swift; sourceTree = "<group>"; };
-		21CCABD2171944B38CFFE643 /* LMSFeatureModelsPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatform.swift; sourceTree = "<group>"; };
-		B9DD0143BF514EB898AEEFAD /* LMSFeatureModelsPlatformCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformCoursesAdmin.swift; sourceTree = "<group>"; };
-		37F009617AFF417CABF397AE /* LMSFeatureModelsPlatformSettingsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformSettingsAdmin.swift; sourceTree = "<group>"; };
-		4643CE61530B4FD8971104A2 /* LMSFeatureModelsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReader.swift; sourceTree = "<group>"; };
-		96F39CB0482F4A64913BB349 /* LMSFeatureModelsReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReading.swift; sourceTree = "<group>"; };
-		E609EA910A5A463B99D7C222 /* LMSFeatureModelsRolesPermissionsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsRolesPermissionsAdmin.swift; sourceTree = "<group>"; };
-		3A9F3F51E5A245A1A459EF71 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTranscriptsAdvisingAdmin.swift; sourceTree = "<group>"; };
-		8E589186B3024558AE276C41 /* LMSFeatureModelsTutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTutor.swift; sourceTree = "<group>"; };
-		DB025E305E73486AB634D170 /* LMSFeatureModelsWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsWallet.swift; sourceTree = "<group>"; };
-		3B3AEDE2A3A24B1FB83AD8CD /* LMSInteractiveModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSInteractiveModels.swift; sourceTree = "<group>"; };
-		7C17447C206F491F86B62429 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
-		FE2DA8F783004A75B61C861E /* LearnerProfileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogic.swift; sourceTree = "<group>"; };
-		B520F7E9737D4C78B5511ADA /* LibraryResourceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogic.swift; sourceTree = "<group>"; };
-		C37D57FE7FD94B599A7462C4 /* LiveGameLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameLogic.swift; sourceTree = "<group>"; };
-		1968A81A18024476BACDA0C8 /* LiveMeetingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogic.swift; sourceTree = "<group>"; };
-		6C2A21241F6A48D79A316B25 /* LiveQuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogic.swift; sourceTree = "<group>"; };
-		48B6B3C5A0A44CF0BE0695FC /* MarketplaceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogic.swift; sourceTree = "<group>"; };
-		E0D94CAC8ADF4E77ADBCE34B /* MasteryLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogic.swift; sourceTree = "<group>"; };
-		76986149DC3348B4AB702714 /* ModuleContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentLogic.swift; sourceTree = "<group>"; };
-		11775417D81E4E9BAE6C9E95 /* ModuleLastVisited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleLastVisited.swift; sourceTree = "<group>"; };
-		D0EA30C7BA6041EF97247A7D /* NotificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLogic.swift; sourceTree = "<group>"; };
-		6855BB77F7A14D1EB6FC6F9B /* OfficeHoursLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogic.swift; sourceTree = "<group>"; };
-		1F81340A6FCF4880BBBA4791 /* OnboardingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModels.swift; sourceTree = "<group>"; };
-		86594C5CEF924F1DB75AEC45 /* OrgBrandingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogic.swift; sourceTree = "<group>"; };
-		8FF8F46759714555BDFE85ED /* OrgStructureAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogic.swift; sourceTree = "<group>"; };
-		E007BE645CB04728BEFB4B4B /* ParentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogic.swift; sourceTree = "<group>"; };
-		B07AEF18A77544789FA89FEA /* PathsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogic.swift; sourceTree = "<group>"; };
-		3CFB99E8194E4D8D91176740 /* PeerReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogic.swift; sourceTree = "<group>"; };
-		26155397F5234AE695039840 /* PeopleAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogic.swift; sourceTree = "<group>"; };
-		F25AC1FC6EA5428E8B72D682 /* PlannerLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerLogic.swift; sourceTree = "<group>"; };
-		5790510331EE4827B84DE958 /* PlannerSnapshotCoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerSnapshotCoding.swift; sourceTree = "<group>"; };
-		37D87AB33B084FB29D7A6D57 /* PlatformCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogic.swift; sourceTree = "<group>"; };
-		0F21F0185187479A99043D89 /* PlatformSettingsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogic.swift; sourceTree = "<group>"; };
-		56248BCF827943AC98A609E6 /* PortfolioLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogic.swift; sourceTree = "<group>"; };
-		D7979B9805F94AC3BA42C0A2 /* ProfileDepthLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogic.swift; sourceTree = "<group>"; };
-		E182B9799F5841BDA349CFB7 /* ProfileDepthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthModels.swift; sourceTree = "<group>"; };
-		CD9C4896A7134E4EBBB34EB7 /* QuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogic.swift; sourceTree = "<group>"; };
-		9C014105AAF843E483AA944A /* ReadingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogic.swift; sourceTree = "<group>"; };
-		B5F385DEC274498C97903AA4 /* RequirementsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogic.swift; sourceTree = "<group>"; };
-		A92202601E40437985EDDDBD /* ReviewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewModels.swift; sourceTree = "<group>"; };
-		7E1B974B7FBA4A0B829A0604 /* RolesPermissionsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogic.swift; sourceTree = "<group>"; };
-		45B5ECA2A97A41E096C017B9 /* SettingsMenuLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogic.swift; sourceTree = "<group>"; };
-		166A6BA560C44113A46D4988 /* TakeAttendanceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogic.swift; sourceTree = "<group>"; };
-		922C235D780B473CBC59D7F5 /* TranscriptsAdvisingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogic.swift; sourceTree = "<group>"; };
-		89473B285B5E49A0A79308DC /* TutorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogic.swift; sourceTree = "<group>"; };
-		EC2751D8B98E43CD9F62F7AD /* TutorStreamClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorStreamClient.swift; sourceTree = "<group>"; };
-		F25FA4F8614F4D7D9EEED7D3 /* VibeActivityLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogic.swift; sourceTree = "<group>"; };
-		24C019B8498C499AAE46FEF3 /* WalletLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogic.swift; sourceTree = "<group>"; };
-		A531E690F2CE4FEB86896985 /* WhiteboardLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogic.swift; sourceTree = "<group>"; };
-		3A2B972D59944A22A14CD382 /* WhiteboardRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardRenderer.swift; sourceTree = "<group>"; };
-		9539914B91EA4AC0A10CD744 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		B8C60DD35D434947B391DCCB /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
-		B87F886051A547F6B9915B17 /* NetworkAuthContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAuthContext.swift; sourceTree = "<group>"; };
-		034243060A9D460D8829F84B /* NetworkBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBootstrap.swift; sourceTree = "<group>"; };
-		6D674B0C9ED146939FC329F3 /* MarkdownTableLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTableLogic.swift; sourceTree = "<group>"; };
-		D83042AE2827442483E3E27C /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
-		FB326385E92C4DA1B823A4F4 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
-		0190BC6FDADE41CCB994CF1F /* NotebookSlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSlashCommands.swift; sourceTree = "<group>"; };
-		9BD6D10890F84565933F42DB /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
-		CDC8BA6757C24485B7248CA1 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
-		2A6CC2ED061F4414B31ABB71 /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
-		8D48D6ED18E84162ADDD9DFD /* CacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStore.swift; sourceTree = "<group>"; };
-		08584DB395634C77BC5D895C /* DownloadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadStore.swift; sourceTree = "<group>"; };
-		66CF0C8E08904DE4BA967198 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
-		7F1594BFF9A242A9A66BDC90 /* OfflineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModels.swift; sourceTree = "<group>"; };
-		5662A6252F164C63B7CDBA00 /* OfflineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineService.swift; sourceTree = "<group>"; };
-		748936187DFB496C964B1168 /* OutboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxStore.swift; sourceTree = "<group>"; };
-		01174D0301DC49278345703C /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
-		0F2AD54DF35243D08D0884D7 /* PushManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushManager.swift; sourceTree = "<group>"; };
-		28F8C9E8AEC94C8CB4048E6F /* RealtimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeManager.swift; sourceTree = "<group>"; };
-		BF143DA58EC349B88DE918D5 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
-		6A1E5E66145E42A1971D08A6 /* ContentLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLinkRouter.swift; sourceTree = "<group>"; };
-		3AD1758A01574A04BD37420F /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
-		CC3755F559B9448F87A2512D /* MobileDestinations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinations.swift; sourceTree = "<group>"; };
-		31CF4329D62D43529C92A419 /* MobileIaPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileIaPreferences.swift; sourceTree = "<group>"; };
-		129D441D1F9D47469C14936A /* MobileProfileDepthPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileProfileDepthPreferences.swift; sourceTree = "<group>"; };
-		18AB82BC37F649188244C769 /* SearchActionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchActionRegistry.swift; sourceTree = "<group>"; };
-		AB95D2CEDEF34154B27C0629 /* SearchModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModels.swift; sourceTree = "<group>"; };
-		F10471B9CC0341E191FCC111 /* SearchPathNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPathNavigator.swift; sourceTree = "<group>"; };
-		89C50C881A26455F812729AB /* SearchRecentsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRecentsStore.swift; sourceTree = "<group>"; };
-		1A3EC0B819B54DD1A3035E15 /* CodeEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditor.swift; sourceTree = "<group>"; };
-		20692C98F7CF4C5E9E630940 /* AdvisingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingView.swift; sourceTree = "<group>"; };
-		49E0B6EB1F464ADEABF0BBEE /* AssignmentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDetailView.swift; sourceTree = "<group>"; };
-		1FB370489A524C4494940128 /* AssignmentDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDraftStore.swift; sourceTree = "<group>"; };
-		0253694A82134E3AAEB30D97 /* AttachmentUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploader.swift; sourceTree = "<group>"; };
-		969DA09CDDFD40049CE615D0 /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
-		3C9B1359A4404825AE15F3A3 /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
-		F42150EF643F4D7D9FFFFAE0 /* GetStartedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStartedView.swift; sourceTree = "<group>"; };
-		10532DC1D669434B82A731A2 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
-		52FE0D2585394BF187ECA1B7 /* MFAChallengeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAChallengeView.swift; sourceTree = "<group>"; };
-		2D04881B017D42D59271A7FF /* MfaPasskeyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MfaPasskeyController.swift; sourceTree = "<group>"; };
-		2F813600B54249D3B9938C60 /* SSOAuthController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOAuthController.swift; sourceTree = "<group>"; };
-		64116C457D144592923CE953 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
-		FF6A680715844859B5AB1482 /* BehaviorRosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorRosterView.swift; sourceTree = "<group>"; };
-		1F834E7C7E2B4F83977CD393 /* HallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HallPassView.swift; sourceTree = "<group>"; };
-		589449D3174C412290E4395C /* MyHallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHallPassView.swift; sourceTree = "<group>"; };
-		A4D5E89F64034E519A897B39 /* BillingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingView.swift; sourceTree = "<group>"; };
-		002621179B3240B88E42D3BE /* CheckoutReturnHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutReturnHandler.swift; sourceTree = "<group>"; };
-		CEBA28AFA45B4196BA532489 /* PurchaseFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseFlow.swift; sourceTree = "<group>"; };
-		4CA12F2E861645A1980CF97B /* BoardAnalyticsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAnalyticsSheet.swift; sourceTree = "<group>"; };
-		8924613254124B5AA8FD0491 /* BoardComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardComposerView.swift; sourceTree = "<group>"; };
-		03216D95DEEE443283E5957E /* BoardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailView.swift; sourceTree = "<group>"; };
-		337088D4F5644F398827A1F8 /* BoardEngagementEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEngagementEnvironment.swift; sourceTree = "<group>"; };
-		BF51B8DD3EC1499B9B67BB98 /* BoardExportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardExportSheet.swift; sourceTree = "<group>"; };
-		83131615195A4ACC8EE64E7D /* BoardModerationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardModerationSettings.swift; sourceTree = "<group>"; };
-		259DF311E035446E813AA4DB /* BoardPostCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPostCard.swift; sourceTree = "<group>"; };
-		C2B34D6497C14CAC8663E762 /* BoardPresentModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPresentModeView.swift; sourceTree = "<group>"; };
-		5B437E7FBB6B460F8178C628 /* BoardSaveAsTemplateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSaveAsTemplateSheet.swift; sourceTree = "<group>"; };
-		1A2E9D9B7CC2408C88DC216F /* BoardShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardShareSheet.swift; sourceTree = "<group>"; };
-		9B45A1B0F53148FEACFB6231 /* BoardSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSocket.swift; sourceTree = "<group>"; };
-		CB51EF4DBC774C6DBD841565 /* BoardSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSurface.swift; sourceTree = "<group>"; };
-		886E207B6264422F8B23AB06 /* BoardSyncStatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSyncStatusChip.swift; sourceTree = "<group>"; };
-		8B3143CE3BEC4D3FB873211C /* BoardTemplatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTemplatePickerView.swift; sourceTree = "<group>"; };
-		490CFC138B7B46DDABD858C5 /* BoardsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsListView.swift; sourceTree = "<group>"; };
-		4D68ECFF7B644E71BC47AE87 /* CardArrangeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardArrangeMenu.swift; sourceTree = "<group>"; };
-		4FC767DDD02B4309BF4ADDC0 /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
-		DED68C4F898B4AA492F84347 /* GradeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSheet.swift; sourceTree = "<group>"; };
-		370BAE4B96A34903AB73ED0C /* CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasLayout.swift; sourceTree = "<group>"; };
-		78BA4EA8C1154A7EA1731CD8 /* ColumnsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnsLayout.swift; sourceTree = "<group>"; };
-		780DA182FF4043B38696D36C /* MapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLayout.swift; sourceTree = "<group>"; };
-		E7CB8C1BE7504CD9B7CEEAC6 /* TimelineLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLayout.swift; sourceTree = "<group>"; };
-		57FDCF46AF3E4B0DA1A173DB /* WallLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallLayout.swift; sourceTree = "<group>"; };
-		611830A137CA49C1959CDE8F /* ModerationQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationQueueView.swift; sourceTree = "<group>"; };
-		2F852E57D2D14F8A95455DBE /* BoardPublicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPublicView.swift; sourceTree = "<group>"; };
-		6055DB2C26AB4129A22E0F29 /* ReactionControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionControl.swift; sourceTree = "<group>"; };
-		8288AA0576624915998DFB6D /* ReportDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDialog.swift; sourceTree = "<group>"; };
-		133747F8014442AEB513EB08 /* CatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogView.swift; sourceTree = "<group>"; };
-		22DF8A394EE945B8B60D579F /* CourseLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLandingView.swift; sourceTree = "<group>"; };
-		02AB0F11CDF54868BE71CFF3 /* ReviewComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewComposer.swift; sourceTree = "<group>"; };
-		847219C1BF3A490581AAEF0D /* ContentPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentPageView.swift; sourceTree = "<group>"; };
-		BB770D3718FF4A90B5384778 /* CourseAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAttendanceView.swift; sourceTree = "<group>"; };
-		87682C9CFE11404282D85EDA /* CourseBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBanner.swift; sourceTree = "<group>"; };
-		6439F689A7D84336B9539BD9 /* CourseDestinationPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDestinationPlaceholder.swift; sourceTree = "<group>"; };
-		A0365B3EC4674A04B2BDFDFB /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
-		8263EB4500D544EE8D550D89 /* CourseGradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradesView.swift; sourceTree = "<group>"; };
-		1DCD2C6E51C24F738ED8C250 /* CourseLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLibraryView.swift; sourceTree = "<group>"; };
-		A025369C914A4C87867124F5 /* CourseMarkdownContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarkdownContentView.swift; sourceTree = "<group>"; };
-		54B6AC4FDA634026875BA2D4 /* CoursePeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleView.swift; sourceTree = "<group>"; };
-		C6DE8049A8EC481999C88093 /* CourseStructureSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseStructureSocket.swift; sourceTree = "<group>"; };
-		7557B966F73F4899BC996BB4 /* CourseSyllabusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyllabusView.swift; sourceTree = "<group>"; };
-		A564BD3178B141A79D7DADA8 /* CourseWorkspaceNav.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseWorkspaceNav.swift; sourceTree = "<group>"; };
-		40536B390EA3411BA49279F6 /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
-		35EB05D53C374ABEB6EA3DD0 /* CanvasImportComingSoonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportComingSoonView.swift; sourceTree = "<group>"; };
-		E9F823AB9D514792B470A794 /* CanvasImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportView.swift; sourceTree = "<group>"; };
-		2BCB46E9122846B5904855D6 /* CourseCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateView.swift; sourceTree = "<group>"; };
-		D1F747815F954B388C7CD9D6 /* ItemDetailRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailRows.swift; sourceTree = "<group>"; };
-		77028F77277348C399FE5293 /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
-		4A6F3A0A6E144C2E9E1DA262 /* LaunchContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContainerView.swift; sourceTree = "<group>"; };
-		41E68A635B7041AE8657D5F3 /* LibraryResourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceView.swift; sourceTree = "<group>"; };
-		A6CAC416D8494E778F4B9787 /* MarkdownCodeBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeBlockView.swift; sourceTree = "<group>"; };
-		E00898CE0B5A4D8F832F234E /* MarkdownTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTableView.swift; sourceTree = "<group>"; };
-		659D85899B3942718E0FCEF8 /* ModuleItemRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleItemRouteView.swift; sourceTree = "<group>"; };
-		B6A7F68903B0466686850D5D /* ModuleListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleListView.swift; sourceTree = "<group>"; };
-		EC0F193562AA48EA9D3B5751 /* RequirementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsView.swift; sourceTree = "<group>"; };
-		E895804DE50A41ED8B232135 /* CourseAccessibilityReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewView.swift; sourceTree = "<group>"; };
-		267410C1A41D49FF99FBB5C7 /* CourseArchivedContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentView.swift; sourceTree = "<group>"; };
-		FCBAB76F491F4138AED91A60 /* CourseBlueprintSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintSettingsView.swift; sourceTree = "<group>"; };
-		FC84EB24717C41269F150D07 /* CourseCrossListingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCrossListingView.swift; sourceTree = "<group>"; };
-		DD02BDC83DB8485CBCE81507 /* CourseFeaturesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesSettingsView.swift; sourceTree = "<group>"; };
-		BFB6A4245D294042A00AA6A4 /* CourseGeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGeneralSettingsView.swift; sourceTree = "<group>"; };
-		5349888EC0114570ACD831E4 /* CourseGradingAgentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsView.swift; sourceTree = "<group>"; };
-		59EF72CCCF474E3AAA676528 /* CourseGradingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingSettingsView.swift; sourceTree = "<group>"; };
-		EA41E9040649456DB33BC162 /* CourseHeroImageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImageEditor.swift; sourceTree = "<group>"; };
-		FBA181A953E14C468095768C /* CourseImportExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportView.swift; sourceTree = "<group>"; };
-		9BE3AA0F3A6F4471AA1C6E35 /* CourseMarketplaceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarketplaceSettingsView.swift; sourceTree = "<group>"; };
-		8BC1C07012AA400FB90CD1B1 /* CourseOutcomesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesSettingsView.swift; sourceTree = "<group>"; };
-		2225D9D07D9C459196127219 /* CoursePlagiarismSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismSettingsView.swift; sourceTree = "<group>"; };
-		4DE94582729E48E39E56B2E9 /* CourseSectionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsSettingsView.swift; sourceTree = "<group>"; };
-		713566F955A64593962A78CF /* CourseSettingsHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsHostView.swift; sourceTree = "<group>"; };
-		1FA5BBF44C9844CEA26C3C6A /* CourseTranslationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsSettingsView.swift; sourceTree = "<group>"; };
-		04F287EF609D48A587AE804D /* TakeAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceView.swift; sourceTree = "<group>"; };
-		8937A1E1F8C542699D4EFCE3 /* VibeActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityView.swift; sourceTree = "<group>"; };
-		D2D25A64C53F44E8A3DCA18F /* WebItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebItemView.swift; sourceTree = "<group>"; };
-		C4FF896DFF2C4573B7293396 /* CredentialDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDetailView.swift; sourceTree = "<group>"; };
-		5D1B0BC5160C4FAF85C3E3A9 /* CredentialsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsView.swift; sourceTree = "<group>"; };
-		2EFFCC5A901E49019C8EBA1D /* DashboardCoursesCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCoursesCarousel.swift; sourceTree = "<group>"; };
-		F4DC62FD64AE4B6D8014259E /* DashboardHeroPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardHeroPanel.swift; sourceTree = "<group>"; };
-		EDBAFCBF1764488498252FCB /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
-		C1A1E7EAE66744EC93DF87FF /* LiveMeetingsRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsRail.swift; sourceTree = "<group>"; };
-		68F065BDB057427B997809FB /* CourseDiscussionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDiscussionsSection.swift; sourceTree = "<group>"; };
-		1E79761A651C453CAD0276FA /* DiscussionThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionThreadView.swift; sourceTree = "<group>"; };
-		6E4292E5B6E44215941C86AE /* DiscussionsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionsListView.swift; sourceTree = "<group>"; };
-		79B640B95186493C897B723A /* PostComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostComposerView.swift; sourceTree = "<group>"; };
-		1435004D17D84682BA71973A /* CourseEvaluationsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseEvaluationsSection.swift; sourceTree = "<group>"; };
-		2FF3D50943E74F2FB0FA5844 /* EvaluationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationFormView.swift; sourceTree = "<group>"; };
-		54C00764961C47D08D3E81CA /* EvaluationResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationResultsView.swift; sourceTree = "<group>"; };
-		5A9C93B850C1470B8EDD80F4 /* CourseFeedSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeedSection.swift; sourceTree = "<group>"; };
-		C7EDA538039A4B58AFB7F963 /* FeedChannelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelView.swift; sourceTree = "<group>"; };
-		B6E2315E98DE4E0595C568E0 /* FeedChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelsView.swift; sourceTree = "<group>"; };
-		767D634EA7C54421A5B762FC /* FeedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogic.swift; sourceTree = "<group>"; };
-		657339EC3D474DAAA0A66C9F /* FeedSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSocket.swift; sourceTree = "<group>"; };
-		E67E5F19F42C4743B164654A /* ShareFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackView.swift; sourceTree = "<group>"; };
-		62C3F47E3007496C8003BA97 /* CourseFilesSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesSocket.swift; sourceTree = "<group>"; };
-		3EBA60D42F624F89B59C7A13 /* CourseFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesView.swift; sourceTree = "<group>"; };
-		E12EC7DB66414805BFD47BEE /* FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.swift; sourceTree = "<group>"; };
-		50423B031C594FD081D8F3D3 /* MarkupOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkupOverlayView.swift; sourceTree = "<group>"; };
-		CF2B964842AE422AB1F8FE31 /* GamificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationView.swift; sourceTree = "<group>"; };
-		DE58E798DDE14728B7048B49 /* GradeFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeFeedbackView.swift; sourceTree = "<group>"; };
-		98606023BD664072A84363A2 /* WhatIfController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIfController.swift; sourceTree = "<group>"; };
-		F830C796E96842FC902C5B4A /* GradingBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradingBacklogView.swift; sourceTree = "<group>"; };
-		CD3539CFC6934AD2BB2F4EAE /* SpeedGraderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderView.swift; sourceTree = "<group>"; };
-		7EC7E1DD087A4E1489ADF74E /* CollabDocView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollabDocView.swift; sourceTree = "<group>"; };
-		E2AC07D555534757A7A76999 /* CourseCollabDocsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCollabDocsSection.swift; sourceTree = "<group>"; };
-		7A28AD16498A4136A77E5F6C /* CourseGroupsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGroupsSection.swift; sourceTree = "<group>"; };
-		E086F925E3C94E3DBF6D5B8D /* GroupSpaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSpaceView.swift; sourceTree = "<group>"; };
-		50C5179B7C504B4C9F06FE64 /* AnnouncementComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementComposerView.swift; sourceTree = "<group>"; };
-		19B357B269DD46DB9FB3C801 /* AnnouncementsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsViews.swift; sourceTree = "<group>"; };
-		9961BE2DA57F4F4ABD8656AB /* BroadcastComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastComposerView.swift; sourceTree = "<group>"; };
-		78DB00E3B5884F338081EA9C /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
-		903A8BB06DD34793B5FC272B /* MoreHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreHubView.swift; sourceTree = "<group>"; };
-		FC6A66930C9247509F766F7F /* ShellHeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHeaderBar.swift; sourceTree = "<group>"; };
-		B7ADBFE36AA24EB7B0908D7B /* TeachHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeachHubView.swift; sourceTree = "<group>"; };
-		4502383E9D304013A8EAB757 /* UniversalSearchPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchPlaceholder.swift; sourceTree = "<group>"; };
-		0396EAFDB8CD498F95D9E93A /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
-		A4B52603AD774852A54614C5 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
-		2B8B2EA90F7F474F93CF162D /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
-		06853E09C60842B0B32A7B61 /* DashboardInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardInsightsSection.swift; sourceTree = "<group>"; };
-		6080ADF9D3C34BBC9A31EA9B /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
-		0D8792C700AE49F4B0D8146F /* AtRiskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtRiskListView.swift; sourceTree = "<group>"; };
-		6BBD4F4A79CB4E4DBF2EE5F3 /* CourseInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseInsightsSection.swift; sourceTree = "<group>"; };
-		9AE1EBB432794F2DA01BFC0D /* StudentProgressDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentProgressDetailView.swift; sourceTree = "<group>"; };
-		6A903C2817C74B468239F028 /* WhatsWorkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsWorkingView.swift; sourceTree = "<group>"; };
-		E418402F1C0442649025F56A /* IntroCelebrationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCelebrationPresenter.swift; sourceTree = "<group>"; };
-		94E155C5C5BB47D28E97E754 /* IntroCompletionCelebrationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCompletionCelebrationSheet.swift; sourceTree = "<group>"; };
-		D0CE4282C6A94244BFF19D3C /* IntroCourseEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseEntryCard.swift; sourceTree = "<group>"; };
-		4180F25AFDF1407D98915D1C /* IntroCourseProgressRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseProgressRail.swift; sourceTree = "<group>"; };
-		5B80C1444C6A48B6A39E2FF2 /* LearnerProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileView.swift; sourceTree = "<group>"; };
-		C89023B353D84747859B117E /* LibraryBrowseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBrowseView.swift; sourceTree = "<group>"; };
-		9229467C210C4301B2D98D60 /* MeetingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailView.swift; sourceTree = "<group>"; };
-		1302D78379A34ED49391CD74 /* MeetingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListView.swift; sourceTree = "<group>"; };
-		C5EEEB959E8549A182B2DE40 /* WhiteboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardView.swift; sourceTree = "<group>"; };
-		EA6C74B0C8A24ADFA92DCB62 /* LiveGameSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameSocket.swift; sourceTree = "<group>"; };
-		9691EB7FB06A4E5DAF1ACA40 /* LiveQuizHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizHubView.swift; sourceTree = "<group>"; };
-		B65BBF0633EB45F0820C1161 /* LiveQuizPlaySurfaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlaySurfaces.swift; sourceTree = "<group>"; };
-		61FBF86F867A46CCACACAEFB /* LiveQuizPlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlayView.swift; sourceTree = "<group>"; };
-		AB840DC10A7340F085F9F10A /* MarketplaceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceDetailView.swift; sourceTree = "<group>"; };
-		68B11BF2897F4875B7A42317 /* MarketplaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceView.swift; sourceTree = "<group>"; };
-		BA2B0D06CC104264A7571102 /* MyPurchasesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPurchasesView.swift; sourceTree = "<group>"; };
-		2E773ADF53394F77BEAFB505 /* CourseMasterySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMasterySection.swift; sourceTree = "<group>"; };
-		2313BB40BCC74375989C45AC /* ReportCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCardListView.swift; sourceTree = "<group>"; };
-		62345060129B4913870E54C1 /* CourseDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDrawer.swift; sourceTree = "<group>"; };
-		6C0688DB90454A19A18E8185 /* DrawerScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScaffold.swift; sourceTree = "<group>"; };
-		4638969A0A9A4BC3AFD33B5F /* DrawerToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerToolbar.swift; sourceTree = "<group>"; };
-		0276213236EA41DD87B05021 /* GlobalDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalDrawer.swift; sourceTree = "<group>"; };
-		5685788C03E1478E8174A5CB /* NotebookDrawingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawingViews.swift; sourceTree = "<group>"; };
-		8E52B98F8D184587BFDA269B /* NotebookEditorSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorSupportViews.swift; sourceTree = "<group>"; };
-		B5408DF2B2B44228B3BEC80B /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
-		EAFF705789F14DA1A6B7774C /* NotebookPagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPagesView.swift; sourceTree = "<group>"; };
-		B43F54B92C1F4A8FB207FE48 /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
-		3BBBE5F676024C5A8546BD9E /* BookingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingSheet.swift; sourceTree = "<group>"; };
-		809FB33A0AD94818A168A9FA /* MyBookingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBookingsView.swift; sourceTree = "<group>"; };
-		6402F22622804592B0BD16AF /* OfficeHoursView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursView.swift; sourceTree = "<group>"; };
-		21416CD8DFA947858881FB67 /* DiagnosticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticView.swift; sourceTree = "<group>"; };
-		E7B8423CB03A421DB125FA7E /* OnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowView.swift; sourceTree = "<group>"; };
-		7495B658AA314BECB39FA0BC /* ConferenceBookingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceBookingView.swift; sourceTree = "<group>"; };
-		C9D4BF14581E46E1877105A7 /* MyConferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyConferencesView.swift; sourceTree = "<group>"; };
-		DF1BEB9B7C19486C90AF60B6 /* ParentAttendanceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentAttendanceDetailView.swift; sourceTree = "<group>"; };
-		028E88D3509D4581AD3B0D49 /* ParentDashboardSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardSections.swift; sourceTree = "<group>"; };
-		79E0738CB7DD4EDAAF0B898E /* ParentDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardView.swift; sourceTree = "<group>"; };
-		CBC689423511413EBBF6A2F0 /* ParentGradesDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGradesDetailView.swift; sourceTree = "<group>"; };
-		4C9913DD13854F259223B9CB /* ParentNotificationPrefsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentNotificationPrefsView.swift; sourceTree = "<group>"; };
-		20DDD4F6F0DF44B790377108 /* DashboardStudySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStudySection.swift; sourceTree = "<group>"; };
-		519A867DDBC343C2BD999131 /* MyPathsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPathsView.swift; sourceTree = "<group>"; };
-		9CFABD1859A945CFB9EE0177 /* PathLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathLandingView.swift; sourceTree = "<group>"; };
-		1C84307E2BC94C6FA15D3BDE /* PathRunnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathRunnerView.swift; sourceTree = "<group>"; };
-		2BB94EA892F64D8D9B8737C2 /* PathsCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsCatalogView.swift; sourceTree = "<group>"; };
-		5D2AD1BAB40F4D73A5DD2DBE /* PeerReviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewDetailView.swift; sourceTree = "<group>"; };
-		7F3BBE2A5AFB4B66ABFEA6C5 /* PeerReviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewListView.swift; sourceTree = "<group>"; };
-		144BCB7F170F41D9B763AE01 /* ReviewsReceivedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsReceivedView.swift; sourceTree = "<group>"; };
-		D62C5B28B5F148DAB9EAC51C /* RubricScorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricScorerView.swift; sourceTree = "<group>"; };
-		60236CCDF7AA48738D0D49FB /* CalendarSubscribeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSubscribeSheet.swift; sourceTree = "<group>"; };
-		7E3F8A9FCD1249E79F8CC819 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
-		8C606E34F9144B64A777B6FC /* ConferenceReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceReminderScheduler.swift; sourceTree = "<group>"; };
-		CAD1CE39301A41058120A843 /* DueReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DueReminderScheduler.swift; sourceTree = "<group>"; };
-		427B5B7A544441FF83DAB84F /* OfficeHoursReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursReminderScheduler.swift; sourceTree = "<group>"; };
-		35482D532A2149B080CD6765 /* PlannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModel.swift; sourceTree = "<group>"; };
-		BADAEEFB6B414AA287062F8B /* PlannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerView.swift; sourceTree = "<group>"; };
-		33C7B900B7ED4925A1869D55 /* TodosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodosView.swift; sourceTree = "<group>"; };
-		A35BC5FD1AF146CBAF2065AB /* ArtifactDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailView.swift; sourceTree = "<group>"; };
-		01E149F4B7DA48DD9F801DD0 /* ArtifactEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactEditorView.swift; sourceTree = "<group>"; };
-		5004097E1B874DDB93242DA0 /* PortfolioArtifactUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioArtifactUploader.swift; sourceTree = "<group>"; };
-		4A30B10FF37F4C73B99B56B6 /* PortfolioDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioDetailView.swift; sourceTree = "<group>"; };
-		5F1211C341964513B98889F4 /* PortfolioView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioView.swift; sourceTree = "<group>"; };
-		849FD0BE416241E8A1617D59 /* AiAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminEntryCard.swift; sourceTree = "<group>"; };
-		68F339E576E4464982A315D3 /* ArchivedCoursesAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminEntryCard.swift; sourceTree = "<group>"; };
-		269BBDA8E3F84DEA9DEA260D /* BiometricLockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricLockView.swift; sourceTree = "<group>"; };
-		72BD8DB3522843548EDB368A /* DeviceSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceSessionsView.swift; sourceTree = "<group>"; };
-		F1D7198549954D4CA1AC7026 /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
-		AF071116BC2F446789DB95AC /* IntegrationsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminEntryCard.swift; sourceTree = "<group>"; };
-		8CF54036E6B3426390D72262 /* IntegrationsEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsEntryCard.swift; sourceTree = "<group>"; };
-		F9E6FEAC28BF4ECBB2548552 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
-		292E60D74B50449DBF81B8D6 /* LearnerProfileEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileEntryCard.swift; sourceTree = "<group>"; };
-		612542398DB34253A6686424 /* MyAccommodationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccommodationsView.swift; sourceTree = "<group>"; };
-		36BBC380C7B14E1C97904F62 /* NotificationPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesView.swift; sourceTree = "<group>"; };
-		366826087F904BB7BC321C08 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
-		D5CEB80575D4484FBEFD5CC5 /* OrgBrandingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminEntryCard.swift; sourceTree = "<group>"; };
-		283D9CE400334AC49AFD50AC /* OrgStructureAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminEntryCard.swift; sourceTree = "<group>"; };
-		CEFE73F8C7ED4996B392B117 /* PeopleAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminEntryCard.swift; sourceTree = "<group>"; };
-		918C26A90C7045FD93FF96C1 /* PlatformSettingsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminEntryCard.swift; sourceTree = "<group>"; };
-		90E99FC07CB54E0C96EA10BD /* ProfileDepthCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthCards.swift; sourceTree = "<group>"; };
-		5FCFBF1C1FCF47BB84AEAF38 /* ProfilePersonalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePersonalDetailsView.swift; sourceTree = "<group>"; };
-		C12BAF195789448DB078C7CF /* ProfileSecurityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSecurityCard.swift; sourceTree = "<group>"; };
-		E057149B676F46098DDDBD1A /* ProfileSettingsCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsCards.swift; sourceTree = "<group>"; };
-		A7F1FD9E84874180BAD8D5DC /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
-		77BF6067904E4A2087EC27CE /* ProfileViewSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewSections.swift; sourceTree = "<group>"; };
-		53305DC75B204D9C81F3585B /* ResearchStudiesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResearchStudiesView.swift; sourceTree = "<group>"; };
-		0A4320E0C0E24EB9BE1B7F58 /* RolesPermissionsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminEntryCard.swift; sourceTree = "<group>"; };
-		D5E6AEEF26D44D3EA65A25A0 /* SettingsAdminHubEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubEntryCard.swift; sourceTree = "<group>"; };
-		F67308866EF5479FA01FC732 /* ShareFeedbackEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackEntryCard.swift; sourceTree = "<group>"; };
-		8BD739C270344ADEB1A3142D /* TranscriptsAdvisingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminEntryCard.swift; sourceTree = "<group>"; };
-		F8BCD90D8A8E4EF4AFB9D583 /* CodeQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeQuestionView.swift; sourceTree = "<group>"; };
-		633C85BCCB7941E5BD24D270 /* LockdownController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockdownController.swift; sourceTree = "<group>"; };
-		7CC57DD00547498A8F4FB307 /* QuizIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizIntroView.swift; sourceTree = "<group>"; };
-		0B9DCCE9B89246218C4CE8EF /* QuizQuestionViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizQuestionViews.swift; sourceTree = "<group>"; };
-		34504285543C4C9A8CD6F5EA /* QuizResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResultsView.swift; sourceTree = "<group>"; };
-		1B81ADC20ABF47A3AD5C31F4 /* QuizTakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizTakerView.swift; sourceTree = "<group>"; };
-		41EC5757A7B946098AC5B893 /* CaptionedPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionedPlayerView.swift; sourceTree = "<group>"; };
-		CAACDFB103B9456BBC73750E /* ContentTranslationControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTranslationControls.swift; sourceTree = "<group>"; };
-		49467C0BBC9C415780029214 /* ImmersiveReaderCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersiveReaderCapabilities.swift; sourceTree = "<group>"; };
-		990F430024144399B37A91A2 /* ReaderLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogic.swift; sourceTree = "<group>"; };
-		9F495ED7A44B4C73968DA21E /* ReaderToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderToolbar.swift; sourceTree = "<group>"; };
-		BBDA47FBE9DE454C9CD75E5D /* ReadingPreferencesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesSheet.swift; sourceTree = "<group>"; };
-		D4AB029FB1A444B3BEA5D695 /* ReadingPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesStore.swift; sourceTree = "<group>"; };
-		56111FF37D29429987AB0096 /* LeveledLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeveledLibraryView.swift; sourceTree = "<group>"; };
-		3B3A83C44B84487CB01EFF3C /* LogReadingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReadingSheet.swift; sourceTree = "<group>"; };
-		9F5A6D6A50874B1FAB312EE8 /* ReadingDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardView.swift; sourceTree = "<group>"; };
-		4BBB673CA4DB420BA37B9208 /* ReviewHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHomeView.swift; sourceTree = "<group>"; };
-		A6440ADA1E9544ECBF69F85E /* ReviewReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReminderScheduler.swift; sourceTree = "<group>"; };
-		A31DE89C777B4A51887F141C /* ReviewSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionView.swift; sourceTree = "<group>"; };
-		F0A178AEF05541188021889B /* UniversalSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchView.swift; sourceTree = "<group>"; };
-		B97B6F26B6DC4092BAB78F26 /* AdminMetricCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminMetricCards.swift; sourceTree = "<group>"; };
-		DB36A44F66604F3C843C50D9 /* AdvisingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingSettingsView.swift; sourceTree = "<group>"; };
-		4C9843014D154611A7BFD0C9 /* AiAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminHubView.swift; sourceTree = "<group>"; };
-		44A56979663249C4AFE83221 /* AiGovernanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiGovernanceView.swift; sourceTree = "<group>"; };
-		889FAFAF774142C2BA86329C /* AiModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsSettingsView.swift; sourceTree = "<group>"; };
-		B3C29C92B3B24E5C86725EE7 /* AiProviderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiProviderSettingsView.swift; sourceTree = "<group>"; };
-		CA28E77314484396AB0AE64A /* AiReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiReportsView.swift; sourceTree = "<group>"; };
-		C4355CA566304FBAAB98D098 /* ArchivedCoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminView.swift; sourceTree = "<group>"; };
-		942584F491914827B95F3282 /* AuditLogAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminView.swift; sourceTree = "<group>"; };
-		88724DBA10A14C4BB795E26F /* BoardsGovernanceAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminView.swift; sourceTree = "<group>"; };
-		914CCB5EAAF34214B8885432 /* CoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesAdminView.swift; sourceTree = "<group>"; };
-		43BFDD3B36BC48A8B13DE360 /* IntegrationsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminView.swift; sourceTree = "<group>"; };
-		79E256FCB9F14A47B25202B5 /* OrgBrandingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminView.swift; sourceTree = "<group>"; };
-		B1B6653C12AF4B4395D2650A /* OrgBrandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingView.swift; sourceTree = "<group>"; };
-		9F3124434EF14E0F9A93AF28 /* OrgStructureAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminView.swift; sourceTree = "<group>"; };
-		12EEAD3B385B4D19A7EE0841 /* OrgStructureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureView.swift; sourceTree = "<group>"; };
-		41EF610BF1484F9AADE2AA95 /* PeopleAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminView.swift; sourceTree = "<group>"; };
-		FF4A03C39AFE47918DBCC377 /* PlatformSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsView.swift; sourceTree = "<group>"; };
-		F67E4C60CD8D4042A5591FEE /* RolesPermissionsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminView.swift; sourceTree = "<group>"; };
-		AE2FA99DD121458D8201C26C /* SystemPromptsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptsView.swift; sourceTree = "<group>"; };
-		D1AF5D02D2464887B58449B2 /* TermsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAdminView.swift; sourceTree = "<group>"; };
-		4D5AD5CA80204A4D9F4EDB14 /* TranscriptsAdvisingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminView.swift; sourceTree = "<group>"; };
-		12B3CD2CBADB4D5CB7B5CD36 /* TranscriptsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsSettingsView.swift; sourceTree = "<group>"; };
-		9240550142D1439DB32F9DDA /* UserDetailAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailAdminView.swift; sourceTree = "<group>"; };
-		EC90322BE577468290B4551A /* SettingsAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubView.swift; sourceTree = "<group>"; };
-		8C311030F725471CBF67D6F8 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
-		871BFA5C95E049CBAFEC0731 /* TutorChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatModel.swift; sourceTree = "<group>"; };
-		9452C8D2829F4FB6B21CAB26 /* TutorChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatView.swift; sourceTree = "<group>"; };
-		3CAB6ED9091E4B3E94718267 /* TutorFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorFlowLayout.swift; sourceTree = "<group>"; };
-		A66A524C7AAC4FB2B017F128 /* TutorLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLauncher.swift; sourceTree = "<group>"; };
-		F9F9005EEE2744EBB7D096EC /* WalletCCRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCCRDetailView.swift; sourceTree = "<group>"; };
-		0BF4CF0A377A4ED5B3DC1AA0 /* WalletCETranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCETranscriptDetailView.swift; sourceTree = "<group>"; };
-		7AACA18723DA4543805BE85B /* WalletOfficialTranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletOfficialTranscriptDetailView.swift; sourceTree = "<group>"; };
-		A9F06C20D3B941B69051DDA0 /* WalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletView.swift; sourceTree = "<group>"; };
-		373523C32EB949A5B9CAA82A /* AccessibilitySupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupportTests.swift; sourceTree = "<group>"; };
-		5A13B3495F1F4A4F819B53AF /* AccountIntegrationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogicTests.swift; sourceTree = "<group>"; };
-		865591C44DA943BAAF006BA8 /* AdvisingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogicTests.swift; sourceTree = "<group>"; };
-		3CCE179E631F4F1587E17C1A /* AiModelsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogicTests.swift; sourceTree = "<group>"; };
-		49FF81B2344C47318DA46DEA /* AnnouncementLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogicTests.swift; sourceTree = "<group>"; };
-		6B763FBAF0F348CEA7B7F700 /* AppleSignInLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInLogicTests.swift; sourceTree = "<group>"; };
-		33B046C3491242F78AFC62B5 /* ArchivedCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
-		ACBA7D88E4324BAA8C417F29 /* AssignmentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogicTests.swift; sourceTree = "<group>"; };
-		2D03F861BB2F42CFA59E0822 /* AuditLogAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogicTests.swift; sourceTree = "<group>"; };
-		8BBC569F456A4BD3B900F0B4 /* AuthCallbackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParserTests.swift; sourceTree = "<group>"; };
-		54F482AACC614C47BB93AC3A /* BehaviorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogicTests.swift; sourceTree = "<group>"; };
-		AFFB9831EC6A4D94810B09A2 /* BillingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogicTests.swift; sourceTree = "<group>"; };
-		A7E50B8DE72E4B06BF467B31 /* BiometricGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGateTests.swift; sourceTree = "<group>"; };
-		5BFF89736CCA439C94F43B27 /* BoardsAdvancedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogicTests.swift; sourceTree = "<group>"; };
-		39F97E50BCA747C9BD1D9FA2 /* BoardsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogicTests.swift; sourceTree = "<group>"; };
-		38FC3FBB11F247FBA7765A55 /* CanvasImportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogicTests.swift; sourceTree = "<group>"; };
-		805240352A4542E6B904D4AC /* CatalogLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogicTests.swift; sourceTree = "<group>"; };
-		E480CDFCB0E5428393B4648B /* ConferenceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogicTests.swift; sourceTree = "<group>"; };
-		F21EB256086B4484BE067D42 /* CourseAccessibilityReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogicTests.swift; sourceTree = "<group>"; };
-		550DA196AE6B43B6B903B0FA /* CourseArchivedContentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogicTests.swift; sourceTree = "<group>"; };
-		C86F2841498A4C32AA7093AA /* CourseBlueprintLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogicTests.swift; sourceTree = "<group>"; };
-		A9D1F7E879D54243A4DA10E1 /* CourseCreateLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogicTests.swift; sourceTree = "<group>"; };
-		47E7A2D79A0A47F1ABD4C3AC /* CourseFeaturesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogicTests.swift; sourceTree = "<group>"; };
-		16533B0965BB4F4DA160F03E /* CourseFileModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileModelsTests.swift; sourceTree = "<group>"; };
-		566A8F4AA7BB49848E5D5552 /* CourseGradingAgentsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogicTests.swift; sourceTree = "<group>"; };
-		CAF4C3297E884354ADDEDFC6 /* CourseGradingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogicTests.swift; sourceTree = "<group>"; };
-		B2A6BF2D82C24B07A02D4F16 /* CourseImportExportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogicTests.swift; sourceTree = "<group>"; };
-		E4FD447ED651463297DB49D6 /* CourseOutcomesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogicTests.swift; sourceTree = "<group>"; };
-		A19A901DA16C44A98BCFC878 /* CoursePeopleLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogicTests.swift; sourceTree = "<group>"; };
-		F2E96F164ACF476A90625A44 /* CoursePlagiarismLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogicTests.swift; sourceTree = "<group>"; };
-		E7FC803557FA400798E517D6 /* CourseReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogicTests.swift; sourceTree = "<group>"; };
-		B15DCDA7BE5F4D968FD8C654 /* CourseSectionsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogicTests.swift; sourceTree = "<group>"; };
-		CEDD54F128A34514B52E92C3 /* CourseSettingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogicTests.swift; sourceTree = "<group>"; };
-		2A9DE4A71F4B41C1A155FAA9 /* CourseTranslationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogicTests.swift; sourceTree = "<group>"; };
-		70C40E4D7ACF46108CCE6999 /* CredentialsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogicTests.swift; sourceTree = "<group>"; };
-		E0EF8D14F18747E4B15D7672 /* DiscussionLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogicTests.swift; sourceTree = "<group>"; };
-		262B5F96B46D4D66AB310255 /* EvaluationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogicTests.swift; sourceTree = "<group>"; };
-		D43ECD1F3A5847A08AA8D7AE /* FeedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogicTests.swift; sourceTree = "<group>"; };
-		32EDCFA8D4C441EC8D01E20E /* FeedbackLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogicTests.swift; sourceTree = "<group>"; };
-		FB4F84C218644FC898D5E1A5 /* GamificationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogicTests.swift; sourceTree = "<group>"; };
-		59A73FC830CB4D27A8DD4B25 /* GradeCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculatorTests.swift; sourceTree = "<group>"; };
-		70912832963940B79AFA8373 /* GroupsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogicTests.swift; sourceTree = "<group>"; };
-		D4DF14D128D64FE3913D78F3 /* I18nTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18nTests.swift; sourceTree = "<group>"; };
-		A0686994B5D846CF87F347DF /* InsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogicTests.swift; sourceTree = "<group>"; };
-		FBF2B2D6C6B44BC2866C2D93 /* InstructorInsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogicTests.swift; sourceTree = "<group>"; };
-		FF38019511514A39A5938F26 /* IntegrationsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogicTests.swift; sourceTree = "<group>"; };
-		2BD8FA95ACA24505AAD62EE7 /* InteractiveLaunchLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogicTests.swift; sourceTree = "<group>"; };
-		8F44242ADD2F4D4384FB8217 /* IntroCourseLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogicTests.swift; sourceTree = "<group>"; };
-		F74498D27D0A423F9F710088 /* LearnerProfileLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogicTests.swift; sourceTree = "<group>"; };
-		0D31802C470C412595FA718E /* LexturesMotionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotionTests.swift; sourceTree = "<group>"; };
-		2BF702B17A3744F4AE9A21DB /* LibraryResourceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogicTests.swift; sourceTree = "<group>"; };
-		14872F45A72248E591C80A5C /* LiveMeetingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogicTests.swift; sourceTree = "<group>"; };
-		71B152116F1844EA939CD2B0 /* LiveQuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogicTests.swift; sourceTree = "<group>"; };
-		4BAEFB24E3C34525BC2F040B /* MarketplaceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogicTests.swift; sourceTree = "<group>"; };
-		53E6ECF6C15C455F86415C69 /* MasteryLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogicTests.swift; sourceTree = "<group>"; };
-		A9D65C9AD65F4155AC1B2C74 /* MobileDestinationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinationsTests.swift; sourceTree = "<group>"; };
-		D553BFCCA75D4ADDB8E03FDA /* ModuleContentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentModelsTests.swift; sourceTree = "<group>"; };
-		DE8A5CE055EE4CBB875FFC50 /* NotificationModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModelsTests.swift; sourceTree = "<group>"; };
-		6453702A8CC84167A99D06FC /* OfficeHoursLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogicTests.swift; sourceTree = "<group>"; };
-		5A17E2E10AB14AF1A4BC0A20 /* OnboardingModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModelsTests.swift; sourceTree = "<group>"; };
-		5E7C6AF633234B11B05AC8B3 /* OrgBrandingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogicTests.swift; sourceTree = "<group>"; };
-		3030AF2E57974257827BCD97 /* OrgStructureAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogicTests.swift; sourceTree = "<group>"; };
-		114DE315F90F46428790C499 /* ParentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogicTests.swift; sourceTree = "<group>"; };
-		5B278631504942649E2B10A7 /* PathsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogicTests.swift; sourceTree = "<group>"; };
-		ABE0AAD7BE7F4DE4A0E2E97E /* PeerReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogicTests.swift; sourceTree = "<group>"; };
-		E780269A3774488C96081F4D /* PeopleAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogicTests.swift; sourceTree = "<group>"; };
-		B1122C950BA74EC3B0F4C4BA /* PeopleAdminMetricsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminMetricsLogicTests.swift; sourceTree = "<group>"; };
-		201E3DED9B6B4C7D9E3CDBA1 /* PlannerModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModelsTests.swift; sourceTree = "<group>"; };
-		3ADE113A4F7D4363B71AAB5D /* PlatformCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
-		4E20A89C03B34AE681FE9B7C /* PlatformSettingsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogicTests.swift; sourceTree = "<group>"; };
-		F6BFD385E20E4874B208B6E8 /* PortfolioLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogicTests.swift; sourceTree = "<group>"; };
-		ED465D36A86D429D8D927E4D /* ProfileDepthLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogicTests.swift; sourceTree = "<group>"; };
-		5BF03A123F79457888EEB315 /* QuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogicTests.swift; sourceTree = "<group>"; };
-		D59CEBA182BF44B2BE3FCADD /* ReaderLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogicTests.swift; sourceTree = "<group>"; };
-		B82D214349F34003A916A5BD /* ReadingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogicTests.swift; sourceTree = "<group>"; };
-		583B845B981A489A80BD757D /* RequirementsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogicTests.swift; sourceTree = "<group>"; };
-		164416E4C983431883516796 /* ReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLogicTests.swift; sourceTree = "<group>"; };
-		C6C08E0BEB834A3EB334C08A /* RolesPermissionsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogicTests.swift; sourceTree = "<group>"; };
-		232FFCED0306441FA66F4EB3 /* SchoolCodeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogicTests.swift; sourceTree = "<group>"; };
-		B291A3D998D4494EB5BF4F69 /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
-		DBB038F7ADFA40A0958FCA12 /* SettingsAccommodationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccommodationsTests.swift; sourceTree = "<group>"; };
-		A0C23C8D85854FB8A73C1AE1 /* SettingsMenuLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogicTests.swift; sourceTree = "<group>"; };
-		8D33288F5C5A4CC4967D0503 /* TakeAttendanceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogicTests.swift; sourceTree = "<group>"; };
-		1A1410FB35F44CC4B312DD2A /* TranscriptsAdvisingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogicTests.swift; sourceTree = "<group>"; };
-		C4BC8DA818EC4DBEB21CB6A3 /* TutorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogicTests.swift; sourceTree = "<group>"; };
-		77D38DC81AAE47D78174340E /* UIModeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIModeLogicTests.swift; sourceTree = "<group>"; };
-		3DECA44A9D514EB9B68544FB /* VibeActivityLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogicTests.swift; sourceTree = "<group>"; };
-		04481C8E09DD46DB93EA9D47 /* WalletLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogicTests.swift; sourceTree = "<group>"; };
-		6C2F1DCD549844B092CD0466 /* WhiteboardLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogicTests.swift; sourceTree = "<group>"; };
-		F1D492B110A3479A86B62F45 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		6678AEC9159340A695FD20AD /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
-		D332EEC5808342AEBD540892 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		399F75F7EF59410184CBA37C /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
+		2ACFD23021C24F8188DFD53D /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C32FF697E67243E080F4BF34 /* LexturesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LexturesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		48DEFBE299634A468607326D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C67025CF88B846CAACE2DA27 /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
+		8BB9F41D2A524DEF9846DACA /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		42BA05FDEBB64BAF93BE2F13 /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
+		BF91E36EF4544195BBD02326 /* AccessibilitySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupport.swift; sourceTree = "<group>"; };
+		0069CCE81BA14890AC1EAC3B /* DictationField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationField.swift; sourceTree = "<group>"; };
+		27A3F5F78EAD4A4DA36C2B0C /* ReadAloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAloud.swift; sourceTree = "<group>"; };
+		754D0E92FDE34E7E8AB24CB5 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		13A1B1EBE2104C3BA7F2ABDC /* AuthCallbackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParser.swift; sourceTree = "<group>"; };
+		3E568CA21DD5463582E682BF /* AuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConstants.swift; sourceTree = "<group>"; };
+		AE836A40074D413B863331C4 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
+		C88441ABD3AF4EA18B9D7919 /* BiometricGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGate.swift; sourceTree = "<group>"; };
+		7E844AA4E55E44D0A44667CE /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
+		C0EB9537C0C44179B8F67001 /* SessionsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsAPI.swift; sourceTree = "<group>"; };
+		5814B80506574CC7A0273C68 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+		185C4FF6313D4A0A87BAF184 /* EnvironmentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentStore.swift; sourceTree = "<group>"; };
+		50E3EE98E2A744009E08B8C6 /* SchoolCodeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogic.swift; sourceTree = "<group>"; };
+		E1391CC0E37F48CCB9C631A4 /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
+		1F9230D0D6774D73B2D53DEF /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
+		F148F9731962426CA4DF6261 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		59E31C9A4AEC4493B8884AEC /* LexturesMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotion.swift; sourceTree = "<group>"; };
+		F1F01FCEF2ED44219E53DD2B /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
+		A0427B681B0B450F9B6F3CD0 /* LexturesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesType.swift; sourceTree = "<group>"; };
+		B7BEFC9869AF45FBB5984148 /* ProfileAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAvatarView.swift; sourceTree = "<group>"; };
+		8B58E98D00DD4DC7936D761A /* SyncStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusView.swift; sourceTree = "<group>"; };
+		3AB4278C38914F3BA5A8C451 /* ThemePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePreference.swift; sourceTree = "<group>"; };
+		D40A0E47E5164CF1B895B900 /* UIMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIMode.swift; sourceTree = "<group>"; };
+		58E74364021942FA9B9032BF /* UnsavedChangesBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsavedChangesBanner.swift; sourceTree = "<group>"; };
+		24E645CC9EAC4B068156F427 /* DateFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
+		9E08FB6345A44C42B2D45068 /* LocaleAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleAPI.swift; sourceTree = "<group>"; };
+		6B1643642F69411C88E9EAAA /* LocalePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalePreferences.swift; sourceTree = "<group>"; };
+		D00A1733168246CB972CC87A /* Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localized.swift; sourceTree = "<group>"; };
+		D68F93E592FB4648929B0871 /* AccountAccommodationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAccommodationModels.swift; sourceTree = "<group>"; };
+		A8DE74B587434CB984788154 /* AccountIntegrationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogic.swift; sourceTree = "<group>"; };
+		7EE5A93F036646F4A0316BF8 /* AdvisingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogic.swift; sourceTree = "<group>"; };
+		8F7FEBC30EB6460BB11D890A /* AiModelsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogic.swift; sourceTree = "<group>"; };
+		B873466B0F9844E38FBD2EEB /* AnnouncementLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogic.swift; sourceTree = "<group>"; };
+		9F0BB372CDF64D93A5EEE8BB /* ArchivedCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogic.swift; sourceTree = "<group>"; };
+		81B01C8A31794FEDB5CA0C3C /* AssignmentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogic.swift; sourceTree = "<group>"; };
+		E63ADFCEC7474296A587ABB7 /* AuditLogAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogic.swift; sourceTree = "<group>"; };
+		C1C627F927094E7DB6B60B7C /* BehaviorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogic.swift; sourceTree = "<group>"; };
+		3FF856F8981D4DBFBDCC78B7 /* BillingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogic.swift; sourceTree = "<group>"; };
+		5CA5BC461B394AC9811974BB /* BoardRealtimeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardRealtimeLogic.swift; sourceTree = "<group>"; };
+		E61598E2C8FD4D32AA09F946 /* BoardsAdvancedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogic.swift; sourceTree = "<group>"; };
+		A418E83F8A8F43E8B4DC3105 /* BoardsGovernanceAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminLogic.swift; sourceTree = "<group>"; };
+		BB8632D3336742959B406677 /* BoardsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogic.swift; sourceTree = "<group>"; };
+		C5F2525060E34C70BCB38510 /* CanvasImportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogic.swift; sourceTree = "<group>"; };
+		2FF05BCBA4D84824A04B9796 /* CanvasImportObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportObservability.swift; sourceTree = "<group>"; };
+		6FBCF0D5A1DA4969968D0D41 /* CatalogLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogic.swift; sourceTree = "<group>"; };
+		BF3E03A9F1A2490DB6A15B8B /* ConferenceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogic.swift; sourceTree = "<group>"; };
+		752DEF0373E54AEF83685C57 /* CourseAccessibilityReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogic.swift; sourceTree = "<group>"; };
+		C7D70879399D4C2887045226 /* CourseArchivedContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogic.swift; sourceTree = "<group>"; };
+		150AD95FB44A4599B3FDADDC /* CourseBlueprintLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogic.swift; sourceTree = "<group>"; };
+		21312747EECB49078649F0D5 /* CourseCreateDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateDraftStore.swift; sourceTree = "<group>"; };
+		3B052C0DDDC34A22B89918ED /* CourseCreateLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogic.swift; sourceTree = "<group>"; };
+		EC02E84D076E4C5B976D43FA /* CourseCreateObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateObservability.swift; sourceTree = "<group>"; };
+		2A64839A40BB48829B81C012 /* CourseFeaturesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogic.swift; sourceTree = "<group>"; };
+		ECAE591DAB9E4F139DEFFE39 /* CourseFileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileLogic.swift; sourceTree = "<group>"; };
+		E2C801B83CE74B5E8A7D2523 /* CourseGradingAgentsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogic.swift; sourceTree = "<group>"; };
+		6BB034F1229147CA87AC6AEE /* CourseGradingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogic.swift; sourceTree = "<group>"; };
+		9E7E228B612E4F19B1399BD7 /* CourseHeroImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImage.swift; sourceTree = "<group>"; };
+		67E04650D5824DDA840FA21B /* CourseImportExportLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogic.swift; sourceTree = "<group>"; };
+		F31F5328B34D4699983E7BF5 /* CourseOutcomesLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogic.swift; sourceTree = "<group>"; };
+		6E7CD0F2D33447528D1C23CA /* CoursePeopleLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogic.swift; sourceTree = "<group>"; };
+		A175A4F351E24D06B14450BD /* CoursePeopleObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleObservability.swift; sourceTree = "<group>"; };
+		C9A8FA6D8AB44BB795EC8499 /* CoursePlagiarismLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogic.swift; sourceTree = "<group>"; };
+		EE3651540DE6426CBA163F6A /* CourseReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogic.swift; sourceTree = "<group>"; };
+		F6FBFA97169645C6BAF9D202 /* CourseSectionsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogic.swift; sourceTree = "<group>"; };
+		54DDFCAFCA054246B428D8D6 /* CourseSettingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogic.swift; sourceTree = "<group>"; };
+		3B9A809DC9D44A81876C84D6 /* CourseTranslationsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogic.swift; sourceTree = "<group>"; };
+		2ED7960BED804EBAB21DB624 /* CredentialsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogic.swift; sourceTree = "<group>"; };
+		FCBA158B2F624AC98BE02A3D /* CurrencyExponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExponent.swift; sourceTree = "<group>"; };
+		E09D6EDF371C48098874B22C /* DiscussionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogic.swift; sourceTree = "<group>"; };
+		B7A4DAAD9D8E4E4EA7299202 /* EvaluationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogic.swift; sourceTree = "<group>"; };
+		58C78219C42C422EA2F7E48C /* FeedbackLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogic.swift; sourceTree = "<group>"; };
+		E4D80581D2F94A02BAAED322 /* FileDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadManager.swift; sourceTree = "<group>"; };
+		12D368F3EC634E2585AAA222 /* GamificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogic.swift; sourceTree = "<group>"; };
+		D213653C2BDE4591B0CCA138 /* GradeCalculator+MyGrades.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GradeCalculator+MyGrades.swift"; sourceTree = "<group>"; };
+		02F05C3B54914F429882583C /* GradeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculator.swift; sourceTree = "<group>"; };
+		19320D4F624D4E81A07DB852 /* GroupsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogic.swift; sourceTree = "<group>"; };
+		F47D6DDC0A834B6396610973 /* InsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogic.swift; sourceTree = "<group>"; };
+		BDB97F9F93694C9793C63614 /* InstructorInsightsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogic.swift; sourceTree = "<group>"; };
+		44B8A1A6109E4556B2336DD9 /* IntegrationsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogic.swift; sourceTree = "<group>"; };
+		3C7E41797A5E4EFE90B176B8 /* InteractiveLaunchLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogic.swift; sourceTree = "<group>"; };
+		E8786D1D4285415199C49EDE /* IntroCourseLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogic.swift; sourceTree = "<group>"; };
+		B98B884A3B324822AB0ABE8A /* IntroCourseObservability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseObservability.swift; sourceTree = "<group>"; };
+		93BD7724C24E4C9B96FF02C2 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
+		696AAE4C18A5412193D9FA8C /* LMSAPIAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAccountIntegrations.swift; sourceTree = "<group>"; };
+		C07DE5F1155441E49DEA50FB /* LMSAPIAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdmin.swift; sourceTree = "<group>"; };
+		1FDA23E010114F39BF8B899B /* LMSAPIAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAdvising.swift; sourceTree = "<group>"; };
+		7538ABD46EAF4599B2C42CE2 /* LMSAPIAnnouncements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAnnouncements.swift; sourceTree = "<group>"; };
+		116C05C9CA2840DCA1A2C4CB /* LMSAPIAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIAuditLog.swift; sourceTree = "<group>"; };
+		7E18FC25D3574725B9548ECC /* LMSAPIBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBehavior.swift; sourceTree = "<group>"; };
+		754564AA344740C1AA7A6323 /* LMSAPIBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBilling.swift; sourceTree = "<group>"; };
+		A0FCF3B0FA264A869E9F6542 /* LMSAPIBoardAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAccess.swift; sourceTree = "<group>"; };
+		486137AACE1A4826A2C71E49 /* LMSAPIBoardAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardAnalytics.swift; sourceTree = "<group>"; };
+		AB9D57FD88E4421DB1887176 /* LMSAPIBoardEngagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardEngagement.swift; sourceTree = "<group>"; };
+		7A356D13BF3A43AA987E66CF /* LMSAPIBoardExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardExport.swift; sourceTree = "<group>"; };
+		1CE2C7EECD8341B99934ABB6 /* LMSAPIBoardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardLayout.swift; sourceTree = "<group>"; };
+		30035C0884734E0482DA7934 /* LMSAPIBoardModeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardModeration.swift; sourceTree = "<group>"; };
+		89B7A32365D24C0880F6F284 /* LMSAPIBoardPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardPosts.swift; sourceTree = "<group>"; };
+		7D118B2EB3134D42A3B2CB7B /* LMSAPIBoardTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoardTemplates.swift; sourceTree = "<group>"; };
+		A01FA21ABFBC4611B3BE640C /* LMSAPIBoards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIBoards.swift; sourceTree = "<group>"; };
+		042BC610AE594924AEB29479 /* LMSAPICanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICanvasImport.swift; sourceTree = "<group>"; };
+		783765A9C2054F2CB418A46D /* LMSAPICatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICatalog.swift; sourceTree = "<group>"; };
+		BA53D0293F9E4CDF93F367BB /* LMSAPICourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseAccessibility.swift; sourceTree = "<group>"; };
+		AC41C117EA1B4D258C520BCA /* LMSAPICourseArchivedContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseArchivedContent.swift; sourceTree = "<group>"; };
+		2599FFE0DE6845D6B74944FF /* LMSAPICourseBlueprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseBlueprint.swift; sourceTree = "<group>"; };
+		EAB2C99B7D8840068A3D4076 /* LMSAPICourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseCreate.swift; sourceTree = "<group>"; };
+		E7E5D01EE7AB43168D2679A3 /* LMSAPICourseFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseFeatures.swift; sourceTree = "<group>"; };
+		DC70B259D43F4D448CFBAAB8 /* LMSAPICourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGrading.swift; sourceTree = "<group>"; };
+		6F34E4E4941749D4877040E7 /* LMSAPICourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseGradingAgents.swift; sourceTree = "<group>"; };
+		C276309B00E2443A93D953C2 /* LMSAPICourseImportExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseImportExport.swift; sourceTree = "<group>"; };
+		1F2E90CB7F4245A4B43AF026 /* LMSAPICoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICoursePlagiarism.swift; sourceTree = "<group>"; };
+		8BC70C9A48C94BF4B4C3BB1E /* LMSAPICourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseReviews.swift; sourceTree = "<group>"; };
+		AA80816617A14D78B9FE54BF /* LMSAPICourseSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSections.swift; sourceTree = "<group>"; };
+		01FF1AF25FF04DD6AB70FB57 /* LMSAPICourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseSettings.swift; sourceTree = "<group>"; };
+		9B2574DCE83C460EA90E3F85 /* LMSAPICourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICourseTranslations.swift; sourceTree = "<group>"; };
+		D7ACD5D8E10340B9B9697ECC /* LMSAPICredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPICredentials.swift; sourceTree = "<group>"; };
+		4E21E540FBF84BFC8F4E2D9A /* LMSAPIDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIDiscussions.swift; sourceTree = "<group>"; };
+		1474A042D5DE49069BED4533 /* LMSAPIEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEportfolio.swift; sourceTree = "<group>"; };
+		00767DB4B92F4E0DA05BD38C /* LMSAPIEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIEvaluations.swift; sourceTree = "<group>"; };
+		4CA1EFB4E5A246FDB803C2DF /* LMSAPIFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeatures.swift; sourceTree = "<group>"; };
+		F75B89DB41E547AA84F61487 /* LMSAPIFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeed.swift; sourceTree = "<group>"; };
+		D3BD38517A854ABB84951E98 /* LMSAPIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeedback.swift; sourceTree = "<group>"; };
+		FA2D858067A24BD0B0F3C5AF /* LMSAPIGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGamification.swift; sourceTree = "<group>"; };
+		F081D2E7003B4AE0B9D681CE /* LMSAPIGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIGroups.swift; sourceTree = "<group>"; };
+		FC6635E0AC104977B2C9A88B /* LMSAPIInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInsights.swift; sourceTree = "<group>"; };
+		2DD9D91E638A4A639AB1CD7C /* LMSAPIInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIInstructorInsights.swift; sourceTree = "<group>"; };
+		B28C4D21531D4A33A1865EAC /* LMSAPIIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIIntroCourse.swift; sourceTree = "<group>"; };
+		7789C8CFDE394EBEBE23881B /* LMSAPILearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILearnerProfile.swift; sourceTree = "<group>"; };
+		E1AB1209784D4AAA9985A44E /* LMSAPILiveQuiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPILiveQuiz.swift; sourceTree = "<group>"; };
+		3B32DB5484C1481CA15B2324 /* LMSAPIMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMarketplace.swift; sourceTree = "<group>"; };
+		AF0133E4DAF845C28F931794 /* LMSAPIMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMastery.swift; sourceTree = "<group>"; };
+		59B1DBF812454BF49DC9A309 /* LMSAPIMobileWave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIMobileWave.swift; sourceTree = "<group>"; };
+		021B46FAE5F947198127DF0E /* LMSAPIOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIOutcomes.swift; sourceTree = "<group>"; };
+		967D00F11FE3420E968C119E /* LMSAPIParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIParent.swift; sourceTree = "<group>"; };
+		9F8B663C1A1B4962B2E66A73 /* LMSAPIPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPaths.swift; sourceTree = "<group>"; };
+		05120AC28E87464DB043E631 /* LMSAPIPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIPeerReview.swift; sourceTree = "<group>"; };
+		23C258FCE4EA4550A8DF0FB2 /* LMSAPIProctoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIProctoring.swift; sourceTree = "<group>"; };
+		DEAAE1D0F18446B0AFCD4F20 /* LMSAPIQuizCodeRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIQuizCodeRun.swift; sourceTree = "<group>"; };
+		E0CE7B57D3C74A39947F0288 /* LMSAPIReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReader.swift; sourceTree = "<group>"; };
+		DD0586DF49BB4BEBAAC22DF6 /* LMSAPIReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReading.swift; sourceTree = "<group>"; };
+		52B43740C05F4E4FAFCF4552 /* LMSAPIReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIReview.swift; sourceTree = "<group>"; };
+		3B7D36BC426C4CFB90398EC9 /* LMSAPITutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPITutor.swift; sourceTree = "<group>"; };
+		24EE42BE8C4F457081935252 /* LMSAPIWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWallet.swift; sourceTree = "<group>"; };
+		BFA8395926874179BC6133B6 /* LMSAPIWhiteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIWhiteboard.swift; sourceTree = "<group>"; };
+		CD727138615C4BB58E5AD531 /* LMSBoardAdvancedModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardAdvancedModels.swift; sourceTree = "<group>"; };
+		F3A22BBC906A4965AD20E9FB /* LMSBoardModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSBoardModels.swift; sourceTree = "<group>"; };
+		1246E4FB56BA4A8EAC0C4755 /* LMSFeatureModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModels.swift; sourceTree = "<group>"; };
+		E01BB4CF617C4AE697326AD2 /* LMSFeatureModelsAccountIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAccountIntegrations.swift; sourceTree = "<group>"; };
+		A191660A8AAC4367BBC6DBC0 /* LMSFeatureModelsAdvising.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAdvising.swift; sourceTree = "<group>"; };
+		A051C237A05542B78195DF54 /* LMSFeatureModelsAiAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAiAdmin.swift; sourceTree = "<group>"; };
+		CE9495FEEA294923AEA5BF53 /* LMSFeatureModelsArchivedCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsArchivedCoursesAdmin.swift; sourceTree = "<group>"; };
+		91A0E5C89ED548A199704515 /* LMSFeatureModelsAuditLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsAuditLog.swift; sourceTree = "<group>"; };
+		35E58DD379584EC9897EBA81 /* LMSFeatureModelsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBehavior.swift; sourceTree = "<group>"; };
+		C298A33135644A24AFBCB734 /* LMSFeatureModelsBilling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsBilling.swift; sourceTree = "<group>"; };
+		F8B8C6B060664460BDBC632C /* LMSFeatureModelsCanvasImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCanvasImport.swift; sourceTree = "<group>"; };
+		E25A51DF333A470280FD211F /* LMSFeatureModelsCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCatalog.swift; sourceTree = "<group>"; };
+		43569D183CA24C02982D1D9B /* LMSFeatureModelsCourseAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseAccessibility.swift; sourceTree = "<group>"; };
+		FAF0237DC5854F459C5FE8E6 /* LMSFeatureModelsCourseCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseCreate.swift; sourceTree = "<group>"; };
+		C2BC6C3FE403447E84BC459A /* LMSFeatureModelsCourseGrading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGrading.swift; sourceTree = "<group>"; };
+		536DE680136F4CDCA73A7D4B /* LMSFeatureModelsCourseGradingAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseGradingAgents.swift; sourceTree = "<group>"; };
+		CF5B6BE5CE3C47CAB01E3445 /* LMSFeatureModelsCourseOutcomes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseOutcomes.swift; sourceTree = "<group>"; };
+		237CEC1FDEA14D838F468EAD /* LMSFeatureModelsCoursePlagiarism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCoursePlagiarism.swift; sourceTree = "<group>"; };
+		92DA2A4D1562445E95C7AC68 /* LMSFeatureModelsCourseReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseReviews.swift; sourceTree = "<group>"; };
+		4B5D34C1A41442759A10378F /* LMSFeatureModelsCourseSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseSettings.swift; sourceTree = "<group>"; };
+		B01AC1FB62E24D11838EAA39 /* LMSFeatureModelsCourseTranslations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCourseTranslations.swift; sourceTree = "<group>"; };
+		E99859DB50F94DCDAFFBC162 /* LMSFeatureModelsCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsCredentials.swift; sourceTree = "<group>"; };
+		9D707EDA39BF4C7695FEDF02 /* LMSFeatureModelsDiscussions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsDiscussions.swift; sourceTree = "<group>"; };
+		D7CD4CE25EE24E1DAC99E738 /* LMSFeatureModelsEportfolio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEportfolio.swift; sourceTree = "<group>"; };
+		D715C2FF7ABC4967AD788A5D /* LMSFeatureModelsEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsEvaluations.swift; sourceTree = "<group>"; };
+		5B72EDBB99BD488F849B8502 /* LMSFeatureModelsFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeed.swift; sourceTree = "<group>"; };
+		9B56FCCE1A1B495BBB800C3A /* LMSFeatureModelsFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsFeedback.swift; sourceTree = "<group>"; };
+		0530E77E12B74004BCD92E74 /* LMSFeatureModelsGamification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGamification.swift; sourceTree = "<group>"; };
+		7EE08986FF7C4EBD9546D49D /* LMSFeatureModelsGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsGroups.swift; sourceTree = "<group>"; };
+		DF4F0AA6B9864CE6BDA4C4F4 /* LMSFeatureModelsInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInsights.swift; sourceTree = "<group>"; };
+		3D1AFD8ED73440A580259DF3 /* LMSFeatureModelsInstructorInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsInstructorInsights.swift; sourceTree = "<group>"; };
+		DACB3E9F0C42444F83FFEC13 /* LMSFeatureModelsIntegrationsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntegrationsAdmin.swift; sourceTree = "<group>"; };
+		6B2BA536957A4BB589B41FB9 /* LMSFeatureModelsIntroCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsIntroCourse.swift; sourceTree = "<group>"; };
+		29CA540852D447A9A5EB534E /* LMSFeatureModelsLearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLearnerProfile.swift; sourceTree = "<group>"; };
+		F2D7E2DC15CD47ABB396D038 /* LMSFeatureModelsLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsLive.swift; sourceTree = "<group>"; };
+		AB72B8AA5B8D4BF283C4812C /* LMSFeatureModelsMarketplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMarketplace.swift; sourceTree = "<group>"; };
+		4285A765335C47D98D5AA5F8 /* LMSFeatureModelsMastery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMastery.swift; sourceTree = "<group>"; };
+		3EAF3DF3E19B47EAA6306310 /* LMSFeatureModelsMobile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsMobile.swift; sourceTree = "<group>"; };
+		FD3E507D2F554E4F8547C016 /* LMSFeatureModelsOrgBrandingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgBrandingAdmin.swift; sourceTree = "<group>"; };
+		3F484F5C857C41B8B8D83F3B /* LMSFeatureModelsOrgStructureAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsOrgStructureAdmin.swift; sourceTree = "<group>"; };
+		C16C35E71B2B44079C194684 /* LMSFeatureModelsParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsParent.swift; sourceTree = "<group>"; };
+		E2118B981A084588B17EA862 /* LMSFeatureModelsPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPaths.swift; sourceTree = "<group>"; };
+		4FEB85F2108F4CDA89C97B20 /* LMSFeatureModelsPeerReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeerReview.swift; sourceTree = "<group>"; };
+		4DD23228423D425187827C43 /* LMSFeatureModelsPeopleAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPeopleAdmin.swift; sourceTree = "<group>"; };
+		3687F3FFC80047629DB76329 /* LMSFeatureModelsPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatform.swift; sourceTree = "<group>"; };
+		F153827ABE574FB28D26FDD5 /* LMSFeatureModelsPlatformCoursesAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformCoursesAdmin.swift; sourceTree = "<group>"; };
+		8F9082A0730B411CBEADB9D7 /* LMSFeatureModelsPlatformSettingsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsPlatformSettingsAdmin.swift; sourceTree = "<group>"; };
+		CFD7A193F6B842AB9AD0E084 /* LMSFeatureModelsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReader.swift; sourceTree = "<group>"; };
+		F493EF6C307441C187C07C95 /* LMSFeatureModelsReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsReading.swift; sourceTree = "<group>"; };
+		F8595E8DCA0142C78593020D /* LMSFeatureModelsRolesPermissionsAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsRolesPermissionsAdmin.swift; sourceTree = "<group>"; };
+		22C2F7DAE4904509A7C51AB2 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTranscriptsAdvisingAdmin.swift; sourceTree = "<group>"; };
+		9B390B819E404BAC9BD710C6 /* LMSFeatureModelsTutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsTutor.swift; sourceTree = "<group>"; };
+		C83EF63F17104ADBBC135CAE /* LMSFeatureModelsWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModelsWallet.swift; sourceTree = "<group>"; };
+		83103D7B44E2473A8E083B12 /* LMSInteractiveModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSInteractiveModels.swift; sourceTree = "<group>"; };
+		C41EC1D1D81843C3AE5D6B7C /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
+		C8F662D40CBC435EA8AB4575 /* LearnerProfileLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogic.swift; sourceTree = "<group>"; };
+		5888F7E8AE85481493777E03 /* LibraryResourceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogic.swift; sourceTree = "<group>"; };
+		67A00E00E7074ED386216A18 /* LiveGameLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameLogic.swift; sourceTree = "<group>"; };
+		978D91FEAC854AC1A7DEE81E /* LiveMeetingsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogic.swift; sourceTree = "<group>"; };
+		9FC24E5FF6DF4E1594203298 /* LiveQuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogic.swift; sourceTree = "<group>"; };
+		324AA97B736A47DEABAEF8B5 /* MarketplaceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogic.swift; sourceTree = "<group>"; };
+		F243E67246474E0E9E9700B4 /* MasteryLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogic.swift; sourceTree = "<group>"; };
+		14C3277E87654FFBB9E8B608 /* ModuleContentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentLogic.swift; sourceTree = "<group>"; };
+		A312A18DBBA04A82928F7F31 /* ModuleLastVisited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleLastVisited.swift; sourceTree = "<group>"; };
+		691310D5834D4D85AA80D7EC /* NotificationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLogic.swift; sourceTree = "<group>"; };
+		2F2DCD08A7254E47904BA8B6 /* OfficeHoursLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogic.swift; sourceTree = "<group>"; };
+		4F3437C6C5E5403389A1408B /* OnboardingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModels.swift; sourceTree = "<group>"; };
+		7A0E3748F97D4C1195784DDD /* OrgBrandingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogic.swift; sourceTree = "<group>"; };
+		71D346F3E4DB4208BE31F01C /* OrgStructureAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogic.swift; sourceTree = "<group>"; };
+		4BA5EC88D6A54B4AA3A4C0D1 /* ParentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogic.swift; sourceTree = "<group>"; };
+		F358BC135D3048869EFE35DA /* PathsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogic.swift; sourceTree = "<group>"; };
+		E7A28AEE5FE14AAC93E51F53 /* PeerReviewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogic.swift; sourceTree = "<group>"; };
+		5FE82C0E43BD4BB798193FAC /* PeopleAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogic.swift; sourceTree = "<group>"; };
+		EC3F76CDFC704620898EB820 /* PlannerLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerLogic.swift; sourceTree = "<group>"; };
+		5BA2A976460E4A0AB1FD5C20 /* PlannerSnapshotCoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerSnapshotCoding.swift; sourceTree = "<group>"; };
+		F0239F95B6144258A56BF208 /* PlatformCoursesAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogic.swift; sourceTree = "<group>"; };
+		6F42C914017E4A18955B7847 /* PlatformSettingsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogic.swift; sourceTree = "<group>"; };
+		11D0756CA8CA470BBF27C53D /* PortfolioLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogic.swift; sourceTree = "<group>"; };
+		8DF820D89BD44A048BF21491 /* ProfileDepthLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogic.swift; sourceTree = "<group>"; };
+		A6E6C53BD425423D97C894BA /* ProfileDepthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthModels.swift; sourceTree = "<group>"; };
+		1195F59ED53A48938097273C /* QuizLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogic.swift; sourceTree = "<group>"; };
+		F51DD3FFD2C24B4A8734F6EE /* ReadingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogic.swift; sourceTree = "<group>"; };
+		B95053CA3B524D51B57E496E /* RequirementsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogic.swift; sourceTree = "<group>"; };
+		FDC0C94610224F1E8DA306D3 /* ReviewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewModels.swift; sourceTree = "<group>"; };
+		52CD5F8EC05E43BDBA7F30C9 /* RolesPermissionsAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogic.swift; sourceTree = "<group>"; };
+		60F67A970A474EBEAFFDB391 /* SettingsMenuLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogic.swift; sourceTree = "<group>"; };
+		7D73263ACDD3471B8D3DEB09 /* TakeAttendanceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogic.swift; sourceTree = "<group>"; };
+		259D4E20FEE14AF788D4414A /* TranscriptsAdvisingAdminLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogic.swift; sourceTree = "<group>"; };
+		A990FFE37A8546BA870D0F0F /* TutorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogic.swift; sourceTree = "<group>"; };
+		769106ABCAAB4179B02463AB /* TutorStreamClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorStreamClient.swift; sourceTree = "<group>"; };
+		9AC94FFFF90F4F1B8917156C /* VibeActivityLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogic.swift; sourceTree = "<group>"; };
+		99D2D4BE9BCE435285FF58B2 /* WalletLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogic.swift; sourceTree = "<group>"; };
+		D7DF4ED214C142B28F0F7C6C /* WhiteboardLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogic.swift; sourceTree = "<group>"; };
+		CCE1C407BBDF4740977C3248 /* WhiteboardRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardRenderer.swift; sourceTree = "<group>"; };
+		C83BBBE62917426DAE86975C /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		9F257901D5014000A8EBE90D /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		D68B209FB8AF410DBD34F031 /* NetworkAuthContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAuthContext.swift; sourceTree = "<group>"; };
+		D572BD0B890840029E117FF8 /* NetworkBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBootstrap.swift; sourceTree = "<group>"; };
+		D2249CF0A07C46B8BFA8BB20 /* MarkdownTableLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTableLogic.swift; sourceTree = "<group>"; };
+		77FD3EEDE8744FF7B0AFC538 /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
+		E4CE9866F2DB4E23BF1F8012 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
+		A80E77440983473EA95A4FB8 /* NotebookSlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSlashCommands.swift; sourceTree = "<group>"; };
+		6637E78D17B64DA29CCAB464 /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
+		960144A5952D4276A7C05E82 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
+		BE9948647BA7401E9F6F93A3 /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
+		29345BCE6B754740843A8BB1 /* CacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStore.swift; sourceTree = "<group>"; };
+		62DA5F6B6B2B4706823CC528 /* DownloadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadStore.swift; sourceTree = "<group>"; };
+		C6D2A5D9447C40FCA57D17F8 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		6931A626E6DE4BFD97A330D0 /* OfflineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModels.swift; sourceTree = "<group>"; };
+		56D1233CE30E43268AFFBED0 /* OfflineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineService.swift; sourceTree = "<group>"; };
+		1F409CE2BF8B4D93B26107EF /* OutboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxStore.swift; sourceTree = "<group>"; };
+		B7DEEE2246B84A8291FF4E39 /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
+		8D2CBA2BC92149079B34E5B4 /* PushManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushManager.swift; sourceTree = "<group>"; };
+		628EE4A22DBC40ADBF48A1FD /* RealtimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeManager.swift; sourceTree = "<group>"; };
+		8E9D774CB8BA476E96510260 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
+		15AD86FA9B7E444D85BE565C /* ContentLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLinkRouter.swift; sourceTree = "<group>"; };
+		7AB7098E697E48EF95C80DAB /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
+		CD45A9FF969B4384BA86BC18 /* MobileDestinations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinations.swift; sourceTree = "<group>"; };
+		677639FB1EC34FE4AE969527 /* MobileIaPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileIaPreferences.swift; sourceTree = "<group>"; };
+		C7DAC2367DC547DD8374E611 /* MobileProfileDepthPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileProfileDepthPreferences.swift; sourceTree = "<group>"; };
+		31F61AC93CAF44F8BB058BF9 /* SearchActionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchActionRegistry.swift; sourceTree = "<group>"; };
+		4EE97A944286469AB5BCD6EA /* SearchModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModels.swift; sourceTree = "<group>"; };
+		467E4692126D4E1FBF694D3F /* SearchPathNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPathNavigator.swift; sourceTree = "<group>"; };
+		722AE47C26754F9FB7BC7FE7 /* SearchRecentsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRecentsStore.swift; sourceTree = "<group>"; };
+		154A15FAD34D4A58B24EE09B /* CodeEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditor.swift; sourceTree = "<group>"; };
+		5530E9E13A8848E09D6085D7 /* AdvisingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingView.swift; sourceTree = "<group>"; };
+		FCBD1F0BA9AE4F6683F4F7A3 /* AssignmentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDetailView.swift; sourceTree = "<group>"; };
+		222A43CE1EE64C479E56D313 /* AssignmentDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDraftStore.swift; sourceTree = "<group>"; };
+		953BC13048144DD7BB15E059 /* AttachmentUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploader.swift; sourceTree = "<group>"; };
+		8E3CF162C00F4464BF4C159A /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
+		76335E8AFED64A7183393292 /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
+		2125355EB6974E71A3CA2EC1 /* GetStartedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStartedView.swift; sourceTree = "<group>"; };
+		D56BEBB06CE44FBAB66FDE47 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		61E7CA262752498EBC9F37C4 /* MFAChallengeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAChallengeView.swift; sourceTree = "<group>"; };
+		3AC2FB7498CB41128E31F74C /* MfaPasskeyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MfaPasskeyController.swift; sourceTree = "<group>"; };
+		D48D2A7865F843E9AE3D5A11 /* SSOAuthController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOAuthController.swift; sourceTree = "<group>"; };
+		C4E8D15FB6C14BD091BD0120 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
+		56CD26A604DD442983974886 /* BehaviorRosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorRosterView.swift; sourceTree = "<group>"; };
+		3CBAB05AF3BE4315AF713859 /* HallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HallPassView.swift; sourceTree = "<group>"; };
+		5A6778CFE234463994858F9B /* MyHallPassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyHallPassView.swift; sourceTree = "<group>"; };
+		F4CD7D697B764F92BF51A7AA /* BillingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingView.swift; sourceTree = "<group>"; };
+		6ECF122BCB5B49188C076AE4 /* CheckoutReturnHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutReturnHandler.swift; sourceTree = "<group>"; };
+		528A15350CAA4ECB8BF82EBD /* PurchaseFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseFlow.swift; sourceTree = "<group>"; };
+		5E02556B74F24A17BA8376FD /* BoardAnalyticsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAnalyticsSheet.swift; sourceTree = "<group>"; };
+		BC42D146F16B4BDAA812C3EF /* BoardComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardComposerView.swift; sourceTree = "<group>"; };
+		02484C6E8F31475FB95C2B07 /* BoardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailView.swift; sourceTree = "<group>"; };
+		78EAA9448BD040DAB66EF2A0 /* BoardEngagementEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEngagementEnvironment.swift; sourceTree = "<group>"; };
+		9D0FE6FD029F4E009765A1B0 /* BoardExportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardExportSheet.swift; sourceTree = "<group>"; };
+		42B87ED193FE417396EB2B4E /* BoardModerationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardModerationSettings.swift; sourceTree = "<group>"; };
+		F5059595D0E24E059420088C /* BoardPostCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPostCard.swift; sourceTree = "<group>"; };
+		4E996C23C6F942F1878DFFFB /* BoardPresentModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPresentModeView.swift; sourceTree = "<group>"; };
+		78BF473B64E846569C3A5978 /* BoardSaveAsTemplateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSaveAsTemplateSheet.swift; sourceTree = "<group>"; };
+		F1080FED284840089F65DDE5 /* BoardShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardShareSheet.swift; sourceTree = "<group>"; };
+		9942E130569A4AB48B2A051E /* BoardSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSocket.swift; sourceTree = "<group>"; };
+		462B3468F5514FA7BBBF3277 /* BoardSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSurface.swift; sourceTree = "<group>"; };
+		791BDC8ACF6D435EAB32CB67 /* BoardSyncStatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSyncStatusChip.swift; sourceTree = "<group>"; };
+		01E582767F06462184FEADE6 /* BoardTemplatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTemplatePickerView.swift; sourceTree = "<group>"; };
+		31FC6C0DCE1B4091B988ED17 /* BoardsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsListView.swift; sourceTree = "<group>"; };
+		5831E2E338A043009714F4CA /* CardArrangeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardArrangeMenu.swift; sourceTree = "<group>"; };
+		55759ED87B334852AA3741F6 /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
+		3891A2BEEA8A4B12A04001EC /* GradeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSheet.swift; sourceTree = "<group>"; };
+		7DA492F2BE1548339ADEA334 /* CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasLayout.swift; sourceTree = "<group>"; };
+		6749D8AD1CC84795999E67B0 /* ColumnsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnsLayout.swift; sourceTree = "<group>"; };
+		60EA2749A48844A58A8DF179 /* MapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLayout.swift; sourceTree = "<group>"; };
+		58CDC3E525A84E28AAC2BFBA /* TimelineLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLayout.swift; sourceTree = "<group>"; };
+		622A895CD460490799FB6A37 /* WallLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallLayout.swift; sourceTree = "<group>"; };
+		6B35607BAD254091AA44612B /* ModerationQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationQueueView.swift; sourceTree = "<group>"; };
+		73CEB85CCEAB433394A7F47B /* BoardPublicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPublicView.swift; sourceTree = "<group>"; };
+		E21EA6406ED74F73879793F0 /* ReactionControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionControl.swift; sourceTree = "<group>"; };
+		EB4559488E1B46FBBA32F113 /* ReportDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDialog.swift; sourceTree = "<group>"; };
+		AD8461C5082547B3986EB882 /* CatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogView.swift; sourceTree = "<group>"; };
+		20E5CD08014E4CCA97CD4DF8 /* CourseLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLandingView.swift; sourceTree = "<group>"; };
+		A0D7698E4A49453A81518DD7 /* ReviewComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewComposer.swift; sourceTree = "<group>"; };
+		C4D2A9F83441479BA727CC45 /* ContentPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentPageView.swift; sourceTree = "<group>"; };
+		F80C96F7C5154E88AAC91702 /* CourseAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAttendanceView.swift; sourceTree = "<group>"; };
+		52E481996B2340459B264B04 /* CourseBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBanner.swift; sourceTree = "<group>"; };
+		19004FBF9EF9417AB20D14FB /* CourseDestinationPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDestinationPlaceholder.swift; sourceTree = "<group>"; };
+		48D042B2C9BB492BBECBFB64 /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
+		3CDC409C63F44BC0BAE119BA /* CourseGradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradesView.swift; sourceTree = "<group>"; };
+		2A294251A80649ECACA3255E /* CourseLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseLibraryView.swift; sourceTree = "<group>"; };
+		3698C94ECDF54D808F2E6A38 /* CourseMarkdownContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarkdownContentView.swift; sourceTree = "<group>"; };
+		C664531BA882440EB0BF2C57 /* CoursePeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleView.swift; sourceTree = "<group>"; };
+		44CB7C7379E8462D8EB901E6 /* CourseStructureSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseStructureSocket.swift; sourceTree = "<group>"; };
+		179AF25F442A4BA1A8C5B84A /* CourseSyllabusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyllabusView.swift; sourceTree = "<group>"; };
+		5AD90B7194D54297A97E2D15 /* CourseWorkspaceNav.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseWorkspaceNav.swift; sourceTree = "<group>"; };
+		0968A034C0FD4A7BA32085DE /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
+		6CD6433A5A6745859F26D7E2 /* CanvasImportComingSoonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportComingSoonView.swift; sourceTree = "<group>"; };
+		B79A38EF73D849B89A24DB63 /* CanvasImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportView.swift; sourceTree = "<group>"; };
+		24B4F1E4C99949DCB57815D2 /* CourseCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateView.swift; sourceTree = "<group>"; };
+		44ECB4A39A1747C8BBAC7CCE /* InlineMarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineMarkdownText.swift; sourceTree = "<group>"; };
+		48213DEC0E36407FA056F408 /* ItemDetailRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailRows.swift; sourceTree = "<group>"; };
+		7697EDBBD47B4C94B5C48B6D /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
+		B52F523B506E47DD9A87703A /* LaunchContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContainerView.swift; sourceTree = "<group>"; };
+		3FB3F7D10F824E8CAF96F9A0 /* LibraryResourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceView.swift; sourceTree = "<group>"; };
+		8351F282776A40C095C1EA50 /* MarkdownCodeBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeBlockView.swift; sourceTree = "<group>"; };
+		4D9DABD8D7824346841D6AD8 /* MarkdownRenderStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderStyle.swift; sourceTree = "<group>"; };
+		164872C278714902AEE2DB47 /* MarkdownTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTableView.swift; sourceTree = "<group>"; };
+		5B5BE60BCECC4042B0C27709 /* ModuleItemRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleItemRouteView.swift; sourceTree = "<group>"; };
+		34CCB948B3AD4913A67A0BA0 /* ModuleListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleListView.swift; sourceTree = "<group>"; };
+		FBB09A194C034B7BA76B7284 /* RequirementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsView.swift; sourceTree = "<group>"; };
+		BF070004C4CA433E8F0F74A7 /* CourseAccessibilityReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewView.swift; sourceTree = "<group>"; };
+		832248171BB1497E8A935DB6 /* CourseArchivedContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentView.swift; sourceTree = "<group>"; };
+		6DF044088FCA451EA8388263 /* CourseBlueprintSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintSettingsView.swift; sourceTree = "<group>"; };
+		869F283288214F60917D5FE2 /* CourseCrossListingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCrossListingView.swift; sourceTree = "<group>"; };
+		2119EC8AFB9F42ADA2BBE773 /* CourseFeaturesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesSettingsView.swift; sourceTree = "<group>"; };
+		25E583694E9B463B9829B3CA /* CourseGeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGeneralSettingsView.swift; sourceTree = "<group>"; };
+		B013FC2F99764401B0DE38C6 /* CourseGradingAgentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsView.swift; sourceTree = "<group>"; };
+		61142908EABC4D26A5A04DE1 /* CourseGradingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingSettingsView.swift; sourceTree = "<group>"; };
+		AA480BF4B3144A949E93817E /* CourseHeroImageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImageEditor.swift; sourceTree = "<group>"; };
+		689FDA3F9E714CAF9E30C243 /* CourseImportExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportView.swift; sourceTree = "<group>"; };
+		527F305D833141F0B9A7F432 /* CourseMarketplaceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMarketplaceSettingsView.swift; sourceTree = "<group>"; };
+		53520527C1094B3D9051FA7A /* CourseOutcomesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesSettingsView.swift; sourceTree = "<group>"; };
+		6289444D5E1340958D35A588 /* CoursePlagiarismSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismSettingsView.swift; sourceTree = "<group>"; };
+		8AE01EA5982740088E1C66E7 /* CourseSectionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsSettingsView.swift; sourceTree = "<group>"; };
+		06D1490287164C789D58C042 /* CourseSettingsHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsHostView.swift; sourceTree = "<group>"; };
+		AFE3DE7CE7F8448E9FAECE4B /* CourseTranslationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsSettingsView.swift; sourceTree = "<group>"; };
+		6F6945859664455189D2B8E3 /* TakeAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceView.swift; sourceTree = "<group>"; };
+		8D45AA78BA294951896232EF /* VibeActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityView.swift; sourceTree = "<group>"; };
+		CF30B7FBA3CB4F8A87934ABB /* WebItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebItemView.swift; sourceTree = "<group>"; };
+		0515955E570A4924AD25F62A /* CredentialDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDetailView.swift; sourceTree = "<group>"; };
+		C045D69C75EE4D01B6900402 /* CredentialsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsView.swift; sourceTree = "<group>"; };
+		7B9BED0E045041E0B67D3E7C /* DashboardCoursesCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCoursesCarousel.swift; sourceTree = "<group>"; };
+		C6E8F9F4B1E74EA89D9CE097 /* DashboardHeroPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardHeroPanel.swift; sourceTree = "<group>"; };
+		E5C8650B918048FFB715D157 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+		024F7FE6C92F47189E4D0743 /* LiveMeetingsRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsRail.swift; sourceTree = "<group>"; };
+		71AA5BA948D94095BB9C37FF /* CourseDiscussionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDiscussionsSection.swift; sourceTree = "<group>"; };
+		0941978D71174F0689587DB0 /* DiscussionThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionThreadView.swift; sourceTree = "<group>"; };
+		318FF7C7D24A4ECDA8227DAE /* DiscussionsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionsListView.swift; sourceTree = "<group>"; };
+		DE854695ECBA4204AB0DE576 /* PostComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostComposerView.swift; sourceTree = "<group>"; };
+		7F2327B1074F4A668A9C4BA8 /* CourseEvaluationsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseEvaluationsSection.swift; sourceTree = "<group>"; };
+		50788B3B53CB42BE8F185D0D /* EvaluationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationFormView.swift; sourceTree = "<group>"; };
+		EB68CA9959D24657B8E7127E /* EvaluationResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationResultsView.swift; sourceTree = "<group>"; };
+		A491D3423B534C4EBD81B475 /* CourseFeedSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeedSection.swift; sourceTree = "<group>"; };
+		8536659166D649D3BDCCC5A5 /* FeedChannelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelView.swift; sourceTree = "<group>"; };
+		6883D3DA4F2343F1A3EA9A79 /* FeedChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedChannelsView.swift; sourceTree = "<group>"; };
+		8AFBD986DC7D49509FF77E4E /* FeedLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogic.swift; sourceTree = "<group>"; };
+		0EACB47FAA72484787927D72 /* FeedSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSocket.swift; sourceTree = "<group>"; };
+		8CD0948FFE1148BBBBBE2D6C /* ShareFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackView.swift; sourceTree = "<group>"; };
+		18097E976BCB4C65A606B828 /* CourseFilesSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesSocket.swift; sourceTree = "<group>"; };
+		CDBDEFECB96647F69BE549DA /* CourseFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFilesView.swift; sourceTree = "<group>"; };
+		CC5969A54F304BF391B96B52 /* FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.swift; sourceTree = "<group>"; };
+		A57EE20D3C8244BF97EE2AA7 /* MarkupOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkupOverlayView.swift; sourceTree = "<group>"; };
+		6BD564B829F54B788712FD2D /* GamificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationView.swift; sourceTree = "<group>"; };
+		ACC43B7F26C946E48F8732A9 /* GradeFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeFeedbackView.swift; sourceTree = "<group>"; };
+		4707DC82B2524CD3BAEEF06F /* WhatIfController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIfController.swift; sourceTree = "<group>"; };
+		46F41DCE71464DB59B5C6663 /* GradingBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradingBacklogView.swift; sourceTree = "<group>"; };
+		91E6EC53A9394379A90D21E2 /* SpeedGraderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderView.swift; sourceTree = "<group>"; };
+		E0CF978646344FCFA4454830 /* CollabDocView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollabDocView.swift; sourceTree = "<group>"; };
+		1A0EAE54E8B14774BF07E17D /* CourseCollabDocsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCollabDocsSection.swift; sourceTree = "<group>"; };
+		A8ED2FABE3594F74881ED2B8 /* CourseGroupsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGroupsSection.swift; sourceTree = "<group>"; };
+		980E64BF62DC4188B34C56BA /* GroupSpaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSpaceView.swift; sourceTree = "<group>"; };
+		8C177A84D04E4331844EEBAE /* AnnouncementComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementComposerView.swift; sourceTree = "<group>"; };
+		80A10F1D947447B5956D48C3 /* AnnouncementsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsViews.swift; sourceTree = "<group>"; };
+		9C0A9806AF8440C4A8C8CDF7 /* BroadcastComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastComposerView.swift; sourceTree = "<group>"; };
+		28100343CFDF4AF59C86A6FC /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		64A1F8CCF9EE4EDA8B5CFF59 /* MoreHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreHubView.swift; sourceTree = "<group>"; };
+		1EB6923BCC1D4805AEFF8239 /* ShellHeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellHeaderBar.swift; sourceTree = "<group>"; };
+		7A0CCD64E62341E68686CFE0 /* TeachHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeachHubView.swift; sourceTree = "<group>"; };
+		DAA66206BD0147519D6AC6FA /* UniversalSearchPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchPlaceholder.swift; sourceTree = "<group>"; };
+		C6D1228B44564E0E8DB04060 /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
+		92D3A231947E4B708305CB2E /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
+		B54FE86CAD8E4067A5F844B7 /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
+		531503917D1E4CE6A75ADE5E /* DashboardInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardInsightsSection.swift; sourceTree = "<group>"; };
+		AAD21BB758214149B940C422 /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
+		7672FF915C65418797A16566 /* AtRiskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtRiskListView.swift; sourceTree = "<group>"; };
+		C541977EC6B04FB6A37B1F29 /* CourseInsightsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseInsightsSection.swift; sourceTree = "<group>"; };
+		53D26361290F44B185668F88 /* StudentProgressDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentProgressDetailView.swift; sourceTree = "<group>"; };
+		5C7B30875E8E4ECDA36E6EAC /* WhatsWorkingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsWorkingView.swift; sourceTree = "<group>"; };
+		00A2632F4E6146C0888CDCAA /* IntroCelebrationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCelebrationPresenter.swift; sourceTree = "<group>"; };
+		048EC217A0B74F2B9BB4EAE2 /* IntroCompletionCelebrationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCompletionCelebrationSheet.swift; sourceTree = "<group>"; };
+		C781C8F72BA844A88D7DFD34 /* IntroCourseEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseEntryCard.swift; sourceTree = "<group>"; };
+		FFF3D3F2BF2B4C4AB6AD00BB /* IntroCourseProgressRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseProgressRail.swift; sourceTree = "<group>"; };
+		E385C465842945319D3820E6 /* LearnerProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileView.swift; sourceTree = "<group>"; };
+		5D02627FB9C849F79EC5C993 /* LibraryBrowseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBrowseView.swift; sourceTree = "<group>"; };
+		DE11AD774E754CB0B4F41F9C /* MeetingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailView.swift; sourceTree = "<group>"; };
+		B6B9189B2A6C4365BDFA77EA /* MeetingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListView.swift; sourceTree = "<group>"; };
+		2019900D80C9473CB449F94E /* WhiteboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardView.swift; sourceTree = "<group>"; };
+		DA09F23627DF4281A4F5A604 /* LiveGameSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveGameSocket.swift; sourceTree = "<group>"; };
+		81513A4BA1FB4B33B26A4904 /* LiveQuizHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizHubView.swift; sourceTree = "<group>"; };
+		8BF86A09506C49D0ACF4694E /* LiveQuizPlaySurfaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlaySurfaces.swift; sourceTree = "<group>"; };
+		B579284FCBF34783ACA74A29 /* LiveQuizPlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizPlayView.swift; sourceTree = "<group>"; };
+		5F0D94941BE3495F961A91A1 /* MarketplaceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceDetailView.swift; sourceTree = "<group>"; };
+		6331924043854C3CBF0A9E5F /* MarketplaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceView.swift; sourceTree = "<group>"; };
+		959FB9FC548444E39D3552DF /* MyPurchasesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPurchasesView.swift; sourceTree = "<group>"; };
+		E203D2C754954BB8A2E97859 /* CourseMasterySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseMasterySection.swift; sourceTree = "<group>"; };
+		BDA42760F06B46B68A649C76 /* ReportCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCardListView.swift; sourceTree = "<group>"; };
+		A58E25472CC4432FA317805B /* CourseDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDrawer.swift; sourceTree = "<group>"; };
+		E1446CD993A4484B907BEBB4 /* DrawerScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScaffold.swift; sourceTree = "<group>"; };
+		70C986E9B6854FC7AD29E25A /* DrawerToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerToolbar.swift; sourceTree = "<group>"; };
+		BC556A9FC50D4E8588B82D1E /* GlobalDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalDrawer.swift; sourceTree = "<group>"; };
+		98011A2A19A74B2DA36D628F /* NotebookDrawingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawingViews.swift; sourceTree = "<group>"; };
+		46BB10FDBC994065AADF8481 /* NotebookEditorSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorSupportViews.swift; sourceTree = "<group>"; };
+		0F5A3677FC5A4F328B8BDB0B /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
+		F23E48BCE4A7490880B6D9E8 /* NotebookPagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPagesView.swift; sourceTree = "<group>"; };
+		6F35E579A8D541FFA66061EF /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
+		A432E81BD5D8424F97BBEE18 /* BookingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingSheet.swift; sourceTree = "<group>"; };
+		CA2504E439EB4BC3B0F5AC9D /* MyBookingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBookingsView.swift; sourceTree = "<group>"; };
+		D00DF85D5B624D7CB6A004AC /* OfficeHoursView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursView.swift; sourceTree = "<group>"; };
+		17F8216A97C24D3EA7598AB2 /* DiagnosticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticView.swift; sourceTree = "<group>"; };
+		774B6FA5FF744EF485F0E850 /* OnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowView.swift; sourceTree = "<group>"; };
+		385A78C7174346588920560C /* ConferenceBookingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceBookingView.swift; sourceTree = "<group>"; };
+		CD7B1D976EE245B68D041D72 /* MyConferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyConferencesView.swift; sourceTree = "<group>"; };
+		E94092F15E26460C816BE4D3 /* ParentAttendanceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentAttendanceDetailView.swift; sourceTree = "<group>"; };
+		7FBDF00E06B4425BB6598B8C /* ParentDashboardSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardSections.swift; sourceTree = "<group>"; };
+		FD18358A0EE94FBD9DCB1140 /* ParentDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentDashboardView.swift; sourceTree = "<group>"; };
+		23AF80C29CDF4624A491DAF9 /* ParentGradesDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGradesDetailView.swift; sourceTree = "<group>"; };
+		1EEF5E4F7B904C2888E1D8D6 /* ParentNotificationPrefsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentNotificationPrefsView.swift; sourceTree = "<group>"; };
+		2D0261A469004ADFB46BA3B2 /* DashboardStudySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStudySection.swift; sourceTree = "<group>"; };
+		0CD12D72F206465DB20F7D92 /* MyPathsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPathsView.swift; sourceTree = "<group>"; };
+		57CD05A1B6F44A0C874FA1A7 /* PathLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathLandingView.swift; sourceTree = "<group>"; };
+		FB651E4D0105497FB87FC85D /* PathRunnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathRunnerView.swift; sourceTree = "<group>"; };
+		E1DD7963C4FB4AF99D362C5D /* PathsCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsCatalogView.swift; sourceTree = "<group>"; };
+		FC4728726CE7444DAC53AE44 /* PeerReviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewDetailView.swift; sourceTree = "<group>"; };
+		97464A6F695B4C1D829E0A31 /* PeerReviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewListView.swift; sourceTree = "<group>"; };
+		348865567B2E49AE8BC76B2B /* ReviewsReceivedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsReceivedView.swift; sourceTree = "<group>"; };
+		8E1FE883E9294779A42DF919 /* RubricScorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricScorerView.swift; sourceTree = "<group>"; };
+		4906C7481D4846209825317F /* CalendarSubscribeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSubscribeSheet.swift; sourceTree = "<group>"; };
+		F63D10FFB5994D85916B3452 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
+		6E2C9AD63AE64C28A581941C /* ConferenceReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceReminderScheduler.swift; sourceTree = "<group>"; };
+		5C9458F0AE1943F5ABED08F8 /* DueReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DueReminderScheduler.swift; sourceTree = "<group>"; };
+		8234B2B85127411A9170A3B4 /* OfficeHoursReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursReminderScheduler.swift; sourceTree = "<group>"; };
+		CCA88792E76548ECB5F42F63 /* PlannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModel.swift; sourceTree = "<group>"; };
+		D4D5DB43679D4F0883B914C9 /* PlannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerView.swift; sourceTree = "<group>"; };
+		3CB75241F3C54D6BAF22C7C5 /* TodosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodosView.swift; sourceTree = "<group>"; };
+		D70B61AEC9A84C17B965B80C /* ArtifactDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailView.swift; sourceTree = "<group>"; };
+		A56725B79B7C4322A19637D3 /* ArtifactEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactEditorView.swift; sourceTree = "<group>"; };
+		A99F8E9BBDA442DAA6DE27D9 /* PortfolioArtifactUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioArtifactUploader.swift; sourceTree = "<group>"; };
+		B914CD8D81974975B0B22EF2 /* PortfolioDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioDetailView.swift; sourceTree = "<group>"; };
+		9DEBFEC34B6F41FB97FC6F29 /* PortfolioView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioView.swift; sourceTree = "<group>"; };
+		592539EF2B3D4074804061C6 /* AiAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminEntryCard.swift; sourceTree = "<group>"; };
+		B1D9881CB51A4181AB4D16D0 /* ArchivedCoursesAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminEntryCard.swift; sourceTree = "<group>"; };
+		F2A64092496C4AD2B8F25D58 /* BiometricLockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricLockView.swift; sourceTree = "<group>"; };
+		88E507504BBD476CA403DD67 /* DeviceSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceSessionsView.swift; sourceTree = "<group>"; };
+		68599A8761C649ABBB52D83B /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
+		3DBEEB71BD314400A927650F /* IntegrationsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminEntryCard.swift; sourceTree = "<group>"; };
+		27E5C27923924FD0A90C01B9 /* IntegrationsEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsEntryCard.swift; sourceTree = "<group>"; };
+		AA4BE77EF7674E1E9E3757D2 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
+		F04F9D5BE5EF4D878ACE1733 /* LearnerProfileEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileEntryCard.swift; sourceTree = "<group>"; };
+		30AE110FA35341549393278C /* MyAccommodationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccommodationsView.swift; sourceTree = "<group>"; };
+		641868BD33C04BE9AF3E8954 /* NotificationPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesView.swift; sourceTree = "<group>"; };
+		63EA9BD24D0C4E8DB20249B6 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+		6AC2145244F94724B67473A5 /* OrgBrandingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminEntryCard.swift; sourceTree = "<group>"; };
+		C1D034344ED842FE8B459C23 /* OrgStructureAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminEntryCard.swift; sourceTree = "<group>"; };
+		89848B70521648509950383E /* PeopleAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminEntryCard.swift; sourceTree = "<group>"; };
+		229CE427FD1A4EF28A143AFE /* PlatformSettingsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminEntryCard.swift; sourceTree = "<group>"; };
+		040626B6A7374B009C3BD9E3 /* ProfileDepthCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthCards.swift; sourceTree = "<group>"; };
+		3477F16CDB66413397751CCB /* ProfilePersonalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePersonalDetailsView.swift; sourceTree = "<group>"; };
+		883E4F888A014172A4ACD859 /* ProfileSecurityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSecurityCard.swift; sourceTree = "<group>"; };
+		8809936E57384A37BBA2F68F /* ProfileSettingsCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingsCards.swift; sourceTree = "<group>"; };
+		309494895CAB4416BC2569D5 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		223A451AED7B4DF08DF67712 /* ProfileViewSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewSections.swift; sourceTree = "<group>"; };
+		5AED4420C17745ADB291B9B8 /* ResearchStudiesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResearchStudiesView.swift; sourceTree = "<group>"; };
+		346A50DE69D841D19BD94AB8 /* RolesPermissionsAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminEntryCard.swift; sourceTree = "<group>"; };
+		32F1150E53D840E3B21131A5 /* SettingsAdminHubEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubEntryCard.swift; sourceTree = "<group>"; };
+		28B39FAB37194467A12B0D1B /* ShareFeedbackEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFeedbackEntryCard.swift; sourceTree = "<group>"; };
+		694198A11E7247BEAB1CFE82 /* TranscriptsAdvisingAdminEntryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminEntryCard.swift; sourceTree = "<group>"; };
+		DD71CD636D5942858C5CD40D /* CodeQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeQuestionView.swift; sourceTree = "<group>"; };
+		6FBCAEDFDB0B4FE9A86D39FE /* LockdownController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockdownController.swift; sourceTree = "<group>"; };
+		E8C82DEEFB314FE3B1262BB5 /* QuizIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizIntroView.swift; sourceTree = "<group>"; };
+		6765D118B5E24C9F9BE2CBDE /* QuizQuestionViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizQuestionViews.swift; sourceTree = "<group>"; };
+		A02C95A7DCC443B2BF852B70 /* QuizResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResultsView.swift; sourceTree = "<group>"; };
+		2E7EE232B3A749DDB1F48C02 /* QuizTakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizTakerView.swift; sourceTree = "<group>"; };
+		5691E7CBA8204B74BF155205 /* CaptionedPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionedPlayerView.swift; sourceTree = "<group>"; };
+		AE44AC00C29F4222A81865E6 /* ContentTranslationControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTranslationControls.swift; sourceTree = "<group>"; };
+		BD37D28F45B2488BA3BFDAD0 /* ImmersiveReaderCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersiveReaderCapabilities.swift; sourceTree = "<group>"; };
+		DBF2041EABAF44E589DA9C66 /* ReaderLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogic.swift; sourceTree = "<group>"; };
+		6D1CA05D397847C18530E5FC /* ReaderToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderToolbar.swift; sourceTree = "<group>"; };
+		D555BC7606A84D7484F73373 /* ReadingPreferencesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesSheet.swift; sourceTree = "<group>"; };
+		CC3C4F7284FF450D85F2EC20 /* ReadingPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferencesStore.swift; sourceTree = "<group>"; };
+		5BB809EFFFB04243A54BEFB5 /* LeveledLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeveledLibraryView.swift; sourceTree = "<group>"; };
+		EC8A987C0A714FDEB2297C6A /* LogReadingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReadingSheet.swift; sourceTree = "<group>"; };
+		1DD831BE987D4190BCF6851C /* ReadingDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardView.swift; sourceTree = "<group>"; };
+		D60C3CA6A5BE45BFB0D1BCC0 /* ReviewHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHomeView.swift; sourceTree = "<group>"; };
+		46422DFEFDB340AC9BCEFBDA /* ReviewReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReminderScheduler.swift; sourceTree = "<group>"; };
+		97400E67C60C4E2192CC0D59 /* ReviewSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionView.swift; sourceTree = "<group>"; };
+		2A8B565C9B67483486E952FE /* UniversalSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalSearchView.swift; sourceTree = "<group>"; };
+		30F39278CAC240B7B0EF370C /* AdminMetricCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminMetricCards.swift; sourceTree = "<group>"; };
+		466D182804AB4200BC2B51AC /* AdvisingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingSettingsView.swift; sourceTree = "<group>"; };
+		D757F646B1574C6C9D533E3E /* AiAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiAdminHubView.swift; sourceTree = "<group>"; };
+		F09FDB3EC56C46ACBA943EB8 /* AiGovernanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiGovernanceView.swift; sourceTree = "<group>"; };
+		4B06D5DC1FD14C06B7AFA51D /* AiModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsSettingsView.swift; sourceTree = "<group>"; };
+		2300CD6C3A8E4E10939991A8 /* AiProviderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiProviderSettingsView.swift; sourceTree = "<group>"; };
+		B3FE1042D83B4C0BA7ED4338 /* AiReportsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiReportsView.swift; sourceTree = "<group>"; };
+		1D53F974E0C14CB28AA79912 /* ArchivedCoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminView.swift; sourceTree = "<group>"; };
+		02AE7753E97A49B49B6FD4DB /* AuditLogAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminView.swift; sourceTree = "<group>"; };
+		3CA4720B61B84CD5813CC3CE /* BoardsGovernanceAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsGovernanceAdminView.swift; sourceTree = "<group>"; };
+		84F3766C479F4F9CA634923F /* CoursesAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesAdminView.swift; sourceTree = "<group>"; };
+		96506190CC5A4108B2477B94 /* IntegrationsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminView.swift; sourceTree = "<group>"; };
+		D7B57D0B310A40D49231F4EC /* OrgBrandingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminView.swift; sourceTree = "<group>"; };
+		530384910C664DFC8EE07B36 /* OrgBrandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingView.swift; sourceTree = "<group>"; };
+		D8CE3A3E34D04EC8B5962871 /* OrgStructureAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminView.swift; sourceTree = "<group>"; };
+		1C7DA1CF78814F369E0C8B70 /* OrgStructureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureView.swift; sourceTree = "<group>"; };
+		31D314EF2EE8456F80C84955 /* PeopleAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminView.swift; sourceTree = "<group>"; };
+		6C89EEE709B84652A6258FAA /* PlatformSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsView.swift; sourceTree = "<group>"; };
+		880351C617DA4F71A53CF111 /* RolesPermissionsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminView.swift; sourceTree = "<group>"; };
+		DB13261BF35E47EB8D1AF53B /* SystemPromptsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptsView.swift; sourceTree = "<group>"; };
+		BFA372629F404455AA0D9CB3 /* TermsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAdminView.swift; sourceTree = "<group>"; };
+		56161BC8160D47CC9E032B96 /* TranscriptsAdvisingAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminView.swift; sourceTree = "<group>"; };
+		34F0283432F14B4389A33A17 /* TranscriptsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsSettingsView.swift; sourceTree = "<group>"; };
+		8E2DF455833C46BDADCD8939 /* UserDetailAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailAdminView.swift; sourceTree = "<group>"; };
+		CBBA2CA382684EE780FCDEC8 /* SettingsAdminHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdminHubView.swift; sourceTree = "<group>"; };
+		3EBFB03D4B1B44B69F7A8928 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		5052260E3DE1456BBA59B151 /* TutorChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatModel.swift; sourceTree = "<group>"; };
+		3223D2B42D3A4F13B49D7F42 /* TutorChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorChatView.swift; sourceTree = "<group>"; };
+		6346A67698B641D7B2D4A441 /* TutorFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorFlowLayout.swift; sourceTree = "<group>"; };
+		6D315B2782FB43308BEF661D /* TutorLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLauncher.swift; sourceTree = "<group>"; };
+		E07BCE656BB942D48E005C49 /* WalletCCRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCCRDetailView.swift; sourceTree = "<group>"; };
+		82B9B807BBC44CDDB7803DA5 /* WalletCETranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCETranscriptDetailView.swift; sourceTree = "<group>"; };
+		DC36E8FB3D78445B83CA8A83 /* WalletOfficialTranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletOfficialTranscriptDetailView.swift; sourceTree = "<group>"; };
+		877ECF71BA4E4ACCBC6DC624 /* WalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletView.swift; sourceTree = "<group>"; };
+		815F27882B8346A1B4F004B0 /* AccessibilitySupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilitySupportTests.swift; sourceTree = "<group>"; };
+		211609286B984816ADBA3FDE /* AccountIntegrationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountIntegrationsLogicTests.swift; sourceTree = "<group>"; };
+		82954E2C195A4EDB952EB64D /* AdvisingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvisingLogicTests.swift; sourceTree = "<group>"; };
+		C73A837B515E4758915D8F04 /* AiModelsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiModelsAdminLogicTests.swift; sourceTree = "<group>"; };
+		40FB17ABC18C40C69D14A910 /* AnnouncementLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementLogicTests.swift; sourceTree = "<group>"; };
+		C9B23AAB14FB4FA6893C0FD6 /* AppleSignInLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInLogicTests.swift; sourceTree = "<group>"; };
+		A207247ECB734CE5A3D0AB73 /* ArchivedCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
+		9ACC207BF99E4112B1FD91A0 /* AssignmentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogicTests.swift; sourceTree = "<group>"; };
+		D89591167FA446A1BDE86825 /* AuditLogAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogAdminLogicTests.swift; sourceTree = "<group>"; };
+		5456F54003A8489AA404FA8B /* AuthCallbackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCallbackParserTests.swift; sourceTree = "<group>"; };
+		9ABAF7EAA4A241BA8367C47A /* BehaviorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorLogicTests.swift; sourceTree = "<group>"; };
+		2A5EABE108A8425AA97D31B3 /* BillingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingLogicTests.swift; sourceTree = "<group>"; };
+		3B63CC51235F434EB769FDEB /* BiometricGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricGateTests.swift; sourceTree = "<group>"; };
+		4965C41B0F214A6D86E4B7C0 /* BoardsAdvancedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsAdvancedLogicTests.swift; sourceTree = "<group>"; };
+		13A4218E42AA4F65B693267C /* BoardsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsLogicTests.swift; sourceTree = "<group>"; };
+		2D60A5AB27874900A0FD5525 /* CanvasImportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasImportLogicTests.swift; sourceTree = "<group>"; };
+		C444EF6A33C848D39DA1435C /* CatalogLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogLogicTests.swift; sourceTree = "<group>"; };
+		BB5FF78599A14807B12C1BD8 /* ConferenceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferenceLogicTests.swift; sourceTree = "<group>"; };
+		CB956A60F93C4587A5625D65 /* CourseAccessibilityReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAccessibilityReviewLogicTests.swift; sourceTree = "<group>"; };
+		81BB058D250E49AABEE076F0 /* CourseArchivedContentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseArchivedContentLogicTests.swift; sourceTree = "<group>"; };
+		B3E82EC8C0914BDBA08B66F3 /* CourseBlueprintLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseBlueprintLogicTests.swift; sourceTree = "<group>"; };
+		F1022F9279574366AE68F41B /* CourseCreateLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseCreateLogicTests.swift; sourceTree = "<group>"; };
+		418F98B49DF342B98B12D211 /* CourseFeaturesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFeaturesLogicTests.swift; sourceTree = "<group>"; };
+		2C279F5C871240AFB016A16D /* CourseFileModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileModelsTests.swift; sourceTree = "<group>"; };
+		49C468A9C56F4A3DB68E4C74 /* CourseGradingAgentsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingAgentsLogicTests.swift; sourceTree = "<group>"; };
+		FDB43C658100448CB1D7112D /* CourseGradingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradingLogicTests.swift; sourceTree = "<group>"; };
+		9B3484ACD97D4FAD938D2786 /* CourseImportExportLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseImportExportLogicTests.swift; sourceTree = "<group>"; };
+		0F28C8F488E84B1F9301B9DD /* CourseOutcomesLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseOutcomesLogicTests.swift; sourceTree = "<group>"; };
+		423B19795811473F88990190 /* CoursePeopleLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePeopleLogicTests.swift; sourceTree = "<group>"; };
+		FFD9AF7175F8483AA685642A /* CoursePlagiarismLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePlagiarismLogicTests.swift; sourceTree = "<group>"; };
+		A35969042DB74D4C80609F6E /* CourseReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseReviewLogicTests.swift; sourceTree = "<group>"; };
+		64B6E5F701DD4593807504CA /* CourseSectionsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionsLogicTests.swift; sourceTree = "<group>"; };
+		D77F6F32A9AD4658B757BDCE /* CourseSettingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsLogicTests.swift; sourceTree = "<group>"; };
+		7CF121729CFF497A8601372F /* CourseTranslationsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseTranslationsLogicTests.swift; sourceTree = "<group>"; };
+		4C1CE4EFA0C9449A86F10FB8 /* CredentialsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsLogicTests.swift; sourceTree = "<group>"; };
+		2899FEBD1E794778A9838B0B /* DiscussionLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionLogicTests.swift; sourceTree = "<group>"; };
+		32217947DFAA418A8AA53BE8 /* EvaluationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationLogicTests.swift; sourceTree = "<group>"; };
+		281C5308887B40D98502BD04 /* FeedLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLogicTests.swift; sourceTree = "<group>"; };
+		8B74676C4A864FCDB403C2F6 /* FeedbackLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackLogicTests.swift; sourceTree = "<group>"; };
+		B011D700883A4C529F40ADF9 /* GamificationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GamificationLogicTests.swift; sourceTree = "<group>"; };
+		61E915F121E2453E9C9DC166 /* GradeCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculatorTests.swift; sourceTree = "<group>"; };
+		DCCD0C7EE0AD43FC8CD9466F /* GroupsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsLogicTests.swift; sourceTree = "<group>"; };
+		7E57C4D83B5E46B989095E89 /* I18nTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18nTests.swift; sourceTree = "<group>"; };
+		EC7E5AECE51C4710BBBD0A6F /* InsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsLogicTests.swift; sourceTree = "<group>"; };
+		2705D55089B644FBB61D7361 /* InstructorInsightsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructorInsightsLogicTests.swift; sourceTree = "<group>"; };
+		E236964F7A21442F920436C6 /* IntegrationsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsAdminLogicTests.swift; sourceTree = "<group>"; };
+		52BD8ADF66B443EB991623CF /* InteractiveLaunchLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLaunchLogicTests.swift; sourceTree = "<group>"; };
+		0FA84104BB084D00AD4D18FE /* IntroCourseLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroCourseLogicTests.swift; sourceTree = "<group>"; };
+		E98DD42CB96146EE8615D9D6 /* LearnerProfileLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileLogicTests.swift; sourceTree = "<group>"; };
+		8427BEB6D23449D59B66DFE0 /* LexturesMotionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesMotionTests.swift; sourceTree = "<group>"; };
+		A897A2A9FCCE46A1BDCDC9F9 /* LibraryResourceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryResourceLogicTests.swift; sourceTree = "<group>"; };
+		21F746768C374CA8ACF3248B /* LiveMeetingsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMeetingsLogicTests.swift; sourceTree = "<group>"; };
+		EC1B2FC2F7D8458FB146B015 /* LiveQuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveQuizLogicTests.swift; sourceTree = "<group>"; };
+		5DF46B174E3E4263B24534FA /* MarkdownRenderStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderStyleTests.swift; sourceTree = "<group>"; };
+		854AF3D78B6847E89C04E6A9 /* MarketplaceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceLogicTests.swift; sourceTree = "<group>"; };
+		C60E8779468140FFA8CF464E /* MasteryLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryLogicTests.swift; sourceTree = "<group>"; };
+		8FE38C4AC86E47F9A5F25151 /* MobileDestinationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDestinationsTests.swift; sourceTree = "<group>"; };
+		04636BF487D0472FB8E01182 /* ModuleContentModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleContentModelsTests.swift; sourceTree = "<group>"; };
+		B2780E67E0D841BA89E1090A /* NotebookMarkdownLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdownLogicTests.swift; sourceTree = "<group>"; };
+		E90152F97EB3408FB6F4FB13 /* NotificationModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModelsTests.swift; sourceTree = "<group>"; };
+		7A1F882C9109483EB074B02D /* OfficeHoursLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeHoursLogicTests.swift; sourceTree = "<group>"; };
+		2D5CB4AF6B8A4E28AA2B4F07 /* OnboardingModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModelsTests.swift; sourceTree = "<group>"; };
+		5A19AEF84EE24A5C8BAC4FEE /* OrgBrandingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgBrandingAdminLogicTests.swift; sourceTree = "<group>"; };
+		3E5132581B344AB09F8BBD7F /* OrgStructureAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgStructureAdminLogicTests.swift; sourceTree = "<group>"; };
+		BA4D3FEAFE024D28B778DBB7 /* ParentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentLogicTests.swift; sourceTree = "<group>"; };
+		DBEE6D9F178F48C0A5DB001C /* PathsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsLogicTests.swift; sourceTree = "<group>"; };
+		F6F2EB641A944265A21C4740 /* PeerReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerReviewLogicTests.swift; sourceTree = "<group>"; };
+		8E8EC4B829AB41B494992851 /* PeopleAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminLogicTests.swift; sourceTree = "<group>"; };
+		1EA6C3C79A9D43F8B386B7DA /* PeopleAdminMetricsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleAdminMetricsLogicTests.swift; sourceTree = "<group>"; };
+		4AC921554B784491AE7C4E2B /* PlannerModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerModelsTests.swift; sourceTree = "<group>"; };
+		82BB7C512915458A972CCC94 /* PlatformCoursesAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCoursesAdminLogicTests.swift; sourceTree = "<group>"; };
+		11EFD56443D14E499E544953 /* PlatformSettingsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsAdminLogicTests.swift; sourceTree = "<group>"; };
+		37EB9B0121EB44D98E4F6BCF /* PortfolioLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioLogicTests.swift; sourceTree = "<group>"; };
+		A1780BBBEDBA4E2DA5DFE1A3 /* ProfileDepthLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDepthLogicTests.swift; sourceTree = "<group>"; };
+		EA865D11B13B40FCB4AE5E04 /* QuizLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLogicTests.swift; sourceTree = "<group>"; };
+		313BD35E54704F289EAC7634 /* ReaderLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLogicTests.swift; sourceTree = "<group>"; };
+		27985FD43E004432B9B0179B /* ReadingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingLogicTests.swift; sourceTree = "<group>"; };
+		6E75E8B939F44588B464D97D /* RequirementsLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequirementsLogicTests.swift; sourceTree = "<group>"; };
+		D16CB5D88367423FBB8154EB /* ReviewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLogicTests.swift; sourceTree = "<group>"; };
+		B1A8A29291324150B8F23295 /* RolesPermissionsAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolesPermissionsAdminLogicTests.swift; sourceTree = "<group>"; };
+		5E283BC2A4784BFD804126CE /* SchoolCodeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchoolCodeLogicTests.swift; sourceTree = "<group>"; };
+		094E01AE9B3E4FF597751CD5 /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
+		9B2CA6FD42FF42908E6CD759 /* SettingsAccommodationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccommodationsTests.swift; sourceTree = "<group>"; };
+		A0970B656B1D4C0E867AF200 /* SettingsMenuLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenuLogicTests.swift; sourceTree = "<group>"; };
+		F19847C3754F4543A31DB248 /* TakeAttendanceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeAttendanceLogicTests.swift; sourceTree = "<group>"; };
+		AF9EF064E0A040799E8BF24C /* TranscriptsAdvisingAdminLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsAdvisingAdminLogicTests.swift; sourceTree = "<group>"; };
+		7757B1CEF39247E4846E6D3F /* TutorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorLogicTests.swift; sourceTree = "<group>"; };
+		0F6C5016CE5F482EBA739D42 /* UIModeLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIModeLogicTests.swift; sourceTree = "<group>"; };
+		ABFB97285A334898B4D61F22 /* VibeActivityLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibeActivityLogicTests.swift; sourceTree = "<group>"; };
+		6AF1C9ACB37C4AF8B0B3D88B /* WalletLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLogicTests.swift; sourceTree = "<group>"; };
+		68884487729C49D5A7060152 /* WhiteboardLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardLogicTests.swift; sourceTree = "<group>"; };
+		98AE7CC27C32455DBCB6B543 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5F90D85ED7EC4470B135AD34 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		9C189C6B90714AFB92B2FD7E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		955CC71A4CB748009BB3E55F /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		28DFD09374804ACA94378472 /* Frameworks */ = {
+		48BFD22254054040909715DC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1319,1280 +1327,1284 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		229B30A95B9B4F4894F99558 /* Lextures */ = {
+		C06A93A6950C40EF8B934068 /* Lextures */ = {
 			isa = PBXGroup;
 			children = (
-				A57DBE192A5549CEB700D64B /* Resources */,
-				2E4D604D3217464FB7714146 /* App */,
-				D4FD305EE8564D5CAEE9C2C1 /* Core */,
-				BF3A1AF775F745A09D339A54 /* Features */,
+				92FA15CD5D56473DB724467D /* Resources */,
+				414D123D471F4ECBB3CB565A /* App */,
+				E59066D0AA2C42CC89465B03 /* Core */,
+				881E268EAA5949768034DD56 /* Features */,
 			);
 			path = Lextures;
 			sourceTree = "<group>";
 		};
-		06964482C25142FFB07CE05C /* LexturesTests */ = {
+		5B3849C2686B4E19ABEBDFE4 /* LexturesTests */ = {
 			isa = PBXGroup;
 			children = (
-				373523C32EB949A5B9CAA82A /* AccessibilitySupportTests.swift */,
-				5A13B3495F1F4A4F819B53AF /* AccountIntegrationsLogicTests.swift */,
-				865591C44DA943BAAF006BA8 /* AdvisingLogicTests.swift */,
-				3CCE179E631F4F1587E17C1A /* AiModelsAdminLogicTests.swift */,
-				49FF81B2344C47318DA46DEA /* AnnouncementLogicTests.swift */,
-				6B763FBAF0F348CEA7B7F700 /* AppleSignInLogicTests.swift */,
-				33B046C3491242F78AFC62B5 /* ArchivedCoursesAdminLogicTests.swift */,
-				ACBA7D88E4324BAA8C417F29 /* AssignmentLogicTests.swift */,
-				2D03F861BB2F42CFA59E0822 /* AuditLogAdminLogicTests.swift */,
-				8BBC569F456A4BD3B900F0B4 /* AuthCallbackParserTests.swift */,
-				54F482AACC614C47BB93AC3A /* BehaviorLogicTests.swift */,
-				AFFB9831EC6A4D94810B09A2 /* BillingLogicTests.swift */,
-				A7E50B8DE72E4B06BF467B31 /* BiometricGateTests.swift */,
-				5BFF89736CCA439C94F43B27 /* BoardsAdvancedLogicTests.swift */,
-				39F97E50BCA747C9BD1D9FA2 /* BoardsLogicTests.swift */,
-				38FC3FBB11F247FBA7765A55 /* CanvasImportLogicTests.swift */,
-				805240352A4542E6B904D4AC /* CatalogLogicTests.swift */,
-				E480CDFCB0E5428393B4648B /* ConferenceLogicTests.swift */,
-				F21EB256086B4484BE067D42 /* CourseAccessibilityReviewLogicTests.swift */,
-				550DA196AE6B43B6B903B0FA /* CourseArchivedContentLogicTests.swift */,
-				C86F2841498A4C32AA7093AA /* CourseBlueprintLogicTests.swift */,
-				A9D1F7E879D54243A4DA10E1 /* CourseCreateLogicTests.swift */,
-				47E7A2D79A0A47F1ABD4C3AC /* CourseFeaturesLogicTests.swift */,
-				16533B0965BB4F4DA160F03E /* CourseFileModelsTests.swift */,
-				566A8F4AA7BB49848E5D5552 /* CourseGradingAgentsLogicTests.swift */,
-				CAF4C3297E884354ADDEDFC6 /* CourseGradingLogicTests.swift */,
-				B2A6BF2D82C24B07A02D4F16 /* CourseImportExportLogicTests.swift */,
-				E4FD447ED651463297DB49D6 /* CourseOutcomesLogicTests.swift */,
-				A19A901DA16C44A98BCFC878 /* CoursePeopleLogicTests.swift */,
-				F2E96F164ACF476A90625A44 /* CoursePlagiarismLogicTests.swift */,
-				E7FC803557FA400798E517D6 /* CourseReviewLogicTests.swift */,
-				B15DCDA7BE5F4D968FD8C654 /* CourseSectionsLogicTests.swift */,
-				CEDD54F128A34514B52E92C3 /* CourseSettingsLogicTests.swift */,
-				2A9DE4A71F4B41C1A155FAA9 /* CourseTranslationsLogicTests.swift */,
-				70C40E4D7ACF46108CCE6999 /* CredentialsLogicTests.swift */,
-				E0EF8D14F18747E4B15D7672 /* DiscussionLogicTests.swift */,
-				262B5F96B46D4D66AB310255 /* EvaluationLogicTests.swift */,
-				D43ECD1F3A5847A08AA8D7AE /* FeedLogicTests.swift */,
-				32EDCFA8D4C441EC8D01E20E /* FeedbackLogicTests.swift */,
-				FB4F84C218644FC898D5E1A5 /* GamificationLogicTests.swift */,
-				59A73FC830CB4D27A8DD4B25 /* GradeCalculatorTests.swift */,
-				70912832963940B79AFA8373 /* GroupsLogicTests.swift */,
-				D4DF14D128D64FE3913D78F3 /* I18nTests.swift */,
-				A0686994B5D846CF87F347DF /* InsightsLogicTests.swift */,
-				FBF2B2D6C6B44BC2866C2D93 /* InstructorInsightsLogicTests.swift */,
-				FF38019511514A39A5938F26 /* IntegrationsAdminLogicTests.swift */,
-				2BD8FA95ACA24505AAD62EE7 /* InteractiveLaunchLogicTests.swift */,
-				8F44242ADD2F4D4384FB8217 /* IntroCourseLogicTests.swift */,
-				F74498D27D0A423F9F710088 /* LearnerProfileLogicTests.swift */,
-				0D31802C470C412595FA718E /* LexturesMotionTests.swift */,
-				2BF702B17A3744F4AE9A21DB /* LibraryResourceLogicTests.swift */,
-				14872F45A72248E591C80A5C /* LiveMeetingsLogicTests.swift */,
-				71B152116F1844EA939CD2B0 /* LiveQuizLogicTests.swift */,
-				4BAEFB24E3C34525BC2F040B /* MarketplaceLogicTests.swift */,
-				53E6ECF6C15C455F86415C69 /* MasteryLogicTests.swift */,
-				A9D65C9AD65F4155AC1B2C74 /* MobileDestinationsTests.swift */,
-				D553BFCCA75D4ADDB8E03FDA /* ModuleContentModelsTests.swift */,
-				DE8A5CE055EE4CBB875FFC50 /* NotificationModelsTests.swift */,
-				6453702A8CC84167A99D06FC /* OfficeHoursLogicTests.swift */,
-				5A17E2E10AB14AF1A4BC0A20 /* OnboardingModelsTests.swift */,
-				5E7C6AF633234B11B05AC8B3 /* OrgBrandingAdminLogicTests.swift */,
-				3030AF2E57974257827BCD97 /* OrgStructureAdminLogicTests.swift */,
-				114DE315F90F46428790C499 /* ParentLogicTests.swift */,
-				5B278631504942649E2B10A7 /* PathsLogicTests.swift */,
-				ABE0AAD7BE7F4DE4A0E2E97E /* PeerReviewLogicTests.swift */,
-				E780269A3774488C96081F4D /* PeopleAdminLogicTests.swift */,
-				B1122C950BA74EC3B0F4C4BA /* PeopleAdminMetricsLogicTests.swift */,
-				201E3DED9B6B4C7D9E3CDBA1 /* PlannerModelsTests.swift */,
-				3ADE113A4F7D4363B71AAB5D /* PlatformCoursesAdminLogicTests.swift */,
-				4E20A89C03B34AE681FE9B7C /* PlatformSettingsAdminLogicTests.swift */,
-				F6BFD385E20E4874B208B6E8 /* PortfolioLogicTests.swift */,
-				ED465D36A86D429D8D927E4D /* ProfileDepthLogicTests.swift */,
-				5BF03A123F79457888EEB315 /* QuizLogicTests.swift */,
-				D59CEBA182BF44B2BE3FCADD /* ReaderLogicTests.swift */,
-				B82D214349F34003A916A5BD /* ReadingLogicTests.swift */,
-				583B845B981A489A80BD757D /* RequirementsLogicTests.swift */,
-				164416E4C983431883516796 /* ReviewLogicTests.swift */,
-				C6C08E0BEB834A3EB334C08A /* RolesPermissionsAdminLogicTests.swift */,
-				232FFCED0306441FA66F4EB3 /* SchoolCodeLogicTests.swift */,
-				B291A3D998D4494EB5BF4F69 /* SearchTests.swift */,
-				DBB038F7ADFA40A0958FCA12 /* SettingsAccommodationsTests.swift */,
-				A0C23C8D85854FB8A73C1AE1 /* SettingsMenuLogicTests.swift */,
-				8D33288F5C5A4CC4967D0503 /* TakeAttendanceLogicTests.swift */,
-				1A1410FB35F44CC4B312DD2A /* TranscriptsAdvisingAdminLogicTests.swift */,
-				C4BC8DA818EC4DBEB21CB6A3 /* TutorLogicTests.swift */,
-				77D38DC81AAE47D78174340E /* UIModeLogicTests.swift */,
-				3DECA44A9D514EB9B68544FB /* VibeActivityLogicTests.swift */,
-				04481C8E09DD46DB93EA9D47 /* WalletLogicTests.swift */,
-				6C2F1DCD549844B092CD0466 /* WhiteboardLogicTests.swift */,
+				815F27882B8346A1B4F004B0 /* AccessibilitySupportTests.swift */,
+				211609286B984816ADBA3FDE /* AccountIntegrationsLogicTests.swift */,
+				82954E2C195A4EDB952EB64D /* AdvisingLogicTests.swift */,
+				C73A837B515E4758915D8F04 /* AiModelsAdminLogicTests.swift */,
+				40FB17ABC18C40C69D14A910 /* AnnouncementLogicTests.swift */,
+				C9B23AAB14FB4FA6893C0FD6 /* AppleSignInLogicTests.swift */,
+				A207247ECB734CE5A3D0AB73 /* ArchivedCoursesAdminLogicTests.swift */,
+				9ACC207BF99E4112B1FD91A0 /* AssignmentLogicTests.swift */,
+				D89591167FA446A1BDE86825 /* AuditLogAdminLogicTests.swift */,
+				5456F54003A8489AA404FA8B /* AuthCallbackParserTests.swift */,
+				9ABAF7EAA4A241BA8367C47A /* BehaviorLogicTests.swift */,
+				2A5EABE108A8425AA97D31B3 /* BillingLogicTests.swift */,
+				3B63CC51235F434EB769FDEB /* BiometricGateTests.swift */,
+				4965C41B0F214A6D86E4B7C0 /* BoardsAdvancedLogicTests.swift */,
+				13A4218E42AA4F65B693267C /* BoardsLogicTests.swift */,
+				2D60A5AB27874900A0FD5525 /* CanvasImportLogicTests.swift */,
+				C444EF6A33C848D39DA1435C /* CatalogLogicTests.swift */,
+				BB5FF78599A14807B12C1BD8 /* ConferenceLogicTests.swift */,
+				CB956A60F93C4587A5625D65 /* CourseAccessibilityReviewLogicTests.swift */,
+				81BB058D250E49AABEE076F0 /* CourseArchivedContentLogicTests.swift */,
+				B3E82EC8C0914BDBA08B66F3 /* CourseBlueprintLogicTests.swift */,
+				F1022F9279574366AE68F41B /* CourseCreateLogicTests.swift */,
+				418F98B49DF342B98B12D211 /* CourseFeaturesLogicTests.swift */,
+				2C279F5C871240AFB016A16D /* CourseFileModelsTests.swift */,
+				49C468A9C56F4A3DB68E4C74 /* CourseGradingAgentsLogicTests.swift */,
+				FDB43C658100448CB1D7112D /* CourseGradingLogicTests.swift */,
+				9B3484ACD97D4FAD938D2786 /* CourseImportExportLogicTests.swift */,
+				0F28C8F488E84B1F9301B9DD /* CourseOutcomesLogicTests.swift */,
+				423B19795811473F88990190 /* CoursePeopleLogicTests.swift */,
+				FFD9AF7175F8483AA685642A /* CoursePlagiarismLogicTests.swift */,
+				A35969042DB74D4C80609F6E /* CourseReviewLogicTests.swift */,
+				64B6E5F701DD4593807504CA /* CourseSectionsLogicTests.swift */,
+				D77F6F32A9AD4658B757BDCE /* CourseSettingsLogicTests.swift */,
+				7CF121729CFF497A8601372F /* CourseTranslationsLogicTests.swift */,
+				4C1CE4EFA0C9449A86F10FB8 /* CredentialsLogicTests.swift */,
+				2899FEBD1E794778A9838B0B /* DiscussionLogicTests.swift */,
+				32217947DFAA418A8AA53BE8 /* EvaluationLogicTests.swift */,
+				281C5308887B40D98502BD04 /* FeedLogicTests.swift */,
+				8B74676C4A864FCDB403C2F6 /* FeedbackLogicTests.swift */,
+				B011D700883A4C529F40ADF9 /* GamificationLogicTests.swift */,
+				61E915F121E2453E9C9DC166 /* GradeCalculatorTests.swift */,
+				DCCD0C7EE0AD43FC8CD9466F /* GroupsLogicTests.swift */,
+				7E57C4D83B5E46B989095E89 /* I18nTests.swift */,
+				EC7E5AECE51C4710BBBD0A6F /* InsightsLogicTests.swift */,
+				2705D55089B644FBB61D7361 /* InstructorInsightsLogicTests.swift */,
+				E236964F7A21442F920436C6 /* IntegrationsAdminLogicTests.swift */,
+				52BD8ADF66B443EB991623CF /* InteractiveLaunchLogicTests.swift */,
+				0FA84104BB084D00AD4D18FE /* IntroCourseLogicTests.swift */,
+				E98DD42CB96146EE8615D9D6 /* LearnerProfileLogicTests.swift */,
+				8427BEB6D23449D59B66DFE0 /* LexturesMotionTests.swift */,
+				A897A2A9FCCE46A1BDCDC9F9 /* LibraryResourceLogicTests.swift */,
+				21F746768C374CA8ACF3248B /* LiveMeetingsLogicTests.swift */,
+				EC1B2FC2F7D8458FB146B015 /* LiveQuizLogicTests.swift */,
+				5DF46B174E3E4263B24534FA /* MarkdownRenderStyleTests.swift */,
+				854AF3D78B6847E89C04E6A9 /* MarketplaceLogicTests.swift */,
+				C60E8779468140FFA8CF464E /* MasteryLogicTests.swift */,
+				8FE38C4AC86E47F9A5F25151 /* MobileDestinationsTests.swift */,
+				04636BF487D0472FB8E01182 /* ModuleContentModelsTests.swift */,
+				B2780E67E0D841BA89E1090A /* NotebookMarkdownLogicTests.swift */,
+				E90152F97EB3408FB6F4FB13 /* NotificationModelsTests.swift */,
+				7A1F882C9109483EB074B02D /* OfficeHoursLogicTests.swift */,
+				2D5CB4AF6B8A4E28AA2B4F07 /* OnboardingModelsTests.swift */,
+				5A19AEF84EE24A5C8BAC4FEE /* OrgBrandingAdminLogicTests.swift */,
+				3E5132581B344AB09F8BBD7F /* OrgStructureAdminLogicTests.swift */,
+				BA4D3FEAFE024D28B778DBB7 /* ParentLogicTests.swift */,
+				DBEE6D9F178F48C0A5DB001C /* PathsLogicTests.swift */,
+				F6F2EB641A944265A21C4740 /* PeerReviewLogicTests.swift */,
+				8E8EC4B829AB41B494992851 /* PeopleAdminLogicTests.swift */,
+				1EA6C3C79A9D43F8B386B7DA /* PeopleAdminMetricsLogicTests.swift */,
+				4AC921554B784491AE7C4E2B /* PlannerModelsTests.swift */,
+				82BB7C512915458A972CCC94 /* PlatformCoursesAdminLogicTests.swift */,
+				11EFD56443D14E499E544953 /* PlatformSettingsAdminLogicTests.swift */,
+				37EB9B0121EB44D98E4F6BCF /* PortfolioLogicTests.swift */,
+				A1780BBBEDBA4E2DA5DFE1A3 /* ProfileDepthLogicTests.swift */,
+				EA865D11B13B40FCB4AE5E04 /* QuizLogicTests.swift */,
+				313BD35E54704F289EAC7634 /* ReaderLogicTests.swift */,
+				27985FD43E004432B9B0179B /* ReadingLogicTests.swift */,
+				6E75E8B939F44588B464D97D /* RequirementsLogicTests.swift */,
+				D16CB5D88367423FBB8154EB /* ReviewLogicTests.swift */,
+				B1A8A29291324150B8F23295 /* RolesPermissionsAdminLogicTests.swift */,
+				5E283BC2A4784BFD804126CE /* SchoolCodeLogicTests.swift */,
+				094E01AE9B3E4FF597751CD5 /* SearchTests.swift */,
+				9B2CA6FD42FF42908E6CD759 /* SettingsAccommodationsTests.swift */,
+				A0970B656B1D4C0E867AF200 /* SettingsMenuLogicTests.swift */,
+				F19847C3754F4543A31DB248 /* TakeAttendanceLogicTests.swift */,
+				AF9EF064E0A040799E8BF24C /* TranscriptsAdvisingAdminLogicTests.swift */,
+				7757B1CEF39247E4846E6D3F /* TutorLogicTests.swift */,
+				0F6C5016CE5F482EBA739D42 /* UIModeLogicTests.swift */,
+				ABFB97285A334898B4D61F22 /* VibeActivityLogicTests.swift */,
+				6AF1C9ACB37C4AF8B0B3D88B /* WalletLogicTests.swift */,
+				68884487729C49D5A7060152 /* WhiteboardLogicTests.swift */,
 			);
 			path = LexturesTests;
 			sourceTree = "<group>";
 		};
-		2E4D604D3217464FB7714146 /* App */ = {
+		414D123D471F4ECBB3CB565A /* App */ = {
 			isa = PBXGroup;
 			children = (
-				BCC21ED0D16140FA8E128181 /* AppDelegate.swift */,
-				2DB3CC07877B4410A1AA5030 /* LexturesApp.swift */,
-				46F09135218740BEA6B986E5 /* RootView.swift */,
+				48DEFBE299634A468607326D /* AppDelegate.swift */,
+				C67025CF88B846CAACE2DA27 /* LexturesApp.swift */,
+				8BB9F41D2A524DEF9846DACA /* RootView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
 		};
-		D4FD305EE8564D5CAEE9C2C1 /* Core */ = {
+		E59066D0AA2C42CC89465B03 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				65338EDF21EF493B9961ADDB /* Accessibility */,
-				962FE4F908C44BC480944DA2 /* Auth */,
-				A907BA58CCFA4E83B2A1DA2C /* Config */,
-				2898A9809A6147F692C2BA59 /* Design */,
-				5D12CF01069C4AB28CBEBDC3 /* I18n */,
-				27231CB0D753412EB241184B /* LMS */,
-				C26454A1C21349CC82CD4A81 /* Networking */,
-				48A959D7B391440691EDC3E9 /* Notebook */,
-				FA86CD845606477697C280BC /* Offline */,
-				405ADFE6368846B5BD802C2D /* Push */,
-				84B0AE89B9E7411E8C7B1161 /* Realtime */,
-				C089B853FDAD4D3BA43BBE1C /* Routing */,
-				2A57ECDF8FAB4563A60CDDE3 /* Search */,
-				54403642A92F4A7B9CC784F4 /* UI */,
+				A14C19A2092C4503A7095580 /* Accessibility */,
+				40C9794E9A5840B58831B423 /* Auth */,
+				685FDBCE9EC44230A8A6A89F /* Config */,
+				4303DF9515E94C39AD5D08AC /* Design */,
+				B6D45C51CA064256A5775CBA /* I18n */,
+				DE1A353BBF964BBDBDF52015 /* LMS */,
+				30F812E806AB477189155317 /* Networking */,
+				BB513A6FFC294AA8A97E7E8F /* Notebook */,
+				5E1A20D62DD54107ACFB15B0 /* Offline */,
+				C16EF71170A64066ADD3BAB5 /* Push */,
+				BADF2DB51E1849F49ADEA51D /* Realtime */,
+				68431E38C86B48A289606969 /* Routing */,
+				100C2BFF784744A59255DE85 /* Search */,
+				91369E9EBCF142CDB0D0A73D /* UI */,
 			);
 			path = Core;
 			sourceTree = "<group>";
 		};
-		BF3A1AF775F745A09D339A54 /* Features */ = {
+		881E268EAA5949768034DD56 /* Features */ = {
 			isa = PBXGroup;
 			children = (
-				8F4FC60E7F9A491B822BEC85 /* Advising */,
-				701D7DF457B14945AF961FB7 /* Assignments */,
-				868E51DFC861421388C8F051 /* Auth */,
-				18F7C9AD9EF54301BC952A4B /* Behavior */,
-				CE2A192438064ADD8CD29594 /* Billing */,
-				87A0EC2E02864041B872FD28 /* Boards */,
-				59658F1ED52246CC8C1222BD /* Catalog */,
-				4AC0D2069A314057A02EFF94 /* Courses */,
-				279E9605180441408A086781 /* Credentials */,
-				660ECF58D7484A1E96CA4C6E /* Dashboard */,
-				0E2973A16C4745AC84DAE787 /* Discussions */,
-				E17E34FD698E4FB1AC724740 /* Evaluations */,
-				043D3E3832C94B41B1F5C614 /* Feed */,
-				E264AE8CB1604CFAA6B13031 /* Feedback */,
-				2D431D38870B44D8905DFF75 /* Files */,
-				D3D59D8988BF410DB2E957D2 /* Gamification */,
-				F6916FBEC6744373B5442108 /* Grades */,
-				A5E76690DDB947A4A80A942B /* Grading */,
-				7878921E3EE94F9085FFAD2D /* Groups */,
-				118A2CF722A84D8FBD93B030 /* Home */,
-				87B67464B37C42ABAD2BF16C /* Inbox */,
-				0F9E926F79CF4392AB2FE1A0 /* Insights */,
-				CD2AB0C3B8EA4EC190369661 /* InstructorInsights */,
-				D3D7D044D9F3465088659F6D /* IntroCourse */,
-				8756C2EE1A6F4AD2BB2A5D32 /* LearnerProfile */,
-				3602C182B393418AB4BB41A4 /* Library */,
-				B65CCA6818A6488C8DC3AD71 /* Live */,
-				7635445760EC40668163A347 /* LiveQuiz */,
-				FEB514283FBA4FA19EA3050A /* Marketplace */,
-				3EE8B30769534A8280558EF0 /* Mastery */,
-				275746F45C544CD59C5755D0 /* Navigation */,
-				8230BF9ACD524647BD94450E /* Notebooks */,
-				95160559E82849F4B6C38B1C /* OfficeHours */,
-				F9DF03E42271490AA7DAA449 /* Onboarding */,
-				511CF8B4AC24421299F8C3DD /* Parent */,
-				7A434A96FCB542F6955BAC95 /* Paths */,
-				391A0103663844CF9D4CE213 /* PeerReview */,
-				AEB080EC28654582A5F5C698 /* Planner */,
-				E2079ED3F1014028BE86AA6B /* Portfolio */,
-				D36507EDCE7F4C758048399C /* Profile */,
-				AC8ADF7A4E63412184F152A6 /* Quiz */,
-				237D6A2B598547BD86AFBCDE /* Reader */,
-				90F66E03E1134348965E60B3 /* Reading */,
-				46868CAEEAB6446F8ABEC2B2 /* Review */,
-				E1A4436428CA4458B73960A1 /* Search */,
-				210F88C32584464BBEE31669 /* Settings */,
-				CA7B2E95CAF54885B79E2BC5 /* Splash */,
-				79EEC603F04B48FBAB3B099C /* Tutor */,
-				7E4FC5D1155B4BB3942A3651 /* Wallet */,
+				15596A5A92C44A73AD1A6B49 /* Advising */,
+				C3E99E91BC994C56A5491135 /* Assignments */,
+				514E02BAD6294A59A66F7573 /* Auth */,
+				B46AE60AA6C845489E33B4D5 /* Behavior */,
+				01786B3F1A9D480E9C0EC9DF /* Billing */,
+				0F5BA1B6D3A542C0AA7861B4 /* Boards */,
+				55D3C151225E40E6B8C11757 /* Catalog */,
+				D8497D0D12BE4EBBA1E53F77 /* Courses */,
+				1D416F2C38CD4C7EB3986DBC /* Credentials */,
+				CCE2BB06D209462584980621 /* Dashboard */,
+				C653EC9D223B44EA89D5B0B0 /* Discussions */,
+				F8D1B3903D1C4613A79C756D /* Evaluations */,
+				7EF785BE2CC84744A7334A12 /* Feed */,
+				F6B9971DAFEC4BAC9AC78E8E /* Feedback */,
+				CDA79730504F48B3ADE02EBC /* Files */,
+				B51B0D28F57C47BBA1738B9F /* Gamification */,
+				D8D4CB63884042DB974963B8 /* Grades */,
+				FF34629FBA434D63B64F925C /* Grading */,
+				4E295F3FBEC5407DA2BDAA6D /* Groups */,
+				1735A207FF734B3CA427042B /* Home */,
+				A7B96E9FF0CF4BAAAB0E67C7 /* Inbox */,
+				F2EF095884CB4B2D9993EC1F /* Insights */,
+				8F58E68B759E425EB72928F0 /* InstructorInsights */,
+				174E1B7B49784788A12E5402 /* IntroCourse */,
+				EE2EF3C362FC408691F00493 /* LearnerProfile */,
+				93E66225C2D64D1FBD951E96 /* Library */,
+				7B8B5C470D684C21B964D06C /* Live */,
+				4B1B1E0F8A994C5E9FB32906 /* LiveQuiz */,
+				AEFB0829690E43488621DE89 /* Marketplace */,
+				0A4EB97A67444CB6AD68172A /* Mastery */,
+				41FF3449C72C4DB8B57C1982 /* Navigation */,
+				0178B15190F244A99E715289 /* Notebooks */,
+				5054832DD2754A4D84CCD240 /* OfficeHours */,
+				CCDF6347A1F1433880A3CF83 /* Onboarding */,
+				1F8BA251A6274429AC06B135 /* Parent */,
+				F94B0016A96148FF985FF083 /* Paths */,
+				812CB5379F604D678B6B49CA /* PeerReview */,
+				89A250F12D784716A409C6CF /* Planner */,
+				7456519654BA4EA2A3DEDECE /* Portfolio */,
+				70A339DCD0ED4E7092F86F53 /* Profile */,
+				4DE366E438714EE488DA3FAC /* Quiz */,
+				4D20B78B3E1546898EA3270B /* Reader */,
+				C426D25894744A6F9FF5F2E5 /* Reading */,
+				0FD2976742C7481B9B490B59 /* Review */,
+				BEC2A502BBB243AB9B6E3F6F /* Search */,
+				DF581E0BCA944946B6E71BCC /* Settings */,
+				95FC6B63134146A39E71A5C1 /* Splash */,
+				57E136DF174C41DA875139CA /* Tutor */,
+				85E299B0490C4FFEAE87D07E /* Wallet */,
 			);
 			path = Features;
 			sourceTree = "<group>";
 		};
-		A57DBE192A5549CEB700D64B /* Resources */ = {
+		92FA15CD5D56473DB724467D /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				F1D492B110A3479A86B62F45 /* Assets.xcassets */,
-				6678AEC9159340A695FD20AD /* Localizable.xcstrings */,
-				D332EEC5808342AEBD540892 /* Info.plist */,
+				98AE7CC27C32455DBCB6B543 /* Assets.xcassets */,
+				5F90D85ED7EC4470B135AD34 /* Localizable.xcstrings */,
+				9C189C6B90714AFB92B2FD7E /* Info.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		65338EDF21EF493B9961ADDB /* Accessibility */ = {
+		A14C19A2092C4503A7095580 /* Accessibility */ = {
 			isa = PBXGroup;
 			children = (
-				2391332DEEEF49AB92138DD9 /* AccessibilityPreferences.swift */,
-				D877139FEBC4481391B5DD95 /* AccessibilitySupport.swift */,
-				7F9F43CFA29B464B8321DE60 /* DictationField.swift */,
-				0C08405046034F249A8E4203 /* ReadAloud.swift */,
+				42BA05FDEBB64BAF93BE2F13 /* AccessibilityPreferences.swift */,
+				BF91E36EF4544195BBD02326 /* AccessibilitySupport.swift */,
+				0069CCE81BA14890AC1EAC3B /* DictationField.swift */,
+				27A3F5F78EAD4A4DA36C2B0C /* ReadAloud.swift */,
 			);
 			path = Accessibility;
 			sourceTree = "<group>";
 		};
-		962FE4F908C44BC480944DA2 /* Auth */ = {
+		40C9794E9A5840B58831B423 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				236584CA08EB4D21A75CB359 /* AuthAPI.swift */,
-				42A6C2CF29B94FD8ACF73AA1 /* AuthCallbackParser.swift */,
-				7CB15491376F47848D44B281 /* AuthConstants.swift */,
-				2B7BD34CEB384CB3B4A718A6 /* AuthSession.swift */,
-				7552797A53BB4FCE9FE53E6D /* BiometricGate.swift */,
-				0E8C1ED70666464594D7B357 /* KeychainStore.swift */,
-				EC0B98E8DFAD4FD4870B4B32 /* SessionsAPI.swift */,
+				754D0E92FDE34E7E8AB24CB5 /* AuthAPI.swift */,
+				13A1B1EBE2104C3BA7F2ABDC /* AuthCallbackParser.swift */,
+				3E568CA21DD5463582E682BF /* AuthConstants.swift */,
+				AE836A40074D413B863331C4 /* AuthSession.swift */,
+				C88441ABD3AF4EA18B9D7919 /* BiometricGate.swift */,
+				7E844AA4E55E44D0A44667CE /* KeychainStore.swift */,
+				C0EB9537C0C44179B8F67001 /* SessionsAPI.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
 		};
-		A907BA58CCFA4E83B2A1DA2C /* Config */ = {
+		685FDBCE9EC44230A8A6A89F /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				DCECD071C74C40B592761510 /* AppConfiguration.swift */,
-				706824795CA64D6CA900F6FD /* EnvironmentStore.swift */,
-				A72B5AE8D40842608ED2A93B /* SchoolCodeLogic.swift */,
+				5814B80506574CC7A0273C68 /* AppConfiguration.swift */,
+				185C4FF6313D4A0A87BAF184 /* EnvironmentStore.swift */,
+				50E3EE98E2A744009E08B8C6 /* SchoolCodeLogic.swift */,
 			);
 			path = Config;
 			sourceTree = "<group>";
 		};
-		2898A9809A6147F692C2BA59 /* Design */ = {
+		4303DF9515E94C39AD5D08AC /* Design */ = {
 			isa = PBXGroup;
 			children = (
-				3D9E89A08F9048A498A3C2C9 /* AuthFieldRepresentable.swift */,
-				1E602BC87C274EB8BF6D2F82 /* BrandLogoView.swift */,
-				94A4411A8DB948DBBC52AB07 /* Haptics.swift */,
-				217B50509F7E4605A3AEA934 /* LexturesMotion.swift */,
-				8C13D65F0331422587A7251A /* LexturesTheme.swift */,
-				39991ABDC8984C10936F533E /* LexturesType.swift */,
-				788BE3FA0266441F8EE51DDA /* ProfileAvatarView.swift */,
-				118A196BFF72440985648417 /* SyncStatusView.swift */,
-				C3F9FFA509F042BA997FB0AD /* ThemePreference.swift */,
-				1A831877A709428DACAE01AA /* UIMode.swift */,
-				31131F38DD8C4F71AB103C65 /* UnsavedChangesBanner.swift */,
+				E1391CC0E37F48CCB9C631A4 /* AuthFieldRepresentable.swift */,
+				1F9230D0D6774D73B2D53DEF /* BrandLogoView.swift */,
+				F148F9731962426CA4DF6261 /* Haptics.swift */,
+				59E31C9A4AEC4493B8884AEC /* LexturesMotion.swift */,
+				F1F01FCEF2ED44219E53DD2B /* LexturesTheme.swift */,
+				A0427B681B0B450F9B6F3CD0 /* LexturesType.swift */,
+				B7BEFC9869AF45FBB5984148 /* ProfileAvatarView.swift */,
+				8B58E98D00DD4DC7936D761A /* SyncStatusView.swift */,
+				3AB4278C38914F3BA5A8C451 /* ThemePreference.swift */,
+				D40A0E47E5164CF1B895B900 /* UIMode.swift */,
+				58E74364021942FA9B9032BF /* UnsavedChangesBanner.swift */,
 			);
 			path = Design;
 			sourceTree = "<group>";
 		};
-		5D12CF01069C4AB28CBEBDC3 /* I18n */ = {
+		B6D45C51CA064256A5775CBA /* I18n */ = {
 			isa = PBXGroup;
 			children = (
-				122671E8CAD442C99A656D34 /* DateFormatting.swift */,
-				820F8FD64D9F4831BF993A8D /* LocaleAPI.swift */,
-				33CA37F7628145F8A5485536 /* LocalePreferences.swift */,
-				BEABF3ECB7BD4EE28923328C /* Localized.swift */,
+				24E645CC9EAC4B068156F427 /* DateFormatting.swift */,
+				9E08FB6345A44C42B2D45068 /* LocaleAPI.swift */,
+				6B1643642F69411C88E9EAAA /* LocalePreferences.swift */,
+				D00A1733168246CB972CC87A /* Localized.swift */,
 			);
 			path = I18n;
 			sourceTree = "<group>";
 		};
-		27231CB0D753412EB241184B /* LMS */ = {
+		DE1A353BBF964BBDBDF52015 /* LMS */ = {
 			isa = PBXGroup;
 			children = (
-				876822D3381A4D0EB3AD2B13 /* AccountAccommodationModels.swift */,
-				46DC0271021341C49AEE4143 /* AccountIntegrationsLogic.swift */,
-				D12E4F4CDA774754BBF2B46E /* AdvisingLogic.swift */,
-				0C94283167EE41B58D02C513 /* AiModelsAdminLogic.swift */,
-				E26AB3D0F63B4B1484296E98 /* AnnouncementLogic.swift */,
-				D9200E6719844BDFA2739BCD /* ArchivedCoursesAdminLogic.swift */,
-				F413FF3F2B574D8BA4A8641A /* AssignmentLogic.swift */,
-				6DA16EC96F3B47B7BB83472D /* AuditLogAdminLogic.swift */,
-				A8218A5DA074493A9E0C1A59 /* BehaviorLogic.swift */,
-				9FE3BC019E0A410DA462E0C9 /* BillingLogic.swift */,
-				9483963ED37B434EAC4A7F8C /* BoardRealtimeLogic.swift */,
-				F1216ABCEF6C4A5092B7575B /* BoardsAdvancedLogic.swift */,
-				425CCC3EE56D42899515B90B /* BoardsGovernanceAdminLogic.swift */,
-				654A68FBFF004593A6234FEA /* BoardsLogic.swift */,
-				1AAD098C5D86467195AAEFB2 /* CanvasImportLogic.swift */,
-				9E2BC38FEABA48CFBA00F250 /* CanvasImportObservability.swift */,
-				DA1B4CAE70324A789B0B2A32 /* CatalogLogic.swift */,
-				902B8828157D4900A862C29C /* ConferenceLogic.swift */,
-				30416340D9054E0B99CD6FC9 /* CourseAccessibilityReviewLogic.swift */,
-				94EF43760CF14277B04B2E26 /* CourseArchivedContentLogic.swift */,
-				20F96BF5345940B29F034AE7 /* CourseBlueprintLogic.swift */,
-				82679475DB4F44808D9B2A80 /* CourseCreateDraftStore.swift */,
-				010D8A6487C848EA8815BE13 /* CourseCreateLogic.swift */,
-				CA41BD3596684A6B9A402E7E /* CourseCreateObservability.swift */,
-				FECCB1A1680B415D932DA179 /* CourseFeaturesLogic.swift */,
-				90F1D7AAFF3346ECAB215A9A /* CourseFileLogic.swift */,
-				CA328ED019264948840DC527 /* CourseGradingAgentsLogic.swift */,
-				D8D4CE8302454BA09CB5BC24 /* CourseGradingLogic.swift */,
-				75E508006F4842A58668DB57 /* CourseHeroImage.swift */,
-				CC62A6B2B27441E5B7915806 /* CourseImportExportLogic.swift */,
-				0C8EA99BDF0A4AF6ACD0C05B /* CourseOutcomesLogic.swift */,
-				1B286388C9EC40C887371ED5 /* CoursePeopleLogic.swift */,
-				89062806BF744D468AA7DFD1 /* CoursePeopleObservability.swift */,
-				F8877458D0E44F6DB649AF12 /* CoursePlagiarismLogic.swift */,
-				35E7C1D0E02D41ADBF4D5464 /* CourseReviewLogic.swift */,
-				CBA37BA46DFF4A6392FE691F /* CourseSectionsLogic.swift */,
-				4323122721FF43A98CBA77DD /* CourseSettingsLogic.swift */,
-				D39DD7B13CC04A99B5EEF892 /* CourseTranslationsLogic.swift */,
-				EA3388A3D4894C97907F21A6 /* CredentialsLogic.swift */,
-				19865D60BF49490CA83E3FC8 /* CurrencyExponent.swift */,
-				821E07F7B3BD4516933FD25F /* DiscussionLogic.swift */,
-				5A5F20597F4246188C41BC16 /* EvaluationLogic.swift */,
-				802E14FA9C1E486E8320D4C9 /* FeedbackLogic.swift */,
-				7DB1D45B7CFF4C63AE669D1A /* FileDownloadManager.swift */,
-				D88B6AF6F97C420CA3528020 /* GamificationLogic.swift */,
-				7E4EAB0E8322489395633B7F /* GradeCalculator+MyGrades.swift */,
-				9A3A0A78C0E24855A2FC15B9 /* GradeCalculator.swift */,
-				2F3D19836EB74186A1414C77 /* GroupsLogic.swift */,
-				E21D78D26D264655AB76C425 /* InsightsLogic.swift */,
-				36A150CD947F4E56BFF48EAD /* InstructorInsightsLogic.swift */,
-				C016EA4D3A0B472CB5D1125D /* IntegrationsAdminLogic.swift */,
-				92A43C87E3984E9097D25841 /* InteractiveLaunchLogic.swift */,
-				919E594A7B8D4B6F98B0B1F7 /* IntroCourseLogic.swift */,
-				6542DA2E77D24963B76CF7C2 /* IntroCourseObservability.swift */,
-				966CD203A95F4B3B819D5965 /* LMSAPI.swift */,
-				60CDA1E5F1194D00ACE24EB7 /* LMSAPIAccountIntegrations.swift */,
-				97217C9DC56846FA9D63293B /* LMSAPIAdmin.swift */,
-				E56A544993F04A8CBB03CEDD /* LMSAPIAdvising.swift */,
-				A150DCF9F7224315B7B30C60 /* LMSAPIAnnouncements.swift */,
-				7F9127F532CB4C378571046A /* LMSAPIAuditLog.swift */,
-				D5B851C9FA0E4125AC76F48A /* LMSAPIBehavior.swift */,
-				46A904A5B0DB4B3098645E2A /* LMSAPIBilling.swift */,
-				994BBFFE141A485DA43BC060 /* LMSAPIBoardAccess.swift */,
-				C71BA7EC2E36488D9549FC98 /* LMSAPIBoardAnalytics.swift */,
-				801E18789F664D0DA7B9F036 /* LMSAPIBoardEngagement.swift */,
-				9A55EC392CA1443EB6FD698D /* LMSAPIBoardExport.swift */,
-				EF09D800BBA244ADB1F89793 /* LMSAPIBoardLayout.swift */,
-				C464E7B7706B46A6A1EC6B2F /* LMSAPIBoardModeration.swift */,
-				86242101E8CC4D4D9DB48D1E /* LMSAPIBoardPosts.swift */,
-				E02AE223E87C46CA849E4F4A /* LMSAPIBoardTemplates.swift */,
-				7E9B571E7F1E4C1D8B0B8EB3 /* LMSAPIBoards.swift */,
-				D8955E4A2CB0471DB37AB7E1 /* LMSAPICanvasImport.swift */,
-				A728634557104CC48E4FA9FA /* LMSAPICatalog.swift */,
-				E3060A84315140D48D885600 /* LMSAPICourseAccessibility.swift */,
-				5AB86D9F3B774232B8B64374 /* LMSAPICourseArchivedContent.swift */,
-				7A7649122040475593E51536 /* LMSAPICourseBlueprint.swift */,
-				F838E38FD3314A86A61313B3 /* LMSAPICourseCreate.swift */,
-				02159D88D4604E099DC45F01 /* LMSAPICourseFeatures.swift */,
-				1C84ED01FAFE4F6A866A68EF /* LMSAPICourseGrading.swift */,
-				E38FAB25C7DD43B284D8EFCD /* LMSAPICourseGradingAgents.swift */,
-				8AD72034B7394CDDB3C71596 /* LMSAPICourseImportExport.swift */,
-				E4B5DBDBE0EA4FD6811B8A9C /* LMSAPICoursePlagiarism.swift */,
-				9C5ECA1E769A42E8AB9D07AC /* LMSAPICourseReviews.swift */,
-				668A5BEF50304DEEB227C929 /* LMSAPICourseSections.swift */,
-				7BF1717F955345CEB67D4387 /* LMSAPICourseSettings.swift */,
-				99E5D70AB65A4BD0842B8517 /* LMSAPICourseTranslations.swift */,
-				4A29CB1E340146B2AB9FC2E4 /* LMSAPICredentials.swift */,
-				068520BD32F0465EBD006759 /* LMSAPIDiscussions.swift */,
-				3131373FEB59466C8AB0AC7C /* LMSAPIEportfolio.swift */,
-				306DA47EB9F146349ADE21A8 /* LMSAPIEvaluations.swift */,
-				9A5CE9C20A164A57A2912047 /* LMSAPIFeatures.swift */,
-				5E2D7AF6A7E74E419C4E3E6D /* LMSAPIFeed.swift */,
-				99D110AD56244378A93E0E15 /* LMSAPIFeedback.swift */,
-				894E2AD904124DDDB1BD3CBF /* LMSAPIGamification.swift */,
-				0AF12B79BA4A4F999CA668DF /* LMSAPIGroups.swift */,
-				9BAA3D5D9FD24A8B9B2EFDDF /* LMSAPIInsights.swift */,
-				80BDAE0779984913A3A462B8 /* LMSAPIInstructorInsights.swift */,
-				35A92F7A21E3452886DEB48E /* LMSAPIIntroCourse.swift */,
-				9E4A56A3B3B84A10991DAF47 /* LMSAPILearnerProfile.swift */,
-				2CDD6A07DA3446248362F3D7 /* LMSAPILiveQuiz.swift */,
-				4288167DEBBD4889AE882767 /* LMSAPIMarketplace.swift */,
-				08FE81C12C6F499187483CE8 /* LMSAPIMastery.swift */,
-				AAD07E78BFB04381B3637B0E /* LMSAPIMobileWave.swift */,
-				C746D09F7AED46FC9EFF8F3A /* LMSAPIOutcomes.swift */,
-				813EBA9635704CB7AA3ED889 /* LMSAPIParent.swift */,
-				9675FBC57BC64C3F9111FD59 /* LMSAPIPaths.swift */,
-				33223C7241234E22923DE250 /* LMSAPIPeerReview.swift */,
-				64F5E609206F4CC4A2CF95E1 /* LMSAPIProctoring.swift */,
-				48FE06D846ED40A58DCE2230 /* LMSAPIQuizCodeRun.swift */,
-				DF8906D74CFF4701B255EAF4 /* LMSAPIReader.swift */,
-				10A0B299B0D94ADC97F88528 /* LMSAPIReading.swift */,
-				60B8FDE10B9B4CEC8A5C6F5E /* LMSAPIReview.swift */,
-				86ED0FB8585D46868F83CB1F /* LMSAPITutor.swift */,
-				207E7D9985164CD29E02D922 /* LMSAPIWallet.swift */,
-				C6D9DD802E174B83AE982827 /* LMSAPIWhiteboard.swift */,
-				F7F968115560419084BFD1DA /* LMSBoardAdvancedModels.swift */,
-				904B49C91AD649B8ACE9FF53 /* LMSBoardModels.swift */,
-				2F30BB03583A40CBACF8BAC7 /* LMSFeatureModels.swift */,
-				5D5AFDFFD4954154AA08B6F0 /* LMSFeatureModelsAccountIntegrations.swift */,
-				D80B84481BE743C8815CE2A1 /* LMSFeatureModelsAdvising.swift */,
-				3EEC8D940813443B82EF99FB /* LMSFeatureModelsAiAdmin.swift */,
-				B1A3ACCAF55B4CB3BC634A50 /* LMSFeatureModelsArchivedCoursesAdmin.swift */,
-				DE63E84856084D178F811FA9 /* LMSFeatureModelsAuditLog.swift */,
-				A9C177FF51E7499F98FEB135 /* LMSFeatureModelsBehavior.swift */,
-				1C8F213D1EFE4B02BE3EA0DC /* LMSFeatureModelsBilling.swift */,
-				189CE9ECC48A43A2934C6332 /* LMSFeatureModelsCanvasImport.swift */,
-				E60FFEEF85CA49868E48854D /* LMSFeatureModelsCatalog.swift */,
-				5D140A0009994251829A8550 /* LMSFeatureModelsCourseAccessibility.swift */,
-				DD8FE4612AF54B47AFEA77FC /* LMSFeatureModelsCourseCreate.swift */,
-				024FE8FC67C4411EA992E641 /* LMSFeatureModelsCourseGrading.swift */,
-				D2290E19122C4493AE1EBD28 /* LMSFeatureModelsCourseGradingAgents.swift */,
-				55830F753A0046C981B6A5A6 /* LMSFeatureModelsCourseOutcomes.swift */,
-				293E953D73FB46039E06FEA4 /* LMSFeatureModelsCoursePlagiarism.swift */,
-				7CB7B6D7573A436D9EE6C0BD /* LMSFeatureModelsCourseReviews.swift */,
-				32C78CFD171E4C50B5AC21BB /* LMSFeatureModelsCourseSettings.swift */,
-				A6602EEA446149C0BF76FD4F /* LMSFeatureModelsCourseTranslations.swift */,
-				215E096BEF9B47F68FB552A7 /* LMSFeatureModelsCredentials.swift */,
-				448F3041DA3349A4B85A5849 /* LMSFeatureModelsDiscussions.swift */,
-				8F09DF8AF0BD45B195F3B93C /* LMSFeatureModelsEportfolio.swift */,
-				C1655E9A8D3C4BF089B81C17 /* LMSFeatureModelsEvaluations.swift */,
-				4B7D2B5DFB6D4597B12EC5CC /* LMSFeatureModelsFeed.swift */,
-				750096FF04F847F08FA588EE /* LMSFeatureModelsFeedback.swift */,
-				888D7AF98DAE4275B6026F44 /* LMSFeatureModelsGamification.swift */,
-				08DB93BEB74C4BDBA17AC808 /* LMSFeatureModelsGroups.swift */,
-				C0BD6CA3F08E413693067FCE /* LMSFeatureModelsInsights.swift */,
-				03308D4ECF2B43DB882A33FF /* LMSFeatureModelsInstructorInsights.swift */,
-				023909062EED4A2B9B375E4A /* LMSFeatureModelsIntegrationsAdmin.swift */,
-				CE321A529D7B4A4DA1F2EDB3 /* LMSFeatureModelsIntroCourse.swift */,
-				734204250DE94773B2699164 /* LMSFeatureModelsLearnerProfile.swift */,
-				98B548F6309447C3A3FBFF17 /* LMSFeatureModelsLive.swift */,
-				0CD04098A231494CA3F09F78 /* LMSFeatureModelsMarketplace.swift */,
-				39DDFFC0D69A491D9DA742FA /* LMSFeatureModelsMastery.swift */,
-				5CAE21F884C8447AA61BF858 /* LMSFeatureModelsMobile.swift */,
-				B1E0AB224456451DBA4E7994 /* LMSFeatureModelsOrgBrandingAdmin.swift */,
-				2C43119FFBC54D04B7C27FD9 /* LMSFeatureModelsOrgStructureAdmin.swift */,
-				550DB0C297164ED9880A4FD7 /* LMSFeatureModelsParent.swift */,
-				F4790175587647C88099ADD4 /* LMSFeatureModelsPaths.swift */,
-				0F3143CD283049999A70EE00 /* LMSFeatureModelsPeerReview.swift */,
-				72B0D6B8EA2C4B84993EA288 /* LMSFeatureModelsPeopleAdmin.swift */,
-				21CCABD2171944B38CFFE643 /* LMSFeatureModelsPlatform.swift */,
-				B9DD0143BF514EB898AEEFAD /* LMSFeatureModelsPlatformCoursesAdmin.swift */,
-				37F009617AFF417CABF397AE /* LMSFeatureModelsPlatformSettingsAdmin.swift */,
-				4643CE61530B4FD8971104A2 /* LMSFeatureModelsReader.swift */,
-				96F39CB0482F4A64913BB349 /* LMSFeatureModelsReading.swift */,
-				E609EA910A5A463B99D7C222 /* LMSFeatureModelsRolesPermissionsAdmin.swift */,
-				3A9F3F51E5A245A1A459EF71 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */,
-				8E589186B3024558AE276C41 /* LMSFeatureModelsTutor.swift */,
-				DB025E305E73486AB634D170 /* LMSFeatureModelsWallet.swift */,
-				3B3AEDE2A3A24B1FB83AD8CD /* LMSInteractiveModels.swift */,
-				7C17447C206F491F86B62429 /* LMSModels.swift */,
-				FE2DA8F783004A75B61C861E /* LearnerProfileLogic.swift */,
-				B520F7E9737D4C78B5511ADA /* LibraryResourceLogic.swift */,
-				C37D57FE7FD94B599A7462C4 /* LiveGameLogic.swift */,
-				1968A81A18024476BACDA0C8 /* LiveMeetingsLogic.swift */,
-				6C2A21241F6A48D79A316B25 /* LiveQuizLogic.swift */,
-				48B6B3C5A0A44CF0BE0695FC /* MarketplaceLogic.swift */,
-				E0D94CAC8ADF4E77ADBCE34B /* MasteryLogic.swift */,
-				76986149DC3348B4AB702714 /* ModuleContentLogic.swift */,
-				11775417D81E4E9BAE6C9E95 /* ModuleLastVisited.swift */,
-				D0EA30C7BA6041EF97247A7D /* NotificationLogic.swift */,
-				6855BB77F7A14D1EB6FC6F9B /* OfficeHoursLogic.swift */,
-				1F81340A6FCF4880BBBA4791 /* OnboardingModels.swift */,
-				86594C5CEF924F1DB75AEC45 /* OrgBrandingAdminLogic.swift */,
-				8FF8F46759714555BDFE85ED /* OrgStructureAdminLogic.swift */,
-				E007BE645CB04728BEFB4B4B /* ParentLogic.swift */,
-				B07AEF18A77544789FA89FEA /* PathsLogic.swift */,
-				3CFB99E8194E4D8D91176740 /* PeerReviewLogic.swift */,
-				26155397F5234AE695039840 /* PeopleAdminLogic.swift */,
-				F25AC1FC6EA5428E8B72D682 /* PlannerLogic.swift */,
-				5790510331EE4827B84DE958 /* PlannerSnapshotCoding.swift */,
-				37D87AB33B084FB29D7A6D57 /* PlatformCoursesAdminLogic.swift */,
-				0F21F0185187479A99043D89 /* PlatformSettingsAdminLogic.swift */,
-				56248BCF827943AC98A609E6 /* PortfolioLogic.swift */,
-				D7979B9805F94AC3BA42C0A2 /* ProfileDepthLogic.swift */,
-				E182B9799F5841BDA349CFB7 /* ProfileDepthModels.swift */,
-				CD9C4896A7134E4EBBB34EB7 /* QuizLogic.swift */,
-				9C014105AAF843E483AA944A /* ReadingLogic.swift */,
-				B5F385DEC274498C97903AA4 /* RequirementsLogic.swift */,
-				A92202601E40437985EDDDBD /* ReviewModels.swift */,
-				7E1B974B7FBA4A0B829A0604 /* RolesPermissionsAdminLogic.swift */,
-				45B5ECA2A97A41E096C017B9 /* SettingsMenuLogic.swift */,
-				166A6BA560C44113A46D4988 /* TakeAttendanceLogic.swift */,
-				922C235D780B473CBC59D7F5 /* TranscriptsAdvisingAdminLogic.swift */,
-				89473B285B5E49A0A79308DC /* TutorLogic.swift */,
-				EC2751D8B98E43CD9F62F7AD /* TutorStreamClient.swift */,
-				F25FA4F8614F4D7D9EEED7D3 /* VibeActivityLogic.swift */,
-				24C019B8498C499AAE46FEF3 /* WalletLogic.swift */,
-				A531E690F2CE4FEB86896985 /* WhiteboardLogic.swift */,
-				3A2B972D59944A22A14CD382 /* WhiteboardRenderer.swift */,
+				D68F93E592FB4648929B0871 /* AccountAccommodationModels.swift */,
+				A8DE74B587434CB984788154 /* AccountIntegrationsLogic.swift */,
+				7EE5A93F036646F4A0316BF8 /* AdvisingLogic.swift */,
+				8F7FEBC30EB6460BB11D890A /* AiModelsAdminLogic.swift */,
+				B873466B0F9844E38FBD2EEB /* AnnouncementLogic.swift */,
+				9F0BB372CDF64D93A5EEE8BB /* ArchivedCoursesAdminLogic.swift */,
+				81B01C8A31794FEDB5CA0C3C /* AssignmentLogic.swift */,
+				E63ADFCEC7474296A587ABB7 /* AuditLogAdminLogic.swift */,
+				C1C627F927094E7DB6B60B7C /* BehaviorLogic.swift */,
+				3FF856F8981D4DBFBDCC78B7 /* BillingLogic.swift */,
+				5CA5BC461B394AC9811974BB /* BoardRealtimeLogic.swift */,
+				E61598E2C8FD4D32AA09F946 /* BoardsAdvancedLogic.swift */,
+				A418E83F8A8F43E8B4DC3105 /* BoardsGovernanceAdminLogic.swift */,
+				BB8632D3336742959B406677 /* BoardsLogic.swift */,
+				C5F2525060E34C70BCB38510 /* CanvasImportLogic.swift */,
+				2FF05BCBA4D84824A04B9796 /* CanvasImportObservability.swift */,
+				6FBCF0D5A1DA4969968D0D41 /* CatalogLogic.swift */,
+				BF3E03A9F1A2490DB6A15B8B /* ConferenceLogic.swift */,
+				752DEF0373E54AEF83685C57 /* CourseAccessibilityReviewLogic.swift */,
+				C7D70879399D4C2887045226 /* CourseArchivedContentLogic.swift */,
+				150AD95FB44A4599B3FDADDC /* CourseBlueprintLogic.swift */,
+				21312747EECB49078649F0D5 /* CourseCreateDraftStore.swift */,
+				3B052C0DDDC34A22B89918ED /* CourseCreateLogic.swift */,
+				EC02E84D076E4C5B976D43FA /* CourseCreateObservability.swift */,
+				2A64839A40BB48829B81C012 /* CourseFeaturesLogic.swift */,
+				ECAE591DAB9E4F139DEFFE39 /* CourseFileLogic.swift */,
+				E2C801B83CE74B5E8A7D2523 /* CourseGradingAgentsLogic.swift */,
+				6BB034F1229147CA87AC6AEE /* CourseGradingLogic.swift */,
+				9E7E228B612E4F19B1399BD7 /* CourseHeroImage.swift */,
+				67E04650D5824DDA840FA21B /* CourseImportExportLogic.swift */,
+				F31F5328B34D4699983E7BF5 /* CourseOutcomesLogic.swift */,
+				6E7CD0F2D33447528D1C23CA /* CoursePeopleLogic.swift */,
+				A175A4F351E24D06B14450BD /* CoursePeopleObservability.swift */,
+				C9A8FA6D8AB44BB795EC8499 /* CoursePlagiarismLogic.swift */,
+				EE3651540DE6426CBA163F6A /* CourseReviewLogic.swift */,
+				F6FBFA97169645C6BAF9D202 /* CourseSectionsLogic.swift */,
+				54DDFCAFCA054246B428D8D6 /* CourseSettingsLogic.swift */,
+				3B9A809DC9D44A81876C84D6 /* CourseTranslationsLogic.swift */,
+				2ED7960BED804EBAB21DB624 /* CredentialsLogic.swift */,
+				FCBA158B2F624AC98BE02A3D /* CurrencyExponent.swift */,
+				E09D6EDF371C48098874B22C /* DiscussionLogic.swift */,
+				B7A4DAAD9D8E4E4EA7299202 /* EvaluationLogic.swift */,
+				58C78219C42C422EA2F7E48C /* FeedbackLogic.swift */,
+				E4D80581D2F94A02BAAED322 /* FileDownloadManager.swift */,
+				12D368F3EC634E2585AAA222 /* GamificationLogic.swift */,
+				D213653C2BDE4591B0CCA138 /* GradeCalculator+MyGrades.swift */,
+				02F05C3B54914F429882583C /* GradeCalculator.swift */,
+				19320D4F624D4E81A07DB852 /* GroupsLogic.swift */,
+				F47D6DDC0A834B6396610973 /* InsightsLogic.swift */,
+				BDB97F9F93694C9793C63614 /* InstructorInsightsLogic.swift */,
+				44B8A1A6109E4556B2336DD9 /* IntegrationsAdminLogic.swift */,
+				3C7E41797A5E4EFE90B176B8 /* InteractiveLaunchLogic.swift */,
+				E8786D1D4285415199C49EDE /* IntroCourseLogic.swift */,
+				B98B884A3B324822AB0ABE8A /* IntroCourseObservability.swift */,
+				93BD7724C24E4C9B96FF02C2 /* LMSAPI.swift */,
+				696AAE4C18A5412193D9FA8C /* LMSAPIAccountIntegrations.swift */,
+				C07DE5F1155441E49DEA50FB /* LMSAPIAdmin.swift */,
+				1FDA23E010114F39BF8B899B /* LMSAPIAdvising.swift */,
+				7538ABD46EAF4599B2C42CE2 /* LMSAPIAnnouncements.swift */,
+				116C05C9CA2840DCA1A2C4CB /* LMSAPIAuditLog.swift */,
+				7E18FC25D3574725B9548ECC /* LMSAPIBehavior.swift */,
+				754564AA344740C1AA7A6323 /* LMSAPIBilling.swift */,
+				A0FCF3B0FA264A869E9F6542 /* LMSAPIBoardAccess.swift */,
+				486137AACE1A4826A2C71E49 /* LMSAPIBoardAnalytics.swift */,
+				AB9D57FD88E4421DB1887176 /* LMSAPIBoardEngagement.swift */,
+				7A356D13BF3A43AA987E66CF /* LMSAPIBoardExport.swift */,
+				1CE2C7EECD8341B99934ABB6 /* LMSAPIBoardLayout.swift */,
+				30035C0884734E0482DA7934 /* LMSAPIBoardModeration.swift */,
+				89B7A32365D24C0880F6F284 /* LMSAPIBoardPosts.swift */,
+				7D118B2EB3134D42A3B2CB7B /* LMSAPIBoardTemplates.swift */,
+				A01FA21ABFBC4611B3BE640C /* LMSAPIBoards.swift */,
+				042BC610AE594924AEB29479 /* LMSAPICanvasImport.swift */,
+				783765A9C2054F2CB418A46D /* LMSAPICatalog.swift */,
+				BA53D0293F9E4CDF93F367BB /* LMSAPICourseAccessibility.swift */,
+				AC41C117EA1B4D258C520BCA /* LMSAPICourseArchivedContent.swift */,
+				2599FFE0DE6845D6B74944FF /* LMSAPICourseBlueprint.swift */,
+				EAB2C99B7D8840068A3D4076 /* LMSAPICourseCreate.swift */,
+				E7E5D01EE7AB43168D2679A3 /* LMSAPICourseFeatures.swift */,
+				DC70B259D43F4D448CFBAAB8 /* LMSAPICourseGrading.swift */,
+				6F34E4E4941749D4877040E7 /* LMSAPICourseGradingAgents.swift */,
+				C276309B00E2443A93D953C2 /* LMSAPICourseImportExport.swift */,
+				1F2E90CB7F4245A4B43AF026 /* LMSAPICoursePlagiarism.swift */,
+				8BC70C9A48C94BF4B4C3BB1E /* LMSAPICourseReviews.swift */,
+				AA80816617A14D78B9FE54BF /* LMSAPICourseSections.swift */,
+				01FF1AF25FF04DD6AB70FB57 /* LMSAPICourseSettings.swift */,
+				9B2574DCE83C460EA90E3F85 /* LMSAPICourseTranslations.swift */,
+				D7ACD5D8E10340B9B9697ECC /* LMSAPICredentials.swift */,
+				4E21E540FBF84BFC8F4E2D9A /* LMSAPIDiscussions.swift */,
+				1474A042D5DE49069BED4533 /* LMSAPIEportfolio.swift */,
+				00767DB4B92F4E0DA05BD38C /* LMSAPIEvaluations.swift */,
+				4CA1EFB4E5A246FDB803C2DF /* LMSAPIFeatures.swift */,
+				F75B89DB41E547AA84F61487 /* LMSAPIFeed.swift */,
+				D3BD38517A854ABB84951E98 /* LMSAPIFeedback.swift */,
+				FA2D858067A24BD0B0F3C5AF /* LMSAPIGamification.swift */,
+				F081D2E7003B4AE0B9D681CE /* LMSAPIGroups.swift */,
+				FC6635E0AC104977B2C9A88B /* LMSAPIInsights.swift */,
+				2DD9D91E638A4A639AB1CD7C /* LMSAPIInstructorInsights.swift */,
+				B28C4D21531D4A33A1865EAC /* LMSAPIIntroCourse.swift */,
+				7789C8CFDE394EBEBE23881B /* LMSAPILearnerProfile.swift */,
+				E1AB1209784D4AAA9985A44E /* LMSAPILiveQuiz.swift */,
+				3B32DB5484C1481CA15B2324 /* LMSAPIMarketplace.swift */,
+				AF0133E4DAF845C28F931794 /* LMSAPIMastery.swift */,
+				59B1DBF812454BF49DC9A309 /* LMSAPIMobileWave.swift */,
+				021B46FAE5F947198127DF0E /* LMSAPIOutcomes.swift */,
+				967D00F11FE3420E968C119E /* LMSAPIParent.swift */,
+				9F8B663C1A1B4962B2E66A73 /* LMSAPIPaths.swift */,
+				05120AC28E87464DB043E631 /* LMSAPIPeerReview.swift */,
+				23C258FCE4EA4550A8DF0FB2 /* LMSAPIProctoring.swift */,
+				DEAAE1D0F18446B0AFCD4F20 /* LMSAPIQuizCodeRun.swift */,
+				E0CE7B57D3C74A39947F0288 /* LMSAPIReader.swift */,
+				DD0586DF49BB4BEBAAC22DF6 /* LMSAPIReading.swift */,
+				52B43740C05F4E4FAFCF4552 /* LMSAPIReview.swift */,
+				3B7D36BC426C4CFB90398EC9 /* LMSAPITutor.swift */,
+				24EE42BE8C4F457081935252 /* LMSAPIWallet.swift */,
+				BFA8395926874179BC6133B6 /* LMSAPIWhiteboard.swift */,
+				CD727138615C4BB58E5AD531 /* LMSBoardAdvancedModels.swift */,
+				F3A22BBC906A4965AD20E9FB /* LMSBoardModels.swift */,
+				1246E4FB56BA4A8EAC0C4755 /* LMSFeatureModels.swift */,
+				E01BB4CF617C4AE697326AD2 /* LMSFeatureModelsAccountIntegrations.swift */,
+				A191660A8AAC4367BBC6DBC0 /* LMSFeatureModelsAdvising.swift */,
+				A051C237A05542B78195DF54 /* LMSFeatureModelsAiAdmin.swift */,
+				CE9495FEEA294923AEA5BF53 /* LMSFeatureModelsArchivedCoursesAdmin.swift */,
+				91A0E5C89ED548A199704515 /* LMSFeatureModelsAuditLog.swift */,
+				35E58DD379584EC9897EBA81 /* LMSFeatureModelsBehavior.swift */,
+				C298A33135644A24AFBCB734 /* LMSFeatureModelsBilling.swift */,
+				F8B8C6B060664460BDBC632C /* LMSFeatureModelsCanvasImport.swift */,
+				E25A51DF333A470280FD211F /* LMSFeatureModelsCatalog.swift */,
+				43569D183CA24C02982D1D9B /* LMSFeatureModelsCourseAccessibility.swift */,
+				FAF0237DC5854F459C5FE8E6 /* LMSFeatureModelsCourseCreate.swift */,
+				C2BC6C3FE403447E84BC459A /* LMSFeatureModelsCourseGrading.swift */,
+				536DE680136F4CDCA73A7D4B /* LMSFeatureModelsCourseGradingAgents.swift */,
+				CF5B6BE5CE3C47CAB01E3445 /* LMSFeatureModelsCourseOutcomes.swift */,
+				237CEC1FDEA14D838F468EAD /* LMSFeatureModelsCoursePlagiarism.swift */,
+				92DA2A4D1562445E95C7AC68 /* LMSFeatureModelsCourseReviews.swift */,
+				4B5D34C1A41442759A10378F /* LMSFeatureModelsCourseSettings.swift */,
+				B01AC1FB62E24D11838EAA39 /* LMSFeatureModelsCourseTranslations.swift */,
+				E99859DB50F94DCDAFFBC162 /* LMSFeatureModelsCredentials.swift */,
+				9D707EDA39BF4C7695FEDF02 /* LMSFeatureModelsDiscussions.swift */,
+				D7CD4CE25EE24E1DAC99E738 /* LMSFeatureModelsEportfolio.swift */,
+				D715C2FF7ABC4967AD788A5D /* LMSFeatureModelsEvaluations.swift */,
+				5B72EDBB99BD488F849B8502 /* LMSFeatureModelsFeed.swift */,
+				9B56FCCE1A1B495BBB800C3A /* LMSFeatureModelsFeedback.swift */,
+				0530E77E12B74004BCD92E74 /* LMSFeatureModelsGamification.swift */,
+				7EE08986FF7C4EBD9546D49D /* LMSFeatureModelsGroups.swift */,
+				DF4F0AA6B9864CE6BDA4C4F4 /* LMSFeatureModelsInsights.swift */,
+				3D1AFD8ED73440A580259DF3 /* LMSFeatureModelsInstructorInsights.swift */,
+				DACB3E9F0C42444F83FFEC13 /* LMSFeatureModelsIntegrationsAdmin.swift */,
+				6B2BA536957A4BB589B41FB9 /* LMSFeatureModelsIntroCourse.swift */,
+				29CA540852D447A9A5EB534E /* LMSFeatureModelsLearnerProfile.swift */,
+				F2D7E2DC15CD47ABB396D038 /* LMSFeatureModelsLive.swift */,
+				AB72B8AA5B8D4BF283C4812C /* LMSFeatureModelsMarketplace.swift */,
+				4285A765335C47D98D5AA5F8 /* LMSFeatureModelsMastery.swift */,
+				3EAF3DF3E19B47EAA6306310 /* LMSFeatureModelsMobile.swift */,
+				FD3E507D2F554E4F8547C016 /* LMSFeatureModelsOrgBrandingAdmin.swift */,
+				3F484F5C857C41B8B8D83F3B /* LMSFeatureModelsOrgStructureAdmin.swift */,
+				C16C35E71B2B44079C194684 /* LMSFeatureModelsParent.swift */,
+				E2118B981A084588B17EA862 /* LMSFeatureModelsPaths.swift */,
+				4FEB85F2108F4CDA89C97B20 /* LMSFeatureModelsPeerReview.swift */,
+				4DD23228423D425187827C43 /* LMSFeatureModelsPeopleAdmin.swift */,
+				3687F3FFC80047629DB76329 /* LMSFeatureModelsPlatform.swift */,
+				F153827ABE574FB28D26FDD5 /* LMSFeatureModelsPlatformCoursesAdmin.swift */,
+				8F9082A0730B411CBEADB9D7 /* LMSFeatureModelsPlatformSettingsAdmin.swift */,
+				CFD7A193F6B842AB9AD0E084 /* LMSFeatureModelsReader.swift */,
+				F493EF6C307441C187C07C95 /* LMSFeatureModelsReading.swift */,
+				F8595E8DCA0142C78593020D /* LMSFeatureModelsRolesPermissionsAdmin.swift */,
+				22C2F7DAE4904509A7C51AB2 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift */,
+				9B390B819E404BAC9BD710C6 /* LMSFeatureModelsTutor.swift */,
+				C83EF63F17104ADBBC135CAE /* LMSFeatureModelsWallet.swift */,
+				83103D7B44E2473A8E083B12 /* LMSInteractiveModels.swift */,
+				C41EC1D1D81843C3AE5D6B7C /* LMSModels.swift */,
+				C8F662D40CBC435EA8AB4575 /* LearnerProfileLogic.swift */,
+				5888F7E8AE85481493777E03 /* LibraryResourceLogic.swift */,
+				67A00E00E7074ED386216A18 /* LiveGameLogic.swift */,
+				978D91FEAC854AC1A7DEE81E /* LiveMeetingsLogic.swift */,
+				9FC24E5FF6DF4E1594203298 /* LiveQuizLogic.swift */,
+				324AA97B736A47DEABAEF8B5 /* MarketplaceLogic.swift */,
+				F243E67246474E0E9E9700B4 /* MasteryLogic.swift */,
+				14C3277E87654FFBB9E8B608 /* ModuleContentLogic.swift */,
+				A312A18DBBA04A82928F7F31 /* ModuleLastVisited.swift */,
+				691310D5834D4D85AA80D7EC /* NotificationLogic.swift */,
+				2F2DCD08A7254E47904BA8B6 /* OfficeHoursLogic.swift */,
+				4F3437C6C5E5403389A1408B /* OnboardingModels.swift */,
+				7A0E3748F97D4C1195784DDD /* OrgBrandingAdminLogic.swift */,
+				71D346F3E4DB4208BE31F01C /* OrgStructureAdminLogic.swift */,
+				4BA5EC88D6A54B4AA3A4C0D1 /* ParentLogic.swift */,
+				F358BC135D3048869EFE35DA /* PathsLogic.swift */,
+				E7A28AEE5FE14AAC93E51F53 /* PeerReviewLogic.swift */,
+				5FE82C0E43BD4BB798193FAC /* PeopleAdminLogic.swift */,
+				EC3F76CDFC704620898EB820 /* PlannerLogic.swift */,
+				5BA2A976460E4A0AB1FD5C20 /* PlannerSnapshotCoding.swift */,
+				F0239F95B6144258A56BF208 /* PlatformCoursesAdminLogic.swift */,
+				6F42C914017E4A18955B7847 /* PlatformSettingsAdminLogic.swift */,
+				11D0756CA8CA470BBF27C53D /* PortfolioLogic.swift */,
+				8DF820D89BD44A048BF21491 /* ProfileDepthLogic.swift */,
+				A6E6C53BD425423D97C894BA /* ProfileDepthModels.swift */,
+				1195F59ED53A48938097273C /* QuizLogic.swift */,
+				F51DD3FFD2C24B4A8734F6EE /* ReadingLogic.swift */,
+				B95053CA3B524D51B57E496E /* RequirementsLogic.swift */,
+				FDC0C94610224F1E8DA306D3 /* ReviewModels.swift */,
+				52CD5F8EC05E43BDBA7F30C9 /* RolesPermissionsAdminLogic.swift */,
+				60F67A970A474EBEAFFDB391 /* SettingsMenuLogic.swift */,
+				7D73263ACDD3471B8D3DEB09 /* TakeAttendanceLogic.swift */,
+				259D4E20FEE14AF788D4414A /* TranscriptsAdvisingAdminLogic.swift */,
+				A990FFE37A8546BA870D0F0F /* TutorLogic.swift */,
+				769106ABCAAB4179B02463AB /* TutorStreamClient.swift */,
+				9AC94FFFF90F4F1B8917156C /* VibeActivityLogic.swift */,
+				99D2D4BE9BCE435285FF58B2 /* WalletLogic.swift */,
+				D7DF4ED214C142B28F0F7C6C /* WhiteboardLogic.swift */,
+				CCE1C407BBDF4740977C3248 /* WhiteboardRenderer.swift */,
 			);
 			path = LMS;
 			sourceTree = "<group>";
 		};
-		C26454A1C21349CC82CD4A81 /* Networking */ = {
+		30F812E806AB477189155317 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
-				9539914B91EA4AC0A10CD744 /* APIClient.swift */,
-				B8C60DD35D434947B391DCCB /* APIError.swift */,
-				B87F886051A547F6B9915B17 /* NetworkAuthContext.swift */,
-				034243060A9D460D8829F84B /* NetworkBootstrap.swift */,
+				C83BBBE62917426DAE86975C /* APIClient.swift */,
+				9F257901D5014000A8EBE90D /* APIError.swift */,
+				D68B209FB8AF410DBD34F031 /* NetworkAuthContext.swift */,
+				D572BD0B890840029E117FF8 /* NetworkBootstrap.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		48A959D7B391440691EDC3E9 /* Notebook */ = {
+		BB513A6FFC294AA8A97E7E8F /* Notebook */ = {
 			isa = PBXGroup;
 			children = (
-				6D674B0C9ED146939FC329F3 /* MarkdownTableLogic.swift */,
-				D83042AE2827442483E3E27C /* NotebookDrawing.swift */,
-				FB326385E92C4DA1B823A4F4 /* NotebookMarkdown.swift */,
-				0190BC6FDADE41CCB994CF1F /* NotebookSlashCommands.swift */,
-				9BD6D10890F84565933F42DB /* NotebookStore.swift */,
-				CDC8BA6757C24485B7248CA1 /* NotebookSync.swift */,
-				2A6CC2ED061F4414B31ABB71 /* NotebookTree.swift */,
+				D2249CF0A07C46B8BFA8BB20 /* MarkdownTableLogic.swift */,
+				77FD3EEDE8744FF7B0AFC538 /* NotebookDrawing.swift */,
+				E4CE9866F2DB4E23BF1F8012 /* NotebookMarkdown.swift */,
+				A80E77440983473EA95A4FB8 /* NotebookSlashCommands.swift */,
+				6637E78D17B64DA29CCAB464 /* NotebookStore.swift */,
+				960144A5952D4276A7C05E82 /* NotebookSync.swift */,
+				BE9948647BA7401E9F6F93A3 /* NotebookTree.swift */,
 			);
 			path = Notebook;
 			sourceTree = "<group>";
 		};
-		FA86CD845606477697C280BC /* Offline */ = {
+		5E1A20D62DD54107ACFB15B0 /* Offline */ = {
 			isa = PBXGroup;
 			children = (
-				8D48D6ED18E84162ADDD9DFD /* CacheStore.swift */,
-				08584DB395634C77BC5D895C /* DownloadStore.swift */,
-				66CF0C8E08904DE4BA967198 /* NetworkMonitor.swift */,
-				7F1594BFF9A242A9A66BDC90 /* OfflineModels.swift */,
-				5662A6252F164C63B7CDBA00 /* OfflineService.swift */,
-				748936187DFB496C964B1168 /* OutboxStore.swift */,
-				01174D0301DC49278345703C /* SyncEngine.swift */,
+				29345BCE6B754740843A8BB1 /* CacheStore.swift */,
+				62DA5F6B6B2B4706823CC528 /* DownloadStore.swift */,
+				C6D2A5D9447C40FCA57D17F8 /* NetworkMonitor.swift */,
+				6931A626E6DE4BFD97A330D0 /* OfflineModels.swift */,
+				56D1233CE30E43268AFFBED0 /* OfflineService.swift */,
+				1F409CE2BF8B4D93B26107EF /* OutboxStore.swift */,
+				B7DEEE2246B84A8291FF4E39 /* SyncEngine.swift */,
 			);
 			path = Offline;
 			sourceTree = "<group>";
 		};
-		405ADFE6368846B5BD802C2D /* Push */ = {
+		C16EF71170A64066ADD3BAB5 /* Push */ = {
 			isa = PBXGroup;
 			children = (
-				0F2AD54DF35243D08D0884D7 /* PushManager.swift */,
+				8D2CBA2BC92149079B34E5B4 /* PushManager.swift */,
 			);
 			path = Push;
 			sourceTree = "<group>";
 		};
-		84B0AE89B9E7411E8C7B1161 /* Realtime */ = {
+		BADF2DB51E1849F49ADEA51D /* Realtime */ = {
 			isa = PBXGroup;
 			children = (
-				28F8C9E8AEC94C8CB4048E6F /* RealtimeManager.swift */,
-				BF143DA58EC349B88DE918D5 /* WebSocketClient.swift */,
+				628EE4A22DBC40ADBF48A1FD /* RealtimeManager.swift */,
+				8E9D774CB8BA476E96510260 /* WebSocketClient.swift */,
 			);
 			path = Realtime;
 			sourceTree = "<group>";
 		};
-		C089B853FDAD4D3BA43BBE1C /* Routing */ = {
+		68431E38C86B48A289606969 /* Routing */ = {
 			isa = PBXGroup;
 			children = (
-				6A1E5E66145E42A1971D08A6 /* ContentLinkRouter.swift */,
-				3AD1758A01574A04BD37420F /* DeepLinkRouter.swift */,
-				CC3755F559B9448F87A2512D /* MobileDestinations.swift */,
-				31CF4329D62D43529C92A419 /* MobileIaPreferences.swift */,
-				129D441D1F9D47469C14936A /* MobileProfileDepthPreferences.swift */,
+				15AD86FA9B7E444D85BE565C /* ContentLinkRouter.swift */,
+				7AB7098E697E48EF95C80DAB /* DeepLinkRouter.swift */,
+				CD45A9FF969B4384BA86BC18 /* MobileDestinations.swift */,
+				677639FB1EC34FE4AE969527 /* MobileIaPreferences.swift */,
+				C7DAC2367DC547DD8374E611 /* MobileProfileDepthPreferences.swift */,
 			);
 			path = Routing;
 			sourceTree = "<group>";
 		};
-		2A57ECDF8FAB4563A60CDDE3 /* Search */ = {
+		100C2BFF784744A59255DE85 /* Search */ = {
 			isa = PBXGroup;
 			children = (
-				18AB82BC37F649188244C769 /* SearchActionRegistry.swift */,
-				AB95D2CEDEF34154B27C0629 /* SearchModels.swift */,
-				F10471B9CC0341E191FCC111 /* SearchPathNavigator.swift */,
-				89C50C881A26455F812729AB /* SearchRecentsStore.swift */,
+				31F61AC93CAF44F8BB058BF9 /* SearchActionRegistry.swift */,
+				4EE97A944286469AB5BCD6EA /* SearchModels.swift */,
+				467E4692126D4E1FBF694D3F /* SearchPathNavigator.swift */,
+				722AE47C26754F9FB7BC7FE7 /* SearchRecentsStore.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
 		};
-		54403642A92F4A7B9CC784F4 /* UI */ = {
+		91369E9EBCF142CDB0D0A73D /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				1A3EC0B819B54DD1A3035E15 /* CodeEditor.swift */,
+				154A15FAD34D4A58B24EE09B /* CodeEditor.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
 		};
-		8F4FC60E7F9A491B822BEC85 /* Advising */ = {
+		15596A5A92C44A73AD1A6B49 /* Advising */ = {
 			isa = PBXGroup;
 			children = (
-				20692C98F7CF4C5E9E630940 /* AdvisingView.swift */,
+				5530E9E13A8848E09D6085D7 /* AdvisingView.swift */,
 			);
 			path = Advising;
 			sourceTree = "<group>";
 		};
-		701D7DF457B14945AF961FB7 /* Assignments */ = {
+		C3E99E91BC994C56A5491135 /* Assignments */ = {
 			isa = PBXGroup;
 			children = (
-				49E0B6EB1F464ADEABF0BBEE /* AssignmentDetailView.swift */,
-				1FB370489A524C4494940128 /* AssignmentDraftStore.swift */,
-				0253694A82134E3AAEB30D97 /* AttachmentUploader.swift */,
+				FCBD1F0BA9AE4F6683F4F7A3 /* AssignmentDetailView.swift */,
+				222A43CE1EE64C479E56D313 /* AssignmentDraftStore.swift */,
+				953BC13048144DD7BB15E059 /* AttachmentUploader.swift */,
 			);
 			path = Assignments;
 			sourceTree = "<group>";
 		};
-		868E51DFC861421388C8F051 /* Auth */ = {
+		514E02BAD6294A59A66F7573 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				969DA09CDDFD40049CE615D0 /* AppleSignInController.swift */,
-				3C9B1359A4404825AE15F3A3 /* AuthFlowView.swift */,
-				F42150EF643F4D7D9FFFFAE0 /* GetStartedView.swift */,
-				10532DC1D669434B82A731A2 /* LoginView.swift */,
-				52FE0D2585394BF187ECA1B7 /* MFAChallengeView.swift */,
-				2D04881B017D42D59271A7FF /* MfaPasskeyController.swift */,
-				2F813600B54249D3B9938C60 /* SSOAuthController.swift */,
-				64116C457D144592923CE953 /* SignupView.swift */,
+				8E3CF162C00F4464BF4C159A /* AppleSignInController.swift */,
+				76335E8AFED64A7183393292 /* AuthFlowView.swift */,
+				2125355EB6974E71A3CA2EC1 /* GetStartedView.swift */,
+				D56BEBB06CE44FBAB66FDE47 /* LoginView.swift */,
+				61E7CA262752498EBC9F37C4 /* MFAChallengeView.swift */,
+				3AC2FB7498CB41128E31F74C /* MfaPasskeyController.swift */,
+				D48D2A7865F843E9AE3D5A11 /* SSOAuthController.swift */,
+				C4E8D15FB6C14BD091BD0120 /* SignupView.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
 		};
-		18F7C9AD9EF54301BC952A4B /* Behavior */ = {
+		B46AE60AA6C845489E33B4D5 /* Behavior */ = {
 			isa = PBXGroup;
 			children = (
-				FF6A680715844859B5AB1482 /* BehaviorRosterView.swift */,
-				1F834E7C7E2B4F83977CD393 /* HallPassView.swift */,
-				589449D3174C412290E4395C /* MyHallPassView.swift */,
+				56CD26A604DD442983974886 /* BehaviorRosterView.swift */,
+				3CBAB05AF3BE4315AF713859 /* HallPassView.swift */,
+				5A6778CFE234463994858F9B /* MyHallPassView.swift */,
 			);
 			path = Behavior;
 			sourceTree = "<group>";
 		};
-		CE2A192438064ADD8CD29594 /* Billing */ = {
+		01786B3F1A9D480E9C0EC9DF /* Billing */ = {
 			isa = PBXGroup;
 			children = (
-				A4D5E89F64034E519A897B39 /* BillingView.swift */,
-				002621179B3240B88E42D3BE /* CheckoutReturnHandler.swift */,
-				CEBA28AFA45B4196BA532489 /* PurchaseFlow.swift */,
+				F4CD7D697B764F92BF51A7AA /* BillingView.swift */,
+				6ECF122BCB5B49188C076AE4 /* CheckoutReturnHandler.swift */,
+				528A15350CAA4ECB8BF82EBD /* PurchaseFlow.swift */,
 			);
 			path = Billing;
 			sourceTree = "<group>";
 		};
-		87A0EC2E02864041B872FD28 /* Boards */ = {
+		0F5BA1B6D3A542C0AA7861B4 /* Boards */ = {
 			isa = PBXGroup;
 			children = (
-				4DAABF4AA127483AB5410F31 /* Layouts */,
-				8390046B0AF344AABF74161A /* Public */,
-				4CA12F2E861645A1980CF97B /* BoardAnalyticsSheet.swift */,
-				8924613254124B5AA8FD0491 /* BoardComposerView.swift */,
-				03216D95DEEE443283E5957E /* BoardDetailView.swift */,
-				337088D4F5644F398827A1F8 /* BoardEngagementEnvironment.swift */,
-				BF51B8DD3EC1499B9B67BB98 /* BoardExportSheet.swift */,
-				83131615195A4ACC8EE64E7D /* BoardModerationSettings.swift */,
-				259DF311E035446E813AA4DB /* BoardPostCard.swift */,
-				C2B34D6497C14CAC8663E762 /* BoardPresentModeView.swift */,
-				5B437E7FBB6B460F8178C628 /* BoardSaveAsTemplateSheet.swift */,
-				1A2E9D9B7CC2408C88DC216F /* BoardShareSheet.swift */,
-				9B45A1B0F53148FEACFB6231 /* BoardSocket.swift */,
-				CB51EF4DBC774C6DBD841565 /* BoardSurface.swift */,
-				886E207B6264422F8B23AB06 /* BoardSyncStatusChip.swift */,
-				8B3143CE3BEC4D3FB873211C /* BoardTemplatePickerView.swift */,
-				490CFC138B7B46DDABD858C5 /* BoardsListView.swift */,
-				4D68ECFF7B644E71BC47AE87 /* CardArrangeMenu.swift */,
-				4FC767DDD02B4309BF4ADDC0 /* CommentSheet.swift */,
-				DED68C4F898B4AA492F84347 /* GradeSheet.swift */,
-				611830A137CA49C1959CDE8F /* ModerationQueueView.swift */,
-				6055DB2C26AB4129A22E0F29 /* ReactionControl.swift */,
-				8288AA0576624915998DFB6D /* ReportDialog.swift */,
+				3848AC4F7010417E901BFEC0 /* Layouts */,
+				F7ECB1D8BA314279B492480A /* Public */,
+				5E02556B74F24A17BA8376FD /* BoardAnalyticsSheet.swift */,
+				BC42D146F16B4BDAA812C3EF /* BoardComposerView.swift */,
+				02484C6E8F31475FB95C2B07 /* BoardDetailView.swift */,
+				78EAA9448BD040DAB66EF2A0 /* BoardEngagementEnvironment.swift */,
+				9D0FE6FD029F4E009765A1B0 /* BoardExportSheet.swift */,
+				42B87ED193FE417396EB2B4E /* BoardModerationSettings.swift */,
+				F5059595D0E24E059420088C /* BoardPostCard.swift */,
+				4E996C23C6F942F1878DFFFB /* BoardPresentModeView.swift */,
+				78BF473B64E846569C3A5978 /* BoardSaveAsTemplateSheet.swift */,
+				F1080FED284840089F65DDE5 /* BoardShareSheet.swift */,
+				9942E130569A4AB48B2A051E /* BoardSocket.swift */,
+				462B3468F5514FA7BBBF3277 /* BoardSurface.swift */,
+				791BDC8ACF6D435EAB32CB67 /* BoardSyncStatusChip.swift */,
+				01E582767F06462184FEADE6 /* BoardTemplatePickerView.swift */,
+				31FC6C0DCE1B4091B988ED17 /* BoardsListView.swift */,
+				5831E2E338A043009714F4CA /* CardArrangeMenu.swift */,
+				55759ED87B334852AA3741F6 /* CommentSheet.swift */,
+				3891A2BEEA8A4B12A04001EC /* GradeSheet.swift */,
+				6B35607BAD254091AA44612B /* ModerationQueueView.swift */,
+				E21EA6406ED74F73879793F0 /* ReactionControl.swift */,
+				EB4559488E1B46FBBA32F113 /* ReportDialog.swift */,
 			);
 			path = Boards;
 			sourceTree = "<group>";
 		};
-		59658F1ED52246CC8C1222BD /* Catalog */ = {
+		55D3C151225E40E6B8C11757 /* Catalog */ = {
 			isa = PBXGroup;
 			children = (
-				133747F8014442AEB513EB08 /* CatalogView.swift */,
-				22DF8A394EE945B8B60D579F /* CourseLandingView.swift */,
-				02AB0F11CDF54868BE71CFF3 /* ReviewComposer.swift */,
+				AD8461C5082547B3986EB882 /* CatalogView.swift */,
+				20E5CD08014E4CCA97CD4DF8 /* CourseLandingView.swift */,
+				A0D7698E4A49453A81518DD7 /* ReviewComposer.swift */,
 			);
 			path = Catalog;
 			sourceTree = "<group>";
 		};
-		4AC0D2069A314057A02EFF94 /* Courses */ = {
+		D8497D0D12BE4EBBA1E53F77 /* Courses */ = {
 			isa = PBXGroup;
 			children = (
-				1C2E30F913D24B4E82AC0C48 /* Create */,
-				7392CA5A807B44BEAA14C8B4 /* Settings */,
-				847219C1BF3A490581AAEF0D /* ContentPageView.swift */,
-				BB770D3718FF4A90B5384778 /* CourseAttendanceView.swift */,
-				87682C9CFE11404282D85EDA /* CourseBanner.swift */,
-				6439F689A7D84336B9539BD9 /* CourseDestinationPlaceholder.swift */,
-				A0365B3EC4674A04B2BDFDFB /* CourseDetailView.swift */,
-				8263EB4500D544EE8D550D89 /* CourseGradesView.swift */,
-				1DCD2C6E51C24F738ED8C250 /* CourseLibraryView.swift */,
-				A025369C914A4C87867124F5 /* CourseMarkdownContentView.swift */,
-				54B6AC4FDA634026875BA2D4 /* CoursePeopleView.swift */,
-				C6DE8049A8EC481999C88093 /* CourseStructureSocket.swift */,
-				7557B966F73F4899BC996BB4 /* CourseSyllabusView.swift */,
-				A564BD3178B141A79D7DADA8 /* CourseWorkspaceNav.swift */,
-				40536B390EA3411BA49279F6 /* CoursesListView.swift */,
-				D1F747815F954B388C7CD9D6 /* ItemDetailRows.swift */,
-				77028F77277348C399FE5293 /* ItemDetailView.swift */,
-				4A6F3A0A6E144C2E9E1DA262 /* LaunchContainerView.swift */,
-				41E68A635B7041AE8657D5F3 /* LibraryResourceView.swift */,
-				A6CAC416D8494E778F4B9787 /* MarkdownCodeBlockView.swift */,
-				E00898CE0B5A4D8F832F234E /* MarkdownTableView.swift */,
-				659D85899B3942718E0FCEF8 /* ModuleItemRouteView.swift */,
-				B6A7F68903B0466686850D5D /* ModuleListView.swift */,
-				EC0F193562AA48EA9D3B5751 /* RequirementsView.swift */,
-				04F287EF609D48A587AE804D /* TakeAttendanceView.swift */,
-				8937A1E1F8C542699D4EFCE3 /* VibeActivityView.swift */,
-				D2D25A64C53F44E8A3DCA18F /* WebItemView.swift */,
+				AB21E3A16F8E41CFAC0240EB /* Create */,
+				8FDBE2B268C14455A370B803 /* Settings */,
+				C4D2A9F83441479BA727CC45 /* ContentPageView.swift */,
+				F80C96F7C5154E88AAC91702 /* CourseAttendanceView.swift */,
+				52E481996B2340459B264B04 /* CourseBanner.swift */,
+				19004FBF9EF9417AB20D14FB /* CourseDestinationPlaceholder.swift */,
+				48D042B2C9BB492BBECBFB64 /* CourseDetailView.swift */,
+				3CDC409C63F44BC0BAE119BA /* CourseGradesView.swift */,
+				2A294251A80649ECACA3255E /* CourseLibraryView.swift */,
+				3698C94ECDF54D808F2E6A38 /* CourseMarkdownContentView.swift */,
+				C664531BA882440EB0BF2C57 /* CoursePeopleView.swift */,
+				44CB7C7379E8462D8EB901E6 /* CourseStructureSocket.swift */,
+				179AF25F442A4BA1A8C5B84A /* CourseSyllabusView.swift */,
+				5AD90B7194D54297A97E2D15 /* CourseWorkspaceNav.swift */,
+				0968A034C0FD4A7BA32085DE /* CoursesListView.swift */,
+				44ECB4A39A1747C8BBAC7CCE /* InlineMarkdownText.swift */,
+				48213DEC0E36407FA056F408 /* ItemDetailRows.swift */,
+				7697EDBBD47B4C94B5C48B6D /* ItemDetailView.swift */,
+				B52F523B506E47DD9A87703A /* LaunchContainerView.swift */,
+				3FB3F7D10F824E8CAF96F9A0 /* LibraryResourceView.swift */,
+				8351F282776A40C095C1EA50 /* MarkdownCodeBlockView.swift */,
+				4D9DABD8D7824346841D6AD8 /* MarkdownRenderStyle.swift */,
+				164872C278714902AEE2DB47 /* MarkdownTableView.swift */,
+				5B5BE60BCECC4042B0C27709 /* ModuleItemRouteView.swift */,
+				34CCB948B3AD4913A67A0BA0 /* ModuleListView.swift */,
+				FBB09A194C034B7BA76B7284 /* RequirementsView.swift */,
+				6F6945859664455189D2B8E3 /* TakeAttendanceView.swift */,
+				8D45AA78BA294951896232EF /* VibeActivityView.swift */,
+				CF30B7FBA3CB4F8A87934ABB /* WebItemView.swift */,
 			);
 			path = Courses;
 			sourceTree = "<group>";
 		};
-		279E9605180441408A086781 /* Credentials */ = {
+		1D416F2C38CD4C7EB3986DBC /* Credentials */ = {
 			isa = PBXGroup;
 			children = (
-				C4FF896DFF2C4573B7293396 /* CredentialDetailView.swift */,
-				5D1B0BC5160C4FAF85C3E3A9 /* CredentialsView.swift */,
+				0515955E570A4924AD25F62A /* CredentialDetailView.swift */,
+				C045D69C75EE4D01B6900402 /* CredentialsView.swift */,
 			);
 			path = Credentials;
 			sourceTree = "<group>";
 		};
-		660ECF58D7484A1E96CA4C6E /* Dashboard */ = {
+		CCE2BB06D209462584980621 /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
-				2EFFCC5A901E49019C8EBA1D /* DashboardCoursesCarousel.swift */,
-				F4DC62FD64AE4B6D8014259E /* DashboardHeroPanel.swift */,
-				EDBAFCBF1764488498252FCB /* DashboardView.swift */,
-				C1A1E7EAE66744EC93DF87FF /* LiveMeetingsRail.swift */,
+				7B9BED0E045041E0B67D3E7C /* DashboardCoursesCarousel.swift */,
+				C6E8F9F4B1E74EA89D9CE097 /* DashboardHeroPanel.swift */,
+				E5C8650B918048FFB715D157 /* DashboardView.swift */,
+				024F7FE6C92F47189E4D0743 /* LiveMeetingsRail.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
 		};
-		0E2973A16C4745AC84DAE787 /* Discussions */ = {
+		C653EC9D223B44EA89D5B0B0 /* Discussions */ = {
 			isa = PBXGroup;
 			children = (
-				68F065BDB057427B997809FB /* CourseDiscussionsSection.swift */,
-				1E79761A651C453CAD0276FA /* DiscussionThreadView.swift */,
-				6E4292E5B6E44215941C86AE /* DiscussionsListView.swift */,
-				79B640B95186493C897B723A /* PostComposerView.swift */,
+				71AA5BA948D94095BB9C37FF /* CourseDiscussionsSection.swift */,
+				0941978D71174F0689587DB0 /* DiscussionThreadView.swift */,
+				318FF7C7D24A4ECDA8227DAE /* DiscussionsListView.swift */,
+				DE854695ECBA4204AB0DE576 /* PostComposerView.swift */,
 			);
 			path = Discussions;
 			sourceTree = "<group>";
 		};
-		E17E34FD698E4FB1AC724740 /* Evaluations */ = {
+		F8D1B3903D1C4613A79C756D /* Evaluations */ = {
 			isa = PBXGroup;
 			children = (
-				1435004D17D84682BA71973A /* CourseEvaluationsSection.swift */,
-				2FF3D50943E74F2FB0FA5844 /* EvaluationFormView.swift */,
-				54C00764961C47D08D3E81CA /* EvaluationResultsView.swift */,
+				7F2327B1074F4A668A9C4BA8 /* CourseEvaluationsSection.swift */,
+				50788B3B53CB42BE8F185D0D /* EvaluationFormView.swift */,
+				EB68CA9959D24657B8E7127E /* EvaluationResultsView.swift */,
 			);
 			path = Evaluations;
 			sourceTree = "<group>";
 		};
-		043D3E3832C94B41B1F5C614 /* Feed */ = {
+		7EF785BE2CC84744A7334A12 /* Feed */ = {
 			isa = PBXGroup;
 			children = (
-				5A9C93B850C1470B8EDD80F4 /* CourseFeedSection.swift */,
-				C7EDA538039A4B58AFB7F963 /* FeedChannelView.swift */,
-				B6E2315E98DE4E0595C568E0 /* FeedChannelsView.swift */,
-				767D634EA7C54421A5B762FC /* FeedLogic.swift */,
-				657339EC3D474DAAA0A66C9F /* FeedSocket.swift */,
+				A491D3423B534C4EBD81B475 /* CourseFeedSection.swift */,
+				8536659166D649D3BDCCC5A5 /* FeedChannelView.swift */,
+				6883D3DA4F2343F1A3EA9A79 /* FeedChannelsView.swift */,
+				8AFBD986DC7D49509FF77E4E /* FeedLogic.swift */,
+				0EACB47FAA72484787927D72 /* FeedSocket.swift */,
 			);
 			path = Feed;
 			sourceTree = "<group>";
 		};
-		E264AE8CB1604CFAA6B13031 /* Feedback */ = {
+		F6B9971DAFEC4BAC9AC78E8E /* Feedback */ = {
 			isa = PBXGroup;
 			children = (
-				E67E5F19F42C4743B164654A /* ShareFeedbackView.swift */,
+				8CD0948FFE1148BBBBBE2D6C /* ShareFeedbackView.swift */,
 			);
 			path = Feedback;
 			sourceTree = "<group>";
 		};
-		2D431D38870B44D8905DFF75 /* Files */ = {
+		CDA79730504F48B3ADE02EBC /* Files */ = {
 			isa = PBXGroup;
 			children = (
-				62C3F47E3007496C8003BA97 /* CourseFilesSocket.swift */,
-				3EBA60D42F624F89B59C7A13 /* CourseFilesView.swift */,
-				E12EC7DB66414805BFD47BEE /* FilePreviewView.swift */,
-				50423B031C594FD081D8F3D3 /* MarkupOverlayView.swift */,
+				18097E976BCB4C65A606B828 /* CourseFilesSocket.swift */,
+				CDBDEFECB96647F69BE549DA /* CourseFilesView.swift */,
+				CC5969A54F304BF391B96B52 /* FilePreviewView.swift */,
+				A57EE20D3C8244BF97EE2AA7 /* MarkupOverlayView.swift */,
 			);
 			path = Files;
 			sourceTree = "<group>";
 		};
-		D3D59D8988BF410DB2E957D2 /* Gamification */ = {
+		B51B0D28F57C47BBA1738B9F /* Gamification */ = {
 			isa = PBXGroup;
 			children = (
-				CF2B964842AE422AB1F8FE31 /* GamificationView.swift */,
+				6BD564B829F54B788712FD2D /* GamificationView.swift */,
 			);
 			path = Gamification;
 			sourceTree = "<group>";
 		};
-		F6916FBEC6744373B5442108 /* Grades */ = {
+		D8D4CB63884042DB974963B8 /* Grades */ = {
 			isa = PBXGroup;
 			children = (
-				DE58E798DDE14728B7048B49 /* GradeFeedbackView.swift */,
-				98606023BD664072A84363A2 /* WhatIfController.swift */,
+				ACC43B7F26C946E48F8732A9 /* GradeFeedbackView.swift */,
+				4707DC82B2524CD3BAEEF06F /* WhatIfController.swift */,
 			);
 			path = Grades;
 			sourceTree = "<group>";
 		};
-		A5E76690DDB947A4A80A942B /* Grading */ = {
+		FF34629FBA434D63B64F925C /* Grading */ = {
 			isa = PBXGroup;
 			children = (
-				F830C796E96842FC902C5B4A /* GradingBacklogView.swift */,
-				CD3539CFC6934AD2BB2F4EAE /* SpeedGraderView.swift */,
+				46F41DCE71464DB59B5C6663 /* GradingBacklogView.swift */,
+				91E6EC53A9394379A90D21E2 /* SpeedGraderView.swift */,
 			);
 			path = Grading;
 			sourceTree = "<group>";
 		};
-		7878921E3EE94F9085FFAD2D /* Groups */ = {
+		4E295F3FBEC5407DA2BDAA6D /* Groups */ = {
 			isa = PBXGroup;
 			children = (
-				7EC7E1DD087A4E1489ADF74E /* CollabDocView.swift */,
-				E2AC07D555534757A7A76999 /* CourseCollabDocsSection.swift */,
-				7A28AD16498A4136A77E5F6C /* CourseGroupsSection.swift */,
-				E086F925E3C94E3DBF6D5B8D /* GroupSpaceView.swift */,
+				E0CF978646344FCFA4454830 /* CollabDocView.swift */,
+				1A0EAE54E8B14774BF07E17D /* CourseCollabDocsSection.swift */,
+				A8ED2FABE3594F74881ED2B8 /* CourseGroupsSection.swift */,
+				980E64BF62DC4188B34C56BA /* GroupSpaceView.swift */,
 			);
 			path = Groups;
 			sourceTree = "<group>";
 		};
-		118A2CF722A84D8FBD93B030 /* Home */ = {
+		1735A207FF734B3CA427042B /* Home */ = {
 			isa = PBXGroup;
 			children = (
-				50C5179B7C504B4C9F06FE64 /* AnnouncementComposerView.swift */,
-				19B357B269DD46DB9FB3C801 /* AnnouncementsViews.swift */,
-				9961BE2DA57F4F4ABD8656AB /* BroadcastComposerView.swift */,
-				78DB00E3B5884F338081EA9C /* MainTabView.swift */,
-				903A8BB06DD34793B5FC272B /* MoreHubView.swift */,
-				FC6A66930C9247509F766F7F /* ShellHeaderBar.swift */,
-				B7ADBFE36AA24EB7B0908D7B /* TeachHubView.swift */,
-				4502383E9D304013A8EAB757 /* UniversalSearchPlaceholder.swift */,
+				8C177A84D04E4331844EEBAE /* AnnouncementComposerView.swift */,
+				80A10F1D947447B5956D48C3 /* AnnouncementsViews.swift */,
+				9C0A9806AF8440C4A8C8CDF7 /* BroadcastComposerView.swift */,
+				28100343CFDF4AF59C86A6FC /* MainTabView.swift */,
+				64A1F8CCF9EE4EDA8B5CFF59 /* MoreHubView.swift */,
+				1EB6923BCC1D4805AEFF8239 /* ShellHeaderBar.swift */,
+				7A0CCD64E62341E68686CFE0 /* TeachHubView.swift */,
+				DAA66206BD0147519D6AC6FA /* UniversalSearchPlaceholder.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
 		};
-		87B67464B37C42ABAD2BF16C /* Inbox */ = {
+		A7B96E9FF0CF4BAAAB0E67C7 /* Inbox */ = {
 			isa = PBXGroup;
 			children = (
-				0396EAFDB8CD498F95D9E93A /* ComposeMessageView.swift */,
-				A4B52603AD774852A54614C5 /* InboxView.swift */,
-				2B8B2EA90F7F474F93CF162D /* MessageDetailView.swift */,
+				C6D1228B44564E0E8DB04060 /* ComposeMessageView.swift */,
+				92D3A231947E4B708305CB2E /* InboxView.swift */,
+				B54FE86CAD8E4067A5F844B7 /* MessageDetailView.swift */,
 			);
 			path = Inbox;
 			sourceTree = "<group>";
 		};
-		0F9E926F79CF4392AB2FE1A0 /* Insights */ = {
+		F2EF095884CB4B2D9993EC1F /* Insights */ = {
 			isa = PBXGroup;
 			children = (
-				06853E09C60842B0B32A7B61 /* DashboardInsightsSection.swift */,
-				6080ADF9D3C34BBC9A31EA9B /* InsightsView.swift */,
+				531503917D1E4CE6A75ADE5E /* DashboardInsightsSection.swift */,
+				AAD21BB758214149B940C422 /* InsightsView.swift */,
 			);
 			path = Insights;
 			sourceTree = "<group>";
 		};
-		CD2AB0C3B8EA4EC190369661 /* InstructorInsights */ = {
+		8F58E68B759E425EB72928F0 /* InstructorInsights */ = {
 			isa = PBXGroup;
 			children = (
-				0D8792C700AE49F4B0D8146F /* AtRiskListView.swift */,
-				6BBD4F4A79CB4E4DBF2EE5F3 /* CourseInsightsSection.swift */,
-				9AE1EBB432794F2DA01BFC0D /* StudentProgressDetailView.swift */,
-				6A903C2817C74B468239F028 /* WhatsWorkingView.swift */,
+				7672FF915C65418797A16566 /* AtRiskListView.swift */,
+				C541977EC6B04FB6A37B1F29 /* CourseInsightsSection.swift */,
+				53D26361290F44B185668F88 /* StudentProgressDetailView.swift */,
+				5C7B30875E8E4ECDA36E6EAC /* WhatsWorkingView.swift */,
 			);
 			path = InstructorInsights;
 			sourceTree = "<group>";
 		};
-		D3D7D044D9F3465088659F6D /* IntroCourse */ = {
+		174E1B7B49784788A12E5402 /* IntroCourse */ = {
 			isa = PBXGroup;
 			children = (
-				E418402F1C0442649025F56A /* IntroCelebrationPresenter.swift */,
-				94E155C5C5BB47D28E97E754 /* IntroCompletionCelebrationSheet.swift */,
-				D0CE4282C6A94244BFF19D3C /* IntroCourseEntryCard.swift */,
-				4180F25AFDF1407D98915D1C /* IntroCourseProgressRail.swift */,
+				00A2632F4E6146C0888CDCAA /* IntroCelebrationPresenter.swift */,
+				048EC217A0B74F2B9BB4EAE2 /* IntroCompletionCelebrationSheet.swift */,
+				C781C8F72BA844A88D7DFD34 /* IntroCourseEntryCard.swift */,
+				FFF3D3F2BF2B4C4AB6AD00BB /* IntroCourseProgressRail.swift */,
 			);
 			path = IntroCourse;
 			sourceTree = "<group>";
 		};
-		8756C2EE1A6F4AD2BB2A5D32 /* LearnerProfile */ = {
+		EE2EF3C362FC408691F00493 /* LearnerProfile */ = {
 			isa = PBXGroup;
 			children = (
-				5B80C1444C6A48B6A39E2FF2 /* LearnerProfileView.swift */,
+				E385C465842945319D3820E6 /* LearnerProfileView.swift */,
 			);
 			path = LearnerProfile;
 			sourceTree = "<group>";
 		};
-		3602C182B393418AB4BB41A4 /* Library */ = {
+		93E66225C2D64D1FBD951E96 /* Library */ = {
 			isa = PBXGroup;
 			children = (
-				C89023B353D84747859B117E /* LibraryBrowseView.swift */,
+				5D02627FB9C849F79EC5C993 /* LibraryBrowseView.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
 		};
-		B65CCA6818A6488C8DC3AD71 /* Live */ = {
+		7B8B5C470D684C21B964D06C /* Live */ = {
 			isa = PBXGroup;
 			children = (
-				9229467C210C4301B2D98D60 /* MeetingDetailView.swift */,
-				1302D78379A34ED49391CD74 /* MeetingListView.swift */,
-				C5EEEB959E8549A182B2DE40 /* WhiteboardView.swift */,
+				DE11AD774E754CB0B4F41F9C /* MeetingDetailView.swift */,
+				B6B9189B2A6C4365BDFA77EA /* MeetingListView.swift */,
+				2019900D80C9473CB449F94E /* WhiteboardView.swift */,
 			);
 			path = Live;
 			sourceTree = "<group>";
 		};
-		7635445760EC40668163A347 /* LiveQuiz */ = {
+		4B1B1E0F8A994C5E9FB32906 /* LiveQuiz */ = {
 			isa = PBXGroup;
 			children = (
-				EA6C74B0C8A24ADFA92DCB62 /* LiveGameSocket.swift */,
-				9691EB7FB06A4E5DAF1ACA40 /* LiveQuizHubView.swift */,
-				B65BBF0633EB45F0820C1161 /* LiveQuizPlaySurfaces.swift */,
-				61FBF86F867A46CCACACAEFB /* LiveQuizPlayView.swift */,
+				DA09F23627DF4281A4F5A604 /* LiveGameSocket.swift */,
+				81513A4BA1FB4B33B26A4904 /* LiveQuizHubView.swift */,
+				8BF86A09506C49D0ACF4694E /* LiveQuizPlaySurfaces.swift */,
+				B579284FCBF34783ACA74A29 /* LiveQuizPlayView.swift */,
 			);
 			path = LiveQuiz;
 			sourceTree = "<group>";
 		};
-		FEB514283FBA4FA19EA3050A /* Marketplace */ = {
+		AEFB0829690E43488621DE89 /* Marketplace */ = {
 			isa = PBXGroup;
 			children = (
-				AB840DC10A7340F085F9F10A /* MarketplaceDetailView.swift */,
-				68B11BF2897F4875B7A42317 /* MarketplaceView.swift */,
-				BA2B0D06CC104264A7571102 /* MyPurchasesView.swift */,
+				5F0D94941BE3495F961A91A1 /* MarketplaceDetailView.swift */,
+				6331924043854C3CBF0A9E5F /* MarketplaceView.swift */,
+				959FB9FC548444E39D3552DF /* MyPurchasesView.swift */,
 			);
 			path = Marketplace;
 			sourceTree = "<group>";
 		};
-		3EE8B30769534A8280558EF0 /* Mastery */ = {
+		0A4EB97A67444CB6AD68172A /* Mastery */ = {
 			isa = PBXGroup;
 			children = (
-				2E773ADF53394F77BEAFB505 /* CourseMasterySection.swift */,
-				2313BB40BCC74375989C45AC /* ReportCardListView.swift */,
+				E203D2C754954BB8A2E97859 /* CourseMasterySection.swift */,
+				BDA42760F06B46B68A649C76 /* ReportCardListView.swift */,
 			);
 			path = Mastery;
 			sourceTree = "<group>";
 		};
-		275746F45C544CD59C5755D0 /* Navigation */ = {
+		41FF3449C72C4DB8B57C1982 /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
-				62345060129B4913870E54C1 /* CourseDrawer.swift */,
-				6C0688DB90454A19A18E8185 /* DrawerScaffold.swift */,
-				4638969A0A9A4BC3AFD33B5F /* DrawerToolbar.swift */,
-				0276213236EA41DD87B05021 /* GlobalDrawer.swift */,
+				A58E25472CC4432FA317805B /* CourseDrawer.swift */,
+				E1446CD993A4484B907BEBB4 /* DrawerScaffold.swift */,
+				70C986E9B6854FC7AD29E25A /* DrawerToolbar.swift */,
+				BC556A9FC50D4E8588B82D1E /* GlobalDrawer.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
 		};
-		8230BF9ACD524647BD94450E /* Notebooks */ = {
+		0178B15190F244A99E715289 /* Notebooks */ = {
 			isa = PBXGroup;
 			children = (
-				5685788C03E1478E8174A5CB /* NotebookDrawingViews.swift */,
-				8E52B98F8D184587BFDA269B /* NotebookEditorSupportViews.swift */,
-				B5408DF2B2B44228B3BEC80B /* NotebookEditorView.swift */,
-				EAFF705789F14DA1A6B7774C /* NotebookPagesView.swift */,
-				B43F54B92C1F4A8FB207FE48 /* NotebooksListView.swift */,
+				98011A2A19A74B2DA36D628F /* NotebookDrawingViews.swift */,
+				46BB10FDBC994065AADF8481 /* NotebookEditorSupportViews.swift */,
+				0F5A3677FC5A4F328B8BDB0B /* NotebookEditorView.swift */,
+				F23E48BCE4A7490880B6D9E8 /* NotebookPagesView.swift */,
+				6F35E579A8D541FFA66061EF /* NotebooksListView.swift */,
 			);
 			path = Notebooks;
 			sourceTree = "<group>";
 		};
-		95160559E82849F4B6C38B1C /* OfficeHours */ = {
+		5054832DD2754A4D84CCD240 /* OfficeHours */ = {
 			isa = PBXGroup;
 			children = (
-				3BBBE5F676024C5A8546BD9E /* BookingSheet.swift */,
-				809FB33A0AD94818A168A9FA /* MyBookingsView.swift */,
-				6402F22622804592B0BD16AF /* OfficeHoursView.swift */,
+				A432E81BD5D8424F97BBEE18 /* BookingSheet.swift */,
+				CA2504E439EB4BC3B0F5AC9D /* MyBookingsView.swift */,
+				D00DF85D5B624D7CB6A004AC /* OfficeHoursView.swift */,
 			);
 			path = OfficeHours;
 			sourceTree = "<group>";
 		};
-		F9DF03E42271490AA7DAA449 /* Onboarding */ = {
+		CCDF6347A1F1433880A3CF83 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
-				21416CD8DFA947858881FB67 /* DiagnosticView.swift */,
-				E7B8423CB03A421DB125FA7E /* OnboardingFlowView.swift */,
+				17F8216A97C24D3EA7598AB2 /* DiagnosticView.swift */,
+				774B6FA5FF744EF485F0E850 /* OnboardingFlowView.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
-		511CF8B4AC24421299F8C3DD /* Parent */ = {
+		1F8BA251A6274429AC06B135 /* Parent */ = {
 			isa = PBXGroup;
 			children = (
-				7495B658AA314BECB39FA0BC /* ConferenceBookingView.swift */,
-				C9D4BF14581E46E1877105A7 /* MyConferencesView.swift */,
-				DF1BEB9B7C19486C90AF60B6 /* ParentAttendanceDetailView.swift */,
-				028E88D3509D4581AD3B0D49 /* ParentDashboardSections.swift */,
-				79E0738CB7DD4EDAAF0B898E /* ParentDashboardView.swift */,
-				CBC689423511413EBBF6A2F0 /* ParentGradesDetailView.swift */,
-				4C9913DD13854F259223B9CB /* ParentNotificationPrefsView.swift */,
+				385A78C7174346588920560C /* ConferenceBookingView.swift */,
+				CD7B1D976EE245B68D041D72 /* MyConferencesView.swift */,
+				E94092F15E26460C816BE4D3 /* ParentAttendanceDetailView.swift */,
+				7FBDF00E06B4425BB6598B8C /* ParentDashboardSections.swift */,
+				FD18358A0EE94FBD9DCB1140 /* ParentDashboardView.swift */,
+				23AF80C29CDF4624A491DAF9 /* ParentGradesDetailView.swift */,
+				1EEF5E4F7B904C2888E1D8D6 /* ParentNotificationPrefsView.swift */,
 			);
 			path = Parent;
 			sourceTree = "<group>";
 		};
-		7A434A96FCB542F6955BAC95 /* Paths */ = {
+		F94B0016A96148FF985FF083 /* Paths */ = {
 			isa = PBXGroup;
 			children = (
-				20DDD4F6F0DF44B790377108 /* DashboardStudySection.swift */,
-				519A867DDBC343C2BD999131 /* MyPathsView.swift */,
-				9CFABD1859A945CFB9EE0177 /* PathLandingView.swift */,
-				1C84307E2BC94C6FA15D3BDE /* PathRunnerView.swift */,
-				2BB94EA892F64D8D9B8737C2 /* PathsCatalogView.swift */,
+				2D0261A469004ADFB46BA3B2 /* DashboardStudySection.swift */,
+				0CD12D72F206465DB20F7D92 /* MyPathsView.swift */,
+				57CD05A1B6F44A0C874FA1A7 /* PathLandingView.swift */,
+				FB651E4D0105497FB87FC85D /* PathRunnerView.swift */,
+				E1DD7963C4FB4AF99D362C5D /* PathsCatalogView.swift */,
 			);
 			path = Paths;
 			sourceTree = "<group>";
 		};
-		391A0103663844CF9D4CE213 /* PeerReview */ = {
+		812CB5379F604D678B6B49CA /* PeerReview */ = {
 			isa = PBXGroup;
 			children = (
-				5D2AD1BAB40F4D73A5DD2DBE /* PeerReviewDetailView.swift */,
-				7F3BBE2A5AFB4B66ABFEA6C5 /* PeerReviewListView.swift */,
-				144BCB7F170F41D9B763AE01 /* ReviewsReceivedView.swift */,
-				D62C5B28B5F148DAB9EAC51C /* RubricScorerView.swift */,
+				FC4728726CE7444DAC53AE44 /* PeerReviewDetailView.swift */,
+				97464A6F695B4C1D829E0A31 /* PeerReviewListView.swift */,
+				348865567B2E49AE8BC76B2B /* ReviewsReceivedView.swift */,
+				8E1FE883E9294779A42DF919 /* RubricScorerView.swift */,
 			);
 			path = PeerReview;
 			sourceTree = "<group>";
 		};
-		AEB080EC28654582A5F5C698 /* Planner */ = {
+		89A250F12D784716A409C6CF /* Planner */ = {
 			isa = PBXGroup;
 			children = (
-				60236CCDF7AA48738D0D49FB /* CalendarSubscribeSheet.swift */,
-				7E3F8A9FCD1249E79F8CC819 /* CalendarView.swift */,
-				8C606E34F9144B64A777B6FC /* ConferenceReminderScheduler.swift */,
-				CAD1CE39301A41058120A843 /* DueReminderScheduler.swift */,
-				427B5B7A544441FF83DAB84F /* OfficeHoursReminderScheduler.swift */,
-				35482D532A2149B080CD6765 /* PlannerModel.swift */,
-				BADAEEFB6B414AA287062F8B /* PlannerView.swift */,
-				33C7B900B7ED4925A1869D55 /* TodosView.swift */,
+				4906C7481D4846209825317F /* CalendarSubscribeSheet.swift */,
+				F63D10FFB5994D85916B3452 /* CalendarView.swift */,
+				6E2C9AD63AE64C28A581941C /* ConferenceReminderScheduler.swift */,
+				5C9458F0AE1943F5ABED08F8 /* DueReminderScheduler.swift */,
+				8234B2B85127411A9170A3B4 /* OfficeHoursReminderScheduler.swift */,
+				CCA88792E76548ECB5F42F63 /* PlannerModel.swift */,
+				D4D5DB43679D4F0883B914C9 /* PlannerView.swift */,
+				3CB75241F3C54D6BAF22C7C5 /* TodosView.swift */,
 			);
 			path = Planner;
 			sourceTree = "<group>";
 		};
-		E2079ED3F1014028BE86AA6B /* Portfolio */ = {
+		7456519654BA4EA2A3DEDECE /* Portfolio */ = {
 			isa = PBXGroup;
 			children = (
-				A35BC5FD1AF146CBAF2065AB /* ArtifactDetailView.swift */,
-				01E149F4B7DA48DD9F801DD0 /* ArtifactEditorView.swift */,
-				5004097E1B874DDB93242DA0 /* PortfolioArtifactUploader.swift */,
-				4A30B10FF37F4C73B99B56B6 /* PortfolioDetailView.swift */,
-				5F1211C341964513B98889F4 /* PortfolioView.swift */,
+				D70B61AEC9A84C17B965B80C /* ArtifactDetailView.swift */,
+				A56725B79B7C4322A19637D3 /* ArtifactEditorView.swift */,
+				A99F8E9BBDA442DAA6DE27D9 /* PortfolioArtifactUploader.swift */,
+				B914CD8D81974975B0B22EF2 /* PortfolioDetailView.swift */,
+				9DEBFEC34B6F41FB97FC6F29 /* PortfolioView.swift */,
 			);
 			path = Portfolio;
 			sourceTree = "<group>";
 		};
-		D36507EDCE7F4C758048399C /* Profile */ = {
+		70A339DCD0ED4E7092F86F53 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
-				849FD0BE416241E8A1617D59 /* AiAdminEntryCard.swift */,
-				68F339E576E4464982A315D3 /* ArchivedCoursesAdminEntryCard.swift */,
-				269BBDA8E3F84DEA9DEA260D /* BiometricLockView.swift */,
-				72BD8DB3522843548EDB368A /* DeviceSessionsView.swift */,
-				F1D7198549954D4CA1AC7026 /* EditProfileView.swift */,
-				AF071116BC2F446789DB95AC /* IntegrationsAdminEntryCard.swift */,
-				8CF54036E6B3426390D72262 /* IntegrationsEntryCard.swift */,
-				F9E6FEAC28BF4ECBB2548552 /* IntegrationsView.swift */,
-				292E60D74B50449DBF81B8D6 /* LearnerProfileEntryCard.swift */,
-				612542398DB34253A6686424 /* MyAccommodationsView.swift */,
-				36BBC380C7B14E1C97904F62 /* NotificationPreferencesView.swift */,
-				366826087F904BB7BC321C08 /* NotificationsView.swift */,
-				D5CEB80575D4484FBEFD5CC5 /* OrgBrandingAdminEntryCard.swift */,
-				283D9CE400334AC49AFD50AC /* OrgStructureAdminEntryCard.swift */,
-				CEFE73F8C7ED4996B392B117 /* PeopleAdminEntryCard.swift */,
-				918C26A90C7045FD93FF96C1 /* PlatformSettingsAdminEntryCard.swift */,
-				90E99FC07CB54E0C96EA10BD /* ProfileDepthCards.swift */,
-				5FCFBF1C1FCF47BB84AEAF38 /* ProfilePersonalDetailsView.swift */,
-				C12BAF195789448DB078C7CF /* ProfileSecurityCard.swift */,
-				E057149B676F46098DDDBD1A /* ProfileSettingsCards.swift */,
-				A7F1FD9E84874180BAD8D5DC /* ProfileView.swift */,
-				77BF6067904E4A2087EC27CE /* ProfileViewSections.swift */,
-				53305DC75B204D9C81F3585B /* ResearchStudiesView.swift */,
-				0A4320E0C0E24EB9BE1B7F58 /* RolesPermissionsAdminEntryCard.swift */,
-				D5E6AEEF26D44D3EA65A25A0 /* SettingsAdminHubEntryCard.swift */,
-				F67308866EF5479FA01FC732 /* ShareFeedbackEntryCard.swift */,
-				8BD739C270344ADEB1A3142D /* TranscriptsAdvisingAdminEntryCard.swift */,
+				592539EF2B3D4074804061C6 /* AiAdminEntryCard.swift */,
+				B1D9881CB51A4181AB4D16D0 /* ArchivedCoursesAdminEntryCard.swift */,
+				F2A64092496C4AD2B8F25D58 /* BiometricLockView.swift */,
+				88E507504BBD476CA403DD67 /* DeviceSessionsView.swift */,
+				68599A8761C649ABBB52D83B /* EditProfileView.swift */,
+				3DBEEB71BD314400A927650F /* IntegrationsAdminEntryCard.swift */,
+				27E5C27923924FD0A90C01B9 /* IntegrationsEntryCard.swift */,
+				AA4BE77EF7674E1E9E3757D2 /* IntegrationsView.swift */,
+				F04F9D5BE5EF4D878ACE1733 /* LearnerProfileEntryCard.swift */,
+				30AE110FA35341549393278C /* MyAccommodationsView.swift */,
+				641868BD33C04BE9AF3E8954 /* NotificationPreferencesView.swift */,
+				63EA9BD24D0C4E8DB20249B6 /* NotificationsView.swift */,
+				6AC2145244F94724B67473A5 /* OrgBrandingAdminEntryCard.swift */,
+				C1D034344ED842FE8B459C23 /* OrgStructureAdminEntryCard.swift */,
+				89848B70521648509950383E /* PeopleAdminEntryCard.swift */,
+				229CE427FD1A4EF28A143AFE /* PlatformSettingsAdminEntryCard.swift */,
+				040626B6A7374B009C3BD9E3 /* ProfileDepthCards.swift */,
+				3477F16CDB66413397751CCB /* ProfilePersonalDetailsView.swift */,
+				883E4F888A014172A4ACD859 /* ProfileSecurityCard.swift */,
+				8809936E57384A37BBA2F68F /* ProfileSettingsCards.swift */,
+				309494895CAB4416BC2569D5 /* ProfileView.swift */,
+				223A451AED7B4DF08DF67712 /* ProfileViewSections.swift */,
+				5AED4420C17745ADB291B9B8 /* ResearchStudiesView.swift */,
+				346A50DE69D841D19BD94AB8 /* RolesPermissionsAdminEntryCard.swift */,
+				32F1150E53D840E3B21131A5 /* SettingsAdminHubEntryCard.swift */,
+				28B39FAB37194467A12B0D1B /* ShareFeedbackEntryCard.swift */,
+				694198A11E7247BEAB1CFE82 /* TranscriptsAdvisingAdminEntryCard.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
 		};
-		AC8ADF7A4E63412184F152A6 /* Quiz */ = {
+		4DE366E438714EE488DA3FAC /* Quiz */ = {
 			isa = PBXGroup;
 			children = (
-				F8BCD90D8A8E4EF4AFB9D583 /* CodeQuestionView.swift */,
-				633C85BCCB7941E5BD24D270 /* LockdownController.swift */,
-				7CC57DD00547498A8F4FB307 /* QuizIntroView.swift */,
-				0B9DCCE9B89246218C4CE8EF /* QuizQuestionViews.swift */,
-				34504285543C4C9A8CD6F5EA /* QuizResultsView.swift */,
-				1B81ADC20ABF47A3AD5C31F4 /* QuizTakerView.swift */,
+				DD71CD636D5942858C5CD40D /* CodeQuestionView.swift */,
+				6FBCAEDFDB0B4FE9A86D39FE /* LockdownController.swift */,
+				E8C82DEEFB314FE3B1262BB5 /* QuizIntroView.swift */,
+				6765D118B5E24C9F9BE2CBDE /* QuizQuestionViews.swift */,
+				A02C95A7DCC443B2BF852B70 /* QuizResultsView.swift */,
+				2E7EE232B3A749DDB1F48C02 /* QuizTakerView.swift */,
 			);
 			path = Quiz;
 			sourceTree = "<group>";
 		};
-		237D6A2B598547BD86AFBCDE /* Reader */ = {
+		4D20B78B3E1546898EA3270B /* Reader */ = {
 			isa = PBXGroup;
 			children = (
-				41EC5757A7B946098AC5B893 /* CaptionedPlayerView.swift */,
-				CAACDFB103B9456BBC73750E /* ContentTranslationControls.swift */,
-				49467C0BBC9C415780029214 /* ImmersiveReaderCapabilities.swift */,
-				990F430024144399B37A91A2 /* ReaderLogic.swift */,
-				9F495ED7A44B4C73968DA21E /* ReaderToolbar.swift */,
-				BBDA47FBE9DE454C9CD75E5D /* ReadingPreferencesSheet.swift */,
-				D4AB029FB1A444B3BEA5D695 /* ReadingPreferencesStore.swift */,
+				5691E7CBA8204B74BF155205 /* CaptionedPlayerView.swift */,
+				AE44AC00C29F4222A81865E6 /* ContentTranslationControls.swift */,
+				BD37D28F45B2488BA3BFDAD0 /* ImmersiveReaderCapabilities.swift */,
+				DBF2041EABAF44E589DA9C66 /* ReaderLogic.swift */,
+				6D1CA05D397847C18530E5FC /* ReaderToolbar.swift */,
+				D555BC7606A84D7484F73373 /* ReadingPreferencesSheet.swift */,
+				CC3C4F7284FF450D85F2EC20 /* ReadingPreferencesStore.swift */,
 			);
 			path = Reader;
 			sourceTree = "<group>";
 		};
-		90F66E03E1134348965E60B3 /* Reading */ = {
+		C426D25894744A6F9FF5F2E5 /* Reading */ = {
 			isa = PBXGroup;
 			children = (
-				56111FF37D29429987AB0096 /* LeveledLibraryView.swift */,
-				3B3A83C44B84487CB01EFF3C /* LogReadingSheet.swift */,
-				9F5A6D6A50874B1FAB312EE8 /* ReadingDashboardView.swift */,
+				5BB809EFFFB04243A54BEFB5 /* LeveledLibraryView.swift */,
+				EC8A987C0A714FDEB2297C6A /* LogReadingSheet.swift */,
+				1DD831BE987D4190BCF6851C /* ReadingDashboardView.swift */,
 			);
 			path = Reading;
 			sourceTree = "<group>";
 		};
-		46868CAEEAB6446F8ABEC2B2 /* Review */ = {
+		0FD2976742C7481B9B490B59 /* Review */ = {
 			isa = PBXGroup;
 			children = (
-				4BBB673CA4DB420BA37B9208 /* ReviewHomeView.swift */,
-				A6440ADA1E9544ECBF69F85E /* ReviewReminderScheduler.swift */,
-				A31DE89C777B4A51887F141C /* ReviewSessionView.swift */,
+				D60C3CA6A5BE45BFB0D1BCC0 /* ReviewHomeView.swift */,
+				46422DFEFDB340AC9BCEFBDA /* ReviewReminderScheduler.swift */,
+				97400E67C60C4E2192CC0D59 /* ReviewSessionView.swift */,
 			);
 			path = Review;
 			sourceTree = "<group>";
 		};
-		E1A4436428CA4458B73960A1 /* Search */ = {
+		BEC2A502BBB243AB9B6E3F6F /* Search */ = {
 			isa = PBXGroup;
 			children = (
-				F0A178AEF05541188021889B /* UniversalSearchView.swift */,
+				2A8B565C9B67483486E952FE /* UniversalSearchView.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
 		};
-		210F88C32584464BBEE31669 /* Settings */ = {
+		DF581E0BCA944946B6E71BCC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				0D1E0D02D4B644B89A64B37E /* Admin */,
-				EC90322BE577468290B4551A /* SettingsAdminHubView.swift */,
+				2533A12FADF14647AC96EC98 /* Admin */,
+				CBBA2CA382684EE780FCDEC8 /* SettingsAdminHubView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
 		};
-		CA7B2E95CAF54885B79E2BC5 /* Splash */ = {
+		95FC6B63134146A39E71A5C1 /* Splash */ = {
 			isa = PBXGroup;
 			children = (
-				8C311030F725471CBF67D6F8 /* SplashView.swift */,
+				3EBFB03D4B1B44B69F7A8928 /* SplashView.swift */,
 			);
 			path = Splash;
 			sourceTree = "<group>";
 		};
-		79EEC603F04B48FBAB3B099C /* Tutor */ = {
+		57E136DF174C41DA875139CA /* Tutor */ = {
 			isa = PBXGroup;
 			children = (
-				871BFA5C95E049CBAFEC0731 /* TutorChatModel.swift */,
-				9452C8D2829F4FB6B21CAB26 /* TutorChatView.swift */,
-				3CAB6ED9091E4B3E94718267 /* TutorFlowLayout.swift */,
-				A66A524C7AAC4FB2B017F128 /* TutorLauncher.swift */,
+				5052260E3DE1456BBA59B151 /* TutorChatModel.swift */,
+				3223D2B42D3A4F13B49D7F42 /* TutorChatView.swift */,
+				6346A67698B641D7B2D4A441 /* TutorFlowLayout.swift */,
+				6D315B2782FB43308BEF661D /* TutorLauncher.swift */,
 			);
 			path = Tutor;
 			sourceTree = "<group>";
 		};
-		7E4FC5D1155B4BB3942A3651 /* Wallet */ = {
+		85E299B0490C4FFEAE87D07E /* Wallet */ = {
 			isa = PBXGroup;
 			children = (
-				F9F9005EEE2744EBB7D096EC /* WalletCCRDetailView.swift */,
-				0BF4CF0A377A4ED5B3DC1AA0 /* WalletCETranscriptDetailView.swift */,
-				7AACA18723DA4543805BE85B /* WalletOfficialTranscriptDetailView.swift */,
-				A9F06C20D3B941B69051DDA0 /* WalletView.swift */,
+				E07BCE656BB942D48E005C49 /* WalletCCRDetailView.swift */,
+				82B9B807BBC44CDDB7803DA5 /* WalletCETranscriptDetailView.swift */,
+				DC36E8FB3D78445B83CA8A83 /* WalletOfficialTranscriptDetailView.swift */,
+				877ECF71BA4E4ACCBC6DC624 /* WalletView.swift */,
 			);
 			path = Wallet;
 			sourceTree = "<group>";
 		};
-		4DAABF4AA127483AB5410F31 /* Layouts */ = {
+		3848AC4F7010417E901BFEC0 /* Layouts */ = {
 			isa = PBXGroup;
 			children = (
-				370BAE4B96A34903AB73ED0C /* CanvasLayout.swift */,
-				78BA4EA8C1154A7EA1731CD8 /* ColumnsLayout.swift */,
-				780DA182FF4043B38696D36C /* MapLayout.swift */,
-				E7CB8C1BE7504CD9B7CEEAC6 /* TimelineLayout.swift */,
-				57FDCF46AF3E4B0DA1A173DB /* WallLayout.swift */,
+				7DA492F2BE1548339ADEA334 /* CanvasLayout.swift */,
+				6749D8AD1CC84795999E67B0 /* ColumnsLayout.swift */,
+				60EA2749A48844A58A8DF179 /* MapLayout.swift */,
+				58CDC3E525A84E28AAC2BFBA /* TimelineLayout.swift */,
+				622A895CD460490799FB6A37 /* WallLayout.swift */,
 			);
 			path = Layouts;
 			sourceTree = "<group>";
 		};
-		8390046B0AF344AABF74161A /* Public */ = {
+		F7ECB1D8BA314279B492480A /* Public */ = {
 			isa = PBXGroup;
 			children = (
-				2F852E57D2D14F8A95455DBE /* BoardPublicView.swift */,
+				73CEB85CCEAB433394A7F47B /* BoardPublicView.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
 		};
-		1C2E30F913D24B4E82AC0C48 /* Create */ = {
+		AB21E3A16F8E41CFAC0240EB /* Create */ = {
 			isa = PBXGroup;
 			children = (
-				35EB05D53C374ABEB6EA3DD0 /* CanvasImportComingSoonView.swift */,
-				E9F823AB9D514792B470A794 /* CanvasImportView.swift */,
-				2BCB46E9122846B5904855D6 /* CourseCreateView.swift */,
+				6CD6433A5A6745859F26D7E2 /* CanvasImportComingSoonView.swift */,
+				B79A38EF73D849B89A24DB63 /* CanvasImportView.swift */,
+				24B4F1E4C99949DCB57815D2 /* CourseCreateView.swift */,
 			);
 			path = Create;
 			sourceTree = "<group>";
 		};
-		7392CA5A807B44BEAA14C8B4 /* Settings */ = {
+		8FDBE2B268C14455A370B803 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				E895804DE50A41ED8B232135 /* CourseAccessibilityReviewView.swift */,
-				267410C1A41D49FF99FBB5C7 /* CourseArchivedContentView.swift */,
-				FCBAB76F491F4138AED91A60 /* CourseBlueprintSettingsView.swift */,
-				FC84EB24717C41269F150D07 /* CourseCrossListingView.swift */,
-				DD02BDC83DB8485CBCE81507 /* CourseFeaturesSettingsView.swift */,
-				BFB6A4245D294042A00AA6A4 /* CourseGeneralSettingsView.swift */,
-				5349888EC0114570ACD831E4 /* CourseGradingAgentsView.swift */,
-				59EF72CCCF474E3AAA676528 /* CourseGradingSettingsView.swift */,
-				EA41E9040649456DB33BC162 /* CourseHeroImageEditor.swift */,
-				FBA181A953E14C468095768C /* CourseImportExportView.swift */,
-				9BE3AA0F3A6F4471AA1C6E35 /* CourseMarketplaceSettingsView.swift */,
-				8BC1C07012AA400FB90CD1B1 /* CourseOutcomesSettingsView.swift */,
-				2225D9D07D9C459196127219 /* CoursePlagiarismSettingsView.swift */,
-				4DE94582729E48E39E56B2E9 /* CourseSectionsSettingsView.swift */,
-				713566F955A64593962A78CF /* CourseSettingsHostView.swift */,
-				1FA5BBF44C9844CEA26C3C6A /* CourseTranslationsSettingsView.swift */,
+				BF070004C4CA433E8F0F74A7 /* CourseAccessibilityReviewView.swift */,
+				832248171BB1497E8A935DB6 /* CourseArchivedContentView.swift */,
+				6DF044088FCA451EA8388263 /* CourseBlueprintSettingsView.swift */,
+				869F283288214F60917D5FE2 /* CourseCrossListingView.swift */,
+				2119EC8AFB9F42ADA2BBE773 /* CourseFeaturesSettingsView.swift */,
+				25E583694E9B463B9829B3CA /* CourseGeneralSettingsView.swift */,
+				B013FC2F99764401B0DE38C6 /* CourseGradingAgentsView.swift */,
+				61142908EABC4D26A5A04DE1 /* CourseGradingSettingsView.swift */,
+				AA480BF4B3144A949E93817E /* CourseHeroImageEditor.swift */,
+				689FDA3F9E714CAF9E30C243 /* CourseImportExportView.swift */,
+				527F305D833141F0B9A7F432 /* CourseMarketplaceSettingsView.swift */,
+				53520527C1094B3D9051FA7A /* CourseOutcomesSettingsView.swift */,
+				6289444D5E1340958D35A588 /* CoursePlagiarismSettingsView.swift */,
+				8AE01EA5982740088E1C66E7 /* CourseSectionsSettingsView.swift */,
+				06D1490287164C789D58C042 /* CourseSettingsHostView.swift */,
+				AFE3DE7CE7F8448E9FAECE4B /* CourseTranslationsSettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
 		};
-		0D1E0D02D4B644B89A64B37E /* Admin */ = {
+		2533A12FADF14647AC96EC98 /* Admin */ = {
 			isa = PBXGroup;
 			children = (
-				B97B6F26B6DC4092BAB78F26 /* AdminMetricCards.swift */,
-				DB36A44F66604F3C843C50D9 /* AdvisingSettingsView.swift */,
-				4C9843014D154611A7BFD0C9 /* AiAdminHubView.swift */,
-				44A56979663249C4AFE83221 /* AiGovernanceView.swift */,
-				889FAFAF774142C2BA86329C /* AiModelsSettingsView.swift */,
-				B3C29C92B3B24E5C86725EE7 /* AiProviderSettingsView.swift */,
-				CA28E77314484396AB0AE64A /* AiReportsView.swift */,
-				C4355CA566304FBAAB98D098 /* ArchivedCoursesAdminView.swift */,
-				942584F491914827B95F3282 /* AuditLogAdminView.swift */,
-				88724DBA10A14C4BB795E26F /* BoardsGovernanceAdminView.swift */,
-				914CCB5EAAF34214B8885432 /* CoursesAdminView.swift */,
-				43BFDD3B36BC48A8B13DE360 /* IntegrationsAdminView.swift */,
-				79E256FCB9F14A47B25202B5 /* OrgBrandingAdminView.swift */,
-				B1B6653C12AF4B4395D2650A /* OrgBrandingView.swift */,
-				9F3124434EF14E0F9A93AF28 /* OrgStructureAdminView.swift */,
-				12EEAD3B385B4D19A7EE0841 /* OrgStructureView.swift */,
-				41EF610BF1484F9AADE2AA95 /* PeopleAdminView.swift */,
-				FF4A03C39AFE47918DBCC377 /* PlatformSettingsView.swift */,
-				F67E4C60CD8D4042A5591FEE /* RolesPermissionsAdminView.swift */,
-				AE2FA99DD121458D8201C26C /* SystemPromptsView.swift */,
-				D1AF5D02D2464887B58449B2 /* TermsAdminView.swift */,
-				4D5AD5CA80204A4D9F4EDB14 /* TranscriptsAdvisingAdminView.swift */,
-				12B3CD2CBADB4D5CB7B5CD36 /* TranscriptsSettingsView.swift */,
-				9240550142D1439DB32F9DDA /* UserDetailAdminView.swift */,
+				30F39278CAC240B7B0EF370C /* AdminMetricCards.swift */,
+				466D182804AB4200BC2B51AC /* AdvisingSettingsView.swift */,
+				D757F646B1574C6C9D533E3E /* AiAdminHubView.swift */,
+				F09FDB3EC56C46ACBA943EB8 /* AiGovernanceView.swift */,
+				4B06D5DC1FD14C06B7AFA51D /* AiModelsSettingsView.swift */,
+				2300CD6C3A8E4E10939991A8 /* AiProviderSettingsView.swift */,
+				B3FE1042D83B4C0BA7ED4338 /* AiReportsView.swift */,
+				1D53F974E0C14CB28AA79912 /* ArchivedCoursesAdminView.swift */,
+				02AE7753E97A49B49B6FD4DB /* AuditLogAdminView.swift */,
+				3CA4720B61B84CD5813CC3CE /* BoardsGovernanceAdminView.swift */,
+				84F3766C479F4F9CA634923F /* CoursesAdminView.swift */,
+				96506190CC5A4108B2477B94 /* IntegrationsAdminView.swift */,
+				D7B57D0B310A40D49231F4EC /* OrgBrandingAdminView.swift */,
+				530384910C664DFC8EE07B36 /* OrgBrandingView.swift */,
+				D8CE3A3E34D04EC8B5962871 /* OrgStructureAdminView.swift */,
+				1C7DA1CF78814F369E0C8B70 /* OrgStructureView.swift */,
+				31D314EF2EE8456F80C84955 /* PeopleAdminView.swift */,
+				6C89EEE709B84652A6258FAA /* PlatformSettingsView.swift */,
+				880351C617DA4F71A53CF111 /* RolesPermissionsAdminView.swift */,
+				DB13261BF35E47EB8D1AF53B /* SystemPromptsView.swift */,
+				BFA372629F404455AA0D9CB3 /* TermsAdminView.swift */,
+				56161BC8160D47CC9E032B96 /* TranscriptsAdvisingAdminView.swift */,
+				34F0283432F14B4389A33A17 /* TranscriptsSettingsView.swift */,
+				8E2DF455833C46BDADCD8939 /* UserDetailAdminView.swift */,
 			);
 			path = Admin;
 			sourceTree = "<group>";
 		};
-		EEA8A3DCA53849119D2E55D7 /* Products */ = {
+		AC8A70B45E3B4B71B611980E /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				45A94E45545C4385825A8FAB /* Lextures.app */,
-				15F81775D0274CCC924659BA /* LexturesTests.xctest */,
+				2ACFD23021C24F8188DFD53D /* Lextures.app */,
+				C32FF697E67243E080F4BF34 /* LexturesTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		18E195655DA64C658129CFC0 /* Config */ = {
+		BB15E2BC76334AFCB70900DA /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				399F75F7EF59410184CBA37C /* Development.xcconfig */,
+				955CC71A4CB748009BB3E55F /* Development.xcconfig */,
 			);
 			path = Config;
 			sourceTree = "<group>";
 		};
-		C58FCA5712CE40849BA70C07 = {
+		81FF414CE6D746BA8BD9CF21 = {
 			isa = PBXGroup;
 			children = (
-				229B30A95B9B4F4894F99558 /* Lextures */,
-				06964482C25142FFB07CE05C /* LexturesTests */,
-				18E195655DA64C658129CFC0 /* Config */,
-				EEA8A3DCA53849119D2E55D7 /* Products */,
+				C06A93A6950C40EF8B934068 /* Lextures */,
+				5B3849C2686B4E19ABEBDFE4 /* LexturesTests */,
+				BB15E2BC76334AFCB70900DA /* Config */,
+				AC8A70B45E3B4B71B611980E /* Products */,
 			);
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		1C95EA15BFA249F09F2F233C /* Lextures */ = {
+		0873EDB97F8E49CE9C6DD710 /* Lextures */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 124F22003E48492986BF0C64 /* Build configuration list for PBXNativeTarget "Lextures" */;
+			buildConfigurationList = C2F3E7878F504E3DADB05975 /* Build configuration list for PBXNativeTarget "Lextures" */;
 			buildPhases = (
-				B327D2048BCD48B6A95C384A /* Sources */,
-				28DFD09374804ACA94378472 /* Frameworks */,
-				C85E3401A43E47C29247FEB8 /* Resources */,
+				D9B05B46D09641EABF347D4D /* Sources */,
+				48BFD22254054040909715DC /* Frameworks */,
+				0002729294E64B80B84C891E /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2600,60 +2612,60 @@
 			);
 			name = "Lextures";
 			productName = Lextures;
-			productReference = 45A94E45545C4385825A8FAB /* Lextures.app */;
+			productReference = 2ACFD23021C24F8188DFD53D /* Lextures.app */;
 			productType = "com.apple.product-type.application";
 		};
-		895620D25C8A4BCA974315E7 /* LexturesTests */ = {
+		4013EA55F52949789118CBDB /* LexturesTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5778F2DD9CE041F4A88C1C97 /* Build configuration list for PBXNativeTarget "LexturesTests" */;
+			buildConfigurationList = DD916C25059446268826810F /* Build configuration list for PBXNativeTarget "LexturesTests" */;
 			buildPhases = (
-				9E1E6DA8B52A40FDB2B4C866 /* Sources */,
-				B9D3D80715914553984DCBCF /* Frameworks */,
+				B4FCA470F3184A7BA3311970 /* Sources */,
+				6BC7D54FBA944EB4BE9C9B65 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				9FABE0A0696C4FADA1748E80 /* PBXTargetDependency */,
+				1A1AE96C1FD54638B5E8D2F2 /* PBXTargetDependency */,
 			);
 			name = "LexturesTests";
 			productName = LexturesTests;
-			productReference = 15F81775D0274CCC924659BA /* LexturesTests.xctest */;
+			productReference = C32FF697E67243E080F4BF34 /* LexturesTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXContainerItemProxy section */
-		F81C8C90259945C7A1597CF7 /* PBXContainerItemProxy */ = {
+		BDEC3D69A2A646D4AD6A2521 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 23ED123BADD24061AF867515 /* Project object */;
+			containerPortal = BDBB0EDFD23F4A249C8FA7F5 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1C95EA15BFA249F09F2F233C;
+			remoteGlobalIDString = 0873EDB97F8E49CE9C6DD710;
 			remoteInfo = Lextures;
 			};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXTargetDependency section */
-		9FABE0A0696C4FADA1748E80 /* PBXTargetDependency */ = {
+		1A1AE96C1FD54638B5E8D2F2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 1C95EA15BFA249F09F2F233C /* Lextures */;
-			targetProxy = F81C8C90259945C7A1597CF7 /* PBXContainerItemProxy */;
+			target = 0873EDB97F8E49CE9C6DD710 /* Lextures */;
+			targetProxy = BDEC3D69A2A646D4AD6A2521 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXProject section */
-		23ED123BADD24061AF867515 /* Project object */ = {
+		BDBB0EDFD23F4A249C8FA7F5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
-					1C95EA15BFA249F09F2F233C = {
+					0873EDB97F8E49CE9C6DD710 = {
 						CreatedOnToolsVersion = 16.0;
 					};
 				};
 			};
-			buildConfigurationList = C0539B66D38A4C3D80C6B2D5 /* Build configuration list for PBXProject "Lextures" */;
+			buildConfigurationList = 714A243CEA884E67B6808006 /* Build configuration list for PBXProject "Lextures" */;
 			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -2661,695 +2673,699 @@
 				en,
 				Base,
 			);
-			mainGroup = C58FCA5712CE40849BA70C07;
-			productRefGroup = EEA8A3DCA53849119D2E55D7 /* Products */;
+			mainGroup = 81FF414CE6D746BA8BD9CF21;
+			productRefGroup = AC8A70B45E3B4B71B611980E /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				1C95EA15BFA249F09F2F233C /* Lextures */,
-				895620D25C8A4BCA974315E7 /* LexturesTests */,
+				0873EDB97F8E49CE9C6DD710 /* Lextures */,
+				4013EA55F52949789118CBDB /* LexturesTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		C85E3401A43E47C29247FEB8 /* Resources */ = {
+		0002729294E64B80B84C891E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			runOnlyForDeploymentPostprocessing = 0;
 			files = (
-				40E58270E8384B91A6D7D8D9 /* Assets.xcassets in Resources */,
-				86440F50A4684F768EF22A0B /* Localizable.xcstrings in Resources */,
+				D3122341196441F4963C7B28 /* Assets.xcassets in Resources */,
+				19B9233A70F1444A911CB5C9 /* Localizable.xcstrings in Resources */,
 			);
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		B327D2048BCD48B6A95C384A /* Sources */ = {
+		D9B05B46D09641EABF347D4D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			runOnlyForDeploymentPostprocessing = 0;
 			files = (
-				6ED369A7EE154CDCBE032887 /* AppDelegate.swift in Sources */,
-				15E1F90879A9406FBBBA92F6 /* LexturesApp.swift in Sources */,
-				20454A04869B4B678FA6157E /* RootView.swift in Sources */,
-				F4F1D79C0F53493EBAF31CCA /* AccessibilityPreferences.swift in Sources */,
-				A3D8BE5BBE4E4EC6922FB9AE /* AccessibilitySupport.swift in Sources */,
-				DC933262AF1C4EE78BDDD135 /* DictationField.swift in Sources */,
-				6A559EEE76EA40B0B5E919D7 /* ReadAloud.swift in Sources */,
-				1F84B57453EC443DBD850C7C /* AuthAPI.swift in Sources */,
-				625DE845245045A9B259C8F2 /* AuthCallbackParser.swift in Sources */,
-				751CB6CA908C42AAA8A799EA /* AuthConstants.swift in Sources */,
-				9B9E21406160409F8D81FB5F /* AuthSession.swift in Sources */,
-				6123B63B7BBD44C0B9A5EEF9 /* BiometricGate.swift in Sources */,
-				AC0EE35E21034BB5BAAD78AC /* KeychainStore.swift in Sources */,
-				BE6ED0BBA1EB4014BEA5B85C /* SessionsAPI.swift in Sources */,
-				41A7DB60D97B43A5ACCDA312 /* AppConfiguration.swift in Sources */,
-				7C05A81CDD024AF5B53CF947 /* EnvironmentStore.swift in Sources */,
-				DBA2446EE0D343D08044259A /* SchoolCodeLogic.swift in Sources */,
-				30F64C0A143A46F59F00F5A1 /* AuthFieldRepresentable.swift in Sources */,
-				45145825BFEA43AC83DDBDD5 /* BrandLogoView.swift in Sources */,
-				D7AA30F9E7B44FBF9D2327B8 /* Haptics.swift in Sources */,
-				62107BFEAA9B4D66973F2017 /* LexturesMotion.swift in Sources */,
-				49400339D9134FFFA49CE52A /* LexturesTheme.swift in Sources */,
-				B22762E1FBD14F85A0D0C148 /* LexturesType.swift in Sources */,
-				5FAA6C38FD1C480DAEE2D729 /* ProfileAvatarView.swift in Sources */,
-				F3CDAC973F184CF48652D5D9 /* SyncStatusView.swift in Sources */,
-				38B668077E8B49F5ACB6FFE0 /* ThemePreference.swift in Sources */,
-				5A9724DB099341E79DA96A47 /* UIMode.swift in Sources */,
-				0E6CE5FAF63D463BAE988E9D /* UnsavedChangesBanner.swift in Sources */,
-				88CA2A3A7A47431DA028824C /* DateFormatting.swift in Sources */,
-				5286BF63D688419CB52D762D /* LocaleAPI.swift in Sources */,
-				AA7440F0963E49EABD664063 /* LocalePreferences.swift in Sources */,
-				5864916C8AA948DA91B23021 /* Localized.swift in Sources */,
-				A77698B1846F4D6E9EFA6BAC /* AccountAccommodationModels.swift in Sources */,
-				47C0179CEEAB4D6F999ECF72 /* AccountIntegrationsLogic.swift in Sources */,
-				DD92909F887D4008BD46B6FE /* AdvisingLogic.swift in Sources */,
-				C81BC21475CA478EA4075B85 /* AiModelsAdminLogic.swift in Sources */,
-				A6C6FCAC87AB4EE381972F02 /* AnnouncementLogic.swift in Sources */,
-				DD96F4097EF446199697B80D /* ArchivedCoursesAdminLogic.swift in Sources */,
-				1A31F1D6D90C4955BD1F573A /* AssignmentLogic.swift in Sources */,
-				30E996A34E254F359D5524D5 /* AuditLogAdminLogic.swift in Sources */,
-				584C5965CF674DBABA550E10 /* BehaviorLogic.swift in Sources */,
-				80CC735067BD4E049A911122 /* BillingLogic.swift in Sources */,
-				D2DA16D6D49B4DD9BBC1742D /* BoardRealtimeLogic.swift in Sources */,
-				F0BD139076674FDC9CBEB5EB /* BoardsAdvancedLogic.swift in Sources */,
-				EEC299626D5E41C8BE6863AA /* BoardsGovernanceAdminLogic.swift in Sources */,
-				B1626F1EDB1940F6B09877D4 /* BoardsLogic.swift in Sources */,
-				64577D94F29F41D69F3429FB /* CanvasImportLogic.swift in Sources */,
-				1F2F3185DD6743408FDD59E7 /* CanvasImportObservability.swift in Sources */,
-				AF97D393CA304376A3EBECFA /* CatalogLogic.swift in Sources */,
-				1CBD8E88A0E746268004C5A7 /* ConferenceLogic.swift in Sources */,
-				04B226DB102E4A8D8F8940D4 /* CourseAccessibilityReviewLogic.swift in Sources */,
-				51951A19C75B49CFB079BAC2 /* CourseArchivedContentLogic.swift in Sources */,
-				2EE334A9DD8843D7B8FED259 /* CourseBlueprintLogic.swift in Sources */,
-				58251CFEB17E4330BC32050D /* CourseCreateDraftStore.swift in Sources */,
-				E0BF1ACE45BE4777989D0FDC /* CourseCreateLogic.swift in Sources */,
-				B25B4B8A5947421BBC083268 /* CourseCreateObservability.swift in Sources */,
-				79F9D65C98C945F28936F111 /* CourseFeaturesLogic.swift in Sources */,
-				9832E919FE9E433DB05F6712 /* CourseFileLogic.swift in Sources */,
-				851C32BA90434973909B7C7C /* CourseGradingAgentsLogic.swift in Sources */,
-				2C7F8DB9A7C74FC09536B274 /* CourseGradingLogic.swift in Sources */,
-				17B40FA2B7084F90BA44AA56 /* CourseHeroImage.swift in Sources */,
-				1BCCDB4F8B184F498D1BA398 /* CourseImportExportLogic.swift in Sources */,
-				B6AC338EF20A481080AAEC66 /* CourseOutcomesLogic.swift in Sources */,
-				044E734121B04AD4AF133F21 /* CoursePeopleLogic.swift in Sources */,
-				E0034CBC4A4A44AA9ACA8F84 /* CoursePeopleObservability.swift in Sources */,
-				5604F5CF805A4EACA96AD8E6 /* CoursePlagiarismLogic.swift in Sources */,
-				964A3784221D48699021420C /* CourseReviewLogic.swift in Sources */,
-				34AE4236646B4DFA92E7EE27 /* CourseSectionsLogic.swift in Sources */,
-				57A71865D4EE48F7946F95E9 /* CourseSettingsLogic.swift in Sources */,
-				56A36D1DABC144AE8BA8EDC2 /* CourseTranslationsLogic.swift in Sources */,
-				D13E48A8AE0A44568B32D385 /* CredentialsLogic.swift in Sources */,
-				31449678DAE74DD994F3444C /* CurrencyExponent.swift in Sources */,
-				98F5A359170E43508EBC1010 /* DiscussionLogic.swift in Sources */,
-				5B293A532CB94B5C8CAC371D /* EvaluationLogic.swift in Sources */,
-				D7E0841ECCFC4A3395EC04C0 /* FeedbackLogic.swift in Sources */,
-				7F239EB29E674FEF9874B4A7 /* FileDownloadManager.swift in Sources */,
-				AFF61B9106234F7D83EBC362 /* GamificationLogic.swift in Sources */,
-				4091BD957DE54482B0A0C8C4 /* GradeCalculator+MyGrades.swift in Sources */,
-				A408256D4D144E1B95481536 /* GradeCalculator.swift in Sources */,
-				B7EF464315D54771870EB1A1 /* GroupsLogic.swift in Sources */,
-				0369207C3D5E44EBA0BEB2C4 /* InsightsLogic.swift in Sources */,
-				002905AB12F64D788195ADD0 /* InstructorInsightsLogic.swift in Sources */,
-				FB2CC0967E66475D95256EBA /* IntegrationsAdminLogic.swift in Sources */,
-				B8320F5DF6B9400F8A47EE47 /* InteractiveLaunchLogic.swift in Sources */,
-				75511354CC734D89A7A9C046 /* IntroCourseLogic.swift in Sources */,
-				9FE504583E704A828E3CBBDC /* IntroCourseObservability.swift in Sources */,
-				DD52F82C382945D2988DB8E3 /* LMSAPI.swift in Sources */,
-				FC08960D992547B69F6FB9EA /* LMSAPIAccountIntegrations.swift in Sources */,
-				2A82B52122014896A389E3CB /* LMSAPIAdmin.swift in Sources */,
-				D5EA0BE7DFD747188BC89A0D /* LMSAPIAdvising.swift in Sources */,
-				FCA20985E69A47AB8768D75D /* LMSAPIAnnouncements.swift in Sources */,
-				CD3E2665C37C4A2CBEB05C30 /* LMSAPIAuditLog.swift in Sources */,
-				5FB0E4CE699F408D908CD65B /* LMSAPIBehavior.swift in Sources */,
-				DE38858E481D4A97B0078961 /* LMSAPIBilling.swift in Sources */,
-				9E8BDF3EE56A4D038A7EC6CA /* LMSAPIBoardAccess.swift in Sources */,
-				77BE2015AE5E4F1EADDE9A8B /* LMSAPIBoardAnalytics.swift in Sources */,
-				BD3D62016549414B9854CC64 /* LMSAPIBoardEngagement.swift in Sources */,
-				9DFF1DA4BB314351964D9086 /* LMSAPIBoardExport.swift in Sources */,
-				2BE5A0593D3A48EBB96A507C /* LMSAPIBoardLayout.swift in Sources */,
-				D47A6CCBA23D418F9A53E695 /* LMSAPIBoardModeration.swift in Sources */,
-				163081DACD874AFC9CEBB4CB /* LMSAPIBoardPosts.swift in Sources */,
-				3F3F700D8EBD494F860E258F /* LMSAPIBoardTemplates.swift in Sources */,
-				3CAF4BC52EE14E59AA9AA375 /* LMSAPIBoards.swift in Sources */,
-				1EC0B2C122144589AD10A89D /* LMSAPICanvasImport.swift in Sources */,
-				AAF254745FA145C4978E8767 /* LMSAPICatalog.swift in Sources */,
-				1074AE412E3D45479E3FC24B /* LMSAPICourseAccessibility.swift in Sources */,
-				B402E25ADDA4412DA067751D /* LMSAPICourseArchivedContent.swift in Sources */,
-				05224A5A9E0D4046809E2B0D /* LMSAPICourseBlueprint.swift in Sources */,
-				1357C78D319D4F308D52A8F8 /* LMSAPICourseCreate.swift in Sources */,
-				BC762DECD0C844329C7F10F9 /* LMSAPICourseFeatures.swift in Sources */,
-				67538CE802674998AE77B463 /* LMSAPICourseGrading.swift in Sources */,
-				A2BF109AE8C949C6937E69CD /* LMSAPICourseGradingAgents.swift in Sources */,
-				8B8F3F12483D438983936BB7 /* LMSAPICourseImportExport.swift in Sources */,
-				4E904AB3021B4420B0C06A3B /* LMSAPICoursePlagiarism.swift in Sources */,
-				48823DAE80D24C32B3F4873D /* LMSAPICourseReviews.swift in Sources */,
-				B2295608748A41B7AC205BCC /* LMSAPICourseSections.swift in Sources */,
-				70BE875893DA41728EF11CF0 /* LMSAPICourseSettings.swift in Sources */,
-				574940E35AB04C66B966557F /* LMSAPICourseTranslations.swift in Sources */,
-				031BF94EDA8941B58ED65CFB /* LMSAPICredentials.swift in Sources */,
-				80612637EAEF448CA0384CBC /* LMSAPIDiscussions.swift in Sources */,
-				B6494DA38A7547888D36551B /* LMSAPIEportfolio.swift in Sources */,
-				9B69CCFEB0034CFEA7F815A6 /* LMSAPIEvaluations.swift in Sources */,
-				5D61EF685351448BA9E2CEE8 /* LMSAPIFeatures.swift in Sources */,
-				E9B249DC0717464180E51A62 /* LMSAPIFeed.swift in Sources */,
-				0CDB3FDC6C064673A5C9FADC /* LMSAPIFeedback.swift in Sources */,
-				59E4A13C071A48CAAE16D8E1 /* LMSAPIGamification.swift in Sources */,
-				0F52C3C798F4427B81D6C8A6 /* LMSAPIGroups.swift in Sources */,
-				E5C077722D6940F78A4293E7 /* LMSAPIInsights.swift in Sources */,
-				7DD3C39B0D0D4D5CAB137BFE /* LMSAPIInstructorInsights.swift in Sources */,
-				99DB368B3BC14B77AED0EA42 /* LMSAPIIntroCourse.swift in Sources */,
-				983CDB5358764FD6989EE994 /* LMSAPILearnerProfile.swift in Sources */,
-				1F65E5A34F584D36BC87EF70 /* LMSAPILiveQuiz.swift in Sources */,
-				6D88B5874E204CF3A2E31F39 /* LMSAPIMarketplace.swift in Sources */,
-				D6CC17B5DA7540AFB7D53BBD /* LMSAPIMastery.swift in Sources */,
-				25BED0BFCE244FDDB113467B /* LMSAPIMobileWave.swift in Sources */,
-				0107441311A1498BA49C74AD /* LMSAPIOutcomes.swift in Sources */,
-				8A9259E216124941B7AAA60B /* LMSAPIParent.swift in Sources */,
-				B89E19B30F1A4B31A8FF9534 /* LMSAPIPaths.swift in Sources */,
-				B9641A3904A14311B0ACECCD /* LMSAPIPeerReview.swift in Sources */,
-				F80F0668233D435AA9111D91 /* LMSAPIProctoring.swift in Sources */,
-				4E0F55A6CE1947508C936550 /* LMSAPIQuizCodeRun.swift in Sources */,
-				F658066BAB224F77B2EE617C /* LMSAPIReader.swift in Sources */,
-				07D34EE7807A46B59DEBC009 /* LMSAPIReading.swift in Sources */,
-				F4F7980EFE93464DA5512090 /* LMSAPIReview.swift in Sources */,
-				4FC4D8989506445D8A22D96B /* LMSAPITutor.swift in Sources */,
-				07E475945B75494B86C0EDD3 /* LMSAPIWallet.swift in Sources */,
-				6BFE443C16D44678883081EF /* LMSAPIWhiteboard.swift in Sources */,
-				4D015EF64B97490DAB901F99 /* LMSBoardAdvancedModels.swift in Sources */,
-				73A688D46E3E48FCA0EE3FBD /* LMSBoardModels.swift in Sources */,
-				57B5A846FD164DA1854CD044 /* LMSFeatureModels.swift in Sources */,
-				955A8DFB29674447B8015D2A /* LMSFeatureModelsAccountIntegrations.swift in Sources */,
-				EC4CFF3700DC422A8E2DFFD7 /* LMSFeatureModelsAdvising.swift in Sources */,
-				13161AA1ADBC4A6685BE7F95 /* LMSFeatureModelsAiAdmin.swift in Sources */,
-				6975DE522A664A1EB37B7F4C /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */,
-				BEA8298EE5BE471F8CF2C10B /* LMSFeatureModelsAuditLog.swift in Sources */,
-				B8AAEFE9A7EF494AA858B3C7 /* LMSFeatureModelsBehavior.swift in Sources */,
-				18B2F850A925428E8F668D01 /* LMSFeatureModelsBilling.swift in Sources */,
-				65B52B889BD547BC9A4643DC /* LMSFeatureModelsCanvasImport.swift in Sources */,
-				E042CA4A3D2F4EC6A718B836 /* LMSFeatureModelsCatalog.swift in Sources */,
-				11725BAAC0164B4F934DDEEE /* LMSFeatureModelsCourseAccessibility.swift in Sources */,
-				D6C37562AEBD4CEA8739A1DE /* LMSFeatureModelsCourseCreate.swift in Sources */,
-				930D5585356C42E6B1E714D3 /* LMSFeatureModelsCourseGrading.swift in Sources */,
-				625835250AA44CAB8BD357AF /* LMSFeatureModelsCourseGradingAgents.swift in Sources */,
-				C0681F597D194C86A516158D /* LMSFeatureModelsCourseOutcomes.swift in Sources */,
-				E33E8694BA8747CF9DA48BD7 /* LMSFeatureModelsCoursePlagiarism.swift in Sources */,
-				76595C5CC6AA4AD09A6DCD57 /* LMSFeatureModelsCourseReviews.swift in Sources */,
-				95816DE8A5154BAAB8FC9CFA /* LMSFeatureModelsCourseSettings.swift in Sources */,
-				8E74170077DB4DE9808236D9 /* LMSFeatureModelsCourseTranslations.swift in Sources */,
-				8944F1C9147041929F16AB50 /* LMSFeatureModelsCredentials.swift in Sources */,
-				B39FDDFD04C94707ABD777F0 /* LMSFeatureModelsDiscussions.swift in Sources */,
-				9F23BC5B6D4740F1B1A95C87 /* LMSFeatureModelsEportfolio.swift in Sources */,
-				D3D780D070DF42ACAA1FFF82 /* LMSFeatureModelsEvaluations.swift in Sources */,
-				4DB2AB512BDB4A53AEE8BB95 /* LMSFeatureModelsFeed.swift in Sources */,
-				742C8A710730478F9387553E /* LMSFeatureModelsFeedback.swift in Sources */,
-				29886400FBD04A58B95CC0B2 /* LMSFeatureModelsGamification.swift in Sources */,
-				8385C939AD84420C94FF12E3 /* LMSFeatureModelsGroups.swift in Sources */,
-				FD948DD685444BF9BCF318B5 /* LMSFeatureModelsInsights.swift in Sources */,
-				6D88CE52C986453A8BF5B0C6 /* LMSFeatureModelsInstructorInsights.swift in Sources */,
-				093D43FBB19545D2AC4E75BD /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */,
-				6894134B17314822902FFAF9 /* LMSFeatureModelsIntroCourse.swift in Sources */,
-				179BA98C79DC4A5E95C34E79 /* LMSFeatureModelsLearnerProfile.swift in Sources */,
-				AA25A097B4D54E04ADEC2434 /* LMSFeatureModelsLive.swift in Sources */,
-				0C741C7AE32844099FB1FBB5 /* LMSFeatureModelsMarketplace.swift in Sources */,
-				0BB69957873C40A780B86B3F /* LMSFeatureModelsMastery.swift in Sources */,
-				4A098125BC2C473F9073B74E /* LMSFeatureModelsMobile.swift in Sources */,
-				494414593D924216A78D4AD8 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */,
-				34EE6AF8F3554C1CAC6172B3 /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */,
-				6ACCA3B209314501B5AA46CD /* LMSFeatureModelsParent.swift in Sources */,
-				FA454F66A1264FBEA9C2B06A /* LMSFeatureModelsPaths.swift in Sources */,
-				4610A27CBA494A13930F773F /* LMSFeatureModelsPeerReview.swift in Sources */,
-				6DF84F2D562042BE961B6EDD /* LMSFeatureModelsPeopleAdmin.swift in Sources */,
-				93D366EE1FF142819422301B /* LMSFeatureModelsPlatform.swift in Sources */,
-				29396971F24F4367A238A82D /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */,
-				9A52A294619B4BA18EC8E197 /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */,
-				7029802B224848E9A126865B /* LMSFeatureModelsReader.swift in Sources */,
-				44F05A1005114E37884E5375 /* LMSFeatureModelsReading.swift in Sources */,
-				2C5D91394CC1432A9C1C7AEB /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */,
-				61D3278D97E84FC39DF35584 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */,
-				F50DD76D2D8A4868B51A8C3E /* LMSFeatureModelsTutor.swift in Sources */,
-				C6F366B4969647F4AEFCC95E /* LMSFeatureModelsWallet.swift in Sources */,
-				B718690ECB8C4105B00637EF /* LMSInteractiveModels.swift in Sources */,
-				628623E4AE6B4DA19322109F /* LMSModels.swift in Sources */,
-				82B05DA5BBF04F6CA95B08A3 /* LearnerProfileLogic.swift in Sources */,
-				5A300C2DE1AB4D8BAB2ABA39 /* LibraryResourceLogic.swift in Sources */,
-				9DBAA00087EE44908764E3A5 /* LiveGameLogic.swift in Sources */,
-				D507791B8EAB4DC28817850A /* LiveMeetingsLogic.swift in Sources */,
-				A3584F94A1494D57BCCBD4CF /* LiveQuizLogic.swift in Sources */,
-				D7807865C9EA4116A413AE18 /* MarketplaceLogic.swift in Sources */,
-				AD5D29047CA546C58B133BCC /* MasteryLogic.swift in Sources */,
-				3CD94916407742879D20E044 /* ModuleContentLogic.swift in Sources */,
-				5D01EB754B7645A6A12F9E6A /* ModuleLastVisited.swift in Sources */,
-				345219F117C0489D85F68966 /* NotificationLogic.swift in Sources */,
-				C02086BBF39A4D788E013067 /* OfficeHoursLogic.swift in Sources */,
-				597F6B4BE5874F68868530FA /* OnboardingModels.swift in Sources */,
-				D73F09E1288A4DDF9D908386 /* OrgBrandingAdminLogic.swift in Sources */,
-				0BB946A1AB534B6085F62EED /* OrgStructureAdminLogic.swift in Sources */,
-				53E1827781ED439DAE9BF12A /* ParentLogic.swift in Sources */,
-				EFD3A6E385E44BF5977B429F /* PathsLogic.swift in Sources */,
-				E4CE1F7DE7F544EB823E2729 /* PeerReviewLogic.swift in Sources */,
-				BE55CC8650BC46489079B9B4 /* PeopleAdminLogic.swift in Sources */,
-				D7784F2CEA6F4CBC924DA81D /* PlannerLogic.swift in Sources */,
-				5D1D2935B55E48899286F045 /* PlannerSnapshotCoding.swift in Sources */,
-				7C17718ECC9E4DE98F4CF7E1 /* PlatformCoursesAdminLogic.swift in Sources */,
-				12A7174B46624AB19D10DEA1 /* PlatformSettingsAdminLogic.swift in Sources */,
-				6E4BFD606DEF461492C0CC34 /* PortfolioLogic.swift in Sources */,
-				A9348C0F85494A02A4D7CE38 /* ProfileDepthLogic.swift in Sources */,
-				31B51BA5175E4674B9955071 /* ProfileDepthModels.swift in Sources */,
-				6F6A3A5298B6448F8C99A3E7 /* QuizLogic.swift in Sources */,
-				3D4B2B612A2C4206A769AACC /* ReadingLogic.swift in Sources */,
-				FF885585D39642C0B45C160C /* RequirementsLogic.swift in Sources */,
-				F9C7058850944E8F95807196 /* ReviewModels.swift in Sources */,
-				D1EE55FB461F463DAB742BBC /* RolesPermissionsAdminLogic.swift in Sources */,
-				A1FBE83DFE4149CEB92B8765 /* SettingsMenuLogic.swift in Sources */,
-				B2E07FFB481C4A5BBE6EF8E0 /* TakeAttendanceLogic.swift in Sources */,
-				C7567ACBBD6F4EECACCE2E4E /* TranscriptsAdvisingAdminLogic.swift in Sources */,
-				232E17A4D7494AE1B6B77E79 /* TutorLogic.swift in Sources */,
-				C044F6B123904CB2A77EB75A /* TutorStreamClient.swift in Sources */,
-				36B0A7F4F4B44BC2A74438AA /* VibeActivityLogic.swift in Sources */,
-				F27F3356FE4F482D8BDBE836 /* WalletLogic.swift in Sources */,
-				768E9C7C01454C198C99336C /* WhiteboardLogic.swift in Sources */,
-				A066A4DDEEE34F5495CD715F /* WhiteboardRenderer.swift in Sources */,
-				81164CE867B049079A45A29D /* APIClient.swift in Sources */,
-				FF6ADB7EFBA647D89ACCDB96 /* APIError.swift in Sources */,
-				18883053C2CF44569CD0FF76 /* NetworkAuthContext.swift in Sources */,
-				648C39D5C7FE43B8B1F16146 /* NetworkBootstrap.swift in Sources */,
-				10385B466EC84FDBA0825283 /* MarkdownTableLogic.swift in Sources */,
-				EC8703EC21534F22B998CF6D /* NotebookDrawing.swift in Sources */,
-				ACEE34B68C1745D38686B7EC /* NotebookMarkdown.swift in Sources */,
-				508C1E9687124A349438D5EE /* NotebookSlashCommands.swift in Sources */,
-				B4D601C0AC7741FAB409722A /* NotebookStore.swift in Sources */,
-				98EF53753BB04B84A456942D /* NotebookSync.swift in Sources */,
-				3172F3227AF54990B74FB813 /* NotebookTree.swift in Sources */,
-				681E8B1C40D540969DF80B6F /* CacheStore.swift in Sources */,
-				E71CF5810718438B94805D18 /* DownloadStore.swift in Sources */,
-				5954DCD025F74B1DAB907502 /* NetworkMonitor.swift in Sources */,
-				64342B0D4ADB4EA7913D491D /* OfflineModels.swift in Sources */,
-				6CE5D9B0001044E7A96C0C1C /* OfflineService.swift in Sources */,
-				DE91392DAAF24F848649990B /* OutboxStore.swift in Sources */,
-				167A204A3A04495A94282ECB /* SyncEngine.swift in Sources */,
-				D77CDD1A60F04BDA84A8AC2A /* PushManager.swift in Sources */,
-				65C54D08FE8A45C7BB5AFF62 /* RealtimeManager.swift in Sources */,
-				BADCC8AA27914AD39AD39E8D /* WebSocketClient.swift in Sources */,
-				CF4AB5B897894BD1BE2F2648 /* ContentLinkRouter.swift in Sources */,
-				7BE976C048F842CE82F153A5 /* DeepLinkRouter.swift in Sources */,
-				567EA4491007481BA5DF9EEE /* MobileDestinations.swift in Sources */,
-				1ED73BFD03AD49F7966024C1 /* MobileIaPreferences.swift in Sources */,
-				D492EBF9575B43CCB7D00891 /* MobileProfileDepthPreferences.swift in Sources */,
-				583F78BCFE074771AFB8CA3A /* SearchActionRegistry.swift in Sources */,
-				406EC6322EBB4CA38E0EF6A1 /* SearchModels.swift in Sources */,
-				74B0E82EE4094B42B32DEB3A /* SearchPathNavigator.swift in Sources */,
-				4BC8D3E45C984AEF8E9EA992 /* SearchRecentsStore.swift in Sources */,
-				25C1DAC6628B40E4B7BB1764 /* CodeEditor.swift in Sources */,
-				4F3D564DFDAA45D485DC08BC /* AdvisingView.swift in Sources */,
-				2B5AC6605D1C41C197E6144E /* AssignmentDetailView.swift in Sources */,
-				44288896B6304DC8833C55B1 /* AssignmentDraftStore.swift in Sources */,
-				0C506D3676A448019F3501F8 /* AttachmentUploader.swift in Sources */,
-				9E093827852844E099424DD5 /* AppleSignInController.swift in Sources */,
-				E71DA52069B94A41A248DC44 /* AuthFlowView.swift in Sources */,
-				3A41AC17DEE546AE8292162B /* GetStartedView.swift in Sources */,
-				9B69C172AE4C4CBB98B3D3AA /* LoginView.swift in Sources */,
-				0DDB95AAB94640099A401E97 /* MFAChallengeView.swift in Sources */,
-				7D119A5127964CCD8B9A239D /* MfaPasskeyController.swift in Sources */,
-				22DDAE6A06A24FDAAFE0A0D3 /* SSOAuthController.swift in Sources */,
-				A6BDD382DFCB4C6CBFC6AEBD /* SignupView.swift in Sources */,
-				CD9CF44DD51A41D4BB5EE71E /* BehaviorRosterView.swift in Sources */,
-				7ED3B55E2F194A148E68FB20 /* HallPassView.swift in Sources */,
-				EAF60A9E783D4A6AA27B1BA4 /* MyHallPassView.swift in Sources */,
-				90DB3F5A985C452CA2BEFF3E /* BillingView.swift in Sources */,
-				2CFDE3DCAFD943DFA374506A /* CheckoutReturnHandler.swift in Sources */,
-				07AC8CA9D7B745DF959322CF /* PurchaseFlow.swift in Sources */,
-				7DFC6F1AB6804EB0B9AD139D /* BoardAnalyticsSheet.swift in Sources */,
-				3087F31746B0445F88163E16 /* BoardComposerView.swift in Sources */,
-				513201C8086B4D4ABAB2D2B6 /* BoardDetailView.swift in Sources */,
-				112B5FC6A26A4C239DEA5E68 /* BoardEngagementEnvironment.swift in Sources */,
-				B628B4D06766416D85DB280C /* BoardExportSheet.swift in Sources */,
-				9350312EFD914AA18023A16A /* BoardModerationSettings.swift in Sources */,
-				E34650CFE1F245C7A1D446E0 /* BoardPostCard.swift in Sources */,
-				9CBB67B45CD6442AAF18BEA6 /* BoardPresentModeView.swift in Sources */,
-				462A976E735E43448BB18912 /* BoardSaveAsTemplateSheet.swift in Sources */,
-				4467D7B9B3724D79AE2541D8 /* BoardShareSheet.swift in Sources */,
-				F0DBF31E806B493FBE728A77 /* BoardSocket.swift in Sources */,
-				CE9000050C4C46DD86BD15AD /* BoardSurface.swift in Sources */,
-				522B18E83695425299B42E93 /* BoardSyncStatusChip.swift in Sources */,
-				55419C0568874D84A05F9222 /* BoardTemplatePickerView.swift in Sources */,
-				DA3CB0D8439B43F9B04AAFC1 /* BoardsListView.swift in Sources */,
-				B1C0367397C4440ABD4A3FF1 /* CardArrangeMenu.swift in Sources */,
-				E632825BF32E431EAB2DC308 /* CommentSheet.swift in Sources */,
-				C33E125522F6463B8588D9DC /* GradeSheet.swift in Sources */,
-				E9500E279FD84474B49E2767 /* CanvasLayout.swift in Sources */,
-				F097D9E47BBD48E4B2995514 /* ColumnsLayout.swift in Sources */,
-				9D718AC9F4EA40A6B67DBBFC /* MapLayout.swift in Sources */,
-				35B8C5A588124A2495CEF149 /* TimelineLayout.swift in Sources */,
-				C4FB2773115A4272B35A725D /* WallLayout.swift in Sources */,
-				B22FFB3070274427A9BA052C /* ModerationQueueView.swift in Sources */,
-				5DDFD0CD90AA4D949D3F81A6 /* BoardPublicView.swift in Sources */,
-				2CBEB5B6A97E4AD49B8E9B90 /* ReactionControl.swift in Sources */,
-				7E6946757D0347E1A59361C3 /* ReportDialog.swift in Sources */,
-				ACDCFD35679449A495D39680 /* CatalogView.swift in Sources */,
-				CF786EBFF6C5411A86A78307 /* CourseLandingView.swift in Sources */,
-				3762E2C6D0CA48B7A02CD6BA /* ReviewComposer.swift in Sources */,
-				68FC92E933224C5AB8D3C8A7 /* ContentPageView.swift in Sources */,
-				086E2770AE5E4D4AA34E78AF /* CourseAttendanceView.swift in Sources */,
-				C9E28C386F1E45C4980FBFBE /* CourseBanner.swift in Sources */,
-				83260790D9E748C38AC0A640 /* CourseDestinationPlaceholder.swift in Sources */,
-				4DD69D0912AF47218F88D530 /* CourseDetailView.swift in Sources */,
-				853F5994106A4F3AB990ECC8 /* CourseGradesView.swift in Sources */,
-				24C3085C652641CD947EC5CC /* CourseLibraryView.swift in Sources */,
-				49E8E80342304542BED428A5 /* CourseMarkdownContentView.swift in Sources */,
-				800AC77153994AE1AB074F25 /* CoursePeopleView.swift in Sources */,
-				6460CCE4EDF641E9AB43BC36 /* CourseStructureSocket.swift in Sources */,
-				43420264D4024516951C37A9 /* CourseSyllabusView.swift in Sources */,
-				6F2FA487AD9A474FBA27747A /* CourseWorkspaceNav.swift in Sources */,
-				03AA2BD5DC0843E29F26566D /* CoursesListView.swift in Sources */,
-				16ACA5E324634EBD9F5D8FEC /* CanvasImportComingSoonView.swift in Sources */,
-				E33361292D104B2FBC9EBD97 /* CanvasImportView.swift in Sources */,
-				9F2FF5D8602D49BB9EF3AAB4 /* CourseCreateView.swift in Sources */,
-				EF354F667A754B4CB3B2E808 /* ItemDetailRows.swift in Sources */,
-				59B70927C9A94595AF643F78 /* ItemDetailView.swift in Sources */,
-				DCEC40B738504791ACDF80AA /* LaunchContainerView.swift in Sources */,
-				3E6A765D21D14E129AB3740E /* LibraryResourceView.swift in Sources */,
-				068C3531D6A04E219A9A8DE0 /* MarkdownCodeBlockView.swift in Sources */,
-				916DEA86CCB2455EB02B79C2 /* MarkdownTableView.swift in Sources */,
-				7E62025B1F4348478529176A /* ModuleItemRouteView.swift in Sources */,
-				4BE9EB7CC590462388982E9D /* ModuleListView.swift in Sources */,
-				69207C1393864BDCAE39E998 /* RequirementsView.swift in Sources */,
-				7821EF2DCC1D4F36A7BDDCF0 /* CourseAccessibilityReviewView.swift in Sources */,
-				30464CEA6CC54B44A858A09C /* CourseArchivedContentView.swift in Sources */,
-				26EE54861D354BF990E116DF /* CourseBlueprintSettingsView.swift in Sources */,
-				5AA3C4A008D749E688257943 /* CourseCrossListingView.swift in Sources */,
-				5AB361DED5A14AB09E19E088 /* CourseFeaturesSettingsView.swift in Sources */,
-				8B2102DFDD9C498D8547CBFB /* CourseGeneralSettingsView.swift in Sources */,
-				E7025A24B32745AEA3557CC6 /* CourseGradingAgentsView.swift in Sources */,
-				6D313D94411C4894945CF1D9 /* CourseGradingSettingsView.swift in Sources */,
-				509D8DAA646A45E284DCCC7B /* CourseHeroImageEditor.swift in Sources */,
-				E1BAD5B13167480E9754514E /* CourseImportExportView.swift in Sources */,
-				C6B6CAB5BF834B7C87C57651 /* CourseMarketplaceSettingsView.swift in Sources */,
-				8A9ACCD6B4C54455887861BB /* CourseOutcomesSettingsView.swift in Sources */,
-				5C6F24975F844463975AB0EF /* CoursePlagiarismSettingsView.swift in Sources */,
-				15846C31C0F34E3997155B24 /* CourseSectionsSettingsView.swift in Sources */,
-				05DDF2F21D4247DA95411261 /* CourseSettingsHostView.swift in Sources */,
-				717C57DFB68848F9BDABD762 /* CourseTranslationsSettingsView.swift in Sources */,
-				DE2BB701059B41B2B66D9BF9 /* TakeAttendanceView.swift in Sources */,
-				7E0CB8C2CDAB46E79723EE12 /* VibeActivityView.swift in Sources */,
-				09E2975018AA4483B41E86CA /* WebItemView.swift in Sources */,
-				402D0BB774624382981F9F26 /* CredentialDetailView.swift in Sources */,
-				78BA3A76893147B4A5737ABB /* CredentialsView.swift in Sources */,
-				3CF154ACD0AF4C26850C3895 /* DashboardCoursesCarousel.swift in Sources */,
-				078F8DA5217C45208D255A55 /* DashboardHeroPanel.swift in Sources */,
-				5C0F730A8CCC4506A5496BBC /* DashboardView.swift in Sources */,
-				1D5E3116179641499E19A849 /* LiveMeetingsRail.swift in Sources */,
-				651F92E886654DF18ABF24B3 /* CourseDiscussionsSection.swift in Sources */,
-				8DC2AFB29CB44E3CB810C74D /* DiscussionThreadView.swift in Sources */,
-				2F9DC1F6EE32484CBBABCC71 /* DiscussionsListView.swift in Sources */,
-				566E104CBB1D406C922336C0 /* PostComposerView.swift in Sources */,
-				3298E94176FD4C4FBDF2852A /* CourseEvaluationsSection.swift in Sources */,
-				20D72CFD7A78479C8F207651 /* EvaluationFormView.swift in Sources */,
-				DE82C7D29D4741279DAA8153 /* EvaluationResultsView.swift in Sources */,
-				B100473493A545AC974176CD /* CourseFeedSection.swift in Sources */,
-				3FA12DC95AA74C2C9EC4BCAC /* FeedChannelView.swift in Sources */,
-				F47EF201B61B48F7BACDBD03 /* FeedChannelsView.swift in Sources */,
-				DDEBC7E31C0045D68325CD41 /* FeedLogic.swift in Sources */,
-				DCB152BA4C474975930194DA /* FeedSocket.swift in Sources */,
-				5F44382D41CB4D548EAB9004 /* ShareFeedbackView.swift in Sources */,
-				7426989562E9444DB451C246 /* CourseFilesSocket.swift in Sources */,
-				F61A96F44BC7447D9A85ACF5 /* CourseFilesView.swift in Sources */,
-				27250EF2EC844ECFB41A423E /* FilePreviewView.swift in Sources */,
-				22C990D73BB54604A866A4B6 /* MarkupOverlayView.swift in Sources */,
-				426C6FBF61FE47208BF75BF1 /* GamificationView.swift in Sources */,
-				66B9B406167D4F02B7E088F1 /* GradeFeedbackView.swift in Sources */,
-				03E52BCDB01948F1A6CD0C84 /* WhatIfController.swift in Sources */,
-				F96BE9C647734EDAAF73934C /* GradingBacklogView.swift in Sources */,
-				1350A36283514ED3AE5B98B6 /* SpeedGraderView.swift in Sources */,
-				7A61CF28A0C5485EA1F34718 /* CollabDocView.swift in Sources */,
-				0FCDDDBD482C46DDA0461CC1 /* CourseCollabDocsSection.swift in Sources */,
-				15D8976AFB32451EB3D4CCDA /* CourseGroupsSection.swift in Sources */,
-				B4EB528F99D34C3F83091138 /* GroupSpaceView.swift in Sources */,
-				0ED62D425A4E451FBF6E7E0A /* AnnouncementComposerView.swift in Sources */,
-				A54A6D3D36D04795AD7F553D /* AnnouncementsViews.swift in Sources */,
-				9AB309A4D92B488DA1EB2DAC /* BroadcastComposerView.swift in Sources */,
-				283F45906F944EAE81A97E84 /* MainTabView.swift in Sources */,
-				A169C2814F1A42D8A7284907 /* MoreHubView.swift in Sources */,
-				D64647424591472CB12CC11B /* ShellHeaderBar.swift in Sources */,
-				1EFCE70315F94C0C92EEF4E4 /* TeachHubView.swift in Sources */,
-				8DC73E8306284B74A24AB14A /* UniversalSearchPlaceholder.swift in Sources */,
-				B97CB5F54C204F83A2274DA9 /* ComposeMessageView.swift in Sources */,
-				C4B4AFAF23E444D684C74E7F /* InboxView.swift in Sources */,
-				6BA3AA98591D46448467F24F /* MessageDetailView.swift in Sources */,
-				7C69AE1F574F4047A3EF86DC /* DashboardInsightsSection.swift in Sources */,
-				241714943727494EBFB5FF96 /* InsightsView.swift in Sources */,
-				740A06DFD62F4D29B36AFC9C /* AtRiskListView.swift in Sources */,
-				73C6E16C6E484470B9E7B784 /* CourseInsightsSection.swift in Sources */,
-				7A0C884A584B4D2FB584B571 /* StudentProgressDetailView.swift in Sources */,
-				606693184E4E4BA39AABB2BE /* WhatsWorkingView.swift in Sources */,
-				5D2F4FB5C52F4FA595A14104 /* IntroCelebrationPresenter.swift in Sources */,
-				EF16E79934FD4222BF0282C4 /* IntroCompletionCelebrationSheet.swift in Sources */,
-				B7F02A7A8E994A0F9731E277 /* IntroCourseEntryCard.swift in Sources */,
-				88956425ADC64D098DB484A6 /* IntroCourseProgressRail.swift in Sources */,
-				36D53233307941019D2C7BFC /* LearnerProfileView.swift in Sources */,
-				B3F5555053E046309DAEC51E /* LibraryBrowseView.swift in Sources */,
-				E5BF3CA3C75442C0915A16B5 /* MeetingDetailView.swift in Sources */,
-				24CEFEFAC27D484D8CA4488A /* MeetingListView.swift in Sources */,
-				50524B78462E46138E798C76 /* WhiteboardView.swift in Sources */,
-				31A43E223AE64CF7B317B52D /* LiveGameSocket.swift in Sources */,
-				54A3749733E34452AABF49F0 /* LiveQuizHubView.swift in Sources */,
-				C3713CE5BCD84D13A708233F /* LiveQuizPlaySurfaces.swift in Sources */,
-				576FE9B632694797BF162106 /* LiveQuizPlayView.swift in Sources */,
-				013DB38E476047E5B10E42C4 /* MarketplaceDetailView.swift in Sources */,
-				FD825CB92D9F4E53B6C36931 /* MarketplaceView.swift in Sources */,
-				0F0885C1A7A442658E9C26BB /* MyPurchasesView.swift in Sources */,
-				8879708009664DF28200AABA /* CourseMasterySection.swift in Sources */,
-				48BF5A9124F8434C87C1624B /* ReportCardListView.swift in Sources */,
-				86BB5688245243B0BA1DE5E6 /* CourseDrawer.swift in Sources */,
-				983B748754844B6F8577C6EB /* DrawerScaffold.swift in Sources */,
-				B381D36A6BA443FAB2EF7852 /* DrawerToolbar.swift in Sources */,
-				3A5938FDCD9243E9A370FB22 /* GlobalDrawer.swift in Sources */,
-				6E60D3E912F14800A3BFDBEC /* NotebookDrawingViews.swift in Sources */,
-				3C32289AF75C4E309711EA94 /* NotebookEditorSupportViews.swift in Sources */,
-				FA31A98E26824E12877C62B9 /* NotebookEditorView.swift in Sources */,
-				C442C7E0CC254DD5975BAE3E /* NotebookPagesView.swift in Sources */,
-				2A0A014EBAF04CEA98BD74EE /* NotebooksListView.swift in Sources */,
-				5DD96E804585487A93D22342 /* BookingSheet.swift in Sources */,
-				23392DD7C8324AEBAA7FCBCA /* MyBookingsView.swift in Sources */,
-				8BFEB92094DD4A6CAD797E5A /* OfficeHoursView.swift in Sources */,
-				7D513B71CE1D44A4B1949DF0 /* DiagnosticView.swift in Sources */,
-				260854A2B9AE45B0A1C9FC0C /* OnboardingFlowView.swift in Sources */,
-				BCB3CC5EF20E4AAC9FF804CF /* ConferenceBookingView.swift in Sources */,
-				2F406664162147C2BD5E3C8E /* MyConferencesView.swift in Sources */,
-				168A2E2592844CF78FEBB370 /* ParentAttendanceDetailView.swift in Sources */,
-				8826351567BC4109BDF7381B /* ParentDashboardSections.swift in Sources */,
-				AF30AF67DF5446A98623E2CB /* ParentDashboardView.swift in Sources */,
-				785871EE701340E2B507B3DF /* ParentGradesDetailView.swift in Sources */,
-				0BD013A4452946769F5F4A6F /* ParentNotificationPrefsView.swift in Sources */,
-				004B2E95410C4CE693140269 /* DashboardStudySection.swift in Sources */,
-				5889497F36044AA98D79B813 /* MyPathsView.swift in Sources */,
-				3A24DF561FD049CE89E0824C /* PathLandingView.swift in Sources */,
-				B9FCFF1F9A0F4A4B9557491E /* PathRunnerView.swift in Sources */,
-				9A195E6758A34DDF8BA6D4EA /* PathsCatalogView.swift in Sources */,
-				2464507F608B4D9F86E0A739 /* PeerReviewDetailView.swift in Sources */,
-				F62CC3ECE02147AF98727689 /* PeerReviewListView.swift in Sources */,
-				FB2A2F3E3B674353B9C1ABAB /* ReviewsReceivedView.swift in Sources */,
-				110B95E7D06F41D98EEE593C /* RubricScorerView.swift in Sources */,
-				93C936E6351E42909BEFFF64 /* CalendarSubscribeSheet.swift in Sources */,
-				271722C4C86E428FA661E784 /* CalendarView.swift in Sources */,
-				1629C666F31944FFAC72E301 /* ConferenceReminderScheduler.swift in Sources */,
-				489FCA1B438644B3965E6729 /* DueReminderScheduler.swift in Sources */,
-				BBB85B31F17F444AA4F67A07 /* OfficeHoursReminderScheduler.swift in Sources */,
-				6FCF7610FB9B4724A89499D1 /* PlannerModel.swift in Sources */,
-				38A42102E27A4C2483A4337C /* PlannerView.swift in Sources */,
-				B53D8D2674ED4316A7691858 /* TodosView.swift in Sources */,
-				658C1E186EA74FAEAA965EE8 /* ArtifactDetailView.swift in Sources */,
-				1CE32F92A4DD4B6797B7BB87 /* ArtifactEditorView.swift in Sources */,
-				912AC1F1D73A4DA3BFCE09C5 /* PortfolioArtifactUploader.swift in Sources */,
-				50C833577E5147D79BAFD02E /* PortfolioDetailView.swift in Sources */,
-				3F563D375D0842BC8CF659C8 /* PortfolioView.swift in Sources */,
-				988D1AE76D7449ABBE80B402 /* AiAdminEntryCard.swift in Sources */,
-				D5B2C7631A3C41D2B3CE4699 /* ArchivedCoursesAdminEntryCard.swift in Sources */,
-				18E7D3CBDC874492BE473861 /* BiometricLockView.swift in Sources */,
-				65BA9A19ECD34E46B75F0388 /* DeviceSessionsView.swift in Sources */,
-				A461B3DDA25A400B8E47CF0A /* EditProfileView.swift in Sources */,
-				EE46711E174C4CF8A90DAD74 /* IntegrationsAdminEntryCard.swift in Sources */,
-				A058ED27325C4EDF80191061 /* IntegrationsEntryCard.swift in Sources */,
-				232A98A3944642D0B5191DDF /* IntegrationsView.swift in Sources */,
-				AE8F3E64ECA24E65A0F62C42 /* LearnerProfileEntryCard.swift in Sources */,
-				DD2BB5D7D51B43E1AD072233 /* MyAccommodationsView.swift in Sources */,
-				5C31A7F145FC463D9F6F5200 /* NotificationPreferencesView.swift in Sources */,
-				6490751995BB44478A5830CC /* NotificationsView.swift in Sources */,
-				D7521F8FD5314D019530DEC1 /* OrgBrandingAdminEntryCard.swift in Sources */,
-				43BDD65562BA4828A30FDE61 /* OrgStructureAdminEntryCard.swift in Sources */,
-				C1DA398745A3417792CDA221 /* PeopleAdminEntryCard.swift in Sources */,
-				51A96095D86A48D99E716480 /* PlatformSettingsAdminEntryCard.swift in Sources */,
-				1B5CD9DECC884CD2AFFF2EA5 /* ProfileDepthCards.swift in Sources */,
-				DBD0B30AA580420AA2E283B0 /* ProfilePersonalDetailsView.swift in Sources */,
-				5698DCD9EA9B44068CDDB85D /* ProfileSecurityCard.swift in Sources */,
-				981C208401B74B6C9998AB92 /* ProfileSettingsCards.swift in Sources */,
-				81DEECEC9D914F06AE2B5B2F /* ProfileView.swift in Sources */,
-				8206C4C37F2949B4B3302494 /* ProfileViewSections.swift in Sources */,
-				209D699F24D347E39DA62895 /* ResearchStudiesView.swift in Sources */,
-				63622B33B9F34BF7973C9FF7 /* RolesPermissionsAdminEntryCard.swift in Sources */,
-				F2F2C8589D5C4364A43B4E4E /* SettingsAdminHubEntryCard.swift in Sources */,
-				5AED2A42200C417D901A3AAA /* ShareFeedbackEntryCard.swift in Sources */,
-				B5CCD9D022344044B331EA01 /* TranscriptsAdvisingAdminEntryCard.swift in Sources */,
-				1A87D70734574A048A8DC349 /* CodeQuestionView.swift in Sources */,
-				E17908C4CA6446149BE0EC97 /* LockdownController.swift in Sources */,
-				E04539B73C8E44DE96E3C469 /* QuizIntroView.swift in Sources */,
-				FA7CC2716D954890A3F5890C /* QuizQuestionViews.swift in Sources */,
-				1FD2CDA0ADAB418B997BA63D /* QuizResultsView.swift in Sources */,
-				A6ED01A672094CE3B09AA985 /* QuizTakerView.swift in Sources */,
-				0BA36578549C4277A43ECCCD /* CaptionedPlayerView.swift in Sources */,
-				E1F0BF5110DB4C24A97D4986 /* ContentTranslationControls.swift in Sources */,
-				6747A8A5EFF84C2D9C98F46D /* ImmersiveReaderCapabilities.swift in Sources */,
-				8CD1372F58304586963CF984 /* ReaderLogic.swift in Sources */,
-				588A85CFE0F0414794AFB234 /* ReaderToolbar.swift in Sources */,
-				42A1556AAD4B4AD1BC0042AB /* ReadingPreferencesSheet.swift in Sources */,
-				D288A4AEBF374F039E752C9A /* ReadingPreferencesStore.swift in Sources */,
-				FB5C34E084D24E9594C76212 /* LeveledLibraryView.swift in Sources */,
-				8D420F0E8EED450E856C6A86 /* LogReadingSheet.swift in Sources */,
-				775B51A27C5345ABBB0D23EF /* ReadingDashboardView.swift in Sources */,
-				1ED91D14ABB64871BA5D370B /* ReviewHomeView.swift in Sources */,
-				11AC31C299564C5FBE87051E /* ReviewReminderScheduler.swift in Sources */,
-				FA96F45D033F489AB83FDE81 /* ReviewSessionView.swift in Sources */,
-				F709C02F211E476BB1FF7DDA /* UniversalSearchView.swift in Sources */,
-				A89A4C91638E4106A0EE487A /* AdminMetricCards.swift in Sources */,
-				5FAB919A843A440E82EE8D04 /* AdvisingSettingsView.swift in Sources */,
-				F2214A1D92FC45BB9CE2ADD2 /* AiAdminHubView.swift in Sources */,
-				50367A9E1471406B80ABF2A1 /* AiGovernanceView.swift in Sources */,
-				FB796A715F674440A6409779 /* AiModelsSettingsView.swift in Sources */,
-				1019816343624011A7B557D1 /* AiProviderSettingsView.swift in Sources */,
-				9546906023EA4DD0BDBCA7B2 /* AiReportsView.swift in Sources */,
-				65E89AD1ED204EC5B795CCA6 /* ArchivedCoursesAdminView.swift in Sources */,
-				65F73CED45624E1BB1713440 /* AuditLogAdminView.swift in Sources */,
-				0D91AF2DB19F485B93D7CD46 /* BoardsGovernanceAdminView.swift in Sources */,
-				D64E4E13C99E4D77B6F6F3F8 /* CoursesAdminView.swift in Sources */,
-				E4750E6368AF4758A9BB3FCB /* IntegrationsAdminView.swift in Sources */,
-				38487F2277664659A792B427 /* OrgBrandingAdminView.swift in Sources */,
-				59AF1E78E14446BDA1C520AB /* OrgBrandingView.swift in Sources */,
-				D7FD88DB8E924B1BA0FEF265 /* OrgStructureAdminView.swift in Sources */,
-				2CA9B5373A0B4233A0A64771 /* OrgStructureView.swift in Sources */,
-				00FD0ED59A7C49D393DA15A3 /* PeopleAdminView.swift in Sources */,
-				28B4BF03E7E34F9DAB34FE6A /* PlatformSettingsView.swift in Sources */,
-				5E588B67C7274185841CDBFC /* RolesPermissionsAdminView.swift in Sources */,
-				880FB92F7CFC41E992B52F78 /* SystemPromptsView.swift in Sources */,
-				0248213F393049E8B93709D2 /* TermsAdminView.swift in Sources */,
-				C27059C4026742968DB0FDCA /* TranscriptsAdvisingAdminView.swift in Sources */,
-				78C7EE57272F4082B42983A2 /* TranscriptsSettingsView.swift in Sources */,
-				EB7EAB8B4A6B4BC6BF148FE1 /* UserDetailAdminView.swift in Sources */,
-				A4F1C583F9C24D03A36D3CFC /* SettingsAdminHubView.swift in Sources */,
-				20F7EAEFC0B14F1BAD3F7C3A /* SplashView.swift in Sources */,
-				22A3489D687C412B90F92BEC /* TutorChatModel.swift in Sources */,
-				8D963B4A899B4A9AB2B8B7E3 /* TutorChatView.swift in Sources */,
-				A1287F5A19914A9EB261277C /* TutorFlowLayout.swift in Sources */,
-				ED9D1E5CFE484120B3D251C4 /* TutorLauncher.swift in Sources */,
-				B517A0B3458F4E1A90327F51 /* WalletCCRDetailView.swift in Sources */,
-				AFF47FE7B05642EDBB6C2886 /* WalletCETranscriptDetailView.swift in Sources */,
-				990C0994B030462C859A17BF /* WalletOfficialTranscriptDetailView.swift in Sources */,
-				CEE26666B51048248A0CB7C0 /* WalletView.swift in Sources */,
+				240E725891A946D08885C587 /* AppDelegate.swift in Sources */,
+				D3158A6047094E109678C04E /* LexturesApp.swift in Sources */,
+				BF3767E999414BCB8FE7FF06 /* RootView.swift in Sources */,
+				239510D3B95E407F93FA9377 /* AccessibilityPreferences.swift in Sources */,
+				9D48DC10D5FA4DA1924942E9 /* AccessibilitySupport.swift in Sources */,
+				7FDD14D2965F46C2981D6162 /* DictationField.swift in Sources */,
+				228C93C1C1C7461AA010DC6E /* ReadAloud.swift in Sources */,
+				A34CD14DAEF84B6689A26A5A /* AuthAPI.swift in Sources */,
+				65D5352C4B094F5FBC5A7C4B /* AuthCallbackParser.swift in Sources */,
+				E3BDDFD9E8C64AEFA657B749 /* AuthConstants.swift in Sources */,
+				CB59C836C8504AB2AE2A0002 /* AuthSession.swift in Sources */,
+				7B7067F5422C4FD583B92F95 /* BiometricGate.swift in Sources */,
+				3D15EB78AC1D4176AFEC622D /* KeychainStore.swift in Sources */,
+				FC12D9DAB2C54204BFF9DC79 /* SessionsAPI.swift in Sources */,
+				CF9E1E4B7DC645C6A42DF6B1 /* AppConfiguration.swift in Sources */,
+				FDBFBF4C39494C95B24424E0 /* EnvironmentStore.swift in Sources */,
+				0987ED60211E4CF599A232E0 /* SchoolCodeLogic.swift in Sources */,
+				97B3815945CF446ABAC90677 /* AuthFieldRepresentable.swift in Sources */,
+				5D9A051F49AC4502B87507ED /* BrandLogoView.swift in Sources */,
+				6F57AEBC0E6B4A03A4EB7CD1 /* Haptics.swift in Sources */,
+				4EF2E72697034CF6ACDBEF99 /* LexturesMotion.swift in Sources */,
+				FE63A2E93C7947E78877C089 /* LexturesTheme.swift in Sources */,
+				9DCB53369DF3421884130349 /* LexturesType.swift in Sources */,
+				897D94C1E6D34B3691F44149 /* ProfileAvatarView.swift in Sources */,
+				E9941B1ED1E04E2E9A0CF097 /* SyncStatusView.swift in Sources */,
+				2FBA46C749524801A4C5D6BE /* ThemePreference.swift in Sources */,
+				E5066CDBEAAA40C6907AAE2A /* UIMode.swift in Sources */,
+				085A467A10964B5ABCD3D5D5 /* UnsavedChangesBanner.swift in Sources */,
+				794A20EE490942E3971E963F /* DateFormatting.swift in Sources */,
+				8493FDD3C7264C6B817772A3 /* LocaleAPI.swift in Sources */,
+				D41ABE75085944DF83CD69B2 /* LocalePreferences.swift in Sources */,
+				21D09E098F224E98A9D6393F /* Localized.swift in Sources */,
+				8E1F4288320B4463B790DC9C /* AccountAccommodationModels.swift in Sources */,
+				BD7530F8E3C84B0CA9DE4347 /* AccountIntegrationsLogic.swift in Sources */,
+				9968113BCCE1445BA7389CBF /* AdvisingLogic.swift in Sources */,
+				ACA42359AF0D40BAA8188BB3 /* AiModelsAdminLogic.swift in Sources */,
+				1FF219B9AE854AE09E8D98A3 /* AnnouncementLogic.swift in Sources */,
+				B27A1C6E5EDE4D02B3C05788 /* ArchivedCoursesAdminLogic.swift in Sources */,
+				BA633B46A19041ADB11491DD /* AssignmentLogic.swift in Sources */,
+				83D707BF5EE04D4C9BE9FF8A /* AuditLogAdminLogic.swift in Sources */,
+				A6084BED41FB411CAD04CF80 /* BehaviorLogic.swift in Sources */,
+				8BBACF5962DB4B83BD07E163 /* BillingLogic.swift in Sources */,
+				462799CE7D3A483A9ACC482D /* BoardRealtimeLogic.swift in Sources */,
+				A19F9E1736274C0186C44B25 /* BoardsAdvancedLogic.swift in Sources */,
+				5D32434460034544A6E21E37 /* BoardsGovernanceAdminLogic.swift in Sources */,
+				76AEDBEE89D1496DBA2C246E /* BoardsLogic.swift in Sources */,
+				36BE2AC2689A4D14963FC35E /* CanvasImportLogic.swift in Sources */,
+				4DB09BEB18624C8DAC03A00B /* CanvasImportObservability.swift in Sources */,
+				49C8456D791647B897FC0F9D /* CatalogLogic.swift in Sources */,
+				08C2762C6232453F8FC0120E /* ConferenceLogic.swift in Sources */,
+				0D15085F7C96411B89E7D8F4 /* CourseAccessibilityReviewLogic.swift in Sources */,
+				78A919BC931D42CC8A8C53F4 /* CourseArchivedContentLogic.swift in Sources */,
+				2A4F4D22793843BE9F3BF0D3 /* CourseBlueprintLogic.swift in Sources */,
+				385DE05194384AF39E76E34B /* CourseCreateDraftStore.swift in Sources */,
+				13062509014549A0A9B3519A /* CourseCreateLogic.swift in Sources */,
+				6DA4BEC68E49448CAE3D8DB5 /* CourseCreateObservability.swift in Sources */,
+				EA485314F84640689A386903 /* CourseFeaturesLogic.swift in Sources */,
+				FE18E33BDD52412D930A5631 /* CourseFileLogic.swift in Sources */,
+				53EA8774096F4C72A463E81D /* CourseGradingAgentsLogic.swift in Sources */,
+				2CF45ACA7FB948F6A7F97BFF /* CourseGradingLogic.swift in Sources */,
+				79DA50595F224D1690B730CD /* CourseHeroImage.swift in Sources */,
+				9963B524737F4357AEB2A067 /* CourseImportExportLogic.swift in Sources */,
+				688FBFFBD7764BC69D763B49 /* CourseOutcomesLogic.swift in Sources */,
+				110C4453D25C4FBEAC6707CC /* CoursePeopleLogic.swift in Sources */,
+				C411FF02FF234B308DA47F86 /* CoursePeopleObservability.swift in Sources */,
+				309E6CC1F9984ED1942BFEAC /* CoursePlagiarismLogic.swift in Sources */,
+				601A00C9DCCF491A99EA6312 /* CourseReviewLogic.swift in Sources */,
+				C9811D8C71C84F0AB7030690 /* CourseSectionsLogic.swift in Sources */,
+				660B923CF33A4629A2A42483 /* CourseSettingsLogic.swift in Sources */,
+				B472932012434DBEB45BEE69 /* CourseTranslationsLogic.swift in Sources */,
+				69A3BABA9AC84CBF8310E63D /* CredentialsLogic.swift in Sources */,
+				9B96254C9DC64382B3589B67 /* CurrencyExponent.swift in Sources */,
+				784F2D0EF9D347C883890507 /* DiscussionLogic.swift in Sources */,
+				4C29F2616BAD4AC2A1A17FB8 /* EvaluationLogic.swift in Sources */,
+				D11F63DD27814C158A3D57E7 /* FeedbackLogic.swift in Sources */,
+				982EDF1CACF74079A2320F04 /* FileDownloadManager.swift in Sources */,
+				54659AF589E54284BF7D2172 /* GamificationLogic.swift in Sources */,
+				75727BAE71F0499E9C6738C4 /* GradeCalculator+MyGrades.swift in Sources */,
+				C8D6494A7A00465D8ADBB657 /* GradeCalculator.swift in Sources */,
+				D42731304DEE497A8FD005F2 /* GroupsLogic.swift in Sources */,
+				22486BC798FE40CBB8BA3C05 /* InsightsLogic.swift in Sources */,
+				4994A5BB02CA4090AC139ECF /* InstructorInsightsLogic.swift in Sources */,
+				8DE068765D6D45AF90A28759 /* IntegrationsAdminLogic.swift in Sources */,
+				30996B616F334582BBF67A11 /* InteractiveLaunchLogic.swift in Sources */,
+				F0BFAAFDB1B24A429598422F /* IntroCourseLogic.swift in Sources */,
+				5EBEA5A2224247EBA6B4CCFB /* IntroCourseObservability.swift in Sources */,
+				93E22620D60849E8BB78AC16 /* LMSAPI.swift in Sources */,
+				49891A28140145539FAB5438 /* LMSAPIAccountIntegrations.swift in Sources */,
+				E6F8820247D840C9B04BBF08 /* LMSAPIAdmin.swift in Sources */,
+				9D6DD08B63B240E897A574FD /* LMSAPIAdvising.swift in Sources */,
+				16B72527F6284ED6AA2DA90A /* LMSAPIAnnouncements.swift in Sources */,
+				87980E620BFC4D4D99BB1A23 /* LMSAPIAuditLog.swift in Sources */,
+				31EF66E980E34557BEBF50F0 /* LMSAPIBehavior.swift in Sources */,
+				D2CBE14D6986402B82413AD5 /* LMSAPIBilling.swift in Sources */,
+				65DB95BBC6F443AEA17F8161 /* LMSAPIBoardAccess.swift in Sources */,
+				4F2DA25C7BD3488BB56FADDA /* LMSAPIBoardAnalytics.swift in Sources */,
+				C4D5FB5D70B441CAB9640EEC /* LMSAPIBoardEngagement.swift in Sources */,
+				0182BBA1A620401E985103C0 /* LMSAPIBoardExport.swift in Sources */,
+				29321170955D4397823E154D /* LMSAPIBoardLayout.swift in Sources */,
+				5C346123E2FE47579E8B5812 /* LMSAPIBoardModeration.swift in Sources */,
+				CF133D650FBA43DEB9578313 /* LMSAPIBoardPosts.swift in Sources */,
+				DF86EB0188B04C01AE4F102E /* LMSAPIBoardTemplates.swift in Sources */,
+				71BA6FFC84B04878BA370CFF /* LMSAPIBoards.swift in Sources */,
+				23316F07C97E46FD9BED6F2B /* LMSAPICanvasImport.swift in Sources */,
+				836A5167E555477ABFE70785 /* LMSAPICatalog.swift in Sources */,
+				73C7958E365E459FBBC2B05E /* LMSAPICourseAccessibility.swift in Sources */,
+				03A9650885DA4A9E8ECAB91E /* LMSAPICourseArchivedContent.swift in Sources */,
+				ABEB447BF62D484ABE5B2646 /* LMSAPICourseBlueprint.swift in Sources */,
+				C405BF5605AC48F7A19B8385 /* LMSAPICourseCreate.swift in Sources */,
+				7DC57A3FC93745239F87E19C /* LMSAPICourseFeatures.swift in Sources */,
+				3210B7B6C8B94FC1BC33ED09 /* LMSAPICourseGrading.swift in Sources */,
+				75D7908CA5484BD4936E722D /* LMSAPICourseGradingAgents.swift in Sources */,
+				81383CFB926A43A491D73398 /* LMSAPICourseImportExport.swift in Sources */,
+				BBE1349E588D468AB05182E9 /* LMSAPICoursePlagiarism.swift in Sources */,
+				D85EDDE499C04996ADC6E33C /* LMSAPICourseReviews.swift in Sources */,
+				3AB1AE726AAE46F9811119E0 /* LMSAPICourseSections.swift in Sources */,
+				463E6EFB171F4B218A4AFED2 /* LMSAPICourseSettings.swift in Sources */,
+				FF4F21F99FB84DFC88B54C0C /* LMSAPICourseTranslations.swift in Sources */,
+				35ACD26635664FB5B9B83089 /* LMSAPICredentials.swift in Sources */,
+				3DB5BFD37E344C81BEF726D3 /* LMSAPIDiscussions.swift in Sources */,
+				6297C32CEBB2437DB2ABD155 /* LMSAPIEportfolio.swift in Sources */,
+				347BDAC60A034CDE8296AB0B /* LMSAPIEvaluations.swift in Sources */,
+				C15B30F14F6340179249738E /* LMSAPIFeatures.swift in Sources */,
+				A72A4A03D5DB4CCB8C2EF62A /* LMSAPIFeed.swift in Sources */,
+				F699FFC6DB87461EBA53FE2F /* LMSAPIFeedback.swift in Sources */,
+				E1AB8D7FCD35477CB3F02623 /* LMSAPIGamification.swift in Sources */,
+				AC1E863CA56F45A4B39E3196 /* LMSAPIGroups.swift in Sources */,
+				813D82FE3E9949D094F6077B /* LMSAPIInsights.swift in Sources */,
+				0F878E226FBD4B09AB3C0C32 /* LMSAPIInstructorInsights.swift in Sources */,
+				F82E2C8F45A64A4DB9ADBB27 /* LMSAPIIntroCourse.swift in Sources */,
+				0BE802E7DBD945A8BD3C69B4 /* LMSAPILearnerProfile.swift in Sources */,
+				A55978E50E784669915A8229 /* LMSAPILiveQuiz.swift in Sources */,
+				EEB27A5AB5794497B0D2E450 /* LMSAPIMarketplace.swift in Sources */,
+				62F975D1A171433FB02FB693 /* LMSAPIMastery.swift in Sources */,
+				EF57F32C16B249A59C1B0A9D /* LMSAPIMobileWave.swift in Sources */,
+				B86CE3E6E2C1410B95DED754 /* LMSAPIOutcomes.swift in Sources */,
+				82349E2D374E44EFA6384DA2 /* LMSAPIParent.swift in Sources */,
+				934754F3673844D6ADC73E1D /* LMSAPIPaths.swift in Sources */,
+				4E2653C7721C4ADE90E0E38D /* LMSAPIPeerReview.swift in Sources */,
+				C12F6B8702F94423B7D9D528 /* LMSAPIProctoring.swift in Sources */,
+				82FD2057433749D0A0BA95B0 /* LMSAPIQuizCodeRun.swift in Sources */,
+				834205D9CAA34D1986FB6277 /* LMSAPIReader.swift in Sources */,
+				11EBA0BF7102475DB405CADA /* LMSAPIReading.swift in Sources */,
+				841FB2BB9D5D4B15B8FD87BB /* LMSAPIReview.swift in Sources */,
+				245688C1364C4EA5915DDDFA /* LMSAPITutor.swift in Sources */,
+				18372484FB8941A5AC4249AF /* LMSAPIWallet.swift in Sources */,
+				0DB86C83EC9E46D29A07C87E /* LMSAPIWhiteboard.swift in Sources */,
+				E7CE05F426644DA5897B0E5D /* LMSBoardAdvancedModels.swift in Sources */,
+				8B0972CBF2D04A14B368D108 /* LMSBoardModels.swift in Sources */,
+				E8D24D84CE224F8DBD5E2411 /* LMSFeatureModels.swift in Sources */,
+				CBE4A8B6A18C4E9A907101DF /* LMSFeatureModelsAccountIntegrations.swift in Sources */,
+				C3842CD715564231AA759EA7 /* LMSFeatureModelsAdvising.swift in Sources */,
+				5FB62DC30515458A8BA807A9 /* LMSFeatureModelsAiAdmin.swift in Sources */,
+				69ED71C918DB4FD5A77936E0 /* LMSFeatureModelsArchivedCoursesAdmin.swift in Sources */,
+				34DE4A2CA55647E681ED10D9 /* LMSFeatureModelsAuditLog.swift in Sources */,
+				2CE8557F96544087B915939D /* LMSFeatureModelsBehavior.swift in Sources */,
+				DF305854A9B3465F809033B7 /* LMSFeatureModelsBilling.swift in Sources */,
+				E9FE5598C89943DD9564C85E /* LMSFeatureModelsCanvasImport.swift in Sources */,
+				1CE59956AA99451EBA69F703 /* LMSFeatureModelsCatalog.swift in Sources */,
+				CEEB499363AA47B9BD4DB1D9 /* LMSFeatureModelsCourseAccessibility.swift in Sources */,
+				C13E314EE9914A0F88C5EA25 /* LMSFeatureModelsCourseCreate.swift in Sources */,
+				3723D36E9F334F7C9BC86A1A /* LMSFeatureModelsCourseGrading.swift in Sources */,
+				E2FB2FC6C5EF473997A646FB /* LMSFeatureModelsCourseGradingAgents.swift in Sources */,
+				324EA67076A64B6F847BFDAD /* LMSFeatureModelsCourseOutcomes.swift in Sources */,
+				4143DD46081F4792B24016AE /* LMSFeatureModelsCoursePlagiarism.swift in Sources */,
+				7D5E8019C8AC43C89611D31C /* LMSFeatureModelsCourseReviews.swift in Sources */,
+				6B41FF45F003438C9CD7DD64 /* LMSFeatureModelsCourseSettings.swift in Sources */,
+				B2686988F6F04B4090F49237 /* LMSFeatureModelsCourseTranslations.swift in Sources */,
+				BD946DC38EDA47218847A225 /* LMSFeatureModelsCredentials.swift in Sources */,
+				01C1E9640176491D835C99C1 /* LMSFeatureModelsDiscussions.swift in Sources */,
+				9DFB3E79F732439E8CEA473B /* LMSFeatureModelsEportfolio.swift in Sources */,
+				4F0E3F4A2DBD4EDEBBD59026 /* LMSFeatureModelsEvaluations.swift in Sources */,
+				F75567D364554666A851761D /* LMSFeatureModelsFeed.swift in Sources */,
+				63C47F3B9CD1428199B41F6E /* LMSFeatureModelsFeedback.swift in Sources */,
+				46C8C80B8CAE4E6D80D77E1C /* LMSFeatureModelsGamification.swift in Sources */,
+				4EE4790234B34E709A12C77B /* LMSFeatureModelsGroups.swift in Sources */,
+				16EAC80ADB914C2BBBE28DD1 /* LMSFeatureModelsInsights.swift in Sources */,
+				8AE4B56B0ABE4960945A8F41 /* LMSFeatureModelsInstructorInsights.swift in Sources */,
+				2FBB27D77EC1440E9353D36C /* LMSFeatureModelsIntegrationsAdmin.swift in Sources */,
+				0AADB5D519824BC0BF643547 /* LMSFeatureModelsIntroCourse.swift in Sources */,
+				7757E1B6A0134FE1B4CAEBE9 /* LMSFeatureModelsLearnerProfile.swift in Sources */,
+				992A92D738DB4C51B68C38D6 /* LMSFeatureModelsLive.swift in Sources */,
+				75A8782B2CE547C187F90CE1 /* LMSFeatureModelsMarketplace.swift in Sources */,
+				66CA3D0F2644484ABE36714B /* LMSFeatureModelsMastery.swift in Sources */,
+				0AEC11C76D7E4ED5ACD4800D /* LMSFeatureModelsMobile.swift in Sources */,
+				0365606EC80F49BDA720B9D5 /* LMSFeatureModelsOrgBrandingAdmin.swift in Sources */,
+				B1DA7F3B2426465F8B2B697A /* LMSFeatureModelsOrgStructureAdmin.swift in Sources */,
+				765D7205C018448BA5CB7585 /* LMSFeatureModelsParent.swift in Sources */,
+				7DEFB3C3FA03419AB8D62785 /* LMSFeatureModelsPaths.swift in Sources */,
+				C46E9A6897934C81868C79D2 /* LMSFeatureModelsPeerReview.swift in Sources */,
+				A0A38195FBB343559254C7E3 /* LMSFeatureModelsPeopleAdmin.swift in Sources */,
+				DE1F5BF161664686B3F986CE /* LMSFeatureModelsPlatform.swift in Sources */,
+				D1E6B8660F554214A2CCA006 /* LMSFeatureModelsPlatformCoursesAdmin.swift in Sources */,
+				F93B651870E641088106001D /* LMSFeatureModelsPlatformSettingsAdmin.swift in Sources */,
+				BC64E58484E34804A6EBD122 /* LMSFeatureModelsReader.swift in Sources */,
+				60F6CA9A2A6B4A63802523D6 /* LMSFeatureModelsReading.swift in Sources */,
+				6EBF6EB0F7FD4DAEA1094256 /* LMSFeatureModelsRolesPermissionsAdmin.swift in Sources */,
+				6AAA48A92983410998A01C76 /* LMSFeatureModelsTranscriptsAdvisingAdmin.swift in Sources */,
+				2BC58B9A6B41442FA1D76296 /* LMSFeatureModelsTutor.swift in Sources */,
+				9744687130044CC9B39025DF /* LMSFeatureModelsWallet.swift in Sources */,
+				58BC60765C004E76B3925EBD /* LMSInteractiveModels.swift in Sources */,
+				9B03252B96D34568B7F8EA2D /* LMSModels.swift in Sources */,
+				54E3BBADE6FA4124AB0FD16D /* LearnerProfileLogic.swift in Sources */,
+				516AA3B61F134041A0DD7696 /* LibraryResourceLogic.swift in Sources */,
+				DB662E4E91804D5397835186 /* LiveGameLogic.swift in Sources */,
+				566B2B6782DE4B3A87939F9C /* LiveMeetingsLogic.swift in Sources */,
+				4480C1BCB27349A6909200C0 /* LiveQuizLogic.swift in Sources */,
+				B8928C79D1314D3CB0C7E4C9 /* MarketplaceLogic.swift in Sources */,
+				886E7AA8383A49DC83C1FB78 /* MasteryLogic.swift in Sources */,
+				96E667E07D0F42619D9D2A39 /* ModuleContentLogic.swift in Sources */,
+				C33B651F4BEE4AFD9BA6A113 /* ModuleLastVisited.swift in Sources */,
+				226EF0559B1049D6B8EA3B6E /* NotificationLogic.swift in Sources */,
+				AD853B2E98F4469B8C1B2403 /* OfficeHoursLogic.swift in Sources */,
+				113C2860AB3F4A9AB10F1938 /* OnboardingModels.swift in Sources */,
+				8F54752BD35B491DA6372FFC /* OrgBrandingAdminLogic.swift in Sources */,
+				F941BCE5E5414D33B51230B7 /* OrgStructureAdminLogic.swift in Sources */,
+				1F74D8F205524A75A1148215 /* ParentLogic.swift in Sources */,
+				293022E9ED5F4F6BAD2BD92D /* PathsLogic.swift in Sources */,
+				FC8F1D359C80452E8055B706 /* PeerReviewLogic.swift in Sources */,
+				999FF64D4B5F49D6BE039FE9 /* PeopleAdminLogic.swift in Sources */,
+				3747DCA0E57E442DB26F1B10 /* PlannerLogic.swift in Sources */,
+				8DF70E53F83A4E2DA95E89EA /* PlannerSnapshotCoding.swift in Sources */,
+				6D797CF5C2B442A9A790A7B8 /* PlatformCoursesAdminLogic.swift in Sources */,
+				64E2F9497D42489385339C34 /* PlatformSettingsAdminLogic.swift in Sources */,
+				DA1D085747E14E45A307FA26 /* PortfolioLogic.swift in Sources */,
+				6106DFE4AC1B414E9E69D471 /* ProfileDepthLogic.swift in Sources */,
+				58BFF00FEA8F4652B49830BE /* ProfileDepthModels.swift in Sources */,
+				66894447C75F4399AD5FCBF9 /* QuizLogic.swift in Sources */,
+				48517E55EB974BEB9602811F /* ReadingLogic.swift in Sources */,
+				83D46D16BDE844E3973F8031 /* RequirementsLogic.swift in Sources */,
+				E28FE2DE3F72446AB723CAD4 /* ReviewModels.swift in Sources */,
+				6A311B5B4C0D47838C805FC9 /* RolesPermissionsAdminLogic.swift in Sources */,
+				F0053352FC944B5B9198349A /* SettingsMenuLogic.swift in Sources */,
+				4ECB87923FCA4E06B317FA12 /* TakeAttendanceLogic.swift in Sources */,
+				38CD2DA112D84039BE13872C /* TranscriptsAdvisingAdminLogic.swift in Sources */,
+				100E500E47654B8E9D58D1BA /* TutorLogic.swift in Sources */,
+				7073B7DC74AC4786922C5A88 /* TutorStreamClient.swift in Sources */,
+				8EA2B955CD3E49F0B814E6EB /* VibeActivityLogic.swift in Sources */,
+				5B3924782AD4464380B2586C /* WalletLogic.swift in Sources */,
+				A8BFC3095651449F93DC57DC /* WhiteboardLogic.swift in Sources */,
+				ECAF8370AF32489CBBB9690A /* WhiteboardRenderer.swift in Sources */,
+				57133A9F3CA54981B73A4429 /* APIClient.swift in Sources */,
+				1DA6D34F38B34B929EA3A4F5 /* APIError.swift in Sources */,
+				8F7AA6EF876C45FBA23429D7 /* NetworkAuthContext.swift in Sources */,
+				240DB855C922497C97B8EBBE /* NetworkBootstrap.swift in Sources */,
+				4207EB18545E4118B229DC7A /* MarkdownTableLogic.swift in Sources */,
+				5C28EEC9903F456FB74CCA22 /* NotebookDrawing.swift in Sources */,
+				A85FE91D01F5467D86B9BF74 /* NotebookMarkdown.swift in Sources */,
+				F3263F6085144AE8B6E39956 /* NotebookSlashCommands.swift in Sources */,
+				DE7D12C90D5F4915B518228C /* NotebookStore.swift in Sources */,
+				E63F7DCEA58948D18358F541 /* NotebookSync.swift in Sources */,
+				30FC256EFC0A4C67B8C9898E /* NotebookTree.swift in Sources */,
+				E9FC59A699384BB4B53A104A /* CacheStore.swift in Sources */,
+				6ED2AA50E9104B3796009C02 /* DownloadStore.swift in Sources */,
+				B3204D72A8CF487EB32BBDCF /* NetworkMonitor.swift in Sources */,
+				DE20FADBCB6145598DCE6369 /* OfflineModels.swift in Sources */,
+				CD937E856ABA41FBAA28CF11 /* OfflineService.swift in Sources */,
+				0B0A7BE81FAF426593571257 /* OutboxStore.swift in Sources */,
+				ED3273E559024ED3AF29401B /* SyncEngine.swift in Sources */,
+				C004C571DCA647FAB2422719 /* PushManager.swift in Sources */,
+				E49CE5F07BA44823B7A607AC /* RealtimeManager.swift in Sources */,
+				E7DA1291B82F4787A193E475 /* WebSocketClient.swift in Sources */,
+				BDEC9A2C593442108AAC86AA /* ContentLinkRouter.swift in Sources */,
+				EC52B2E9900C4798AC33C2E8 /* DeepLinkRouter.swift in Sources */,
+				08460599AB95423A832FF804 /* MobileDestinations.swift in Sources */,
+				1F572F4ACC5C4E2B94139944 /* MobileIaPreferences.swift in Sources */,
+				16DB0460AAFB4F54A7A202F4 /* MobileProfileDepthPreferences.swift in Sources */,
+				A25D499594014184AF31C9A5 /* SearchActionRegistry.swift in Sources */,
+				91EE4551F6854DDDB913DB66 /* SearchModels.swift in Sources */,
+				76905E28FB2144DE911C42A4 /* SearchPathNavigator.swift in Sources */,
+				6214C6A27B964B9E8EAC9F89 /* SearchRecentsStore.swift in Sources */,
+				A6EE2A3D824341B487A1C244 /* CodeEditor.swift in Sources */,
+				962AAE04805E4891B9E03C61 /* AdvisingView.swift in Sources */,
+				506F118453554CDB9C4B0B3A /* AssignmentDetailView.swift in Sources */,
+				FCD3EBD366FF45099486D63D /* AssignmentDraftStore.swift in Sources */,
+				12DF11AD3F7242768F33B2B6 /* AttachmentUploader.swift in Sources */,
+				2F2E132CE72C4567BE0726BD /* AppleSignInController.swift in Sources */,
+				D732685C0FF0488BBAA22982 /* AuthFlowView.swift in Sources */,
+				6ED640DD957543A4B99A7A7D /* GetStartedView.swift in Sources */,
+				D92F4EA291BE409F9437894D /* LoginView.swift in Sources */,
+				FEF892DF287A43FEA76DB673 /* MFAChallengeView.swift in Sources */,
+				0C438CB84F7C4745A2173C55 /* MfaPasskeyController.swift in Sources */,
+				B5FB4F9C3EBD40689AD7D2C4 /* SSOAuthController.swift in Sources */,
+				BEAB9B110A7C4F4C86512B73 /* SignupView.swift in Sources */,
+				32E42FD57CDD4F7FA04D067E /* BehaviorRosterView.swift in Sources */,
+				7F4DC548B19A44CF976A2382 /* HallPassView.swift in Sources */,
+				8210AE54E6404D42BDD72612 /* MyHallPassView.swift in Sources */,
+				8BEBC50CA2D94EB283B57E00 /* BillingView.swift in Sources */,
+				5DA781C1560E43C59BB181B7 /* CheckoutReturnHandler.swift in Sources */,
+				F8184F209BE44FB98AD75351 /* PurchaseFlow.swift in Sources */,
+				44C6DEB1E13C418FB2B4B741 /* BoardAnalyticsSheet.swift in Sources */,
+				E442ECB676D24A8AA8999603 /* BoardComposerView.swift in Sources */,
+				6A23CC2CB34F4B3CBF53151A /* BoardDetailView.swift in Sources */,
+				2BDA6EE9C1914949AF185F06 /* BoardEngagementEnvironment.swift in Sources */,
+				4ABF4AD4F6414BD587FC9BD9 /* BoardExportSheet.swift in Sources */,
+				B8014C6F26404C1ABA54B98A /* BoardModerationSettings.swift in Sources */,
+				F3374E3122724407AE1831A0 /* BoardPostCard.swift in Sources */,
+				EC846646414D4294AE2C7F30 /* BoardPresentModeView.swift in Sources */,
+				7B7CDBEA9C244789A77F4E3E /* BoardSaveAsTemplateSheet.swift in Sources */,
+				C1AA183B64CA4D568D35D3EF /* BoardShareSheet.swift in Sources */,
+				6D5C9E70F3AB49D18718B941 /* BoardSocket.swift in Sources */,
+				19A59B1D142B49E5BF348176 /* BoardSurface.swift in Sources */,
+				BCFE3FDF7C9D4F8D95D844C9 /* BoardSyncStatusChip.swift in Sources */,
+				1500C44153F64F46BA19FEDE /* BoardTemplatePickerView.swift in Sources */,
+				D9A3B0E1CCF54F389CD76AE0 /* BoardsListView.swift in Sources */,
+				88F3DF69B1624E3CA3FD9DFB /* CardArrangeMenu.swift in Sources */,
+				2D070B2A301444FF9F81D8DE /* CommentSheet.swift in Sources */,
+				2ECDD0555E6E4CE3A8A7B431 /* GradeSheet.swift in Sources */,
+				A8AF49F2654C4782A91B097C /* CanvasLayout.swift in Sources */,
+				B1DA0AE34E8948A9A34EB674 /* ColumnsLayout.swift in Sources */,
+				38E2D8D116B54D3F88483BE8 /* MapLayout.swift in Sources */,
+				5C2CD71B7A444B4EB9CBE622 /* TimelineLayout.swift in Sources */,
+				0478D5C26401485C9A2B466E /* WallLayout.swift in Sources */,
+				7FA1D5569FE8478ABFE88B8F /* ModerationQueueView.swift in Sources */,
+				3A50627DBB5B4A19B671B4B3 /* BoardPublicView.swift in Sources */,
+				65EC8B13D15B4D2B96E59EA4 /* ReactionControl.swift in Sources */,
+				10E4F32A4A9242A5A73A1925 /* ReportDialog.swift in Sources */,
+				6B661E3E666B48F88DCE5603 /* CatalogView.swift in Sources */,
+				E6293FFB9D94420AA03C70B6 /* CourseLandingView.swift in Sources */,
+				DA9186FA5F724E1596DE3289 /* ReviewComposer.swift in Sources */,
+				95C4FED9BC85471B8C4B228A /* ContentPageView.swift in Sources */,
+				6ACAFC4A055D44D4961384D1 /* CourseAttendanceView.swift in Sources */,
+				A55BFC1B5155444E965DFB29 /* CourseBanner.swift in Sources */,
+				6F7CFC38EAB844AFA156D9A1 /* CourseDestinationPlaceholder.swift in Sources */,
+				DD9A0C83F05E468F9BF5A80F /* CourseDetailView.swift in Sources */,
+				8DC0B320947C4B87A6B1552F /* CourseGradesView.swift in Sources */,
+				71C7B5CE78344BD4A8A7DF83 /* CourseLibraryView.swift in Sources */,
+				1DBFF471525B40B49FD04BC6 /* CourseMarkdownContentView.swift in Sources */,
+				ADB207B1CDA446F38AE15A03 /* CoursePeopleView.swift in Sources */,
+				FA51F10B12C54219AA1E340E /* CourseStructureSocket.swift in Sources */,
+				B35F4473DC82444F9894D7B1 /* CourseSyllabusView.swift in Sources */,
+				83710C4019E642D19616CC1F /* CourseWorkspaceNav.swift in Sources */,
+				A140069F4BE9482386F0326C /* CoursesListView.swift in Sources */,
+				FABDFE1B10C24681A491EE9C /* CanvasImportComingSoonView.swift in Sources */,
+				074A6C21C2384BE89EEA579C /* CanvasImportView.swift in Sources */,
+				00F69700725A40AB9E788676 /* CourseCreateView.swift in Sources */,
+				E08082B023EB45019F6A65BD /* InlineMarkdownText.swift in Sources */,
+				BC6EA35F8FFB45219353899B /* ItemDetailRows.swift in Sources */,
+				86DD243A03AB41BFAA0043F9 /* ItemDetailView.swift in Sources */,
+				BA1CCA84DD474F1FA3B6F11F /* LaunchContainerView.swift in Sources */,
+				E63BC5C8B8CF4270ADFF79AA /* LibraryResourceView.swift in Sources */,
+				E736CBCD3B144852A9714FCF /* MarkdownCodeBlockView.swift in Sources */,
+				FDB100E93E9942A2A744701C /* MarkdownRenderStyle.swift in Sources */,
+				3530A1790E3B465BA5C255E0 /* MarkdownTableView.swift in Sources */,
+				78F21148716D4FDCA5D867DC /* ModuleItemRouteView.swift in Sources */,
+				D1B0205939D647B887577239 /* ModuleListView.swift in Sources */,
+				1CFCB09E8128482A8D29C675 /* RequirementsView.swift in Sources */,
+				DAF121923DF8456388604A78 /* CourseAccessibilityReviewView.swift in Sources */,
+				F458E8B903514623A9796AB5 /* CourseArchivedContentView.swift in Sources */,
+				B7267D8EF6684472A2568BD7 /* CourseBlueprintSettingsView.swift in Sources */,
+				01B444792F274BD5A8C03389 /* CourseCrossListingView.swift in Sources */,
+				D0DB5D7329D9462BA89B3886 /* CourseFeaturesSettingsView.swift in Sources */,
+				5CA59FC4749C4B8783B32EAF /* CourseGeneralSettingsView.swift in Sources */,
+				38CDFDDD198444F7B965E076 /* CourseGradingAgentsView.swift in Sources */,
+				EE60AB03848A41A7BABB6BA4 /* CourseGradingSettingsView.swift in Sources */,
+				44834B1BD5F044B0965F161E /* CourseHeroImageEditor.swift in Sources */,
+				14AB4B00A96E435D9E8D72F3 /* CourseImportExportView.swift in Sources */,
+				30570D437C9F482F9061E426 /* CourseMarketplaceSettingsView.swift in Sources */,
+				2E0EA4B077894D279ADDEA2D /* CourseOutcomesSettingsView.swift in Sources */,
+				6F89BBA520FC42C99E5754EE /* CoursePlagiarismSettingsView.swift in Sources */,
+				38FC70DC9501453DB9EAF5B6 /* CourseSectionsSettingsView.swift in Sources */,
+				23078AF7C7B4495BB15EDA93 /* CourseSettingsHostView.swift in Sources */,
+				34C4D843CA64495FBAFC9060 /* CourseTranslationsSettingsView.swift in Sources */,
+				02FBBACE4E5F4B068231651B /* TakeAttendanceView.swift in Sources */,
+				715F2DD426814864A39A79D4 /* VibeActivityView.swift in Sources */,
+				B380509EE6BD4726A0BD70AA /* WebItemView.swift in Sources */,
+				B0CADD61C68041C9B8B30DF7 /* CredentialDetailView.swift in Sources */,
+				7B7BDE6F40DE4FAD94975F7C /* CredentialsView.swift in Sources */,
+				4470D49B89A146B4B656D74D /* DashboardCoursesCarousel.swift in Sources */,
+				CFF920103B414BF08BB4B508 /* DashboardHeroPanel.swift in Sources */,
+				CC144EE80A654553BC154DA8 /* DashboardView.swift in Sources */,
+				429EE63084EC44F29DB30CAB /* LiveMeetingsRail.swift in Sources */,
+				E92D89082F1D41EAA1C98233 /* CourseDiscussionsSection.swift in Sources */,
+				02495A339C6F41D2BA1EFAA5 /* DiscussionThreadView.swift in Sources */,
+				E331288A0F674EEA94B24A3E /* DiscussionsListView.swift in Sources */,
+				D0E82E8FC22B442B941693A0 /* PostComposerView.swift in Sources */,
+				5BA81EB8CDA24A7EBE984486 /* CourseEvaluationsSection.swift in Sources */,
+				994D4272D09A4266B81C10E2 /* EvaluationFormView.swift in Sources */,
+				3750DD3F1BCB4B0199594517 /* EvaluationResultsView.swift in Sources */,
+				29242711A5FC47B694263955 /* CourseFeedSection.swift in Sources */,
+				5E0B56C819FC40499848E34D /* FeedChannelView.swift in Sources */,
+				D80E0F81FBFD45BF8EF8A9B9 /* FeedChannelsView.swift in Sources */,
+				F1A4B1B5F5DC4291B37A14F8 /* FeedLogic.swift in Sources */,
+				A3731DB6E85E4FAE82310A82 /* FeedSocket.swift in Sources */,
+				D4777BE989634FE19684A17F /* ShareFeedbackView.swift in Sources */,
+				80ADB85FC1A8409BA6F57698 /* CourseFilesSocket.swift in Sources */,
+				946FDBDCD2914D88821BFC89 /* CourseFilesView.swift in Sources */,
+				98E2D68BCA964AE0AFBD4616 /* FilePreviewView.swift in Sources */,
+				F711F2F8D1F2444D8F0059F0 /* MarkupOverlayView.swift in Sources */,
+				A6406B6A53A14BECAEFE6BE0 /* GamificationView.swift in Sources */,
+				8ACF1E26FFC7451E8ED323DE /* GradeFeedbackView.swift in Sources */,
+				4C1FAB2031E94160AEF0F39A /* WhatIfController.swift in Sources */,
+				B109E49708B346F8AE19D0DF /* GradingBacklogView.swift in Sources */,
+				36268A9B409440A2991B997E /* SpeedGraderView.swift in Sources */,
+				54A37B117E42410D92826745 /* CollabDocView.swift in Sources */,
+				9A1F9515EBB24991992B4E20 /* CourseCollabDocsSection.swift in Sources */,
+				46AA01AD5D1640469E8357F4 /* CourseGroupsSection.swift in Sources */,
+				4F24ADE138A44690B717B9AF /* GroupSpaceView.swift in Sources */,
+				59CDBAED2BA84E2489149137 /* AnnouncementComposerView.swift in Sources */,
+				15581A68133149139B6B6063 /* AnnouncementsViews.swift in Sources */,
+				BBC7C359B9754362ABCC094E /* BroadcastComposerView.swift in Sources */,
+				74120AB8F1214541A94A002F /* MainTabView.swift in Sources */,
+				A38F8CF989CF483B8C742305 /* MoreHubView.swift in Sources */,
+				A375E55BAA2A4A85BFF6DA0E /* ShellHeaderBar.swift in Sources */,
+				91A4B4AF5ECB458591DED7FE /* TeachHubView.swift in Sources */,
+				01C2021DA8724C4F8B4489FA /* UniversalSearchPlaceholder.swift in Sources */,
+				D03EDFA65CB94AD49A23D07C /* ComposeMessageView.swift in Sources */,
+				B7317102138D45648DE78440 /* InboxView.swift in Sources */,
+				DB9E6921DF2D4ECE9DD3131A /* MessageDetailView.swift in Sources */,
+				AA4CC32004DB48CEBE2ADD44 /* DashboardInsightsSection.swift in Sources */,
+				AC5DEED5C2134E8EA30F97A6 /* InsightsView.swift in Sources */,
+				745E4A013F3F4DBCAE694434 /* AtRiskListView.swift in Sources */,
+				B72C210EF12B46FE8255BDAC /* CourseInsightsSection.swift in Sources */,
+				055C2D867C904934B52F3E69 /* StudentProgressDetailView.swift in Sources */,
+				74D6E4758A6B4F2DBFB8FF70 /* WhatsWorkingView.swift in Sources */,
+				FA4D50265A784D8FABF995F8 /* IntroCelebrationPresenter.swift in Sources */,
+				7AFFC51DBBCF4C1A92C3F8FD /* IntroCompletionCelebrationSheet.swift in Sources */,
+				A2EF87A864774480A56DDB30 /* IntroCourseEntryCard.swift in Sources */,
+				FA8524D1DAFA4A1AB3505A11 /* IntroCourseProgressRail.swift in Sources */,
+				07B3A259F1494F5E9F9BC6D2 /* LearnerProfileView.swift in Sources */,
+				3750F0C2E07147D4B6270002 /* LibraryBrowseView.swift in Sources */,
+				2ADF58AB69E7437F8715D93F /* MeetingDetailView.swift in Sources */,
+				BD12AE60FB6045C083DD2CD5 /* MeetingListView.swift in Sources */,
+				BF6C6F1D5AAD49DBA79A7D77 /* WhiteboardView.swift in Sources */,
+				2D00E33E6CF54F61A901E1AC /* LiveGameSocket.swift in Sources */,
+				D96DF573596B41388A8C8CA9 /* LiveQuizHubView.swift in Sources */,
+				4C0FA75A018448B6844536AA /* LiveQuizPlaySurfaces.swift in Sources */,
+				5E29E0AB8B17400FB0DDD8D7 /* LiveQuizPlayView.swift in Sources */,
+				D870E7A5D79547E988417CF7 /* MarketplaceDetailView.swift in Sources */,
+				0AD8C4F49F5849AC888C86DF /* MarketplaceView.swift in Sources */,
+				16DEB596B0494E5C8F122577 /* MyPurchasesView.swift in Sources */,
+				2B7A05CE6FDE41788801778C /* CourseMasterySection.swift in Sources */,
+				D8A97A50811C4BCD93CDCDA5 /* ReportCardListView.swift in Sources */,
+				A27F0E4449CE474AAA9174A0 /* CourseDrawer.swift in Sources */,
+				60A013C7F62D4BB7BB038A90 /* DrawerScaffold.swift in Sources */,
+				1F4B76F746B94060B2A5CDD1 /* DrawerToolbar.swift in Sources */,
+				A139A816FD314BD3A5043667 /* GlobalDrawer.swift in Sources */,
+				2B5EC07E690943609A5C616B /* NotebookDrawingViews.swift in Sources */,
+				BBE29386B2B4402A9941F7D9 /* NotebookEditorSupportViews.swift in Sources */,
+				CA70EF63897F49B786B225CA /* NotebookEditorView.swift in Sources */,
+				19E93DB8211E400688115BEA /* NotebookPagesView.swift in Sources */,
+				9A147E80CBC44402B0130242 /* NotebooksListView.swift in Sources */,
+				B2A7C2F7696F44D9B504C32C /* BookingSheet.swift in Sources */,
+				8F8141BD6FA54CC3B2F9134B /* MyBookingsView.swift in Sources */,
+				E5E05D80234E4F20891D8E4B /* OfficeHoursView.swift in Sources */,
+				9A83BDA7F65F4830990E28D1 /* DiagnosticView.swift in Sources */,
+				7FF900EF4CEB473CA26E50E0 /* OnboardingFlowView.swift in Sources */,
+				B4BA69CEA39F41498E73A9DB /* ConferenceBookingView.swift in Sources */,
+				F50D333188834A1F97F2EF83 /* MyConferencesView.swift in Sources */,
+				541666AE1C7D4EEAA5429BD6 /* ParentAttendanceDetailView.swift in Sources */,
+				781B8CD946FA42EDB9EC487C /* ParentDashboardSections.swift in Sources */,
+				D5BA0C24AEB94A79AF7DAD1B /* ParentDashboardView.swift in Sources */,
+				68746262C0C14747ACC5E4FE /* ParentGradesDetailView.swift in Sources */,
+				D27FC3C1650B4D2AAD3E230A /* ParentNotificationPrefsView.swift in Sources */,
+				55F12AC896D249D4A2251BFC /* DashboardStudySection.swift in Sources */,
+				8FA67D0A5FED4611B2E5BFF4 /* MyPathsView.swift in Sources */,
+				A5238D23338D4929AF95DBFA /* PathLandingView.swift in Sources */,
+				7AFB454C765A4532B6109E88 /* PathRunnerView.swift in Sources */,
+				72861B8A8A9E45EBB7C628FA /* PathsCatalogView.swift in Sources */,
+				50B051D0E6EF4F18BFC52BFB /* PeerReviewDetailView.swift in Sources */,
+				32B112939A2D4A489AD3E86B /* PeerReviewListView.swift in Sources */,
+				BEE087DF4C394B4E819F6717 /* ReviewsReceivedView.swift in Sources */,
+				7B1294501E8B4C8DB62A2E31 /* RubricScorerView.swift in Sources */,
+				3F4C647187A848AE87F2AC69 /* CalendarSubscribeSheet.swift in Sources */,
+				429BCEDAFD7F4D0C9C41FCBB /* CalendarView.swift in Sources */,
+				B86B1B2AF4B443D0A4DD113B /* ConferenceReminderScheduler.swift in Sources */,
+				482290ADF9CB4F1A9FA0C3AE /* DueReminderScheduler.swift in Sources */,
+				9FEFD60A895E4E44AF52FC80 /* OfficeHoursReminderScheduler.swift in Sources */,
+				6235F0C5CBB54BDA965DD437 /* PlannerModel.swift in Sources */,
+				1C9E6551E0E64368BA9A4D6E /* PlannerView.swift in Sources */,
+				4898E73B3D9C4C46AFD959FF /* TodosView.swift in Sources */,
+				9A6CA6BE6BAF4314957B71AD /* ArtifactDetailView.swift in Sources */,
+				2FAC9721ADA74435BECEE7FC /* ArtifactEditorView.swift in Sources */,
+				B27F3BFCA52E4D1187C4FF7B /* PortfolioArtifactUploader.swift in Sources */,
+				0D96BC8D62B645949D97CC57 /* PortfolioDetailView.swift in Sources */,
+				8341D1F8E54E4269B367A930 /* PortfolioView.swift in Sources */,
+				F3B6BD11E6794E459EE723B9 /* AiAdminEntryCard.swift in Sources */,
+				156A40230FC94EF7B063C3A9 /* ArchivedCoursesAdminEntryCard.swift in Sources */,
+				03CE9CB6CF1B41D7A0AC9DE8 /* BiometricLockView.swift in Sources */,
+				5FE93E88622040D6A23C4A8B /* DeviceSessionsView.swift in Sources */,
+				1B6D93F7DC3A4ADAA1703D91 /* EditProfileView.swift in Sources */,
+				4E2BEF195A7540FCBCBBF523 /* IntegrationsAdminEntryCard.swift in Sources */,
+				17699894CF734423B1810202 /* IntegrationsEntryCard.swift in Sources */,
+				F72E0A5059D449DFAD5A4CE3 /* IntegrationsView.swift in Sources */,
+				C32EFCEB65F342B1BD901EC9 /* LearnerProfileEntryCard.swift in Sources */,
+				45D0B94381C54DD9A46B980C /* MyAccommodationsView.swift in Sources */,
+				F8A8CA34DD5248E198ADEDE1 /* NotificationPreferencesView.swift in Sources */,
+				0935B7CEF8A14D9F8C0342C7 /* NotificationsView.swift in Sources */,
+				74E2107E87FC4613905F4BBB /* OrgBrandingAdminEntryCard.swift in Sources */,
+				9D3C641B6E06434F9A489533 /* OrgStructureAdminEntryCard.swift in Sources */,
+				C25D7F0B62C04EAA8F510D80 /* PeopleAdminEntryCard.swift in Sources */,
+				73D070D590B54C59BA6D89F4 /* PlatformSettingsAdminEntryCard.swift in Sources */,
+				7C6879BE72D64794A3A4370C /* ProfileDepthCards.swift in Sources */,
+				D8592ED7E4B140B2825D9BEC /* ProfilePersonalDetailsView.swift in Sources */,
+				50879B7AF9CF4BCB9C720100 /* ProfileSecurityCard.swift in Sources */,
+				1208ABCC1A064031A6748CC6 /* ProfileSettingsCards.swift in Sources */,
+				A0EE8A9FCDEA4755AC6AD5A9 /* ProfileView.swift in Sources */,
+				8655EDCE0C1846C7855C55C0 /* ProfileViewSections.swift in Sources */,
+				0F7BBEE32D964C7F8EEDEA18 /* ResearchStudiesView.swift in Sources */,
+				310279C1035A4E7DAA8A4DC6 /* RolesPermissionsAdminEntryCard.swift in Sources */,
+				6C4F19F1954243F0826A96E2 /* SettingsAdminHubEntryCard.swift in Sources */,
+				18250A1593BE4CB1991A68D8 /* ShareFeedbackEntryCard.swift in Sources */,
+				CACA2DD9E49346AEA08893A4 /* TranscriptsAdvisingAdminEntryCard.swift in Sources */,
+				302A06DBACF7406DAFD4A0E9 /* CodeQuestionView.swift in Sources */,
+				4F9DAEEDB26541AABC17C6CE /* LockdownController.swift in Sources */,
+				B748606474484111B73691B2 /* QuizIntroView.swift in Sources */,
+				596EE131CF8D47E7A9311A5E /* QuizQuestionViews.swift in Sources */,
+				473462BCE7684B44B380A32F /* QuizResultsView.swift in Sources */,
+				88FD7F199B27482CACFC5D59 /* QuizTakerView.swift in Sources */,
+				5AA6AEA33B1E409AB6888F0D /* CaptionedPlayerView.swift in Sources */,
+				7CBE738084DA452B8FAFB32B /* ContentTranslationControls.swift in Sources */,
+				D8E45C0A2E884945B4A1AA41 /* ImmersiveReaderCapabilities.swift in Sources */,
+				FFD93AA9D5124D20A7F3484D /* ReaderLogic.swift in Sources */,
+				90AC42CD64A048F0BFFB6BA4 /* ReaderToolbar.swift in Sources */,
+				C4CE1383CBB64D8FA63EBF2A /* ReadingPreferencesSheet.swift in Sources */,
+				97BC3EDD867D418E9EC69204 /* ReadingPreferencesStore.swift in Sources */,
+				33883F4C4CA64C1EB3E340AB /* LeveledLibraryView.swift in Sources */,
+				B54D947779A240E6AA303510 /* LogReadingSheet.swift in Sources */,
+				CC512AC43B434B9A922BB0AC /* ReadingDashboardView.swift in Sources */,
+				7EF4EC3EF7644B63B8D12684 /* ReviewHomeView.swift in Sources */,
+				68DC76A3A65C4EDE938E3446 /* ReviewReminderScheduler.swift in Sources */,
+				945C1A9C455643069DF05690 /* ReviewSessionView.swift in Sources */,
+				4DAAEC930A39445F9B51D291 /* UniversalSearchView.swift in Sources */,
+				D90135D7FD1B4A04BC9294AA /* AdminMetricCards.swift in Sources */,
+				FD17B0656CDE4AB08E8673B5 /* AdvisingSettingsView.swift in Sources */,
+				BA35B15C5E0A41EF8FD2E6D5 /* AiAdminHubView.swift in Sources */,
+				576E6A5DEEBF42B5AADB411B /* AiGovernanceView.swift in Sources */,
+				4111A83ADCAC413689A3E0A5 /* AiModelsSettingsView.swift in Sources */,
+				BE519708C3C243EE9C2EBA7D /* AiProviderSettingsView.swift in Sources */,
+				6AA80F451C054584A8DE520B /* AiReportsView.swift in Sources */,
+				9B229FD9B1224282B9AA85A8 /* ArchivedCoursesAdminView.swift in Sources */,
+				2D49A7B336A74EE0A11D13DC /* AuditLogAdminView.swift in Sources */,
+				A0A10166BBC44489B7AB0F81 /* BoardsGovernanceAdminView.swift in Sources */,
+				C4C3441D100F43F39882BF04 /* CoursesAdminView.swift in Sources */,
+				24156EB0BE74406F92C4FF99 /* IntegrationsAdminView.swift in Sources */,
+				F881C5FA406E4711A0FB30BE /* OrgBrandingAdminView.swift in Sources */,
+				4AB9E3A8C59F4F89A903F617 /* OrgBrandingView.swift in Sources */,
+				588328F541FA475FACB717B7 /* OrgStructureAdminView.swift in Sources */,
+				EE768E0C0828429C8D916854 /* OrgStructureView.swift in Sources */,
+				43064F63BF904BA990B88E23 /* PeopleAdminView.swift in Sources */,
+				94EBD100C5D04CE8BBD552EB /* PlatformSettingsView.swift in Sources */,
+				748C8C9178184C2CA3DD46D5 /* RolesPermissionsAdminView.swift in Sources */,
+				64966FD197AA44D9A6F60CE9 /* SystemPromptsView.swift in Sources */,
+				AA8D98D4A34944CC87EB9922 /* TermsAdminView.swift in Sources */,
+				C6666DFD63064A7E9849784B /* TranscriptsAdvisingAdminView.swift in Sources */,
+				DA7784D0FDB741498D67B357 /* TranscriptsSettingsView.swift in Sources */,
+				F5DF3579B496478C8C58850A /* UserDetailAdminView.swift in Sources */,
+				CB990445D4064516976730CD /* SettingsAdminHubView.swift in Sources */,
+				BD27BE34B7054ADE84D4808F /* SplashView.swift in Sources */,
+				886FBEC3140242A1BA44825E /* TutorChatModel.swift in Sources */,
+				8A10CFB4C61E44BE835BFF10 /* TutorChatView.swift in Sources */,
+				32DC0B8667B541929156076E /* TutorFlowLayout.swift in Sources */,
+				AABE9F5B4EE042D0B602FD28 /* TutorLauncher.swift in Sources */,
+				E44E98544E5D44798AE35167 /* WalletCCRDetailView.swift in Sources */,
+				FB5AEC562CA14B04A563CC3F /* WalletCETranscriptDetailView.swift in Sources */,
+				C8F94F30867A46D0861FE535 /* WalletOfficialTranscriptDetailView.swift in Sources */,
+				1B0E9238582A467987E23888 /* WalletView.swift in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		9E1E6DA8B52A40FDB2B4C866 /* Sources */ = {
+		B4FCA470F3184A7BA3311970 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			runOnlyForDeploymentPostprocessing = 0;
 			files = (
-				A23C0799C9D5426B91951786 /* AccessibilitySupportTests.swift in Sources */,
-				1994EFB9430B407BB04A3A7A /* AccountIntegrationsLogicTests.swift in Sources */,
-				F2DCFE74B99E4C36AF1CDFE4 /* AdvisingLogicTests.swift in Sources */,
-				3F6D6C71ECC34DD89E5D8DB0 /* AiModelsAdminLogicTests.swift in Sources */,
-				8EF49AF757964F3FA83DC6D5 /* AnnouncementLogicTests.swift in Sources */,
-				D26D2A6793B043DAB9A426AD /* AppleSignInLogicTests.swift in Sources */,
-				9A97E0D3542C4B7EA5F79622 /* ArchivedCoursesAdminLogicTests.swift in Sources */,
-				B52A437D41414FF4BC756B89 /* AssignmentLogicTests.swift in Sources */,
-				08789C3FDA64436EAF36AD7C /* AuditLogAdminLogicTests.swift in Sources */,
-				82A951442D6E4BFBA1171B21 /* AuthCallbackParserTests.swift in Sources */,
-				61198ECE5E1041468DE0B80A /* BehaviorLogicTests.swift in Sources */,
-				9BEC92F81DA44E92B5D7C768 /* BillingLogicTests.swift in Sources */,
-				24567DB9CFE541B9A11D661B /* BiometricGateTests.swift in Sources */,
-				52BD152816234B4BB35A5E79 /* BoardsAdvancedLogicTests.swift in Sources */,
-				B0B3BC864AA54AC095F4CBCA /* BoardsLogicTests.swift in Sources */,
-				22CB296FDC75473EB06C7704 /* CanvasImportLogicTests.swift in Sources */,
-				BBE628DF72F94D6D8F4FAC85 /* CatalogLogicTests.swift in Sources */,
-				5686955245F34B759BD4C41B /* ConferenceLogicTests.swift in Sources */,
-				E08A73F841714561BA2FF8EF /* CourseAccessibilityReviewLogicTests.swift in Sources */,
-				9237F4A866D74B20B3000265 /* CourseArchivedContentLogicTests.swift in Sources */,
-				37B9948867FB4B779B88D0FF /* CourseBlueprintLogicTests.swift in Sources */,
-				5CE78B0F31214C66A526476D /* CourseCreateLogicTests.swift in Sources */,
-				A76CB6FC18E64768A79D0D8E /* CourseFeaturesLogicTests.swift in Sources */,
-				35FE576C56B342CF9FBA9E24 /* CourseFileModelsTests.swift in Sources */,
-				CEAE609950C8411FB1582E11 /* CourseGradingAgentsLogicTests.swift in Sources */,
-				F795215E985444169BB9F10F /* CourseGradingLogicTests.swift in Sources */,
-				96F2D3104820409688B27A99 /* CourseImportExportLogicTests.swift in Sources */,
-				40A952AFC87949D89BDFDEF2 /* CourseOutcomesLogicTests.swift in Sources */,
-				A5E9605AA60241558C833BE9 /* CoursePeopleLogicTests.swift in Sources */,
-				32FBA9724D734FBEB97F3B1A /* CoursePlagiarismLogicTests.swift in Sources */,
-				E98EF898FC3B4BEE94D33E12 /* CourseReviewLogicTests.swift in Sources */,
-				64482DC9BB234AD586064698 /* CourseSectionsLogicTests.swift in Sources */,
-				024E9164F7D046E99E396E7C /* CourseSettingsLogicTests.swift in Sources */,
-				AF4F359F681742A6B319F4D4 /* CourseTranslationsLogicTests.swift in Sources */,
-				97E2A381F45543519879F02D /* CredentialsLogicTests.swift in Sources */,
-				B84920E40A0C49FEBBF062DF /* DiscussionLogicTests.swift in Sources */,
-				EB3A9F3EA1454D34B09EAD5C /* EvaluationLogicTests.swift in Sources */,
-				CA23903478C24FF19420A3DA /* FeedLogicTests.swift in Sources */,
-				1E50EEC9131644CA94A9BC1A /* FeedbackLogicTests.swift in Sources */,
-				79975C08D6A94A9E9257F513 /* GamificationLogicTests.swift in Sources */,
-				507450EE9B44461F987791F3 /* GradeCalculatorTests.swift in Sources */,
-				A9F1798F9AEF41A9A9DD4C07 /* GroupsLogicTests.swift in Sources */,
-				F6A478037DE143208F54EE24 /* I18nTests.swift in Sources */,
-				4218315B4F5D411EA5FED6AB /* InsightsLogicTests.swift in Sources */,
-				205AA6319E3A4CABBA071659 /* InstructorInsightsLogicTests.swift in Sources */,
-				F9429E0163E0422BA909AADF /* IntegrationsAdminLogicTests.swift in Sources */,
-				27048DD189624218A3D9EA63 /* InteractiveLaunchLogicTests.swift in Sources */,
-				8F0235BD407A4F6FB044E84C /* IntroCourseLogicTests.swift in Sources */,
-				62C6355F8D3947F4A6BBDC7B /* LearnerProfileLogicTests.swift in Sources */,
-				606E7F5B576145F183AE8773 /* LexturesMotionTests.swift in Sources */,
-				851D35021CA3471E82CE76F8 /* LibraryResourceLogicTests.swift in Sources */,
-				6982609AD79E4AC4A422425F /* LiveMeetingsLogicTests.swift in Sources */,
-				E242AD182E624AF48AE00B19 /* LiveQuizLogicTests.swift in Sources */,
-				AB6E3BB8C19646CD8F65649E /* MarketplaceLogicTests.swift in Sources */,
-				25AED480499D437B8DC4CE95 /* MasteryLogicTests.swift in Sources */,
-				602715CA35FD410A82DE5CD5 /* MobileDestinationsTests.swift in Sources */,
-				A7693FDB85E9410B9A5041AF /* ModuleContentModelsTests.swift in Sources */,
-				FC55C1D14A454B0FA30F13DF /* NotificationModelsTests.swift in Sources */,
-				6A8E25277A364360BB65ACF6 /* OfficeHoursLogicTests.swift in Sources */,
-				BF0564D785B241C68D466A0A /* OnboardingModelsTests.swift in Sources */,
-				0C52FC70DBAD4D86AA0543FA /* OrgBrandingAdminLogicTests.swift in Sources */,
-				4E9184D5D15D432F8D01B21C /* OrgStructureAdminLogicTests.swift in Sources */,
-				5E1F943D21FF466FAB849AB9 /* ParentLogicTests.swift in Sources */,
-				894A900460EE4AC1A6F32B83 /* PathsLogicTests.swift in Sources */,
-				B6C5C79CDC00441DB2E96564 /* PeerReviewLogicTests.swift in Sources */,
-				5D8FB83EE1784AA9834AF116 /* PeopleAdminLogicTests.swift in Sources */,
-				28A35BBFB4FD4A7B90D31F79 /* PeopleAdminMetricsLogicTests.swift in Sources */,
-				A70BDCB9398842E78C2B9DE1 /* PlannerModelsTests.swift in Sources */,
-				75F57C4C09F449DF9CA31233 /* PlatformCoursesAdminLogicTests.swift in Sources */,
-				A10E5A2734A24CD9B3D1C6EB /* PlatformSettingsAdminLogicTests.swift in Sources */,
-				17A60B25F39A46F79C695BFC /* PortfolioLogicTests.swift in Sources */,
-				D1C85862113641E3ABEA0EE8 /* ProfileDepthLogicTests.swift in Sources */,
-				3DD7B3543EE44F449E16C4A3 /* QuizLogicTests.swift in Sources */,
-				B12D7287F1B5479481CEFC9F /* ReaderLogicTests.swift in Sources */,
-				F559AC6173C54430ADC4CF98 /* ReadingLogicTests.swift in Sources */,
-				3E747E0812D94FD4B3A68293 /* RequirementsLogicTests.swift in Sources */,
-				CA27E0A6B66846B78ABDB0E6 /* ReviewLogicTests.swift in Sources */,
-				0D177076EAB349BA880EB4FD /* RolesPermissionsAdminLogicTests.swift in Sources */,
-				5741663D14FD43D7B577FFA3 /* SchoolCodeLogicTests.swift in Sources */,
-				0F9BB204DA8B4F88856BF2CC /* SearchTests.swift in Sources */,
-				383DA9C55A7740BDAB59BA67 /* SettingsAccommodationsTests.swift in Sources */,
-				0BBABC3CD8E54355BB464CE0 /* SettingsMenuLogicTests.swift in Sources */,
-				C9FE307022A24D8EB0AF2915 /* TakeAttendanceLogicTests.swift in Sources */,
-				825A451207EC4A378798D7F1 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */,
-				3944357D2583408395A57ED8 /* TutorLogicTests.swift in Sources */,
-				A7EB2920495A4EE4AD2481E4 /* UIModeLogicTests.swift in Sources */,
-				D6224B6580C04B12A4C74A73 /* VibeActivityLogicTests.swift in Sources */,
-				08CD949DE86247FBB8107C76 /* WalletLogicTests.swift in Sources */,
-				978593606D454E40B811DDC5 /* WhiteboardLogicTests.swift in Sources */,
+				57A97D7429D64E39A3579A72 /* AccessibilitySupportTests.swift in Sources */,
+				5120B88C62194109BDA91E66 /* AccountIntegrationsLogicTests.swift in Sources */,
+				530BCEC8DCDB438D8982765E /* AdvisingLogicTests.swift in Sources */,
+				CE7B6A467D0A40B49A3046FE /* AiModelsAdminLogicTests.swift in Sources */,
+				277DA9184D854CAAB92D91BE /* AnnouncementLogicTests.swift in Sources */,
+				002B53E3646445088F1F012E /* AppleSignInLogicTests.swift in Sources */,
+				F88378C305294860A839D6D1 /* ArchivedCoursesAdminLogicTests.swift in Sources */,
+				26C3F6B141584EAA81BCAD41 /* AssignmentLogicTests.swift in Sources */,
+				395F9B7ED8954949AD9FF536 /* AuditLogAdminLogicTests.swift in Sources */,
+				93AA2ACE3B0E436F9366D9A9 /* AuthCallbackParserTests.swift in Sources */,
+				3AE68EBB7DAB4FBFA2CD4C3C /* BehaviorLogicTests.swift in Sources */,
+				0046F0DD46804DD2BCC3C17F /* BillingLogicTests.swift in Sources */,
+				94DDF97828D147469EB851B1 /* BiometricGateTests.swift in Sources */,
+				809175F2CCAC40438E08DD31 /* BoardsAdvancedLogicTests.swift in Sources */,
+				383266D98F4F4120B60B7726 /* BoardsLogicTests.swift in Sources */,
+				8B664563762B460AB4572916 /* CanvasImportLogicTests.swift in Sources */,
+				F09E461DAA2E45978262D4A4 /* CatalogLogicTests.swift in Sources */,
+				368798378CD84E039799EAEA /* ConferenceLogicTests.swift in Sources */,
+				EF9D6FE117584AE0A6E1E479 /* CourseAccessibilityReviewLogicTests.swift in Sources */,
+				47D96D3C23E84F1E8B3439EC /* CourseArchivedContentLogicTests.swift in Sources */,
+				58A90479BDCD42E5B86E1593 /* CourseBlueprintLogicTests.swift in Sources */,
+				4EEE681736574464AB0D44A6 /* CourseCreateLogicTests.swift in Sources */,
+				3ED806CD70334015B26BB8CA /* CourseFeaturesLogicTests.swift in Sources */,
+				0C3D47AEF68D451081B866D9 /* CourseFileModelsTests.swift in Sources */,
+				2BF298D68F034BCBA88676CF /* CourseGradingAgentsLogicTests.swift in Sources */,
+				5EB0CB4685294FD985610BD7 /* CourseGradingLogicTests.swift in Sources */,
+				28096A60B53B4DC48D902404 /* CourseImportExportLogicTests.swift in Sources */,
+				9661B34023F3417A9289E9DA /* CourseOutcomesLogicTests.swift in Sources */,
+				EB9C414783E24AE3938FEE83 /* CoursePeopleLogicTests.swift in Sources */,
+				803355198DE84312B00EEF6B /* CoursePlagiarismLogicTests.swift in Sources */,
+				8408F1012BB1432EB56C470B /* CourseReviewLogicTests.swift in Sources */,
+				D532541CEF9548C2B34F7535 /* CourseSectionsLogicTests.swift in Sources */,
+				5689EDC948304F298739625D /* CourseSettingsLogicTests.swift in Sources */,
+				EF9846D4464740F380C37A87 /* CourseTranslationsLogicTests.swift in Sources */,
+				7529AA44DAFB43E99ADECA6D /* CredentialsLogicTests.swift in Sources */,
+				B2DBE14BE7F64544966082B7 /* DiscussionLogicTests.swift in Sources */,
+				A1D5C56A8E344EAFBACC7C35 /* EvaluationLogicTests.swift in Sources */,
+				D7901A53D7884F90B1A51037 /* FeedLogicTests.swift in Sources */,
+				1F8366B441054C13B54E758A /* FeedbackLogicTests.swift in Sources */,
+				27A854C542464A4BA0F79ED8 /* GamificationLogicTests.swift in Sources */,
+				777EFEB4E8B944F386678D3E /* GradeCalculatorTests.swift in Sources */,
+				BCBFFF3641164CE494E83790 /* GroupsLogicTests.swift in Sources */,
+				73F8B712205046ED8D7F2F84 /* I18nTests.swift in Sources */,
+				F169B4F28EA24B019CE5DFDA /* InsightsLogicTests.swift in Sources */,
+				545D648D1A1745D899C3E8F2 /* InstructorInsightsLogicTests.swift in Sources */,
+				067B2BAE409C4159A355BEA5 /* IntegrationsAdminLogicTests.swift in Sources */,
+				AA03DB3FA49B49FE8D2ADA0E /* InteractiveLaunchLogicTests.swift in Sources */,
+				B32463EFC6094592BEE07740 /* IntroCourseLogicTests.swift in Sources */,
+				AD0F9DB79E9244BF909AABBF /* LearnerProfileLogicTests.swift in Sources */,
+				6B59078A87D64B57ACC8757A /* LexturesMotionTests.swift in Sources */,
+				E628602F8B35472D8DF7B1EA /* LibraryResourceLogicTests.swift in Sources */,
+				9CEBF3BE9511495D949ADD0A /* LiveMeetingsLogicTests.swift in Sources */,
+				06C3CEF59C1C4CE290B7C342 /* LiveQuizLogicTests.swift in Sources */,
+				93039533CCFD4DA19D4E6EFF /* MarkdownRenderStyleTests.swift in Sources */,
+				09929548D33445B29B9C439E /* MarketplaceLogicTests.swift in Sources */,
+				0C24F3E25B7D45F79A4F0B7D /* MasteryLogicTests.swift in Sources */,
+				C195101C016C479F81CE9EDA /* MobileDestinationsTests.swift in Sources */,
+				E4ABE07F1C394EF98D2C9717 /* ModuleContentModelsTests.swift in Sources */,
+				AE0327D9102F4CC58008B6BB /* NotebookMarkdownLogicTests.swift in Sources */,
+				6BD36E65FE764C50861C2505 /* NotificationModelsTests.swift in Sources */,
+				F0AF9957D9064367A34028B9 /* OfficeHoursLogicTests.swift in Sources */,
+				B4DB643004924B3B8652780F /* OnboardingModelsTests.swift in Sources */,
+				B0C2AA0267EF4141A7F1CDB0 /* OrgBrandingAdminLogicTests.swift in Sources */,
+				066465F02A3E44B9A7E5B80D /* OrgStructureAdminLogicTests.swift in Sources */,
+				BF0628E37D384A7FBD883B3D /* ParentLogicTests.swift in Sources */,
+				5F2F1EB90880426887D4538C /* PathsLogicTests.swift in Sources */,
+				03036CF1FCC04A03B6BE4623 /* PeerReviewLogicTests.swift in Sources */,
+				407F6D81F5B74C21A199BAC7 /* PeopleAdminLogicTests.swift in Sources */,
+				1E788BCE8D7C46578ACF6F90 /* PeopleAdminMetricsLogicTests.swift in Sources */,
+				5F2E636E72714BAF97C3BE3D /* PlannerModelsTests.swift in Sources */,
+				2B34BF9141B548E0AF398995 /* PlatformCoursesAdminLogicTests.swift in Sources */,
+				2D9C6408AF88442F8FEF8EEA /* PlatformSettingsAdminLogicTests.swift in Sources */,
+				8B803539203D41C5BB05FF18 /* PortfolioLogicTests.swift in Sources */,
+				242B8D51724945219BF5C15E /* ProfileDepthLogicTests.swift in Sources */,
+				A64A85A6032A46ABB86F7659 /* QuizLogicTests.swift in Sources */,
+				258A6F160B0642E0A992971E /* ReaderLogicTests.swift in Sources */,
+				36B7D7960FFC4EADA9F2A077 /* ReadingLogicTests.swift in Sources */,
+				CC5EA2607D504120AB18646C /* RequirementsLogicTests.swift in Sources */,
+				930EAC750D6B421EAF7DDFEC /* ReviewLogicTests.swift in Sources */,
+				B48907B2DDFF45A4809AF6D0 /* RolesPermissionsAdminLogicTests.swift in Sources */,
+				C664F3DD33B14077B246EBFC /* SchoolCodeLogicTests.swift in Sources */,
+				DD7DB2BFF30F4823AF4C3896 /* SearchTests.swift in Sources */,
+				49F1811D65E843018ADB7D17 /* SettingsAccommodationsTests.swift in Sources */,
+				CD90F2D580BF42C78050252F /* SettingsMenuLogicTests.swift in Sources */,
+				922365EE47B64847AB3FBFC3 /* TakeAttendanceLogicTests.swift in Sources */,
+				6591684EC46A43A98EE07406 /* TranscriptsAdvisingAdminLogicTests.swift in Sources */,
+				BB0F590A59E64399AE8CBB1B /* TutorLogicTests.swift in Sources */,
+				F44134C31B564701BB2AE1A9 /* UIModeLogicTests.swift in Sources */,
+				AE4DCED03D3546DC844254BA /* VibeActivityLogicTests.swift in Sources */,
+				E3AF358694E74BFB8578CF29 /* WalletLogicTests.swift in Sources */,
+				0686C91BC3DF4BD5B3015C21 /* WhiteboardLogicTests.swift in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		B9D3D80715914553984DCBCF /* Frameworks */ = {
+		6BC7D54FBA944EB4BE9C9B65 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3359,7 +3375,7 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		FF23C941B86E45C095EB5875 /* Debug */ = {
+		1599B1A7E63D49C0B18C9865 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -3378,7 +3394,7 @@
 			};
 			name = Debug;
 		};
-		D6D9D66AD0634D95950BFDD3 /* Release */ = {
+		E9E7771BB46D447F9B0CA130 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -3396,9 +3412,9 @@
 			};
 			name = Release;
 		};
-		A48046996F994381A3A34768 /* Debug */ = {
+		0CE1712B58FA4DC1BF33E8B4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
+			baseConfigurationReference = 955CC71A4CB748009BB3E55F /* Development.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3425,9 +3441,9 @@
 			};
 			name = Debug;
 		};
-		0FFD2B9BF0E14FF4B27B9E0A /* Release */ = {
+		F38B08BE24204B4397AC216E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
+			baseConfigurationReference = 955CC71A4CB748009BB3E55F /* Development.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3453,9 +3469,9 @@
 			};
 			name = Release;
 		};
-		16605693C9494548B4785C08 /* Debug */ = {
+		215857767F744069AF6924B7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
+			baseConfigurationReference = 955CC71A4CB748009BB3E55F /* Development.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -3471,9 +3487,9 @@
 			};
 			name = Debug;
 		};
-		62F9529641134890BC589ED0 /* Release */ = {
+		0C9FC36E956A43D8AE2F0CD0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 399F75F7EF59410184CBA37C /* Development.xcconfig */;
+			baseConfigurationReference = 955CC71A4CB748009BB3E55F /* Development.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -3492,34 +3508,34 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		C0539B66D38A4C3D80C6B2D5 /* Build configuration list for PBXProject "Lextures" */ = {
+		714A243CEA884E67B6808006 /* Build configuration list for PBXProject "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF23C941B86E45C095EB5875 /* Debug */,
-				D6D9D66AD0634D95950BFDD3 /* Release */,
+				1599B1A7E63D49C0B18C9865 /* Debug */,
+				E9E7771BB46D447F9B0CA130 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		124F22003E48492986BF0C64 /* Build configuration list for PBXNativeTarget "Lextures" */ = {
+		C2F3E7878F504E3DADB05975 /* Build configuration list for PBXNativeTarget "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A48046996F994381A3A34768 /* Debug */,
-				0FFD2B9BF0E14FF4B27B9E0A /* Release */,
+				0CE1712B58FA4DC1BF33E8B4 /* Debug */,
+				F38B08BE24204B4397AC216E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5778F2DD9CE041F4A88C1C97 /* Build configuration list for PBXNativeTarget "LexturesTests" */ = {
+		DD916C25059446268826810F /* Build configuration list for PBXNativeTarget "LexturesTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				16605693C9494548B4785C08 /* Debug */,
-				62F9529641134890BC589ED0 /* Release */,
+				215857767F744069AF6924B7 /* Debug */,
+				0C9FC36E956A43D8AE2F0CD0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 23ED123BADD24061AF867515 /* Project object */;
+	rootObject = BDBB0EDFD23F4A249C8FA7F5 /* Project object */;
 }

--- a/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
+++ b/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1C95EA15BFA249F09F2F233C"
+               BlueprintIdentifier = "0873EDB97F8E49CE9C6DD710"
                BuildableName = "Lextures.app"
                BlueprintName = "Lextures"
                ReferencedContainer = "container:Lextures.xcodeproj">
@@ -36,7 +36,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1C95EA15BFA249F09F2F233C"
+            BlueprintIdentifier = "0873EDB97F8E49CE9C6DD710"
             BuildableName = "Lextures.app"
             BlueprintName = "Lextures"
             ReferencedContainer = "container:Lextures.xcodeproj">
@@ -54,7 +54,7 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "895620D25C8A4BCA974315E7"
+               BlueprintIdentifier = "4013EA55F52949789118CBDB"
                BuildableName = "LexturesTests.xctest"
                BlueprintName = "LexturesTests"
                ReferencedContainer = "container:Lextures.xcodeproj">

--- a/clients/ios/Lextures/Core/Accessibility/AccessibilitySupport.swift
+++ b/clients/ios/Lextures/Core/Accessibility/AccessibilitySupport.swift
@@ -37,31 +37,70 @@ enum AccessibilitySupport {
         return sentences
     }
 
-    /// Strip lightweight markdown to plain text for read-aloud.
+    /// Plain-text projection for read-aloud (CT.M2 FR-12 / AC-10).
+    /// Uses the shared block parser so tables/code/math linearise without pipe/fence markup.
     static func plainText(fromMarkdown markdown: String) -> String {
-        var lines: [String] = []
-        for rawLine in markdown.split(whereSeparator: \.isNewline) {
-            var line = String(rawLine)
-            let inlineReplacements: [(String, String)] = [
-                (#"!\[[^\]]*\]\([^)]*\)"#, ""),
-                (#"\[([^\]]+)\]\([^)]*\)"#, "$1"),
-                (#"`{1,3}[^`]+`{1,3}"#, ""),
-                (#"\*\*([^*]+)\*\*"#, "$1"),
-                (#"\*([^*]+)\*"#, "$1"),
-                (#"__([^_]+)__"#, "$1"),
-                (#"_([^_]+)_"#, "$1"),
-            ]
-            for (pattern, template) in inlineReplacements {
-                line = line.replacingOccurrences(of: pattern, with: template, options: .regularExpression)
+        var parts: [String] = []
+        for block in NotebookMarkdown.parseBlocks(markdown) {
+            switch block.kind {
+            case .heading(_, let text), .paragraph(let text), .quote(let text):
+                appendStripped(text, into: &parts)
+            case .bulletItem(let text, _), .taskItem(_, let text, _), .orderedItem(_, let text, _):
+                appendStripped(text, into: &parts)
+            case .task(let task):
+                appendStripped(task.text, into: &parts)
+            case .code(_, let source):
+                let trimmed = source.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { parts.append(trimmed) }
+            case .math(let latex, _):
+                let trimmed = latex.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { parts.append(trimmed) }
+            case .table(_, let header, let rows):
+                let headerLine = header.map(stripInlineMarkdown).filter { !$0.isEmpty }.joined(separator: ", ")
+                if !headerLine.isEmpty { parts.append(headerLine) }
+                for row in rows {
+                    let rowLine = row.map(stripInlineMarkdown).filter { !$0.isEmpty }.joined(separator: ", ")
+                    if !rowLine.isEmpty { parts.append(rowLine) }
+                }
+            case .toolFence(_, let toolId, _):
+                if !toolId.isEmpty { parts.append(toolId) }
+            case .image(let alt, _):
+                if !alt.isEmpty { parts.append(alt) }
+            case .drawing:
+                parts.append("Drawing")
+            case .divider:
+                continue
             }
-            line = line.replacingOccurrences(of: #"^#{1,6}\s+"#, with: "", options: .regularExpression)
-            line = line.replacingOccurrences(of: #"^>\s?"#, with: "", options: .regularExpression)
-            line = line.replacingOccurrences(of: #"^[-*+]\s+"#, with: "", options: .regularExpression)
-            line = line.replacingOccurrences(of: #"^\d+\.\s+"#, with: "", options: .regularExpression)
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty { lines.append(trimmed) }
         }
-        return lines.joined(separator: " ")
+        return parts.joined(separator: " ")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func appendStripped(_ text: String, into parts: inout [String]) {
+        let stripped = stripInlineMarkdown(text)
+        if !stripped.isEmpty { parts.append(stripped) }
+    }
+
+    /// Strip lightweight inline markdown markers from a single run of text.
+    static func stripInlineMarkdown(_ text: String) -> String {
+        var line = text
+        let inlineReplacements: [(String, String)] = [
+            (#"!\[[^\]]*\]\([^)]*\)"#, ""),
+            (#"\[([^\]]+)\]\([^)]*\)"#, "$1"),
+            (#"`([^`]+)`"#, "$1"),
+            (#"\*\*([^*]+)\*\*"#, "$1"),
+            (#"\*([^*]+)\*"#, "$1"),
+            (#"__([^_]+)__"#, "$1"),
+            (#"_([^_]+)_"#, "$1"),
+            (#"~~([^~]+)~~"#, "$1"),
+            (#"\$\$([^$]+)\$\$"#, "$1"),
+            (#"\$([^$]+)\$"#, "$1"),
+        ]
+        for (pattern, template) in inlineReplacements {
+            line = line.replacingOccurrences(of: pattern, with: template, options: .regularExpression)
+        }
+        return line.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func relativeLuminance(_ color: ColorComponents) -> Double {

--- a/clients/ios/Lextures/Features/Assignments/AssignmentDetailView.swift
+++ b/clients/ios/Lextures/Features/Assignments/AssignmentDetailView.swift
@@ -169,7 +169,7 @@ struct AssignmentDetailView: View {
     private func instructionsCard(_ markdown: String) -> some View {
         LMSCard {
             readerToolbar(markdown: markdown)
-            MarkdownTextView(markdown: markdown)
+            CourseMarkdownContentView(markdown: markdown)
                 .lexturesReadableText()
         }
     }
@@ -255,9 +255,7 @@ struct AssignmentDetailView: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(LexturesTheme.coral)
             if let feedback = mySubmission?.revisionFeedback, !feedback.isEmpty {
-                Text(feedback)
-                    .font(.caption)
-                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                CourseMarkdownContentView(markdown: feedback, compact: true)
             }
             if let revisionDue = LMSDates.parse(mySubmission?.revisionDueAt) {
                 Text(L.format("mobile.assignment.revisionDue", revisionDue.formatted(date: .abbreviated, time: .shortened)))

--- a/clients/ios/Lextures/Features/Boards/BoardPostCard.swift
+++ b/clients/ios/Lextures/Features/Boards/BoardPostCard.swift
@@ -256,7 +256,7 @@ struct BoardPostCard: View {
         case .text:
             let plain = BoardsLogic.bodyPlainText(post)
             if !plain.isEmpty {
-                MarkdownTextView(markdown: plain)
+                CourseMarkdownContentView(markdown: plain, compact: true)
             }
         case .image:
             mediaAttachment(kind: .image)

--- a/clients/ios/Lextures/Features/Courses/CourseMarkdownContentView.swift
+++ b/clients/ios/Lextures/Features/Courses/CourseMarkdownContentView.swift
@@ -2,16 +2,20 @@ import SwiftUI
 import AVKit
 
 /// Read-only markdown reader for course content pages (NotebookMarkdown blocks + math/video).
+/// CT.M2: single renderer for all reading surfaces; `compact` caps spacing; `suppressAffordances`
+/// hides copy/expand/link escapes during lockdown quizzes (FR-11 / FR-13).
 struct CourseMarkdownContentView: View {
     @Environment(AuthSession.self) private var session
     @Environment(\.colorScheme) private var colorScheme
     let markdown: String
     var captionsEnabled = false
+    var compact = false
+    var suppressAffordances = false
     @State private var cachedMarkdown = ""
     @State private var cachedBlocks: [NotebookBlock] = []
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: MarkdownRenderStyle.blockSpacing(compact: compact)) {
             ForEach(cachedBlocks) { block in
                 blockView(block)
             }
@@ -31,9 +35,9 @@ struct CourseMarkdownContentView: View {
         switch block.kind {
         case .heading(let level, let text):
             Text(inline(text))
-                .font(LexturesTheme.displayFont(level == 1 ? 24 : level == 2 ? 19 : 16))
+                .font(LexturesTheme.displayFont(MarkdownRenderStyle.headingPointSize(level: level, compact: compact)))
                 .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                .padding(.top, level == 1 ? 6 : 2)
+                .padding(.top, MarkdownRenderStyle.headingTopPadding(level: level, compact: compact))
         case .paragraph(let text):
             if let videoURL = ModuleContentMedia.videoURL(in: text) {
                 if captionsEnabled {
@@ -82,11 +86,20 @@ struct CourseMarkdownContentView: View {
                     .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
             }
         case .code(let language, let source):
-            MarkdownCodeBlockView(language: language, source: source)
+            MarkdownCodeBlockView(
+                language: language,
+                source: source,
+                suppressCopy: suppressAffordances
+            )
         case .math(let latex, let display):
             MathLatexView(latex: latex, displayMode: display)
         case .table(let align, let header, let rows):
-            MarkdownTableView(align: align, header: header, rows: rows)
+            MarkdownTableView(
+                align: align,
+                header: header,
+                rows: rows,
+                suppressExpand: suppressAffordances
+            )
         case .toolFence(_, let toolId, _):
             Label {
                 Text(L.format("mobile.markdown.tool.placeholder", toolId))
@@ -95,7 +108,7 @@ struct CourseMarkdownContentView: View {
                 Image(systemName: "puzzlepiece.extension")
             }
             .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-            .padding(12)
+            .padding(compact ? 8 : 12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(LexturesTheme.sceneBackground(for: colorScheme))
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -115,17 +128,16 @@ struct CourseMarkdownContentView: View {
         if segments.count == 1, case .text(let only) = segments[0] {
             Text(inline(only))
                 .font(.subheadline)
-                .lineSpacing(3)
+                .lineSpacing(compact ? 1 : 3)
                 .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
         } else {
-            // Flow inline math within a wrapping HStack of text runs.
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: compact ? 4 : 6) {
                 ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
                     switch segment {
                     case .text(let value):
                         Text(inline(value))
                             .font(.subheadline)
-                            .lineSpacing(3)
+                            .lineSpacing(compact ? 1 : 3)
                             .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
                     case .math(let latex, let display):
                         MathLatexView(latex: latex, displayMode: display)
@@ -136,10 +148,7 @@ struct CourseMarkdownContentView: View {
     }
 
     private func inline(_ text: String) -> AttributedString {
-        (try? AttributedString(
-            markdown: text,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )) ?? AttributedString(text)
+        MarkdownRenderStyle.inlineAttributedString(text, suppressLinks: suppressAffordances)
     }
 }
 

--- a/clients/ios/Lextures/Features/Courses/CourseSyllabusView.swift
+++ b/clients/ios/Lextures/Features/Courses/CourseSyllabusView.swift
@@ -59,7 +59,7 @@ struct CourseSyllabusSection: View {
                     .font(LexturesTheme.displayFont(18))
                     .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
             }
-            MarkdownTextView(markdown: section.markdown)
+            CourseMarkdownContentView(markdown: section.markdown)
         }
     }
 

--- a/clients/ios/Lextures/Features/Courses/InlineMarkdownText.swift
+++ b/clients/ios/Lextures/Features/Courses/InlineMarkdownText.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Inline-only markdown label for quiz choices and compact rows (CT.M2 FR-3).
+/// Renders bold/italic/code/links as styled text inside a single accessibility element.
+struct InlineMarkdownText: View {
+    let markdown: String
+    var suppressLinks = false
+    var font: Font = .subheadline
+
+    var body: some View {
+        Text(MarkdownRenderStyle.inlineAttributedString(markdown, suppressLinks: suppressLinks))
+            .font(font)
+            .multilineTextAlignment(.leading)
+            .accessibilityLabel(MarkdownRenderStyle.plainLabel(markdown))
+    }
+}

--- a/clients/ios/Lextures/Features/Courses/ItemDetailView.swift
+++ b/clients/ios/Lextures/Features/Courses/ItemDetailView.swift
@@ -239,7 +239,7 @@ struct ItemDetailView: View {
     private func contentCard(_ markdown: String) -> some View {
         LMSCard {
             readerToolbar(markdown: markdown)
-            MarkdownTextView(markdown: markdown)
+            CourseMarkdownContentView(markdown: markdown)
                 .lexturesReadableText()
         }
         .accessibilityElement(children: .contain)
@@ -364,125 +364,5 @@ enum ItemKind {
     /// Kinds the module list can navigate to (including placeholders for upcoming epics).
     static func isOpenable(_ kind: String) -> Bool {
         ModuleContentLogic.isNavigable(kind)
-    }
-}
-
-/// CT.M1 shim for legacy call sites. When `ffMobileRichMarkdown` is on (default),
-/// delegates to `CourseMarkdownContentView`; otherwise keeps the lightweight legacy path.
-struct MarkdownTextView: View {
-    @Environment(AppShellModel.self) private var shell
-    @Environment(\.colorScheme) private var colorScheme
-    let markdown: String
-
-    var body: some View {
-        if shell.platformFeatures.ffMobileRichMarkdown {
-            CourseMarkdownContentView(markdown: markdown)
-        } else {
-            LegacyMarkdownTextView(markdown: markdown)
-        }
-    }
-}
-
-/// Pre-CT.M1 lightweight renderer retained for feature-flag rollback.
-private struct LegacyMarkdownTextView: View {
-    @Environment(\.colorScheme) private var colorScheme
-    let markdown: String
-
-    private enum Block: Identifiable {
-        case heading(level: Int, text: String, id: Int)
-        case bullet(text: String, id: Int)
-        case numbered(index: String, text: String, id: Int)
-        case paragraph(text: String, id: Int)
-
-        var id: Int {
-            switch self {
-            case .heading(_, _, let id), .bullet(_, let id), .numbered(_, _, let id), .paragraph(_, let id):
-                return id
-            }
-        }
-    }
-
-    private var blocks: [Block] {
-        var out: [Block] = []
-        var paragraph: [String] = []
-        var counter = 0
-
-        func flushParagraph() {
-            guard !paragraph.isEmpty else { return }
-            out.append(.paragraph(text: paragraph.joined(separator: " "), id: counter))
-            counter += 1
-            paragraph = []
-        }
-
-        for rawLine in markdown.components(separatedBy: .newlines) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            if line.isEmpty {
-                flushParagraph()
-            } else if line.hasPrefix("#") {
-                flushParagraph()
-                let level = line.prefix(while: { $0 == "#" }).count
-                let text = line.drop(while: { $0 == "#" }).trimmingCharacters(in: .whitespaces)
-                out.append(.heading(level: min(level, 3), text: text, id: counter))
-                counter += 1
-            } else if line.hasPrefix("- ") || line.hasPrefix("* ") {
-                flushParagraph()
-                out.append(.bullet(text: String(line.dropFirst(2)), id: counter))
-                counter += 1
-            } else if let match = line.range(of: #"^\d+\.\s+"#, options: .regularExpression) {
-                flushParagraph()
-                let index = line[..<match.upperBound].trimmingCharacters(in: .whitespaces)
-                out.append(.numbered(index: index, text: String(line[match.upperBound...]), id: counter))
-                counter += 1
-            } else {
-                paragraph.append(line)
-            }
-        }
-        flushParagraph()
-        return out
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(blocks) { block in
-                switch block {
-                case .heading(let level, let text, _):
-                    Text(inline(text))
-                        .font(LexturesTheme.displayFont(level == 1 ? 21 : level == 2 ? 18 : 16))
-                        .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                        .padding(.top, 4)
-                case .bullet(let text, _):
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Circle()
-                            .fill(LexturesTheme.accent(for: colorScheme))
-                            .frame(width: 5, height: 5)
-                            .padding(.top, 6)
-                        Text(inline(text))
-                            .font(.subheadline)
-                            .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                    }
-                case .numbered(let index, let text, _):
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text(index)
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(LexturesTheme.accent(for: colorScheme))
-                        Text(inline(text))
-                            .font(.subheadline)
-                            .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                    }
-                case .paragraph(let text, _):
-                    Text(inline(text))
-                        .font(.subheadline)
-                        .lineSpacing(3)
-                        .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                }
-            }
-        }
-    }
-
-    private func inline(_ text: String) -> AttributedString {
-        (try? AttributedString(
-            markdown: text,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )) ?? AttributedString(text)
     }
 }

--- a/clients/ios/Lextures/Features/Courses/MarkdownCodeBlockView.swift
+++ b/clients/ios/Lextures/Features/Courses/MarkdownCodeBlockView.swift
@@ -2,10 +2,12 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 /// Fenced code block: language label, monospace, horizontal scroll, copy (CT.M1 FR-7).
+/// `suppressCopy` hides the clipboard affordance during lockdown quizzes (CT.M2 FR-13).
 struct MarkdownCodeBlockView: View {
     @Environment(\.colorScheme) private var colorScheme
     let language: String?
     let source: String
+    var suppressCopy = false
     @State private var copied = false
 
     var body: some View {
@@ -15,17 +17,19 @@ struct MarkdownCodeBlockView: View {
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
                 Spacer()
-                Button {
-                    UIPasteboard.general.string = source
-                    copied = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
-                } label: {
-                    Text(copied ? L.text("mobile.markdown.code.copied") : L.text("mobile.markdown.code.copy"))
-                        .font(.caption2.weight(.semibold))
+                if MarkdownRenderStyle.allowsAffordances(suppressAffordances: suppressCopy) {
+                    Button {
+                        UIPasteboard.general.string = source
+                        copied = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
+                    } label: {
+                        Text(copied ? L.text("mobile.markdown.code.copied") : L.text("mobile.markdown.code.copy"))
+                            .font(.caption2.weight(.semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                    .accessibilityLabel(L.text("mobile.markdown.code.copy"))
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(LexturesTheme.accent(for: colorScheme))
-                .accessibilityLabel(L.text("mobile.markdown.code.copy"))
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)

--- a/clients/ios/Lextures/Features/Courses/MarkdownRenderStyle.swift
+++ b/clients/ios/Lextures/Features/Courses/MarkdownRenderStyle.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Foundation
+
+/// Spacing and typography tokens for the shared markdown renderer (CT.M2 FR-11 / FR-13).
+enum MarkdownRenderStyle {
+    static func blockSpacing(compact: Bool) -> CGFloat { compact ? 6 : 12 }
+
+    static func headingPointSize(level: Int, compact: Bool) -> CGFloat {
+        if compact {
+            switch level {
+            case 1: return 18
+            case 2: return 16
+            default: return 15
+            }
+        }
+        switch level {
+        case 1: return 24
+        case 2: return 19
+        default: return 16
+        }
+    }
+
+    static func headingTopPadding(level: Int, compact: Bool) -> CGFloat {
+        if compact { return level == 1 ? 2 : 0 }
+        return level == 1 ? 6 : 2
+    }
+
+    /// FR-13: copy, table expand, and link navigation are suppressed during lockdown quizzes.
+    static func allowsAffordances(suppressAffordances: Bool) -> Bool { !suppressAffordances }
+
+    /// Strip link destinations so AttributedString does not create tappable runs (choices / lockdown).
+    static func sourceForInlineRendering(_ text: String, suppressLinks: Bool) -> String {
+        guard suppressLinks else { return text }
+        return text.replacingOccurrences(
+            of: #"\[([^\]]+)\]\([^)]*\)"#,
+            with: "$1",
+            options: .regularExpression
+        )
+    }
+
+    static func inlineAttributedString(_ text: String, suppressLinks: Bool = false) -> AttributedString {
+        let source = sourceForInlineRendering(text, suppressLinks: suppressLinks)
+        return (try? AttributedString(
+            markdown: source,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(source)
+    }
+
+    /// Plain label for a11y / merged choice semantics (formatting must not fragment the name).
+    static func plainLabel(_ text: String) -> String {
+        AccessibilitySupport.plainText(fromMarkdown: text)
+    }
+}

--- a/clients/ios/Lextures/Features/Courses/MarkdownTableView.swift
+++ b/clients/ios/Lextures/Features/Courses/MarkdownTableView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 /// Inline GFM table with horizontal scroll and expand affordance (CT.M1 FR-5 / FR-6).
+/// `suppressExpand` hides the full-screen escape hatch during lockdown quizzes (CT.M2 FR-13).
 struct MarkdownTableView: View {
     @Environment(\.colorScheme) private var colorScheme
     let align: [MarkdownTableAlign]
     let header: [String]
     let rows: [[String]]
+    var suppressExpand = false
     @State private var showFullScreen = false
 
     private let minColumnWidth: CGFloat = 96
@@ -15,15 +17,17 @@ struct MarkdownTableView: View {
             ScrollView(.horizontal, showsIndicators: true) {
                 tableGrid(minWidth: minColumnWidth)
             }
-            Button {
-                showFullScreen = true
-            } label: {
-                Label(L.text("mobile.markdown.table.expand"), systemImage: "arrow.up.left.and.arrow.down.right")
-                    .font(.caption.weight(.semibold))
+            if MarkdownRenderStyle.allowsAffordances(suppressAffordances: suppressExpand) {
+                Button {
+                    showFullScreen = true
+                } label: {
+                    Label(L.text("mobile.markdown.table.expand"), systemImage: "arrow.up.left.and.arrow.down.right")
+                        .font(.caption.weight(.semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                .accessibilityHint(L.text("mobile.markdown.table.expandHint"))
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(LexturesTheme.accent(for: colorScheme))
-            .accessibilityHint(L.text("mobile.markdown.table.expandHint"))
         }
         .fullScreenCover(isPresented: $showFullScreen) {
             MarkdownTableFullScreenView(align: align, header: header, rows: rows)

--- a/clients/ios/Lextures/Features/Discussions/DiscussionThreadView.swift
+++ b/clients/ios/Lextures/Features/Discussions/DiscussionThreadView.swift
@@ -111,9 +111,7 @@ struct DiscussionThreadView: View {
                         contentId: thread.id,
                         contentType: "discussion_post"
                     )
-                    Text(thread.bodyPlainText)
-                        .font(.body)
-                        .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                    CourseMarkdownContentView(markdown: thread.bodyPlainText, compact: true)
                         .textSelection(.enabled)
                         .lexturesReadableText()
                 }
@@ -140,9 +138,7 @@ struct DiscussionThreadView: View {
                     contentId: post.id,
                     contentType: "discussion_post"
                 )
-                Text(post.bodyPlainText)
-                    .font(.body)
-                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                CourseMarkdownContentView(markdown: post.bodyPlainText, compact: true)
                     .textSelection(.enabled)
                     .lexturesReadableText()
                     .padding(.leading, CGFloat(min(nested.depth, 6)) * 12)

--- a/clients/ios/Lextures/Features/Grades/GradeFeedbackView.swift
+++ b/clients/ios/Lextures/Features/Grades/GradeFeedbackView.swift
@@ -132,18 +132,14 @@ struct GradeFeedbackView: View {
                             }
                         }
                         if let description = criterion.description?.nilIfEmpty {
-                            Text(description)
-                                .font(.caption)
-                                .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                            CourseMarkdownContentView(markdown: description, compact: true)
                         }
                         if let score = grade?.rubricScores?[criterion.id],
                            let level = matchedLevel(criterion: criterion, score: score) {
                             Text(level.label)
                                 .font(.caption.weight(.medium))
                             if let note = level.description?.nilIfEmpty {
-                                Text(note)
-                                    .font(.caption)
-                                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                                CourseMarkdownContentView(markdown: note, compact: true)
                             }
                         }
                     }
@@ -159,9 +155,7 @@ struct GradeFeedbackView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(title)
                     .font(LexturesTheme.displayFont(16))
-                Text(body)
-                    .font(.subheadline)
-                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                CourseMarkdownContentView(markdown: body, compact: true)
             }
         }
     }
@@ -177,8 +171,7 @@ struct GradeFeedbackView: View {
                             Text(name)
                                 .font(.caption.weight(.semibold))
                         }
-                        Text(comment.body)
-                            .font(.subheadline)
+                        CourseMarkdownContentView(markdown: comment.body, compact: true)
                     }
                     .padding(.vertical, 2)
                 }

--- a/clients/ios/Lextures/Features/Home/AnnouncementsViews.swift
+++ b/clients/ios/Lextures/Features/Home/AnnouncementsViews.swift
@@ -30,9 +30,7 @@ struct AnnouncementCard: View {
                             .font(.caption2)
                             .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
                     }
-                    Text(broadcast.body)
-                        .font(.caption)
-                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                    CourseMarkdownContentView(markdown: broadcast.body, compact: true)
                         .lineLimit(3)
                 }
             }
@@ -127,9 +125,7 @@ struct AnnouncementsListView: View {
                                         .font(.caption2)
                                         .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
                                 }
-                                Text(broadcast.body)
-                                    .font(.caption)
-                                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                                CourseMarkdownContentView(markdown: broadcast.body, compact: true)
                             }
                         }
                     }

--- a/clients/ios/Lextures/Features/Quiz/QuizIntroView.swift
+++ b/clients/ios/Lextures/Features/Quiz/QuizIntroView.swift
@@ -44,7 +44,7 @@ struct QuizIntroView: View {
                         if let markdown = detail?.markdown ?? quizPayload?.markdown,
                            !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                             LMSCard {
-                                CourseMarkdownContentView(markdown: markdown)
+                                CourseMarkdownContentView(markdown: markdown, compact: false)
                                     .lexturesReadableText()
                             }
                         }

--- a/clients/ios/Lextures/Features/Quiz/QuizQuestionViews.swift
+++ b/clients/ios/Lextures/Features/Quiz/QuizQuestionViews.swift
@@ -12,6 +12,8 @@ struct QuizQuestionView: View {
     let onChange: (QuizAnswerState) -> Void
     let isFlagged: Bool
     let onToggleFlag: () -> Void
+    /// CT.M2 FR-13: suppress copy / table expand / link taps during lockdown quizzes.
+    var suppressAffordances = false
 
     private var kind: QuizQuestionKind { QuizQuestionKind(raw: question.questionType) }
 
@@ -44,7 +46,10 @@ struct QuizQuestionView: View {
 
     @ViewBuilder
     private var promptView: some View {
-        CourseMarkdownContentView(markdown: question.prompt)
+        CourseMarkdownContentView(
+            markdown: question.prompt,
+            suppressAffordances: suppressAffordances
+        )
             .lexturesReadableText()
             .padding(.vertical, 4)
     }
@@ -155,18 +160,23 @@ struct QuizQuestionView: View {
                 Image(systemName: selected ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: uiMode.drawerIconPointSize))
                     .foregroundStyle(selected ? LexturesTheme.primary : LexturesTheme.textSecondary(for: colorScheme))
-                Text(label)
-                    .font(.system(size: uiMode.baseBodyPointSize))
-                    .multilineTextAlignment(.leading)
-                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                    .accessibilityHidden(true)
+                InlineMarkdownText(
+                    markdown: label,
+                    suppressLinks: suppressAffordances,
+                    font: .system(size: uiMode.baseBodyPointSize)
+                )
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
                 Spacer(minLength: 0)
             }
             .padding(uiMode.isYoung ? 16 : 12)
             .frame(minHeight: uiMode.choiceButtonMinHeight)
             .background(selected ? LexturesTheme.primary.opacity(0.12) : LexturesTheme.sceneBackground(for: colorScheme))
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(MarkdownRenderStyle.plainLabel(label))
     }
 
     private var numericInput: some View {
@@ -257,8 +267,7 @@ struct QuizQuestionView: View {
                     Text("\(index + 1).")
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(LexturesTheme.accent(for: colorScheme))
-                    Text(item)
-                        .font(.subheadline)
+                    InlineMarkdownText(markdown: item, suppressLinks: suppressAffordances)
                     Spacer()
                     VStack(spacing: 4) {
                         Button {
@@ -305,8 +314,11 @@ struct QuizQuestionView: View {
         return VStack(alignment: .leading, spacing: 10) {
             ForEach(pairs, id: \.leftId) { pair in
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(pair.left)
-                        .font(.subheadline.weight(.medium))
+                    InlineMarkdownText(
+                        markdown: pair.left,
+                        suppressLinks: suppressAffordances,
+                        font: .subheadline.weight(.medium)
+                    )
                     Picker(L.text("mobile.quiz.matchSelect"), selection: Binding(
                         get: { answer.matching?[pair.leftId] ?? "" },
                         set: { value in
@@ -323,7 +335,7 @@ struct QuizQuestionView: View {
                     )) {
                         Text(L.text("mobile.quiz.matchNone")).tag("")
                         ForEach(rights, id: \.self) { right in
-                            Text(right).tag(right)
+                            Text(MarkdownRenderStyle.plainLabel(right)).tag(right)
                         }
                     }
                     .pickerStyle(.menu)

--- a/clients/ios/Lextures/Features/Quiz/QuizResultsView.swift
+++ b/clients/ios/Lextures/Features/Quiz/QuizResultsView.swift
@@ -91,9 +91,7 @@ struct QuizResultsView: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
                     if let prompt = question.promptSnapshot, !prompt.isEmpty {
-                        Text(prompt)
-                            .font(.subheadline)
-                            .lineLimit(4)
+                        CourseMarkdownContentView(markdown: prompt, compact: true)
                     }
                     if let awarded = question.pointsAwarded {
                         HStack {

--- a/clients/ios/Lextures/Features/Quiz/QuizTakerView.swift
+++ b/clients/ios/Lextures/Features/Quiz/QuizTakerView.swift
@@ -413,7 +413,8 @@ struct QuizTakerView: View {
                                     } else {
                                         model.flaggedIds.insert(question.id)
                                     }
-                                }
+                                },
+                                suppressAffordances: model.serverLockdown || deviceLockdownRequired
                             )
                         }
                         .padding(16)

--- a/clients/ios/Lextures/Features/Review/ReviewSessionView.swift
+++ b/clients/ios/Lextures/Features/Review/ReviewSessionView.swift
@@ -294,24 +294,26 @@ private struct ReviewQuestionPreview: View {
                     HStack(spacing: 10) {
                         Image(systemName: "circle")
                             .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-                        Text(choice)
-                            .font(.subheadline)
+                        InlineMarkdownText(markdown: choice)
                             .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
                         Spacer(minLength: 0)
                     }
                     .padding(10)
                     .background(LexturesTheme.cardBackground(for: colorScheme))
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(MarkdownRenderStyle.plainLabel(choice))
                 }
             case .ordering:
                 ForEach(Array(QuizLogic.orderingItems(question).enumerated()), id: \.offset) { index, item in
                     HStack {
                         Text("\(index + 1).")
                             .font(.caption.monospaced())
-                        Text(item)
-                            .font(.subheadline)
+                        InlineMarkdownText(markdown: item)
                         Spacer(minLength: 0)
                     }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(MarkdownRenderStyle.plainLabel(item))
                 }
             default:
                 EmptyView()

--- a/clients/ios/Lextures/Features/Tutor/TutorChatView.swift
+++ b/clients/ios/Lextures/Features/Tutor/TutorChatView.swift
@@ -240,7 +240,7 @@ private struct TutorMessageBubble: View {
                         .font(.body)
                         .foregroundStyle(.white)
                 } else {
-                    CourseMarkdownContentView(markdown: message.content)
+                    CourseMarkdownContentView(markdown: message.content, compact: true)
                     if !message.citations.isEmpty {
                         TutorFlowLayout(spacing: 6) {
                             ForEach(message.citations, id: \.chunkId) { citation in

--- a/clients/ios/LexturesTests/AccessibilitySupportTests.swift
+++ b/clients/ios/LexturesTests/AccessibilitySupportTests.swift
@@ -12,6 +12,25 @@ final class AccessibilitySupportTests: XCTestCase {
         XCTAssertEqual(plain, "Title Bold text with link.")
     }
 
+    func testPlainTextFromMarkdownLinearisesTablesWithoutPipes() {
+        let md = """
+        | Week | Topic |
+        | --- | --- |
+        | 1 | Intro |
+        | 2 | Labs |
+        """
+        let plain = AccessibilitySupport.plainText(fromMarkdown: md)
+        XCTAssertFalse(plain.contains("|"))
+        XCTAssertTrue(plain.contains("Week"))
+        XCTAssertTrue(plain.contains("Intro"))
+    }
+
+    func testPlainTextFromMarkdownSpeaksCodeWithoutFences() {
+        let plain = AccessibilitySupport.plainText(fromMarkdown: "```python\nprint(1)\n```")
+        XCTAssertFalse(plain.contains("```"))
+        XCTAssertTrue(plain.contains("print(1)"))
+    }
+
     func testContrastRatioMeetsWCAGAAForBrandText() {
         XCTAssertTrue(LexturesTheme.primaryTextContrastMeetsAA)
         let ratio = AccessibilitySupport.contrastRatio(

--- a/clients/ios/LexturesTests/MarkdownRenderStyleTests.swift
+++ b/clients/ios/LexturesTests/MarkdownRenderStyleTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Lextures
+
+final class MarkdownRenderStyleTests: XCTestCase {
+    func testCompactSpacingIsTighterThanDefault() {
+        XCTAssertEqual(MarkdownRenderStyle.blockSpacing(compact: false), 12)
+        XCTAssertEqual(MarkdownRenderStyle.blockSpacing(compact: true), 6)
+        XCTAssertLessThan(
+            MarkdownRenderStyle.headingPointSize(level: 1, compact: true),
+            MarkdownRenderStyle.headingPointSize(level: 1, compact: false)
+        )
+    }
+
+    func testLockdownSuppressesAffordances() {
+        XCTAssertTrue(MarkdownRenderStyle.allowsAffordances(suppressAffordances: false))
+        XCTAssertFalse(MarkdownRenderStyle.allowsAffordances(suppressAffordances: true))
+    }
+
+    func testInlineSourceStripsLinksWhenSuppressed() {
+        let raw = "See [docs](https://example.com) and **bold**"
+        let suppressed = MarkdownRenderStyle.sourceForInlineRendering(raw, suppressLinks: true)
+        XCTAssertEqual(suppressed, "See docs and **bold**")
+        XCTAssertEqual(MarkdownRenderStyle.sourceForInlineRendering(raw, suppressLinks: false), raw)
+    }
+
+    func testPlainLabelMergesChoiceText() {
+        let label = MarkdownRenderStyle.plainLabel("Use `print()` and **bold**")
+        XCTAssertEqual(label, "Use print() and bold")
+        XCTAssertFalse(label.contains("`"))
+        XCTAssertFalse(label.contains("**"))
+    }
+}

--- a/clients/ios/LexturesTests/NotebookMarkdownLogicTests.swift
+++ b/clients/ios/LexturesTests/NotebookMarkdownLogicTests.swift
@@ -99,7 +99,7 @@ final class NotebookMarkdownLogicTests: XCTestCase {
             let id = fixture["id"] as? String ?? "?"
             let markdown = fixture["markdown"] as? String ?? ""
             let expected = fixture["kinds"] as? [String] ?? []
-            let actual = NotebookMarkdown.parseBlocks(markdown).map(NotebookMarkdown.fixtureKindName)
+            let actual = NotebookMarkdown.parseBlocks(markdown).map { NotebookMarkdown.fixtureKindName($0.kind) }
             XCTAssertEqual(actual, expected, "fixture \(id)")
         }
     }

--- a/clients/ios/LexturesTests/NotebookMarkdownLogicTests.swift
+++ b/clients/ios/LexturesTests/NotebookMarkdownLogicTests.swift
@@ -105,19 +105,31 @@ final class NotebookMarkdownLogicTests: XCTestCase {
     }
 
     private func fixtureCorpusURL() -> URL {
-        // Repo layout: clients/ios/LexturesTests → ../../mobile/fixtures/markdown/corpus.json
+        // Repo layout: clients/ios/LexturesTests/File.swift → ../../../mobile/fixtures/markdown/corpus.json
         let thisFile = URL(fileURLWithPath: #filePath)
         let corpus = thisFile
             .deletingLastPathComponent() // LexturesTests
             .deletingLastPathComponent() // ios
+            .deletingLastPathComponent() // clients
             .appendingPathComponent("mobile/fixtures/markdown/corpus.json")
         if FileManager.default.fileExists(atPath: corpus.path) { return corpus }
-        // Fallback: walk up from CWD for CI checkouts.
-        var dir = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        for _ in 0 ..< 6 {
-            let candidate = dir.appendingPathComponent("clients/mobile/fixtures/markdown/corpus.json")
-            if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
-            dir = dir.deletingLastPathComponent()
+        // Fallback: walk up from CWD (and from #filePath) for CI / DerivedData checkouts.
+        var searchRoots = [
+            URL(fileURLWithPath: FileManager.default.currentDirectoryPath),
+            thisFile.deletingLastPathComponent(),
+        ]
+        for root in searchRoots {
+            var dir = root
+            for _ in 0 ..< 8 {
+                for relative in [
+                    "clients/mobile/fixtures/markdown/corpus.json",
+                    "mobile/fixtures/markdown/corpus.json",
+                ] {
+                    let candidate = dir.appendingPathComponent(relative)
+                    if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+                }
+                dir = dir.deletingLastPathComponent()
+            }
         }
         return corpus
     }

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -110,9 +110,9 @@ Access and refresh tokens are stored in the Keychain. MFA-required accounts show
 
 Notebooks are device-local (same model as the web app's localStorage notebooks, format v2), keyed per signed-in user.
 
-## Markdown engine (CT.M1)
+## Markdown engine (CT.M1 / CT.M2)
 
-Course and notebook readers share one parser (`Core/Notebook/NotebookMarkdown.swift` + `MarkdownTableLogic.swift`) and one renderer (`CourseMarkdownContentView`). The engine handles GFM tables (with blank-line healing parity to web `normalizeMarkdownTables`), fenced code (language + copy), `$`/`$$` math (monospace fallback with a11y labels), GFM task lists, and ` ```lex-tool ` placeholders (raw JSON never shown). Shared golden fixtures live in `clients/mobile/fixtures/markdown/corpus.json`. Unit coverage: `LexturesTests/NotebookMarkdownLogicTests.swift`. Feature flag: `ffMobileRichMarkdown` (default on).
+Course and notebook readers share one parser (`Core/Notebook/NotebookMarkdown.swift` + `MarkdownTableLogic.swift`) and **one** renderer (`CourseMarkdownContentView`). Assignments, quizzes (prompt/choices/review), syllabus, item detail, boards, portfolio, tutor, discussions, announcements, and grade feedback all use that renderer. Pass `compact: true` in chat/cards/list rows; pass `suppressAffordances: true` during lockdown quizzes so copy/table-expand/link taps stay closed. The legacy `MarkdownTextView` is deleted — CI enforces this via `scripts/check-mobile-markdown-renderer.sh`. Shared golden fixtures: `clients/mobile/fixtures/markdown/corpus.json`. Unit coverage: `LexturesTests/NotebookMarkdownLogicTests.swift`, `MarkdownRenderStyleTests.swift`. Feature flag: `ffMobileRichMarkdown` (default on).
 
 ## Realtime sockets
 

--- a/docs/completed/content_tools/CT.M2-mobile-rich-content-parity-assignments-quizzes.md
+++ b/docs/completed/content_tools/CT.M2-mobile-rich-content-parity-assignments-quizzes.md
@@ -10,7 +10,7 @@
 | **Section** | Content Tools (CT) — Mobile |
 | **Severity** | MAJOR |
 | **Markets** | K12 / HE / HS |
-| **Status (today)** | THIN |
+| **Status (today)** | DONE |
 | **Estimated effort** | S (1w) |
 | **Owner (proposed)** | Mobile squad |
 | **Depends on** | CT.M1 |

--- a/docs/completed/content_tools/README.md
+++ b/docs/completed/content_tools/README.md
@@ -26,5 +26,6 @@
 | **CT.22** | [Inline Discussion](CT.22-tool-inline-discussion.md) |
 | **CT.23** | [Flashcards & Spaced Recall](CT.23-tool-flashcards-and-spaced-recall.md) |
 | **CT.M1** | [Mobile markdown engine: tables, code, math & media](CT.M1-mobile-markdown-engine-tables-code-math.md) |
+| **CT.M2** | [Mobile rich content parity: assignments, quizzes, syllabus & discussions](CT.M2-mobile-rich-content-parity-assignments-quizzes.md) |
 
 Remaining plans live under [`docs/plan/content_tools/`](../../plan/content_tools/README.md).

--- a/docs/plan/content_tools/README.md
+++ b/docs/plan/content_tools/README.md
@@ -149,7 +149,7 @@ in this series adds a migration or an endpoint** — mobile consumes the shipped
 | ID | Plan | Severity | Effort | Depends on | Delivers |
 |---|---|---|---|---|---|
 | **CT.M1** | [Mobile markdown engine: tables, code, math & media](../../completed/content_tools/CT.M1-mobile-markdown-engine-tables-code-math.md) | DONE | M | — | One parser/renderer per platform; GFM tables, fenced code, typeset math, inline formatting; `lex-tool` parsed and hidden |
-| **CT.M2** | [Rich content parity: assignments, quizzes, syllabus, discussions](CT.M2-mobile-rich-content-parity-assignments-quizzes.md) | MAJOR | S | CT.M1 | Every reader on one renderer; markdown in quiz prompts, **choices**, feedback and review; legacy renderers deleted |
+| **CT.M2** | [Rich content parity: assignments, quizzes, syllabus, discussions](../../completed/content_tools/CT.M2-mobile-rich-content-parity-assignments-quizzes.md) | DONE | S | CT.M1 | Every reader on one renderer; markdown in quiz prompts, **choices**, feedback and review; legacy renderers deleted |
 | **CT.M3** | [Content tool host & state persistence](CT.M3-mobile-content-tool-host-and-state.md) | BLOCKER | M | CT.M1, CT.M2 | Flag plumbing, batched instance fetch, `ToolFrame`, autosave + revision conflicts, submit, actions, offline outbox, a11y baseline |
 | **CT.M4** | [Sandboxed WebView tool host](CT.M4-mobile-sandboxed-webview-tool-host.md) | MAJOR | M | CT.M3 | CT.5 `postMessage` bridge in WKWebView/Android WebView — the long tail and marketplace tools without a mobile release per tool |
 | **CT.M5** | [Tool pack 1 — check & commit](CT.M5-mobile-tools-check-and-commit.md) | MAJOR | M | CT.M3 | `inline_questions`, `predict_reveal`, `class_pulse`, `flashcards` |

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -4891,6 +4891,28 @@
       }
     },
     {
+      "id": "ct-m2-mobile-rich-content-parity-assignments-quizzes",
+      "path": "docs/completed/content_tools/CT.M2-mobile-rich-content-parity-assignments-quizzes.md",
+      "markets": [
+        "ALL"
+      ],
+      "risk": "major",
+      "client": "mobile",
+      "coverage": "not-applicable",
+      "rationale": "Mobile client story: migrates every reading surface onto the CT.M1 renderer (assignments, quizzes, syllabus, discussions, etc.). Covered by native unit suites + CI grep gate; web Playwright is not the coverage surface.",
+      "owner": "Mobile",
+      "reviewed": true,
+      "flags": {
+        "settingsToggle": true,
+        "disabledState": true,
+        "enabledJourney": "n/a",
+        "authorization": "n/a",
+        "dependency": true,
+        "rollback": true,
+        "notes": "Depends on CT.M1 renderer. Reuses ffMobileRichMarkdown; compact + suppressAffordances modes; scripts/check-mobile-markdown-renderer.sh blocks legacy MarkdownTextView/MarkdownText/stripInline."
+      }
+    },
+    {
       "id": "node-code-test-runner",
       "path": "docs/completed/agent-grader/node-code-test-runner.md",
       "markets": [

--- a/scripts/check-mobile-markdown-renderer.sh
+++ b/scripts/check-mobile-markdown-renderer.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# CT.M2 AC-7 / FR-10 — fail CI if legacy markdown renderers are reintroduced.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+failures=0
+
+check_absent() {
+  local label="$1"
+  local pattern="$2"
+  shift 2
+  local matches
+  matches="$(rg -n -g '*.swift' -g '*.kt' \
+    --glob '!**/*Test*' --glob '!**/*Tests*' \
+    -e "$pattern" "$@" 2>/dev/null || true)"
+  if [[ -n "$matches" ]]; then
+    echo "FAIL: $label — production references must be removed (CT.M2):"
+    echo "$matches"
+    failures=$((failures + 1))
+  else
+    echo "OK: no production matches for $label"
+  fi
+}
+
+check_absent "MarkdownTextView (iOS legacy)" '\bMarkdownTextView\b' \
+  "$ROOT/clients/ios"
+check_absent "MarkdownText( (Android legacy shim)" '\bMarkdownText\(' \
+  "$ROOT/clients/android"
+# Legacy helper was `stripInline`; do not match the CT.M2 `stripInlineMarkdown` projector.
+check_absent "stripInline (Android legacy)" '\bstripInline\b' \
+  "$ROOT/clients/android"
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures mobile markdown renderer gate(s) failed"
+  exit 1
+fi
+
+echo "Mobile markdown renderer gate passed (single CT.M1 renderer per platform)."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CT.M2 migrates every mobile reading surface onto the CT.M1 markdown renderer and deletes the legacy reduced renderers.

- **One renderer**: assignments, quiz intro/prompt/choices/review, syllabus, item detail, boards, portfolio, tutor, discussions, announcements, feed, grade feedback, and review sessions all use `CourseMarkdownContentView` (iOS) / `NotebookContentView` (Android).
- **`compact` mode** for chat bubbles, board cards, and list rows (same parser, tighter spacing).
- **`suppressAffordances`** during lockdown quizzes hides code copy, table full-screen expand, and link taps (FR-13 / AC-6).
- **Quiz choices** render inline markdown with a single merged a11y label and ≥44pt/48dp targets.
- **Read-aloud** plain-text projection linearises tables/code/math (no pipe characters).
- **Legacy deleted**: `MarkdownTextView` / `LegacyMarkdownTextView` (iOS), `MarkdownText` shim (Android).
- **CI gate**: `scripts/check-mobile-markdown-renderer.sh` wired into iOS and Android workflows (AC-7).
- Plan moved to `docs/completed/content_tools/`; E2E.4 disposition added (`not-applicable` / mobile-native).

## Checklist

- [x] Tests added/updated as appropriate (`MarkdownRenderStyleTests`, accessibility table/code projection tests, Android unit tests green locally)
- [x] Structure: no new layering violations intended; mobile-only change surface
- [x] Disposition added in `e2e/coverage/completed-feature-manifest.json`; `e2e:coverage:check` OK
- [x] Flagged feature notes: `ffMobileRichMarkdown` + lockdown affordance suppression documented in READMEs / manifest flags

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb538-2753-70e5-a6cb-7d76136538b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb538-2753-70e5-a6cb-7d76136538b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

