### PR TITLE
feat: embed course files in export/import and one-click rubric Build with AI

### DIFF
--- a/clients/web/package-lock.json
+++ b/clients/web/package-lock.json
@@ -5711,9 +5711,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -83,7 +83,7 @@
   },
   "overrides": {
     "@babel/core": "^7.29.6",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "js-yaml": "4.3.0",
     "markdown-it": "^14.2.0",
     "postcss": "8.5.23"

--- a/clients/web/src/components/assignment/assignment-page-settings-panel.tsx
+++ b/clients/web/src/components/assignment/assignment-page-settings-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { ChevronDown, Loader2, Plus, Search, Trash2 } from 'lucide-react'
+import { ChevronDown, Loader2, Plus, Search, Sparkles, Trash2 } from 'lucide-react'
 import {
   generateAssignmentRubric,
   GRADING_SCHEME_DISPLAY_TYPES,
@@ -11,6 +11,7 @@ import {
   type RubricCriterion,
   type RubricLevel,
 } from '../../lib/courses-api'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import {
   getMatchingSettingIds,
   sectionHasMatchingSettings,
@@ -32,6 +33,10 @@ import {
   RelativeScheduleBanner,
   ScheduleDatetimeField,
 } from '../lms/schedule-datetime-field'
+
+/** Default instructions when the instructor uses one-click Build with AI from assignment content. */
+const DEFAULT_RUBRIC_AI_PROMPT =
+  'Generate a clear, fair grading rubric based on the assignment content. Align criteria with the tasks, reflection prompts, and learning goals implied by the assignment. Use shared proficiency levels across criteria and match total points when assignment points are set.'
 
 export type AssignmentPageSettingsPanelProps = {
   disabled?: boolean
@@ -1067,16 +1072,18 @@ function RubricEditorModal({
 
   useEffect(() => {
     if (!open) return
-    if (mode === 'create' || seed == null) {
-      setDraft(normalizeRubricLevels(createDefaultRubric(pointsWorth)))
-    } else {
+    // Prefer an explicit seed (edit, or create-from-AI) over the empty template.
+    if (seed != null) {
       setDraft(normalizeRubricLevels(cloneRubric(seed)))
+    } else {
+      setDraft(normalizeRubricLevels(createDefaultRubric(pointsWorth)))
     }
   }, [open, mode, seed, pointsWorth])
 
   useEffect(() => {
     if (!open) return
     setAiError(null)
+    setAiInstruction('')
   }, [open])
 
   useEffect(() => {
@@ -1194,11 +1201,7 @@ function RubricEditorModal({
 
   async function generateRubricFromAi() {
     if (!courseCode || !assignmentItemId) return
-    const text = aiInstruction.trim()
-    if (!text) {
-      setAiError('Describe what you want the rubric to assess.')
-      return
-    }
+    const text = aiInstruction.trim() || DEFAULT_RUBRIC_AI_PROMPT
     setAiBusy(true)
     setAiError(null)
     try {
@@ -1296,7 +1299,7 @@ function RubricEditorModal({
                 value={aiInstruction}
                 disabled={disabled || aiBusy}
                 onChange={(e) => setAiInstruction(e.target.value)}
-                placeholder="Describe the rubric (criteria, proficiency levels, what to emphasize)…"
+                placeholder="Optional: emphasize criteria or levels (e.g. “4 levels, weight writing quality”). Leave blank to build from the assignment content."
                 className={`mt-1.5 ${inputClass} min-h-[4.5rem] resize-y`}
               />
               <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -1306,12 +1309,12 @@ function RubricEditorModal({
                   onClick={() => void generateRubricFromAi()}
                   className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-2 text-xs font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
                 >
-                  {aiBusy ? <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden /> : null}
+                  {aiBusy ? <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden /> : <Sparkles className="size-3.5 shrink-0" aria-hidden />}
                   {aiBusy ? 'Generating…' : 'Generate draft'}
                 </button>
                 <span className="text-[11px] text-slate-600 dark:text-neutral-400">
-                  The full assignment text from the editor is included automatically. Fills the grid below;
-                  nothing is stored until you click Save rubric.
+                  Uses the full assignment text from the editor. Fills the grid below; nothing is stored until
+                  you click Save rubric.
                 </span>
               </div>
               {aiError ? <p className="mt-2 text-xs text-rose-600 dark:text-rose-400">{aiError}</p> : null}
@@ -1634,39 +1637,90 @@ function AssignmentRubricSection({
   assignmentItemId?: string
   assignmentMarkdown?: string
 }) {
+  const { aiConfigured } = usePlatformFeatures()
   const [editorOpen, setEditorOpen] = useState(false)
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create')
+  /** Seed used when opening the editor after a one-click AI build (before Save rubric). */
+  const [editorSeed, setEditorSeed] = useState<RubricDefinition | null>(null)
+  const [aiBusy, setAiBusy] = useState(false)
+  const [aiError, setAiError] = useState<string | null>(null)
 
   const totalMax = draftRubric ? rubricMaxSum(draftRubric) : 0
   const pointsMismatch =
     pointsWorth != null && pointsWorth > 0 && draftRubric && Math.abs(totalMax - pointsWorth) > 1e-6
 
+  const aiAvailable = Boolean(aiConfigured && courseCode && assignmentItemId)
+
   function openCreate() {
+    setEditorSeed(null)
     setEditorMode('create')
     setEditorOpen(true)
   }
 
   function openEdit() {
     if (!draftRubric) return
+    setEditorSeed(null)
     setEditorMode('edit')
     setEditorOpen(true)
   }
+
+  async function buildWithAi() {
+    if (!courseCode || !assignmentItemId || aiBusy) return
+    setAiBusy(true)
+    setAiError(null)
+    try {
+      const { rubric } = await generateAssignmentRubric(courseCode, assignmentItemId, {
+        prompt: DEFAULT_RUBRIC_AI_PROMPT,
+        assignmentMarkdown: assignmentMarkdown ?? '',
+      })
+      const normalized = normalizeRubricLevels(rubric)
+      setEditorSeed(normalized)
+      setEditorMode(draftRubric ? 'edit' : 'create')
+      setEditorOpen(true)
+    } catch (e) {
+      setAiError(e instanceof Error ? e.message : 'Could not generate rubric.')
+    } finally {
+      setAiBusy(false)
+    }
+  }
+
+  const buildWithAiButton = aiAvailable ? (
+    <button
+      type="button"
+      disabled={disabled || aiBusy}
+      onClick={() => void buildWithAi()}
+      className="inline-flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-700 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-300 hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-indigo-900/60 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-950/70"
+    >
+      {aiBusy ? (
+        <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
+      ) : (
+        <Sparkles className="size-4 shrink-0" aria-hidden />
+      )}
+      {aiBusy ? 'Building…' : 'Build with AI'}
+    </button>
+  ) : null
 
   return (
     <div className="space-y-3 pt-1">
       <p className="text-[11px] leading-relaxed text-slate-500 dark:text-neutral-400">
         Optional structured grading: each row is a criterion, each column is a rating. Add or edit in the
         dialog—changes apply when you save the rubric, then save the assignment from the toolbar.
+        {aiAvailable
+          ? ' Build with AI drafts a rubric from the current assignment content for you to review.'
+          : null}
       </p>
       {!draftRubric ? (
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={openCreate}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
-        >
-          Add rubric
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            disabled={disabled || aiBusy}
+            onClick={openCreate}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          >
+            Add rubric
+          </button>
+          {buildWithAiButton}
+        </div>
       ) : (
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0 text-sm text-slate-700 dark:text-neutral-300">
@@ -1688,9 +1742,10 @@ function AssignmentRubricSection({
             ) : null}
           </div>
           <div className="flex flex-wrap gap-2">
+            {buildWithAiButton}
             <button
               type="button"
-              disabled={disabled}
+              disabled={disabled || aiBusy}
               onClick={openEdit}
               className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
             >
@@ -1698,7 +1753,7 @@ function AssignmentRubricSection({
             </button>
             <button
               type="button"
-              disabled={disabled}
+              disabled={disabled || aiBusy}
               onClick={() => onDraftRubricChange(null)}
               className="rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:text-neutral-400 dark:hover:bg-neutral-800"
             >
@@ -1707,18 +1762,23 @@ function AssignmentRubricSection({
           </div>
         </div>
       )}
+      {aiError ? <p className="text-xs text-rose-600 dark:text-rose-400">{aiError}</p> : null}
       <RubricEditorModal
         open={editorOpen}
         mode={editorMode}
-        seed={draftRubric}
+        seed={editorSeed ?? draftRubric}
         pointsWorth={pointsWorth}
         disabled={disabled}
         courseCode={courseCode}
         assignmentItemId={assignmentItemId}
         assignmentMarkdown={assignmentMarkdown}
-        onClose={() => setEditorOpen(false)}
+        onClose={() => {
+          setEditorOpen(false)
+          setEditorSeed(null)
+        }}
         onSave={(r) => {
           onDraftRubricChange(r)
+          setEditorSeed(null)
           setEditorOpen(false)
         }}
       />

--- a/clients/web/src/lib/__tests__/course-export-import-stats.test.ts
+++ b/clients/web/src/lib/__tests__/course-export-import-stats.test.ts
@@ -45,6 +45,9 @@ describe('summarizeCourseExportBundle', () => {
     expect(stats.assignmentGroups).toBe(2)
     expect(stats.enrollments).toBe(2)
     expect(stats.contentToolInstances).toBe(0)
+    expect(stats.courseFiles).toBe(0)
+    expect(stats.fileItems).toBe(0)
+    expect(stats.fileFolders).toBe(0)
     expect(stats.hasCourseSettings).toBe(true)
 
     const lines = courseExportImportStatLines(stats)
@@ -69,6 +72,27 @@ describe('summarizeCourseExportBundle', () => {
     )
   })
 
+  it('counts course files and file manager items', () => {
+    const stats = summarizeCourseExportBundle({
+      formatVersion: 1,
+      courseCode: 'C-FILES',
+      structure: [],
+      courseFiles: [{ id: 'f1', originalFilename: 'a.png', contentBase64: 'YQ==' }],
+      fileFolders: [{ id: 'd1', name: 'Docs' }],
+      fileItems: [
+        { id: 'i1', originalFilename: 'syllabus.pdf', contentBase64: 'YQ==' },
+        { id: 'i2', originalFilename: 'rubric.docx', contentBase64: 'YQ==' },
+      ],
+    })
+    expect(stats.courseFiles).toBe(1)
+    expect(stats.fileFolders).toBe(1)
+    expect(stats.fileItems).toBe(2)
+    const lines = courseExportImportStatLines(stats)
+    expect(lines.find((l) => l.key === 'courseFiles')?.count).toBe(1)
+    expect(lines.find((l) => l.key === 'fileItems')?.count).toBe(2)
+    expect(lines.find((l) => l.key === 'fileFolders')?.count).toBe(1)
+  })
+
   it('falls back to body maps when structure is empty', () => {
     const stats = summarizeCourseExportBundle({
       formatVersion: 1,
@@ -83,6 +107,7 @@ describe('summarizeCourseExportBundle', () => {
     expect(stats.assignments).toBe(1)
     expect(stats.quizzes).toBe(0)
     expect(stats.contentToolInstances).toBe(0)
+    expect(stats.courseFiles).toBe(0)
   })
 
   it('rejects non-objects', () => {

--- a/clients/web/src/lib/course-export-import-stats.ts
+++ b/clients/web/src/lib/course-export-import-stats.ts
@@ -20,6 +20,12 @@ export type CourseExportImportStats = {
   enrollments: number
   /** Placed content-tool instances in the export (authoring only; no learner state). */
   contentToolInstances: number
+  /** Embedded content files (course.course_files) with optional base64 bodies. */
+  courseFiles: number
+  /** File-manager files (course.file_items). */
+  fileItems: number
+  /** File-manager folders (course.file_folders). */
+  fileFolders: number
   /** True when the export includes a non-empty course settings snapshot. */
   hasCourseSettings: boolean
 }
@@ -133,6 +139,9 @@ export function summarizeCourseExportBundle(parsed: unknown): CourseExportImport
   const contentToolInstances = Array.isArray(parsed.contentToolInstances)
     ? parsed.contentToolInstances.length
     : 0
+  const courseFiles = Array.isArray(parsed.courseFiles) ? parsed.courseFiles.length : 0
+  const fileItems = Array.isArray(parsed.fileItems) ? parsed.fileItems.length : 0
+  const fileFolders = Array.isArray(parsed.fileFolders) ? parsed.fileFolders.length : 0
 
   return {
     sourceCourseCode,
@@ -148,6 +157,9 @@ export function summarizeCourseExportBundle(parsed: unknown): CourseExportImport
     assignmentGroups,
     enrollments,
     contentToolInstances,
+    courseFiles,
+    fileItems,
+    fileFolders,
     hasCourseSettings: course != null,
   }
 }
@@ -166,6 +178,9 @@ export function courseExportImportStatLines(stats: CourseExportImportStats): Cou
     { key: 'assignmentGroups', label: 'Assignment groups', count: stats.assignmentGroups },
     { key: 'enrollments', label: 'Enrollments', count: stats.enrollments },
     { key: 'contentToolInstances', label: 'Content tools', count: stats.contentToolInstances },
+    { key: 'courseFiles', label: 'Embedded files', count: stats.courseFiles },
+    { key: 'fileFolders', label: 'File folders', count: stats.fileFolders },
+    { key: 'fileItems', label: 'Course files', count: stats.fileItems },
   ]
   return lines.filter((l) => l.count > 0)
 }
@@ -184,10 +199,10 @@ export function importModeLabel(mode: 'erase' | 'mergeAdd' | 'overwrite'): strin
 export function importModeSummary(mode: 'erase' | 'mergeAdd' | 'overwrite'): string {
   switch (mode) {
     case 'erase':
-      return 'Existing modules and related content will be removed, then this file will be applied. Syllabus, grading groups, and course settings from the file replace the current ones. If the file includes enrollments, the roster is replaced except for the course creator’s teacher enrollment.'
+      return 'Existing modules, course files, and related content will be removed, then this file will be applied. Syllabus, grading groups, and course settings from the file replace the current ones. Embedded and file-manager files in the export are restored (base64). If the file includes enrollments, the roster is replaced except for the course creator’s teacher enrollment.'
     case 'mergeAdd':
-      return 'Existing content is kept. Only missing syllabus sections, assignment groups, and outline items (by id) are added, with bodies for new items. If the file includes enrollments, missing roster rows are added.'
+      return 'Existing content is kept. Only missing syllabus sections, assignment groups, outline items (by id), and course files (by id) are added, with bodies for new items. If the file includes enrollments, missing roster rows are added.'
     case 'overwrite':
-      return 'This course will be updated from the file: syllabus and grading are replaced, settings refresh, every listed outline item is upserted, items not in the file are removed, and module bodies are refreshed. If the file includes enrollments, the roster is replaced except for the course creator’s teacher enrollment.'
+      return 'This course will be updated from the file: syllabus and grading are replaced, settings refresh, every listed outline item is upserted, items not in the file are removed, module bodies are refreshed, and course files from the export are restored (base64). If the file includes enrollments, the roster is replaced except for the course creator’s teacher enrollment.'
   }
 }

--- a/server/internal/httpserver/course_export_import.go
+++ b/server/internal/httpserver/course_export_import.go
@@ -41,7 +41,12 @@ func (d Deps) handleCourseExportGet() http.HandlerFunc {
 			return
 		}
 
-		bundle, err := courseexportimport.BuildExport(r.Context(), d.Pool, courseCode)
+		cfg := d.effectiveConfig()
+		blobOpts := courseexportimport.BlobOptions{
+			FilesRoot: cfg.CourseFilesRoot,
+			Storage:   d.Storage,
+		}
+		bundle, err := courseexportimport.BuildExport(r.Context(), d.Pool, courseCode, blobOpts)
 		if err != nil {
 			if errors.Is(err, courseexportimport.ErrNotFound) {
 				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
@@ -102,7 +107,12 @@ func (d Deps) handleCourseImportPost() http.HandlerFunc {
 			return
 		}
 
-		err = courseexportimport.ApplyImport(r.Context(), d.Pool, courseCode, req.Mode, req.Export, nil)
+		cfg := d.effectiveConfig()
+		blobOpts := courseexportimport.BlobOptions{
+			FilesRoot: cfg.CourseFilesRoot,
+			Storage:   d.Storage,
+		}
+		err = courseexportimport.ApplyImport(r.Context(), d.Pool, courseCode, req.Mode, req.Export, nil, blobOpts)
 		if err != nil {
 			if errors.Is(err, courseexportimport.ErrNotFound) {
 				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")

--- a/server/internal/httpserver/module_assignment_rubric_ai.go
+++ b/server/internal/httpserver/module_assignment_rubric_ai.go
@@ -98,10 +98,6 @@ func (d Deps) handleGenerateAssignmentRubric() http.HandlerFunc {
 			return
 		}
 		prompt := strings.TrimSpace(body.Prompt)
-		if prompt == "" {
-			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Instructions are required.")
-			return
-		}
 		if utf8.RuneCountInString(prompt) > assignmentrubricai.MaxPromptRunes {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Instructions are too long.")
 			return
@@ -114,6 +110,7 @@ func (d Deps) handleGenerateAssignmentRubric() http.HandlerFunc {
 				return
 			}
 		}
+		// Empty prompt is allowed: service uses DefaultUserPrompt grounded on assignment title + body.
 
 		orgID := d.orgIDPtrForUser(r.Context(), viewer)
 		if !d.aiConfigured(r.Context(), orgID) {

--- a/server/internal/models/courseexport/types.go
+++ b/server/internal/models/courseexport/types.go
@@ -104,6 +104,38 @@ type ExportedContentToolInstance struct {
 	Status              string          `json:"status"`
 }
 
+// ExportedCourseFile is an embedded content asset (course.course_files) with base64 body.
+// IDs are preserved so markdown / hero URLs of the form
+// /api/v1/courses/{code}/course-files/{id}/content keep resolving after import.
+type ExportedCourseFile struct {
+	ID               uuid.UUID `json:"id"`
+	OriginalFilename string    `json:"originalFilename"`
+	MimeType         string    `json:"mimeType"`
+	ByteSize         int64     `json:"byteSize"`
+	// ContentBase64 is the raw file bytes (standard base64). Omitted when the blob
+	// was missing at export time.
+	ContentBase64 string `json:"contentBase64,omitempty"`
+}
+
+// ExportedFileFolder is a course file-manager folder (course.file_folders).
+type ExportedFileFolder struct {
+	ID       uuid.UUID  `json:"id"`
+	ParentID *uuid.UUID `json:"parentId"`
+	Name     string     `json:"name"`
+}
+
+// ExportedFileItem is a course file-manager file (course.file_items) with base64 body.
+// IDs are preserved so /api/v1/courses/{code}/files/items/{id}/content URLs keep resolving.
+type ExportedFileItem struct {
+	ID               uuid.UUID  `json:"id"`
+	FolderID         *uuid.UUID `json:"folderId"`
+	OriginalFilename string     `json:"originalFilename"`
+	DisplayName      string     `json:"displayName"`
+	MimeType         string     `json:"mimeType"`
+	ByteSize         int64      `json:"byteSize"`
+	ContentBase64    string     `json:"contentBase64,omitempty"`
+}
+
 type ExportedContentPageBody struct {
 	Markdown string     `json:"markdown"`
 	DueAt    *time.Time `json:"dueAt"`
@@ -192,6 +224,11 @@ type CourseExportV1 struct {
 	// Content tool authoring only — never learner state / events.
 	ContentToolSettings  *ExportedContentToolSettings  `json:"contentToolSettings,omitempty"`
 	ContentToolInstances []ExportedContentToolInstance `json:"contentToolInstances,omitempty"`
+	// Embedded content images (course.course_files) with base64 bodies.
+	CourseFiles []ExportedCourseFile `json:"courseFiles,omitempty"`
+	// File manager hierarchy (course.file_folders + course.file_items).
+	FileFolders []ExportedFileFolder `json:"fileFolders,omitempty"`
+	FileItems   []ExportedFileItem   `json:"fileItems,omitempty"`
 }
 
 type CourseImportRequest struct {

--- a/server/internal/service/assignmentrubricai/service.go
+++ b/server/internal/service/assignmentrubricai/service.go
@@ -45,6 +45,10 @@ Rules:
 - Within each criterion, points should usually be non-decreasing as quality improves.
 - When assignment points are provided, the sum of each criterion's maximum level points must equal that total exactly.`
 
+// DefaultUserPrompt is used when the instructor clicks Build with AI without extra instructions.
+// Generation still grounds on assignment title + body when provided.
+const DefaultUserPrompt = `Generate a clear, fair grading rubric based on the assignment content. Align criteria with the tasks, reflection prompts, and learning goals implied by the assignment. Use shared proficiency levels across criteria and match total points when assignment points are set.`
+
 // Service provides AI-backed assignment rubric generation.
 type Service struct {
 	Name string
@@ -96,7 +100,8 @@ func Generate(
 ) (*assignmentrubric.RubricDefinition, aiprovider.CallMeta, error) {
 	prompt := strings.TrimSpace(input.Prompt)
 	if prompt == "" {
-		return nil, aiprovider.CallMeta{}, fmt.Errorf("instructions are required")
+		// One-click Build with AI: ground on assignment title/body without extra instructor text.
+		prompt = DefaultUserPrompt
 	}
 	if utf8.RuneCountInString(prompt) > MaxPromptRunes {
 		return nil, aiprovider.CallMeta{}, fmt.Errorf("instructions are too long (max %d characters)", MaxPromptRunes)
@@ -104,6 +109,9 @@ func Generate(
 	md := strings.TrimSpace(input.AssignmentMarkdown)
 	if utf8.RuneCountInString(md) > MaxAssignmentMarkdownRunes {
 		return nil, aiprovider.CallMeta{}, fmt.Errorf("assignment body is too long (max %d characters)", MaxAssignmentMarkdownRunes)
+	}
+	if strings.TrimSpace(input.AssignmentTitle) == "" && md == "" && strings.TrimSpace(input.Prompt) == "" {
+		return nil, aiprovider.CallMeta{}, fmt.Errorf("assignment content is required to generate a rubric")
 	}
 
 	sys := strings.TrimSpace(systemPrompt)

--- a/server/internal/service/assignmentrubricai/service_test.go
+++ b/server/internal/service/assignmentrubricai/service_test.go
@@ -2,6 +2,7 @@ package assignmentrubricai
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/lextures/lextures/server/internal/models/assignmentrubric"
@@ -80,9 +81,15 @@ func TestNormalizeRubricGridPadsLevels(t *testing.T) {
 	}
 }
 
-func TestGenerate_rejectsEmptyPrompt(t *testing.T) {
+func TestGenerate_rejectsEmptyContext(t *testing.T) {
 	_, _, err := Generate(context.Background(), nil, "model", "", GenerateInput{})
-	if err == nil || err.Error() != "instructions are required" {
+	if err == nil || err.Error() != "assignment content is required to generate a rubric" {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestDefaultUserPrompt_nonEmpty(t *testing.T) {
+	if strings.TrimSpace(DefaultUserPrompt) == "" {
+		t.Fatal("DefaultUserPrompt must be non-empty for one-click Build with AI")
 	}
 }

--- a/server/internal/service/courseexportimport/export.go
+++ b/server/internal/service/courseexportimport/export.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/coursemodulequizzes"
 	"github.com/lextures/lextures/server/internal/repos/coursestructure"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
+	"github.com/lextures/lextures/server/internal/service/filestorage"
 )
 
 const exportFormatVersion int32 = 1
@@ -47,13 +48,25 @@ type Bundle struct {
 	// Content tool authoring only — never learner state/events/grade links.
 	ContentToolSettings  *courseexport.ExportedContentToolSettings  `json:"contentToolSettings,omitempty"`
 	ContentToolInstances []courseexport.ExportedContentToolInstance `json:"contentToolInstances,omitempty"`
+	// Embedded content images (course.course_files) with base64 bodies.
+	CourseFiles []courseexport.ExportedCourseFile `json:"courseFiles,omitempty"`
+	// File manager hierarchy with base64 bodies on each item.
+	FileFolders []courseexport.ExportedFileFolder `json:"fileFolders,omitempty"`
+	FileItems   []courseexport.ExportedFileItem   `json:"fileItems,omitempty"`
+}
+
+// BlobOptions configures how export/import reads and writes course file blobs.
+// When Storage is nil, FilesRoot (or "data/course-files") is used for local disk I/O.
+type BlobOptions struct {
+	FilesRoot string
+	Storage   filestorage.Driver
 }
 
 // ErrNotFound is returned when the course code does not exist.
 var ErrNotFound = errors.New("course not found")
 
 // BuildExport builds a full course JSON export bundle (Rust `build_export`).
-func BuildExport(ctx context.Context, pool *pgxpool.Pool, courseCode string) (*Bundle, error) {
+func BuildExport(ctx context.Context, pool *pgxpool.Pool, courseCode string, blobOpts BlobOptions) (*Bundle, error) {
 	if pool == nil {
 		return nil, errors.New("db pool is nil")
 	}
@@ -364,6 +377,10 @@ func BuildExport(ctx context.Context, pool *pgxpool.Pool, courseCode string) (*B
 			})
 		}
 		bundle.ContentToolInstances = out
+	}
+
+	if err := attachCourseFilesToExport(ctx, pool, courseID, courseCode, blobOpts, bundle); err != nil {
+		return nil, err
 	}
 
 	return bundle, nil

--- a/server/internal/service/courseexportimport/files.go
+++ b/server/internal/service/courseexportimport/files.go
@@ -1,0 +1,290 @@
+package courseexportimport
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/models/courseexport"
+	"github.com/lextures/lextures/server/internal/repos/coursefiles"
+)
+
+const (
+	maxExportCourseFiles     = 5000
+	maxExportFileFolders     = 5000
+	maxExportFileItems       = 5000
+	maxExportSingleFileBytes = 50 << 20  // 50 MiB
+	maxExportTotalFileBytes  = 250 << 20 // 250 MiB
+)
+
+func (o BlobOptions) filesRoot() string {
+	root := strings.TrimSpace(o.FilesRoot)
+	if root == "" {
+		return "data/course-files"
+	}
+	return filepath.Clean(root)
+}
+
+// readCourseFileBlob loads bytes for a course.course_files storage key.
+// Mirrors httpserver.readCourseFileRowBytes (storage driver, then disk layouts).
+func (o BlobOptions) readCourseFileBlob(ctx context.Context, courseCode, storageKey string) ([]byte, error) {
+	if o.Storage != nil {
+		rc, err := o.Storage.GetObject(ctx, storageKey)
+		if err == nil {
+			defer func() { _ = rc.Close() }()
+			return io.ReadAll(rc)
+		}
+	}
+	root := o.filesRoot()
+	if b, err := os.ReadFile(coursefiles.BlobDiskPath(root, courseCode, storageKey)); err == nil {
+		return b, nil
+	}
+	legacyPath := filepath.Join(root, courseCode, storageKey)
+	b, err := os.ReadFile(legacyPath)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// readFileItemBlob loads bytes for a course.file_items storage key.
+func (o BlobOptions) readFileItemBlob(ctx context.Context, courseCode, storageKey string) ([]byte, error) {
+	if o.Storage != nil {
+		rc, err := o.Storage.GetObject(ctx, storageKey)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = rc.Close() }()
+		return io.ReadAll(rc)
+	}
+	root := o.filesRoot()
+	p := filepath.Join(root, courseCode, storageKey)
+	return os.ReadFile(p)
+}
+
+// writeCourseFileBlob stores an embedded course.course_files blob.
+func (o BlobOptions) writeCourseFileBlob(ctx context.Context, courseCode, storageKey, mimeType string, data []byte) error {
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	if o.Storage != nil {
+		return o.Storage.PutObject(ctx, storageKey, bytes.NewReader(data), int64(len(data)), mimeType)
+	}
+	// Match handlePostCourseFileMultipart local layout (BlobDiskPath).
+	p := coursefiles.BlobDiskPath(o.filesRoot(), courseCode, storageKey)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0o644)
+}
+
+// writeFileItemBlob stores a course.file_items blob.
+func (o BlobOptions) writeFileItemBlob(ctx context.Context, courseCode, storageKey, mimeType string, data []byte) error {
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	if o.Storage != nil {
+		return o.Storage.PutObject(ctx, storageKey, bytes.NewReader(data), int64(len(data)), mimeType)
+	}
+	// Match handlePostCourseFileItem / canvas import local layout.
+	p := filepath.Join(o.filesRoot(), courseCode, filepath.FromSlash(storageKey))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0o644)
+}
+
+func attachCourseFilesToExport(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	courseCode string,
+	blobOpts BlobOptions,
+	bundle *Bundle,
+) error {
+	var totalBytes int64
+
+	// --- course.course_files (embedded content) ---
+	cfRows, err := pool.Query(ctx, `
+		SELECT id, storage_key, original_filename, mime_type, byte_size
+		FROM course.course_files
+		WHERE course_id = $1
+		ORDER BY created_at ASC, id ASC
+	`, courseID)
+	if err != nil {
+		return err
+	}
+	defer cfRows.Close()
+	courseFiles := make([]courseexport.ExportedCourseFile, 0)
+	for cfRows.Next() {
+		var (
+			id               uuid.UUID
+			storageKey       string
+			originalFilename string
+			mimeType         string
+			byteSize         int64
+		)
+		if err := cfRows.Scan(&id, &storageKey, &originalFilename, &mimeType, &byteSize); err != nil {
+			return err
+		}
+		if len(courseFiles) >= maxExportCourseFiles {
+			return fmt.Errorf("too many course files to export (max %d)", maxExportCourseFiles)
+		}
+		ex := courseexport.ExportedCourseFile{
+			ID:               id,
+			OriginalFilename: originalFilename,
+			MimeType:         mimeType,
+			ByteSize:         byteSize,
+		}
+		if data, rerr := blobOpts.readCourseFileBlob(ctx, courseCode, storageKey); rerr == nil {
+			if int64(len(data)) > maxExportSingleFileBytes {
+				return fmt.Errorf("course file %q exceeds export size limit (%d bytes)", originalFilename, maxExportSingleFileBytes)
+			}
+			totalBytes += int64(len(data))
+			if totalBytes > maxExportTotalFileBytes {
+				return fmt.Errorf("total course file payload exceeds export size limit (%d bytes)", maxExportTotalFileBytes)
+			}
+			ex.ContentBase64 = base64.StdEncoding.EncodeToString(data)
+			ex.ByteSize = int64(len(data))
+		}
+		// Missing blobs: still export metadata so import can recreate the row id
+		// (content URL will 404 until re-uploaded).
+		courseFiles = append(courseFiles, ex)
+	}
+	if err := cfRows.Err(); err != nil {
+		return err
+	}
+	if len(courseFiles) > 0 {
+		bundle.CourseFiles = courseFiles
+	}
+
+	// --- file manager folders (parents before children via created_at) ---
+	folderRows, err := pool.Query(ctx, `
+		SELECT id, parent_id, name
+		FROM course.file_folders
+		WHERE course_id = $1
+		ORDER BY created_at ASC, id ASC
+	`, courseID)
+	if err != nil {
+		return err
+	}
+	defer folderRows.Close()
+	folders := make([]courseexport.ExportedFileFolder, 0)
+	for folderRows.Next() {
+		var f courseexport.ExportedFileFolder
+		if err := folderRows.Scan(&f.ID, &f.ParentID, &f.Name); err != nil {
+			return err
+		}
+		if len(folders) >= maxExportFileFolders {
+			return fmt.Errorf("too many file folders to export (max %d)", maxExportFileFolders)
+		}
+		folders = append(folders, f)
+	}
+	if err := folderRows.Err(); err != nil {
+		return err
+	}
+	if len(folders) > 0 {
+		bundle.FileFolders = folders
+	}
+
+	// --- file manager items ---
+	itemRows, err := pool.Query(ctx, `
+		SELECT id, folder_id, storage_key, original_filename, display_name, mime_type, byte_size
+		FROM course.file_items
+		WHERE course_id = $1
+		ORDER BY created_at ASC, id ASC
+	`, courseID)
+	if err != nil {
+		return err
+	}
+	defer itemRows.Close()
+	items := make([]courseexport.ExportedFileItem, 0)
+	for itemRows.Next() {
+		var (
+			id               uuid.UUID
+			folderID         *uuid.UUID
+			storageKey       string
+			originalFilename string
+			displayName      string
+			mimeType         string
+			byteSize         int64
+		)
+		if err := itemRows.Scan(&id, &folderID, &storageKey, &originalFilename, &displayName, &mimeType, &byteSize); err != nil {
+			return err
+		}
+		if len(items) >= maxExportFileItems {
+			return fmt.Errorf("too many file manager items to export (max %d)", maxExportFileItems)
+		}
+		ex := courseexport.ExportedFileItem{
+			ID:               id,
+			FolderID:         folderID,
+			OriginalFilename: originalFilename,
+			DisplayName:      displayName,
+			MimeType:         mimeType,
+			ByteSize:         byteSize,
+		}
+		if data, rerr := blobOpts.readFileItemBlob(ctx, courseCode, storageKey); rerr == nil {
+			if int64(len(data)) > maxExportSingleFileBytes {
+				return fmt.Errorf("file manager item %q exceeds export size limit (%d bytes)", displayName, maxExportSingleFileBytes)
+			}
+			totalBytes += int64(len(data))
+			if totalBytes > maxExportTotalFileBytes {
+				return fmt.Errorf("total course file payload exceeds export size limit (%d bytes)", maxExportTotalFileBytes)
+			}
+			ex.ContentBase64 = base64.StdEncoding.EncodeToString(data)
+			ex.ByteSize = int64(len(data))
+		}
+		items = append(items, ex)
+	}
+	if err := itemRows.Err(); err != nil {
+		return err
+	}
+	if len(items) > 0 {
+		bundle.FileItems = items
+	}
+	return nil
+}
+
+// decodeFileContent decodes base64 content and enforces size caps.
+func decodeFileContent(label, b64 string, declaredSize int64) ([]byte, error) {
+	b64 = strings.TrimSpace(b64)
+	if b64 == "" {
+		return nil, nil
+	}
+	// Guard against pathological base64 length before allocating.
+	// base64 expands ~4/3; allow a little overhead for padding.
+	approx := (int64(len(b64)) * 3) / 4
+	if approx > maxExportSingleFileBytes+1024 {
+		return nil, InvalidInput(fmt.Sprintf("%s content is too large.", label))
+	}
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		// Also accept raw URL-safe encodings that some clients produce.
+		data, err = base64.URLEncoding.DecodeString(b64)
+		if err != nil {
+			return nil, InvalidInput(fmt.Sprintf("%s contentBase64 is not valid base64.", label))
+		}
+	}
+	if int64(len(data)) > maxExportSingleFileBytes {
+		return nil, InvalidInput(fmt.Sprintf("%s content exceeds size limit (%d bytes).", label, maxExportSingleFileBytes))
+	}
+	if declaredSize > 0 && declaredSize != int64(len(data)) {
+		// Trust decoded length; mismatch is allowed (declared may be stale).
+		_ = declaredSize
+	}
+	return data, nil
+}
+
+// newImportStorageKey builds a storage key unique to the target course.
+func newImportStorageKey(prefix, courseCode, filename string) string {
+	ext := filepath.Ext(filename)
+	return fmt.Sprintf("%s/%s/%s%s", prefix, courseCode, uuid.New().String(), ext)
+}

--- a/server/internal/service/courseexportimport/files_test.go
+++ b/server/internal/service/courseexportimport/files_test.go
@@ -1,0 +1,175 @@
+package courseexportimport
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/lextures/lextures/server/internal/models/courseexport"
+	"github.com/lextures/lextures/server/internal/repos/coursefiles"
+)
+
+func TestDecodeFileContent_RoundTrip(t *testing.T) {
+	raw := []byte("hello course file")
+	b64 := base64.StdEncoding.EncodeToString(raw)
+	got, err := decodeFileContent("test", b64, int64(len(raw)))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("got %q want %q", got, raw)
+	}
+}
+
+func TestDecodeFileContent_Empty(t *testing.T) {
+	got, err := decodeFileContent("test", "", 0)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("want nil for empty content, got %v", got)
+	}
+}
+
+func TestDecodeFileContent_InvalidBase64(t *testing.T) {
+	_, err := decodeFileContent("test", "!!!not-base64!!!", 0)
+	if !IsInvalidInput(err) {
+		t.Fatalf("want InvalidInput, got %v", err)
+	}
+}
+
+func TestRewriteCourseFileURLsInBundle(t *testing.T) {
+	pageID := uuid.New()
+	hero := "/api/v1/courses/C-SRC/course-files/abc/content"
+	ex := &Bundle{
+		CourseCode: "C-SRC",
+		Course: courseexport.CourseExportSnapshot{
+			HeroImageURL: &hero,
+		},
+		Syllabus: nil,
+		ContentPages: map[uuid.UUID]courseexport.ExportedContentPageBody{
+			pageID: {Markdown: "![x](/api/v1/courses/C-SRC/files/items/xyz/content)"},
+		},
+		Assignments: map[uuid.UUID]courseexport.ExportedAssignmentBody{},
+		Quizzes:     map[uuid.UUID]courseexport.ExportedQuizBody{},
+	}
+	rewriteCourseFileURLsInBundle(ex, "C-SRC", "C-DST")
+	if ex.Course.HeroImageURL == nil || *ex.Course.HeroImageURL != "/api/v1/courses/C-DST/course-files/abc/content" {
+		t.Fatalf("hero = %v", ex.Course.HeroImageURL)
+	}
+	if got := ex.ContentPages[pageID].Markdown; got != "![x](/api/v1/courses/C-DST/files/items/xyz/content)" {
+		t.Fatalf("markdown = %q", got)
+	}
+}
+
+func TestRewriteCourseFileURLsInBundle_SameCodeNoop(t *testing.T) {
+	hero := "/api/v1/courses/C-A/course-files/abc/content"
+	ex := &Bundle{
+		Course: courseexport.CourseExportSnapshot{HeroImageURL: &hero},
+	}
+	rewriteCourseFileURLsInBundle(ex, "C-A", "C-A")
+	if *ex.Course.HeroImageURL != hero {
+		t.Fatalf("unexpected rewrite: %s", *ex.Course.HeroImageURL)
+	}
+}
+
+func TestBlobOptions_WriteReadCourseFile(t *testing.T) {
+	root := t.TempDir()
+	opts := BlobOptions{FilesRoot: root}
+	courseCode := "C-TEST01"
+	key := "files/" + courseCode + "/" + uuid.New().String() + ".txt"
+	data := []byte("embedded image bytes")
+	ctx := context.Background()
+	if err := opts.writeCourseFileBlob(ctx, courseCode, key, "text/plain", data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Local layout uses BlobDiskPath (basename only).
+	wantPath := coursefiles.BlobDiskPath(root, courseCode, key)
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected blob at %s: %v", wantPath, err)
+	}
+	got, err := opts.readCourseFileBlob(ctx, courseCode, key)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("got %q want %q", got, data)
+	}
+}
+
+func TestBlobOptions_WriteReadFileItem(t *testing.T) {
+	root := t.TempDir()
+	opts := BlobOptions{FilesRoot: root}
+	courseCode := "C-TEST01"
+	key := "managed-files/" + courseCode + "/" + uuid.New().String() + ".pdf"
+	data := []byte("%PDF-1.4 test")
+	ctx := context.Background()
+	if err := opts.writeFileItemBlob(ctx, courseCode, key, "application/pdf", data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wantPath := filepath.Join(root, courseCode, filepath.FromSlash(key))
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected blob at %s: %v", wantPath, err)
+	}
+	got, err := opts.readFileItemBlob(ctx, courseCode, key)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("got %q want %q", got, data)
+	}
+}
+
+func TestValidateCourseFilesExport_OK(t *testing.T) {
+	fileID := uuid.New()
+	folderID := uuid.New()
+	itemID := uuid.New()
+	ex := &Bundle{
+		FormatVersion: 1,
+		CourseCode:    "C-SRC",
+		CourseFiles: []courseexport.ExportedCourseFile{
+			{
+				ID:               fileID,
+				OriginalFilename: "pic.png",
+				MimeType:         "image/png",
+				ByteSize:         1,
+				ContentBase64:    base64.StdEncoding.EncodeToString([]byte("x")),
+			},
+		},
+		FileFolders: []courseexport.ExportedFileFolder{
+			{ID: folderID, Name: "Handouts"},
+		},
+		FileItems: []courseexport.ExportedFileItem{
+			{
+				ID:               itemID,
+				FolderID:         &folderID,
+				OriginalFilename: "notes.pdf",
+				DisplayName:      "Notes",
+				MimeType:         "application/pdf",
+				ByteSize:         1,
+				ContentBase64:    base64.StdEncoding.EncodeToString([]byte("y")),
+			},
+		},
+	}
+	if err := validateCourseFilesExport(ex); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestValidateCourseFilesExport_DuplicateID(t *testing.T) {
+	id := uuid.New()
+	ex := &Bundle{
+		CourseFiles: []courseexport.ExportedCourseFile{
+			{ID: id, OriginalFilename: "a.png"},
+			{ID: id, OriginalFilename: "b.png"},
+		},
+	}
+	err := validateCourseFilesExport(ex)
+	if !IsInvalidInput(err) {
+		t.Fatalf("want InvalidInput, got %v", err)
+	}
+}

--- a/server/internal/service/courseexportimport/import.go
+++ b/server/internal/service/courseexportimport/import.go
@@ -67,6 +67,7 @@ func ApplyImport(
 	mode courseexport.CourseImportMode,
 	ex *Bundle,
 	canvasInclude *courseexport.CanvasImportInclude,
+	blobOpts BlobOptions,
 ) error {
 	if pool == nil {
 		return errors.New("db pool is nil")
@@ -87,6 +88,9 @@ func ApplyImport(
 		return err
 	}
 
+	// Rewrite embedded file URLs when importing into a different course code.
+	rewriteCourseFileURLsInBundle(ex, ex.CourseCode, targetCourseCode)
+
 	courseIDPtr, err := course.GetIDByCourseCode(ctx, pool, targetCourseCode)
 	if err != nil {
 		return err
@@ -99,10 +103,12 @@ func ApplyImport(
 	applyGrades := true
 	applySettings := true
 	applyEnrollments := true
+	applyFiles := true
 	if canvasInclude != nil {
 		applyGrades = canvasInclude.Grades
 		applySettings = canvasInclude.Settings
 		applyEnrollments = canvasInclude.Enrollments
+		applyFiles = canvasInclude.Files
 	}
 	// JSON imports erase the outline even when the bundle has no structure rows.
 	// Canvas partial imports skip that when every content category was unchecked.
@@ -207,6 +213,14 @@ func ApplyImport(
 	// Canvas partial imports that skipped outline still apply CT when present in the bundle.
 	if err := applyContentTools(ctx, pool, courseID, mode, ex, mergeInserted); err != nil {
 		return err
+	}
+
+	// Course files + file manager (base64 bodies) after bodies so hero/markdown
+	// path rewrites are already applied and ids stay stable for content URLs.
+	if applyFiles {
+		if err := applyCourseFiles(ctx, pool, courseID, targetCourseCode, mode, ex, blobOpts); err != nil {
+			return err
+		}
 	}
 
 	if applyEnrollments {

--- a/server/internal/service/courseexportimport/import_apply_files.go
+++ b/server/internal/service/courseexportimport/import_apply_files.go
@@ -1,0 +1,401 @@
+package courseexportimport
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/models/courseexport"
+)
+
+// applyCourseFiles restores embedded course files + file-manager hierarchy.
+// IDs are preserved so markdown / hero URLs keep resolving.
+//
+// Legacy export bundles without any file rows leave the target file set unchanged
+// (so older backups do not wipe images). When the export includes file rows:
+//   - erase: replace the whole file set
+//   - overwrite: upsert export rows and prune extras
+//   - mergeAdd: insert missing ids only
+func applyCourseFiles(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	targetCourseCode string,
+	mode courseexport.CourseImportMode,
+	ex *Bundle,
+	blobOpts BlobOptions,
+) error {
+	hasAny := len(ex.CourseFiles) > 0 || len(ex.FileFolders) > 0 || len(ex.FileItems) > 0
+	if !hasAny {
+		return nil
+	}
+
+	switch mode {
+	case courseexport.CourseImportModeErase:
+		if err := deleteAllCourseFiles(ctx, pool, courseID); err != nil {
+			return err
+		}
+		if err := importFileFolders(ctx, pool, courseID, ex.FileFolders, false); err != nil {
+			return err
+		}
+		if err := importCourseFileRows(ctx, pool, courseID, targetCourseCode, ex.CourseFiles, blobOpts, false); err != nil {
+			return err
+		}
+		return importFileItems(ctx, pool, courseID, targetCourseCode, ex.FileItems, blobOpts, false)
+
+	case courseexport.CourseImportModeOverwrite:
+		if err := importFileFolders(ctx, pool, courseID, ex.FileFolders, false); err != nil {
+			return err
+		}
+		if err := importCourseFileRows(ctx, pool, courseID, targetCourseCode, ex.CourseFiles, blobOpts, false); err != nil {
+			return err
+		}
+		if err := importFileItems(ctx, pool, courseID, targetCourseCode, ex.FileItems, blobOpts, false); err != nil {
+			return err
+		}
+		return pruneCourseFilesNotInExport(ctx, pool, courseID, ex)
+
+	case courseexport.CourseImportModeMergeAdd:
+		if err := importFileFolders(ctx, pool, courseID, ex.FileFolders, true); err != nil {
+			return err
+		}
+		if err := importCourseFileRows(ctx, pool, courseID, targetCourseCode, ex.CourseFiles, blobOpts, true); err != nil {
+			return err
+		}
+		return importFileItems(ctx, pool, courseID, targetCourseCode, ex.FileItems, blobOpts, true)
+	}
+	return nil
+}
+
+func deleteAllCourseFiles(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) error {
+	// file_items first (no FK from folders), then folders (self-referential parent), then course_files.
+	if _, err := pool.Exec(ctx, `DELETE FROM course.file_items WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM course.file_folders WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM course.course_files WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func pruneCourseFilesNotInExport(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, ex *Bundle) error {
+	keepCF := make([]uuid.UUID, 0, len(ex.CourseFiles))
+	for _, f := range ex.CourseFiles {
+		keepCF = append(keepCF, f.ID)
+	}
+	if len(keepCF) == 0 {
+		if _, err := pool.Exec(ctx, `DELETE FROM course.course_files WHERE course_id = $1`, courseID); err != nil {
+			return err
+		}
+	} else {
+		if _, err := pool.Exec(ctx, `
+			DELETE FROM course.course_files
+			WHERE course_id = $1 AND NOT (id = ANY($2::uuid[]))
+		`, courseID, keepCF); err != nil {
+			return err
+		}
+	}
+
+	keepItems := make([]uuid.UUID, 0, len(ex.FileItems))
+	for _, f := range ex.FileItems {
+		keepItems = append(keepItems, f.ID)
+	}
+	if len(keepItems) == 0 {
+		if _, err := pool.Exec(ctx, `DELETE FROM course.file_items WHERE course_id = $1`, courseID); err != nil {
+			return err
+		}
+	} else {
+		if _, err := pool.Exec(ctx, `
+			DELETE FROM course.file_items
+			WHERE course_id = $1 AND NOT (id = ANY($2::uuid[]))
+		`, courseID, keepItems); err != nil {
+			return err
+		}
+	}
+
+	keepFolders := make([]uuid.UUID, 0, len(ex.FileFolders))
+	for _, f := range ex.FileFolders {
+		keepFolders = append(keepFolders, f.ID)
+	}
+	if len(keepFolders) == 0 {
+		if _, err := pool.Exec(ctx, `DELETE FROM course.file_folders WHERE course_id = $1`, courseID); err != nil {
+			return err
+		}
+	} else {
+		// Delete deepest folders first by repeating until none left (children cascade via parent FK).
+		// Safer: delete folders not in keep list; ON DELETE CASCADE on parent_id removes children,
+		// but we want to keep descendants that are in the export — so only delete folders whose
+		// id is not in keep (children not in keep also get deleted when parent is kept? No —
+		// orphan children would remain. Delete all not-in-keep; CASCADE only fires when parent
+		// is deleted. A kept parent with deleted child is fine.
+		if _, err := pool.Exec(ctx, `
+			DELETE FROM course.file_folders
+			WHERE course_id = $1 AND NOT (id = ANY($2::uuid[]))
+		`, courseID, keepFolders); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func importFileFolders(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	folders []courseexport.ExportedFileFolder,
+	mergeSkipExisting bool,
+) error {
+	// Export orders by created_at so parents typically appear before children.
+	// Re-order defensively: roots first, then anything whose parent is already inserted.
+	remaining := make([]courseexport.ExportedFileFolder, 0, len(folders))
+	remaining = append(remaining, folders...)
+	inserted := map[uuid.UUID]struct{}{}
+	for len(remaining) > 0 {
+		progress := 0
+		next := remaining[:0]
+		for _, f := range remaining {
+			if f.ID == uuid.Nil {
+				return InvalidInput("Each file folder needs a valid id.")
+			}
+			if f.ParentID != nil {
+				if _, ok := inserted[*f.ParentID]; !ok {
+					// Parent may already exist in the DB (merge) or appear later in remaining.
+					var exists bool
+					_ = pool.QueryRow(ctx, `
+						SELECT EXISTS(SELECT 1 FROM course.file_folders WHERE id = $1 AND course_id = $2)
+					`, *f.ParentID, courseID).Scan(&exists)
+					if !exists {
+						// Keep for a later pass if parent is still in the export batch.
+						next = append(next, f)
+						continue
+					}
+				}
+			}
+			if mergeSkipExisting {
+				var exists bool
+				if err := pool.QueryRow(ctx, `
+					SELECT EXISTS(SELECT 1 FROM course.file_folders WHERE id = $1 AND course_id = $2)
+				`, f.ID, courseID).Scan(&exists); err != nil {
+					return err
+				}
+				if exists {
+					inserted[f.ID] = struct{}{}
+					progress++
+					continue
+				}
+			}
+			name := strings.TrimSpace(f.Name)
+			if name == "" {
+				return InvalidInput(fmt.Sprintf("File folder %s needs a name.", f.ID))
+			}
+			if _, err := pool.Exec(ctx, `
+				INSERT INTO course.file_folders (id, course_id, parent_id, name, created_at, updated_at)
+				VALUES ($1, $2, $3, $4, NOW(), NOW())
+				ON CONFLICT (id) DO UPDATE SET
+					parent_id = EXCLUDED.parent_id,
+					name = EXCLUDED.name,
+					updated_at = NOW()
+				WHERE course.file_folders.course_id = $2
+			`, f.ID, courseID, f.ParentID, name); err != nil {
+				return err
+			}
+			inserted[f.ID] = struct{}{}
+			progress++
+		}
+		if progress == 0 {
+			return InvalidInput("File folder parent references form a cycle or reference missing parents.")
+		}
+		remaining = next
+	}
+	return nil
+}
+
+func importCourseFileRows(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	courseCode string,
+	files []courseexport.ExportedCourseFile,
+	blobOpts BlobOptions,
+	mergeSkipExisting bool,
+) error {
+	for _, f := range files {
+		if f.ID == uuid.Nil {
+			return InvalidInput("Each course file needs a valid id.")
+		}
+		if mergeSkipExisting {
+			var exists bool
+			if err := pool.QueryRow(ctx, `
+				SELECT EXISTS(SELECT 1 FROM course.course_files WHERE id = $1 AND course_id = $2)
+			`, f.ID, courseID).Scan(&exists); err != nil {
+				return err
+			}
+			if exists {
+				continue
+			}
+		}
+		data, err := decodeFileContent(fmt.Sprintf("Course file %s", f.ID), f.ContentBase64, f.ByteSize)
+		if err != nil {
+			return err
+		}
+		filename := strings.TrimSpace(f.OriginalFilename)
+		if filename == "" {
+			filename = "file"
+		}
+		mime := strings.TrimSpace(f.MimeType)
+		if mime == "" {
+			mime = "application/octet-stream"
+		}
+		storageKey := newImportStorageKey("files", courseCode, filename)
+		byteSize := f.ByteSize
+		if data != nil {
+			byteSize = int64(len(data))
+			if err := blobOpts.writeCourseFileBlob(ctx, courseCode, storageKey, mime, data); err != nil {
+				return fmt.Errorf("store course file %s: %w", f.ID, err)
+			}
+		} else {
+			// No body: still register metadata with a fresh key so the id exists for links.
+			if byteSize < 0 {
+				byteSize = 0
+			}
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO course.course_files (id, course_id, storage_key, original_filename, mime_type, byte_size, uploaded_by)
+			VALUES ($1, $2, $3, $4, $5, $6, NULL)
+			ON CONFLICT (id) DO UPDATE SET
+				storage_key = EXCLUDED.storage_key,
+				original_filename = EXCLUDED.original_filename,
+				mime_type = EXCLUDED.mime_type,
+				byte_size = EXCLUDED.byte_size
+			WHERE course.course_files.course_id = $2
+		`, f.ID, courseID, storageKey, filename, mime, byteSize); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func importFileItems(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	courseCode string,
+	items []courseexport.ExportedFileItem,
+	blobOpts BlobOptions,
+	mergeSkipExisting bool,
+) error {
+	for _, it := range items {
+		if it.ID == uuid.Nil {
+			return InvalidInput("Each file manager item needs a valid id.")
+		}
+		if mergeSkipExisting {
+			var exists bool
+			if err := pool.QueryRow(ctx, `
+				SELECT EXISTS(SELECT 1 FROM course.file_items WHERE id = $1 AND course_id = $2)
+			`, it.ID, courseID).Scan(&exists); err != nil {
+				return err
+			}
+			if exists {
+				continue
+			}
+		}
+		data, err := decodeFileContent(fmt.Sprintf("File item %s", it.ID), it.ContentBase64, it.ByteSize)
+		if err != nil {
+			return err
+		}
+		filename := strings.TrimSpace(it.OriginalFilename)
+		if filename == "" {
+			filename = "file"
+		}
+		display := strings.TrimSpace(it.DisplayName)
+		if display == "" {
+			display = filename
+		}
+		mime := strings.TrimSpace(it.MimeType)
+		if mime == "" {
+			mime = "application/octet-stream"
+		}
+		ext := filepath.Ext(filename)
+		storageKey := fmt.Sprintf("managed-files/%s/%s%s", courseCode, uuid.New().String(), ext)
+		byteSize := it.ByteSize
+		if data != nil {
+			byteSize = int64(len(data))
+			if err := blobOpts.writeFileItemBlob(ctx, courseCode, storageKey, mime, data); err != nil {
+				return fmt.Errorf("store file item %s: %w", it.ID, err)
+			}
+		} else if byteSize < 0 {
+			byteSize = 0
+		}
+		// folder_id may be null (root). If set, ensure it exists in this course (or leave null).
+		folderID := it.FolderID
+		if folderID != nil {
+			var exists bool
+			_ = pool.QueryRow(ctx, `
+				SELECT EXISTS(SELECT 1 FROM course.file_folders WHERE id = $1 AND course_id = $2)
+			`, *folderID, courseID).Scan(&exists)
+			if !exists {
+				folderID = nil
+			}
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO course.file_items (
+				id, course_id, folder_id, storage_key, original_filename, display_name,
+				mime_type, byte_size, uploaded_by, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULL, NOW(), NOW())
+			ON CONFLICT (id) DO UPDATE SET
+				folder_id = EXCLUDED.folder_id,
+				storage_key = EXCLUDED.storage_key,
+				original_filename = EXCLUDED.original_filename,
+				display_name = EXCLUDED.display_name,
+				mime_type = EXCLUDED.mime_type,
+				byte_size = EXCLUDED.byte_size,
+				updated_at = NOW()
+			WHERE course.file_items.course_id = $2
+		`, it.ID, courseID, folderID, storageKey, filename, display, mime, byteSize); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// rewriteCourseFileURLsInBundle rewrites absolute course-file API paths from the
+// source course code to the target so embedded images work after cross-course import.
+func rewriteCourseFileURLsInBundle(ex *Bundle, sourceCode, targetCode string) {
+	sourceCode = strings.TrimSpace(sourceCode)
+	targetCode = strings.TrimSpace(targetCode)
+	if sourceCode == "" || targetCode == "" || sourceCode == targetCode {
+		return
+	}
+	fromPrefix := "/api/v1/courses/" + sourceCode + "/"
+	toPrefix := "/api/v1/courses/" + targetCode + "/"
+	rewrite := func(s string) string {
+		return strings.ReplaceAll(s, fromPrefix, toPrefix)
+	}
+
+	if ex.Course.HeroImageURL != nil {
+		u := rewrite(*ex.Course.HeroImageURL)
+		ex.Course.HeroImageURL = &u
+	}
+	for i := range ex.Syllabus {
+		ex.Syllabus[i].Markdown = rewrite(ex.Syllabus[i].Markdown)
+	}
+	for id, body := range ex.ContentPages {
+		body.Markdown = rewrite(body.Markdown)
+		ex.ContentPages[id] = body
+	}
+	for id, body := range ex.Assignments {
+		body.Markdown = rewrite(body.Markdown)
+		ex.Assignments[id] = body
+	}
+	for id, body := range ex.Quizzes {
+		body.Markdown = rewrite(body.Markdown)
+		ex.Quizzes[id] = body
+	}
+}

--- a/server/internal/service/courseexportimport/import_validate.go
+++ b/server/internal/service/courseexportimport/import_validate.go
@@ -146,14 +146,8 @@ func validateCourseFilesExport(ex *Bundle) error {
 		if it.ByteSize < 0 {
 			return InvalidInput(fmt.Sprintf("File item %s has invalid byteSize.", it.ID))
 		}
-		if it.FolderID != nil {
-			if _, ok := seenFolders[*it.FolderID]; !ok {
-				// Parent may already exist on the target course; only require presence
-				// when folders are listed in this export and the id is unknown here.
-				// Soft-check: if export includes folders, parent should be among them
-				// or be null. Unknown parents are nulled on import.
-			}
-		}
+		// Unknown folder parents (not listed in this export) are nulled on import;
+		// they may already exist on the target course.
 		if b64 := strings.TrimSpace(it.ContentBase64); b64 != "" {
 			approx := (int64(len(b64)) * 3) / 4
 			if approx > maxExportSingleFileBytes+1024 {

--- a/server/internal/service/courseexportimport/import_validate.go
+++ b/server/internal/service/courseexportimport/import_validate.go
@@ -75,7 +75,97 @@ func validateExportPayload(ex *Bundle) error {
 	if err := validateContentToolsExport(ex); err != nil {
 		return err
 	}
+	if err := validateCourseFilesExport(ex); err != nil {
+		return err
+	}
 	return validateExportEnrollments(ex.Enrollments)
+}
+
+func validateCourseFilesExport(ex *Bundle) error {
+	if len(ex.CourseFiles) > maxExportCourseFiles {
+		return InvalidInput(fmt.Sprintf("Too many course files in export (max %d).", maxExportCourseFiles))
+	}
+	if len(ex.FileFolders) > maxExportFileFolders {
+		return InvalidInput(fmt.Sprintf("Too many file folders in export (max %d).", maxExportFileFolders))
+	}
+	if len(ex.FileItems) > maxExportFileItems {
+		return InvalidInput(fmt.Sprintf("Too many file items in export (max %d).", maxExportFileItems))
+	}
+	seenFiles := map[uuid.UUID]struct{}{}
+	var totalApprox int64
+	for _, f := range ex.CourseFiles {
+		if f.ID == uuid.Nil {
+			return InvalidInput("Each course file needs a valid id.")
+		}
+		if _, ok := seenFiles[f.ID]; ok {
+			return InvalidInput("Duplicate course file id.")
+		}
+		seenFiles[f.ID] = struct{}{}
+		if strings.TrimSpace(f.OriginalFilename) == "" {
+			return InvalidInput(fmt.Sprintf("Course file %s needs originalFilename.", f.ID))
+		}
+		if f.ByteSize < 0 {
+			return InvalidInput(fmt.Sprintf("Course file %s has invalid byteSize.", f.ID))
+		}
+		if b64 := strings.TrimSpace(f.ContentBase64); b64 != "" {
+			approx := (int64(len(b64)) * 3) / 4
+			if approx > maxExportSingleFileBytes+1024 {
+				return InvalidInput(fmt.Sprintf("Course file %s content is too large.", f.ID))
+			}
+			totalApprox += approx
+		}
+	}
+	seenFolders := map[uuid.UUID]struct{}{}
+	for _, f := range ex.FileFolders {
+		if f.ID == uuid.Nil {
+			return InvalidInput("Each file folder needs a valid id.")
+		}
+		if _, ok := seenFolders[f.ID]; ok {
+			return InvalidInput("Duplicate file folder id.")
+		}
+		seenFolders[f.ID] = struct{}{}
+		if strings.TrimSpace(f.Name) == "" {
+			return InvalidInput(fmt.Sprintf("File folder %s needs a name.", f.ID))
+		}
+		if len(f.Name) > 255 {
+			return InvalidInput(fmt.Sprintf("File folder %s name is too long.", f.ID))
+		}
+	}
+	seenItems := map[uuid.UUID]struct{}{}
+	for _, it := range ex.FileItems {
+		if it.ID == uuid.Nil {
+			return InvalidInput("Each file item needs a valid id.")
+		}
+		if _, ok := seenItems[it.ID]; ok {
+			return InvalidInput("Duplicate file item id.")
+		}
+		seenItems[it.ID] = struct{}{}
+		if strings.TrimSpace(it.OriginalFilename) == "" && strings.TrimSpace(it.DisplayName) == "" {
+			return InvalidInput(fmt.Sprintf("File item %s needs a name.", it.ID))
+		}
+		if it.ByteSize < 0 {
+			return InvalidInput(fmt.Sprintf("File item %s has invalid byteSize.", it.ID))
+		}
+		if it.FolderID != nil {
+			if _, ok := seenFolders[*it.FolderID]; !ok {
+				// Parent may already exist on the target course; only require presence
+				// when folders are listed in this export and the id is unknown here.
+				// Soft-check: if export includes folders, parent should be among them
+				// or be null. Unknown parents are nulled on import.
+			}
+		}
+		if b64 := strings.TrimSpace(it.ContentBase64); b64 != "" {
+			approx := (int64(len(b64)) * 3) / 4
+			if approx > maxExportSingleFileBytes+1024 {
+				return InvalidInput(fmt.Sprintf("File item %s content is too large.", it.ID))
+			}
+			totalApprox += approx
+		}
+	}
+	if totalApprox > maxExportTotalFileBytes {
+		return InvalidInput(fmt.Sprintf("Total file content in export exceeds size limit (%d bytes).", maxExportTotalFileBytes))
+	}
+	return nil
 }
 
 func validateContentToolsExport(ex *Bundle) error {


### PR DESCRIPTION
## Summary
- Embed `course.course_files` and file-manager folders/items (base64 bodies) in course JSON export/import, with size limits, validation, blob I/O via storage or disk, and content URL rewrites when the course code changes.
- Surface embedded/file-manager counts and clearer import-mode copy in the web export/import stats UI.
- Add one-click **Build with AI** for assignment rubrics: empty prompts use a default grounded on assignment title/body; optional instructions remain available in the rubric editor.

## Test plan
- [ ] Export a course that has embedded content images and file-manager files; confirm the JSON includes `courseFiles`, `fileFolders`, and `fileItems` with base64 when blobs are present
- [ ] Import that export into another course (erase/merge/overwrite); confirm files restore and content URLs resolve under the target course code
- [ ] Import with missing/oversized blobs; confirm validation errors are clear
- [ ] With AI configured, open assignment settings → **Build with AI** drafts a rubric from assignment content without extra instructions
- [ ] In the rubric modal, leave instructions blank and click Generate draft; confirm default prompt path works and Save still required
- [ ] `go test ./internal/service/courseexportimport/ ./internal/service/assignmentrubricai/ -count=1 -short`
- [ ] `npm run test -- course-export-import-stats` (or full web tests if preferred)