### PR TITLE
feat(server): CC.2 course checklist state API and dismissals

### DIFF
--- a/docs/api-changelog-course-checklist.md
+++ b/docs/api-changelog-course-checklist.md
@@ -1,0 +1,20 @@
+# API changelog — Course Checklist (CC.2)
+
+## 2026-08 — Checklist state API & dismissals
+
+New staff-only routes under `/api/v1/courses/{course_code}/checklist…`:
+
+| Verb | Path | Notes |
+|---|---|---|
+| GET | `/checklist` | Full checklist; `?includeNotApplicable=1` includes N/A items |
+| GET | `/checklist/summary` | Badge counters; served from warm snapshot when possible |
+| POST | `/checklist/refresh` | Force recomputation (6/min/course) |
+| GET | `/checklist/history` | Recent dismiss/restore audit events (≤ 100) |
+| POST | `/checklist/items/{item_id}/dismiss` | Body `{ reason?, note? }` |
+| POST | `/checklist/items/{item_id}/restore` | Undo dismissal |
+| POST | `/checklist/items/{item_id}/recheck` | Re-evaluate one item into the snapshot |
+
+Authorisation: course `item:create` (owner/instructor/teacher/designer) or org/platform admin.
+Students, TAs, observers, and other non-staff roles receive `403`. Unknown/inaccessible courses receive `404` with the same body.
+
+See OpenAPI (`server/internal/openapi/openapi.json`) and [CC.2 plan](completed/checklist/CC.2-checklist-state-api-and-dismissals.md).

--- a/docs/completed/checklist/CC.2-checklist-state-api-and-dismissals.md
+++ b/docs/completed/checklist/CC.2-checklist-state-api-and-dismissals.md
@@ -1,6 +1,6 @@
 # CC.2 — Checklist State, API & Dismissals
 
-> Implementation plan. Source: Course Checklist product request. Folder overview: [README](README.md).
+> Implementation plan. Source: Course Checklist product request. Folder overview: [README](../../plan/checklist/README.md).
 
 ## Metadata
 
@@ -10,7 +10,7 @@
 | **Section** | Course Checklist |
 | **Severity** | MAJOR |
 | **Markets** | K12 / HE / HS |
-| **Status (today)** | MISSING |
+| **Status (today)** | DONE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Server / platform team |
 | **Depends on** | CC.1 |
@@ -405,8 +405,8 @@ None. No model calls, no prompts, no inference in CC.2.
   `server/internal/httpserver/course_outcomes_report.go` (staff-guard pattern),
   `server/internal/repos/course/factory_reset.go`, `server/internal/service/coursecopy/copy.go`,
   `server/internal/openapi/openapi.json`, `server/migrations/`.
-- Precedent in-repo: [PS.2 pinned-settings data model & API](../../completed/settings/PS.2-pinned-settings-data-model-and-api.md)
+- Precedent in-repo: [PS.2 pinned-settings data model & API](../settings/PS.2-pinned-settings-data-model-and-api.md)
   (string-keyed per-user state, no per-setting migration).
-- Related plans: [CC.1](../../completed/checklist/CC.1-checklist-registry-and-evaluation-engine.md),
-  [CC.7](CC.7-web-checklist-page-and-nav-badge.md), [CC.9](CC.9-mobile-checklist-ios-and-android.md),
-  [CC.10](CC.10-analytics-guidance-and-rollout.md).
+- Related plans: [CC.1](CC.1-checklist-registry-and-evaluation-engine.md),
+  [CC.7](../../plan/checklist/CC.7-web-checklist-page-and-nav-badge.md), [CC.9](../../plan/checklist/CC.9-mobile-checklist-ios-and-android.md),
+  [CC.10](../../plan/checklist/CC.10-analytics-guidance-and-rollout.md).

--- a/docs/plan/checklist/README.md
+++ b/docs/plan/checklist/README.md
@@ -16,7 +16,7 @@ Every plan follows [_TEMPLATE.md](../_TEMPLATE.md).
 | ID | Plan | Layer | Effort | Depends on |
 |---|---|---|---|---|
 | CC.1 | [Checklist rule registry & evaluation engine](../../completed/checklist/CC.1-checklist-registry-and-evaluation-engine.md) ✅ | Server | M | — |
-| CC.2 | [Checklist state, API & dismissals](CC.2-checklist-state-api-and-dismissals.md) | Server | M | CC.1 |
+| CC.2 | [Checklist state, API & dismissals](../../completed/checklist/CC.2-checklist-state-api-and-dismissals.md) ✅ | Server | M | CC.1 |
 | CC.3 | [Rule pack A — foundations, orientation, policies & people](CC.3-rule-pack-foundations-and-orientation.md) (33 rules) | Server | M | CC.1, CC.2 |
 | CC.4 | [Rule pack B — structure, content & outcome alignment](CC.4-rule-pack-structure-outcomes-alignment.md) (22 rules) | Server | M | CC.1, CC.2 |
 | CC.5 | [Rule pack C — assessment, grading, feedback & interaction](CC.5-rule-pack-assessment-feedback-interaction.md) (26 rules) | Server | M | CC.1, CC.2 |

--- a/docs/runbooks/course-checklist.md
+++ b/docs/runbooks/course-checklist.md
@@ -37,7 +37,35 @@ on the next snapshot TTL; dismissals remain valid.
 Revert the rules/`RETIRED_ITEM_IDS` change. If `EngineVersion` was bumped, leave it bumped
 (monotonic) or accept a second bump on restore.
 
+## Tune snapshot TTL
+
+| Env | Default | Effect |
+|---|---|---|
+| `CHECKLIST_SNAPSHOT_TTL` | `15m` | How long a warm snapshot serves `/checklist` and `/summary` without re-evaluating |
+| `CHECKLIST_EVIDENCE_MAX_ROWS` | `200` | Evidence row cap per finding (CC.1/CC.2) |
+
+## Force-refresh a course
+
+`POST /api/v1/courses/{course_code}/checklist/refresh` (staff) bypasses TTL. Rate-limited to 6/min/course.
+
+## Inspect dismissals
+
+```sql
+SELECT item_id, dismiss_reason, dismiss_note, dismissed_at, dismissed_by_user_id
+FROM course.course_checklist_item_state
+WHERE course_id = $1 AND dismissed_at IS NOT NULL;
+
+SELECT item_id, action, actor_user_id, reason, occurred_at
+FROM course.course_checklist_events
+WHERE course_id = $1
+ORDER BY occurred_at DESC
+LIMIT 100;
+```
+
+Nightly sweeper `scheduled.course_checklist_retention` deletes untouched snapshots (90d) and aged events (400d).
+
 ## Related
 
 - Dev guide: [course-checklist-engine.md](../dev/course-checklist-engine.md)
 - ADR: [0003-course-checklist-code-registry.md](../adr/0003-course-checklist-code-registry.md)
+- Plan: [CC.2](../completed/checklist/CC.2-checklist-state-api-and-dismissals.md)

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -4067,7 +4067,7 @@
         "authorization": true,
         "dependency": "n/a",
         "rollback": false,
-        "notes": "Matrix covers course flag; generation/serving journeys tracked under AC.2\u2013AC.6 gaps."
+        "notes": "Matrix covers course flag; generation/serving journeys tracked under AC.2–AC.6 gaps."
       }
     },
     {
@@ -4154,7 +4154,7 @@
       "risk": "critical",
       "client": "web",
       "coverage": "smoke",
-      "rationale": "API bind/refresh + instructor workspace post-assessment picker and effectiveness chip; full pre\u2192serve\u2192post causal journey remains backlog.",
+      "rationale": "API bind/refresh + instructor workspace post-assessment picker and effectiveness chip; full pre→serve→post causal journey remains backlog.",
       "owner": "Learning Platform",
       "specs": [
         {
@@ -4259,7 +4259,7 @@
         "authorization": true,
         "dependency": "n/a",
         "rollback": false,
-        "notes": "CT.1 foundations only; authoring UI and student runtime tracked under CT.2\u2013CT.3."
+        "notes": "CT.1 foundations only; authoring UI and student runtime tracked under CT.2–CT.3."
       }
     },
     {
@@ -4361,7 +4361,7 @@
       "risk": "major",
       "client": "web",
       "coverage": "journey",
-      "rationale": "Playwright covers sandbox_probe iframe mount, interact\u2192save\u2192grade loop, hostile cookie/parent/storage/fetch containment, and admin migration dry-run reporting.",
+      "rationale": "Playwright covers sandbox_probe iframe mount, interact→save→grade loop, hostile cookie/parent/storage/fetch containment, and admin migration dry-run reporting.",
       "owner": "Learning Platform",
       "specs": [
         {
@@ -4499,7 +4499,7 @@
       "risk": "major",
       "client": "web",
       "coverage": "journey",
-      "rationale": "Playwright covers ask \u2192 cited dry-run answer persistence, reload restore, daily rate-limit message, and instructor enrollment reset clearing the transcript.",
+      "rationale": "Playwright covers ask → cited dry-run answer persistence, reload restore, daily rate-limit message, and instructor enrollment reset clearing the transcript.",
       "owner": "AI Platform",
       "specs": [
         {
@@ -4526,7 +4526,7 @@
       "risk": "major",
       "client": "web",
       "coverage": "journey",
-      "rationale": "Playwright covers answer-key redaction, wrong\u2192retry\u2192correct scoring, sequential locking, attempt exhaustion, idempotent submit, host render, and instructor option-distribution analytics.",
+      "rationale": "Playwright covers answer-key redaction, wrong→retry→correct scoring, sequential locking, attempt exhaustion, idempotent submit, host render, and instructor option-distribution analytics.",
       "owner": "Assessment",
       "specs": [
         {
@@ -4553,7 +4553,7 @@
       "risk": "major",
       "client": "web",
       "coverage": "journey",
-      "rationale": "Playwright covers reveal redaction, confidence-required gate, commit\u2192reveal, irreversibility (action + PUT), peer small-n suppression, reflection, host render/reload persistence, and CT.4 reset restoring the gate.",
+      "rationale": "Playwright covers reveal redaction, confidence-required gate, commit→reveal, irreversibility (action + PUT), peer small-n suppression, reflection, host render/reload persistence, and CT.4 reset restoring the gate.",
       "owner": "Assessment",
       "specs": [
         {
@@ -4715,7 +4715,7 @@
       "risk": "major",
       "client": "web",
       "coverage": "journey",
-      "rationale": "Playwright covers sensitive-field redaction, sequential lock, wrong\u2192hint\u2192algebraic normalisation correct, attempt exhaustion\u2192reveal_step, locale numeric input, analytics facets, and UI mount.",
+      "rationale": "Playwright covers sensitive-field redaction, sequential lock, wrong→hint→algebraic normalisation correct, attempt exhaustion→reveal_step, locale numeric input, analytics facets, and UI mount.",
       "owner": "Assessment",
       "specs": [
         {
@@ -4921,7 +4921,7 @@
       "risk": "critical",
       "client": "mobile",
       "coverage": "not-applicable",
-      "rationale": "Mobile client story: Content Tool host + state persistence (fence\u2192instance, ToolFrame, autosave/conflict/offline, noop_probe). Covered by native unit suites + shared fixtures; web Playwright is not the coverage surface.",
+      "rationale": "Mobile client story: Content Tool host + state persistence (fence→instance, ToolFrame, autosave/conflict/offline, noop_probe). Covered by native unit suites + shared fixtures; web Playwright is not the coverage surface.",
       "owner": "Mobile",
       "reviewed": true,
       "flags": {
@@ -4943,7 +4943,7 @@
       "risk": "major",
       "client": "mobile",
       "coverage": "not-applicable",
-      "rationale": "Mobile client story: sandboxed WebView tool host (CT.5 bridge, opaque origin, native\u2192sandbox\u2192placeholder). Covered by native unit suites + shared bridge fixtures (AC-16); web Playwright is not the coverage surface.",
+      "rationale": "Mobile client story: sandboxed WebView tool host (CT.5 bridge, opaque origin, native→sandbox→placeholder). Covered by native unit suites + shared bridge fixtures (AC-16); web Playwright is not the coverage surface.",
       "owner": "Mobile",
       "reviewed": true,
       "flags": {
@@ -5009,7 +5009,7 @@
       "risk": "major",
       "client": "mobile",
       "coverage": "not-applicable",
-      "rationale": "Mobile client story: native pack-3 renderers (sort_sequence, highlight_annotate, diagram_hotspot) on the CT.M3 host with tap-to-assign alternatives (WCAG \u00a72.5.7). Covered by ContentToolPack3Logic unit suites + shared pack3-logic fixtures (AC-15); web Playwright is not the coverage surface.",
+      "rationale": "Mobile client story: native pack-3 renderers (sort_sequence, highlight_annotate, diagram_hotspot) on the CT.M3 host with tap-to-assign alternatives (WCAG §2.5.7). Covered by ContentToolPack3Logic unit suites + shared pack3-logic fixtures (AC-15); web Playwright is not the coverage surface.",
       "owner": "Mobile",
       "reviewed": true,
       "flags": {
@@ -5088,6 +5088,35 @@
         "dependency": "n/a",
         "rollback": true,
         "notes": "No feature flag by design. Retire via RETIRED_ITEM_IDS; EngineVersion bump invalidates CC.2 caches. Depends on nothing; unblocks CC.2+."
+      }
+    },
+    {
+      "id": "CC.2",
+      "path": "docs/completed/checklist/CC.2-checklist-state-api-and-dismissals.md",
+      "markets": [
+        "K12",
+        "HE",
+        "HS"
+      ],
+      "risk": "major",
+      "client": "ops",
+      "coverage": "smoke",
+      "rationale": "Staff-only checklist state API (dismiss/restore/summary). Playwright API-level smoke; deep authz/single-flight covered by Go DB tests.",
+      "owner": "Learning Platform",
+      "reviewed": true,
+      "specs": [
+        {
+          "path": "e2e/tests/course-checklist.spec.ts"
+        }
+      ],
+      "flags": {
+        "settingsToggle": false,
+        "disabledState": "n/a",
+        "enabledJourney": true,
+        "authorization": true,
+        "dependency": "CC.1",
+        "rollback": true,
+        "notes": "No feature flag. Snapshot TTL via CHECKLIST_SNAPSHOT_TTL. Unblocks CC.3–CC.7/CC.9."
       }
     },
     {
@@ -9533,7 +9562,7 @@
       "risk": "minor",
       "client": "web",
       "coverage": "journey",
-      "rationale": "Playwright journey selects across paragraphs on a content page and asserts \u2318/Ctrl+C copies every paragraph.",
+      "rationale": "Playwright journey selects across paragraphs on a content page and asserts ⌘/Ctrl+C copies every paragraph.",
       "owner": "Web Platform",
       "specs": [
         {

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -5114,7 +5114,7 @@
         "disabledState": "n/a",
         "enabledJourney": true,
         "authorization": true,
-        "dependency": "CC.1",
+        "dependency": "n/a",
         "rollback": true,
         "notes": "No feature flag. Snapshot TTL via CHECKLIST_SNAPSHOT_TTL. Unblocks CC.3–CC.7/CC.9."
       }

--- a/e2e/tests/course-checklist.spec.ts
+++ b/e2e/tests/course-checklist.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Course Checklist state API (CC.2) — API-level Playwright suite.
+ *
+ * Checklist coverage:
+ *   [x] Unauthenticated GET /checklist returns 401
+ *   [x] Student GET /checklist returns 403
+ *   [x] Teacher GET /checklist returns 200 with summary
+ *   [x] Teacher dismisses item → badge decrements → restore → badge increments
+ */
+
+import { test, expect } from '@playwright/test'
+import { apiSignup, apiCreateCourse, apiEnroll } from '../fixtures/api.js'
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const PASSWORD = 'E2eTestPass1!'
+
+let _seq = 0
+function uniqueEmail(prefix = 'cc2') {
+  return `e2e-${prefix}-${Date.now()}-${++_seq}@test.invalid`
+}
+
+test('Course checklist: unauthenticated GET returns 401', async () => {
+  const res = await fetch(`${API_BASE}/api/v1/courses/C-FAKE/checklist`)
+  expect(res.status).toBe(401)
+})
+
+test('Course checklist: student receives 403; teacher dismiss/restore updates badge', async () => {
+  const teacherEmail = uniqueEmail('cc2-teacher')
+  const studentEmail = uniqueEmail('cc2-student')
+  const { access_token: teacherTok } = await apiSignup({ email: teacherEmail, password: PASSWORD })
+  const { access_token: studentTok } = await apiSignup({ email: studentEmail, password: PASSWORD })
+  const course = await apiCreateCourse(teacherTok, { title: 'CC2 Checklist Course' })
+  await apiEnroll(teacherTok, course.courseCode, teacherEmail, 'teacher')
+  await apiEnroll(teacherTok, course.courseCode, studentEmail, 'student')
+
+  const studentRes = await fetch(`${API_BASE}/api/v1/courses/${course.courseCode}/checklist`, {
+    headers: { Authorization: `Bearer ${studentTok}` },
+  })
+  expect(studentRes.status).toBe(403)
+  const studentBody = await studentRes.text()
+  expect(studentBody).not.toContain('Set course start')
+
+  const listRes = await fetch(`${API_BASE}/api/v1/courses/${course.courseCode}/checklist`, {
+    headers: { Authorization: `Bearer ${teacherTok}` },
+  })
+  expect(listRes.status).toBe(200)
+  const list = await listRes.json()
+  expect(list.engineVersion).toBeGreaterThanOrEqual(1)
+  expect(typeof list.catalogVersion).toBe('string')
+  const beforeEssential = list.summary.outstandingEssential as number
+  expect(beforeEssential).toBeGreaterThanOrEqual(1)
+
+  const dismissRes = await fetch(
+    `${API_BASE}/api/v1/courses/${course.courseCode}/checklist/items/course.dates/dismiss`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${teacherTok}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ reason: 'not_applicable', note: 'e2e dismiss' }),
+    },
+  )
+  expect(dismissRes.status).toBe(200)
+
+  const summaryAfterDismiss = await fetch(
+    `${API_BASE}/api/v1/courses/${course.courseCode}/checklist/summary`,
+    { headers: { Authorization: `Bearer ${teacherTok}` } },
+  )
+  expect(summaryAfterDismiss.status).toBe(200)
+  const summary1 = await summaryAfterDismiss.json()
+  expect(summary1.dismissed).toBe(1)
+  expect(summary1.outstandingEssential).toBe(beforeEssential - 1)
+
+  const restoreRes = await fetch(
+    `${API_BASE}/api/v1/courses/${course.courseCode}/checklist/items/course.dates/restore`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${teacherTok}` },
+    },
+  )
+  expect(restoreRes.status).toBe(200)
+
+  const summaryAfterRestore = await fetch(
+    `${API_BASE}/api/v1/courses/${course.courseCode}/checklist/summary`,
+    { headers: { Authorization: `Bearer ${teacherTok}` } },
+  )
+  const summary2 = await summaryAfterRestore.json()
+  expect(summary2.dismissed).toBe(0)
+  expect(summary2.outstandingEssential).toBe(beforeEssential)
+})

--- a/e2e/tests/course-checklist.spec.ts
+++ b/e2e/tests/course-checklist.spec.ts
@@ -31,7 +31,7 @@ test('Course checklist: student receives 403; teacher dismiss/restore updates ba
   const { access_token: studentTok } = await apiSignup({ email: studentEmail, password: PASSWORD })
   const course = await apiCreateCourse(teacherTok, { title: 'CC2 Checklist Course' })
   await apiEnroll(teacherTok, course.courseCode, teacherEmail, 'teacher')
-  await apiEnroll(teacherTok, course.courseCode, studentEmail, 'student')
+  await apiEnroll(teacherTok, course.courseCode, studentEmail, 'student', studentTok)
 
   const studentRes = await fetch(`${API_BASE}/api/v1/courses/${course.courseCode}/checklist`, {
     headers: { Authorization: `Bearer ${studentTok}` },

--- a/server/.env.example
+++ b/server/.env.example
@@ -66,6 +66,10 @@ PUBLIC_WEB_ORIGIN=http://localhost:5173
 # CONTENT_TOOLS_ASYNC_RESET_THRESHOLD=200
 # CONTENT_TOOLS_SANDBOX_MODE=optin  # off | optin | required (CT.5)
 
+# Course Checklist (CC.2) snapshot cache tuning.
+# CHECKLIST_SNAPSHOT_TTL=15m
+# CHECKLIST_EVIDENCE_MAX_ROWS=200
+
 # API keys and integration credentials (prefer Settings UI where supported)
 # OpenRouter API key: Settings → Intelligence → Models (stored in platform_app_settings)
 # PLATFORM_SECRETS_KEY=   # base64 32-byte AES key for encrypted SMTP password and AI provider BYOK credentials in DB (openssl rand -base64 32)

--- a/server/internal/background/course_checklist_retention.go
+++ b/server/internal/background/course_checklist_retention.go
@@ -1,0 +1,33 @@
+package background
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/scheduler"
+	"github.com/lextures/lextures/server/internal/service/coursechecklist"
+)
+
+// RegisterCourseChecklistRetentionJobs registers the CC.2 nightly retention sweeper.
+func RegisterCourseChecklistRetentionJobs(r *Registry, pool *pgxpool.Pool) {
+	if r == nil || pool == nil {
+		return
+	}
+	r.Register(scheduler.JobTypeCourseChecklistRetention, HandlerFunc(func(ctx context.Context, _ json.RawMessage) error {
+		snapshots, events, err := coursechecklist.SweepRetention(ctx, pool, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		if snapshots > 0 || events > 0 {
+			slog.Info("scheduled.course_checklist_retention",
+				"snapshots_deleted", snapshots,
+				"events_deleted", events,
+			)
+		}
+		return nil
+	}))
+}

--- a/server/internal/background/jobqueue_email.go
+++ b/server/internal/background/jobqueue_email.go
@@ -96,6 +96,7 @@ func RegisterBuiltinJobs(r *Registry, pool *pgxpool.Pool, cfgSrc ConfigSource) {
 	RegisterContentToolsPreviewJobs(r, pool)
 	RegisterContentToolsMigrationJobs(r, pool)
 	RegisterContentToolsAnalyticsJobs(r, pool)
+	RegisterCourseChecklistRetentionJobs(r, pool)
 	registerScheduledJobs(r, pool, cfgSrc)
 }
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lextures/lextures/server/internal/redisclient"
 )
@@ -224,6 +225,12 @@ type Config struct {
 
 	// TusUploadTTLHours is how long stalled (incomplete) tus uploads are retained before cleanup (default 48).
 	TusUploadTTLHours int
+
+	// ChecklistSnapshotTTL is how long a course checklist evaluation snapshot stays warm (CC.2).
+	// Env: CHECKLIST_SNAPSHOT_TTL (Go duration, default 15m).
+	ChecklistSnapshotTTL time.Duration
+	// ChecklistEvidenceMaxRows caps evidence rows per finding (CC.2; default 200).
+	ChecklistEvidenceMaxRows int
 
 	// DRMEnabled gates watermarking and DRM features (plan 8.10). Defaults to false; enterprise-only.
 	DRMEnabled bool
@@ -957,6 +964,9 @@ func Load() Config {
 
 		TusUploadTTLHours: tusUploadTTLHours(),
 
+		ChecklistSnapshotTTL:     checklistSnapshotTTL(),
+		ChecklistEvidenceMaxRows: intEnvDefault("CHECKLIST_EVIDENCE_MAX_ROWS", 200),
+
 		DRMHMACSecret: firstNonEmptyTrimmed("DRM_HMAC_SECRET"),
 
 		TranscodeRetainSourceDays: transcodeRetainSourceDays(),
@@ -1449,6 +1459,18 @@ func tusUploadTTLHours() int {
 		return 48
 	}
 	return n
+}
+
+func checklistSnapshotTTL() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("CHECKLIST_SNAPSHOT_TTL"))
+	if raw == "" {
+		return 15 * time.Minute
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return 15 * time.Minute
+	}
+	return d
 }
 
 func storagePresignTTL() int {

--- a/server/internal/httpserver/course_checklist.go
+++ b/server/internal/httpserver/course_checklist.go
@@ -1,0 +1,154 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/courseroles"
+	"github.com/lextures/lextures/server/internal/ratelimit"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	ccrepo "github.com/lextures/lextures/server/internal/repos/coursechecklist"
+	"github.com/lextures/lextures/server/internal/repos/enrollment"
+	"github.com/lextures/lextures/server/internal/repos/orgroles"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/service/coursechecklist"
+)
+
+func (d Deps) registerCourseChecklistRoutes(r chi.Router) {
+	r.Get("/api/v1/courses/{course_code}/checklist", d.handleCourseChecklistGet())
+	r.Get("/api/v1/courses/{course_code}/checklist/summary", d.handleCourseChecklistSummary())
+	r.Post("/api/v1/courses/{course_code}/checklist/refresh", d.handleCourseChecklistRefresh())
+	r.Get("/api/v1/courses/{course_code}/checklist/history", d.handleCourseChecklistHistory())
+	r.Post("/api/v1/courses/{course_code}/checklist/items/{item_id}/dismiss", d.handleCourseChecklistDismiss())
+	r.Post("/api/v1/courses/{course_code}/checklist/items/{item_id}/restore", d.handleCourseChecklistRestore())
+	r.Post("/api/v1/courses/{course_code}/checklist/items/{item_id}/recheck", d.handleCourseChecklistRecheck())
+}
+
+// requireCourseChecklistAccess enforces FR-1 / FR-2 / FR-3 for every checklist route.
+func (d Deps) requireCourseChecklistAccess(w http.ResponseWriter, r *http.Request) (courseCode string, userID uuid.UUID, ok bool) {
+	userID, ok = d.meUserID(w, r)
+	if !ok {
+		return "", uuid.Nil, false
+	}
+	courseCode = strings.TrimSpace(chi.URLParam(r, "course_code"))
+	if courseCode == "" {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing course code.")
+		return "", uuid.Nil, false
+	}
+	ctx := r.Context()
+	if d.Pool == nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Server misconfiguration.")
+		return "", uuid.Nil, false
+	}
+	courseID, err := course.GetIDByCourseCode(ctx, d.Pool, courseCode)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+		return "", uuid.Nil, false
+	}
+	if courseID == nil {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+		return "", uuid.Nil, false
+	}
+	if !auth.AccessKeyAllowsCourse(ctx, *courseID) {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+		return "", uuid.Nil, false
+	}
+
+	ga, err := rbac.UserHasPermission(ctx, d.Pool, userID, permGlobalRBACManage)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+		return "", uuid.Nil, false
+	}
+	if ga {
+		return courseCode, userID, true
+	}
+
+	orgID, err := course.CourseOrgID(ctx, d.Pool, courseCode)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+		return "", uuid.Nil, false
+	}
+	if orgID != nil {
+		isAdmin, err := orgroles.UserHasRole(ctx, d.Pool, userID, *orgID, orgroles.RoleOrgAdmin)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			return "", uuid.Nil, false
+		}
+		if isAdmin {
+			return courseCode, userID, true
+		}
+	}
+
+	canEdit, err := courseroles.UserHasPermission(ctx, d.Pool, userID, "course:"+courseCode+":item:create")
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+		return "", uuid.Nil, false
+	}
+	if canEdit {
+		return courseCode, userID, true
+	}
+
+	hasAccess, err := enrollment.UserHasAccess(ctx, d.Pool, courseCode, userID)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify course access.")
+		return "", uuid.Nil, false
+	}
+	if hasAccess {
+		apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "Forbidden.")
+		return "", uuid.Nil, false
+	}
+	apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+	return "", uuid.Nil, false
+}
+
+func (d Deps) checklistService() *coursechecklist.Service {
+	ttl := d.effectiveConfig().ChecklistSnapshotTTL
+	return coursechecklist.NewService(d.Pool, ttl)
+}
+
+func (d Deps) checklistRateLimited(w http.ResponseWriter, r *http.Request, key string, limit int) bool {
+	if limit <= 0 {
+		return false
+	}
+	limiter := d.buildRateLimiter()
+	rule := config.RateLimitRule{Limit: limit, Window: time.Minute}
+	dec := limiter.Allow(r.Context(), key, rule, ratelimit.LimitTypeToken)
+	if dec.Allowed {
+		return false
+	}
+	ratelimit.RecordExceeded("course_checklist", ratelimit.LimitTypeToken)
+	w.Header().Set("Retry-After", strconv.Itoa(dec.RetryAfter))
+	apierr.WriteJSON(w, http.StatusTooManyRequests, apierr.CodeRateLimited, "Too many checklist requests. Try again later.")
+	return true
+}
+
+func writeChecklistJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeChecklistServiceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, coursechecklist.ErrCourseNotFound):
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+	case errors.Is(err, coursechecklist.ErrItemNotFound):
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Checklist item not found.")
+	case errors.Is(err, ccrepo.ErrInvalidReason):
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid dismiss reason.")
+	case errors.Is(err, ccrepo.ErrNoteTooLong):
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Dismiss note must be 500 characters or fewer.")
+	default:
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to process checklist request.")
+	}
+}

--- a/server/internal/httpserver/course_checklist_db_test.go
+++ b/server/internal/httpserver/course_checklist_db_test.go
@@ -1,0 +1,411 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/courseroles"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/user"
+	"github.com/lextures/lextures/server/internal/service/coursechecklist"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestCourseChecklist_AuthzDismissRestoreSummary_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	signer := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
+	ts := time.Now().Format("20060102150405")
+	instEmail := "cc2-inst-" + ts + "@e.com"
+	stuEmail := "cc2-stu-" + ts + "@e.com"
+	taEmail := "cc2-ta-" + ts + "@e.com"
+	ph, _ := auth.HashPassword("longpassword0")
+	inst, _ := user.InsertUser(ctx, pool, instEmail, ph, strPtr("Instructor"))
+	stu, _ := user.InsertUser(ctx, pool, stuEmail, ph, strPtr("Student"))
+	ta, _ := user.InsertUser(ctx, pool, taEmail, ph, strPtr("TA"))
+	instID, _ := uuid.Parse(inst.ID)
+	stuID, _ := uuid.Parse(stu.ID)
+	taID, _ := uuid.Parse(ta.ID)
+
+	courseCode := "C-" + fmt.Sprintf("%06X", time.Now().UnixNano()%0xFFFFFF)
+	var courseID uuid.UUID
+	err = pool.QueryRow(ctx, `
+INSERT INTO course.courses (title, course_code, org_id, created_by_user_id)
+VALUES ('Checklist API Test', $2, (SELECT id FROM tenant.organizations WHERE slug = 'default' LIMIT 1), $1)
+RETURNING id
+`, instID, courseCode).Scan(&courseID)
+	if err != nil {
+		t.Fatalf("course: %v", err)
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("tx: %v", err)
+	}
+	for _, pair := range []struct {
+		uid  uuid.UUID
+		role string
+	}{
+		{instID, "teacher"},
+		{stuID, "student"},
+		{taID, "ta"},
+	} {
+		_, err = tx.Exec(ctx, `
+INSERT INTO course.course_enrollments (course_id, user_id, role) VALUES ($1, $2, $3)
+ON CONFLICT DO NOTHING
+`, courseID, pair.uid, pair.role)
+		if err != nil {
+			t.Fatalf("enroll %s: %v", pair.role, err)
+		}
+		if err := courseroles.RefreshManagedGrantsForCourseUser(ctx, tx, pair.uid, courseID, courseCode); err != nil {
+			t.Fatalf("grants: %v", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	instTok, _ := signer.Sign(ctx, inst.ID, instEmail, "", "", nil)
+	stuTok, _ := signer.Sign(ctx, stu.ID, stuEmail, "", "", nil)
+	taTok, _ := signer.Sign(ctx, ta.ID, taEmail, "", "", nil)
+
+	d := Deps{Pool: pool, JWTSigner: signer, Config: config.Config{ChecklistSnapshotTTL: 15 * time.Minute}}
+	h := NewHandler(d)
+
+	// Student → 403, no item titles leaked.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+stuTok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("student GET: %d %s", w.Code, w.Body.String())
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte("Set course")) {
+		t.Fatalf("student body leaked titles: %s", w.Body.String())
+	}
+
+	// TA → 403
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+taTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("ta GET: %d %s", w.Code, w.Body.String())
+	}
+
+	// Unknown course / unenrolled shape: same 404 body.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/C-DOESNOTEXIST/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing course: %d", w.Code)
+	}
+	missingBody := w.Body.String()
+
+	// Teacher GET (cold) then warm hit.
+	beforeHit := testutil.ToFloat64(coursechecklist.SnapshotHitsCounter().WithLabelValues("hit"))
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("teacher GET cold: %d %s", w.Code, w.Body.String())
+	}
+	var checklist coursechecklist.ChecklistResponse
+	if err := json.NewDecoder(w.Body).Decode(&checklist); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if checklist.Summary.OutstandingEssential < 1 {
+		t.Fatalf("expected outstanding essentials, got %+v", checklist.Summary)
+	}
+	outstandingBefore := checklist.Summary.OutstandingEssential
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("teacher GET warm: %d %s", w.Code, w.Body.String())
+	}
+	afterHit := testutil.ToFloat64(coursechecklist.SnapshotHitsCounter().WithLabelValues("hit"))
+	if afterHit < beforeHit+1 {
+		t.Fatalf("expected snapshot hit increment, before=%v after=%v", beforeHit, afterHit)
+	}
+
+	// Dismiss course.dates (essential todo in the CC.1 reference catalog).
+	body := []byte(`{"reason":"not_applicable","note":"pass/fail seminar"}`)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/courses/"+courseCode+"/checklist/items/course.dates/dismiss", bytes.NewReader(body))
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("dismiss: %d %s", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if err := json.NewDecoder(w.Body).Decode(&checklist); err != nil {
+		t.Fatalf("decode after dismiss: %v", err)
+	}
+	if len(checklist.Dismissed) != 1 || checklist.Dismissed[0].ID != "course.dates" {
+		t.Fatalf("dismissed pile: %+v", checklist.Dismissed)
+	}
+	for _, cat := range checklist.Categories {
+		for _, it := range cat.Items {
+			if it.ID == "course.dates" {
+				t.Fatal("dismissed item still inline")
+			}
+		}
+	}
+	if checklist.Summary.Dismissed != 1 || checklist.Summary.OutstandingEssential != outstandingBefore-1 {
+		t.Fatalf("summary after dismiss: %+v (before essential %d)", checklist.Summary, outstandingBefore)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist/summary", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("summary: %d %s", w.Code, w.Body.String())
+	}
+	var summary coursechecklist.ChecklistSummary
+	if err := json.NewDecoder(w.Body).Decode(&summary); err != nil {
+		t.Fatalf("summary decode: %v", err)
+	}
+	if summary.Dismissed != 1 {
+		t.Fatalf("summary dismissed=%d", summary.Dismissed)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist/history", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("history: %d %s", w.Code, w.Body.String())
+	}
+	var hist coursechecklist.HistoryResponse
+	if err := json.NewDecoder(w.Body).Decode(&hist); err != nil {
+		t.Fatalf("history decode: %v", err)
+	}
+	if len(hist.Events) < 1 || hist.Events[0].Action != "dismiss" {
+		t.Fatalf("history events: %+v", hist.Events)
+	}
+
+	// Restore
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/courses/"+courseCode+"/checklist/items/course.dates/restore", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("restore: %d %s", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if err := json.NewDecoder(w.Body).Decode(&checklist); err != nil {
+		t.Fatalf("decode after restore: %v", err)
+	}
+	if checklist.Summary.Dismissed != 0 {
+		t.Fatalf("expected 0 dismissed, got %+v", checklist.Summary)
+	}
+	found := false
+	for _, cat := range checklist.Categories {
+		for _, it := range cat.Items {
+			if it.ID == "course.dates" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("restored item missing from categories")
+	}
+
+	// Unknown item_id → 404 not_found, no row
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/courses/"+courseCode+"/checklist/items/not.a.real.item/dismiss", bytes.NewReader([]byte(`{}`)))
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+instTok)
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unknown item: %d %s", w.Code, w.Body.String())
+	}
+	var errBody struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &errBody)
+	if errBody.Error.Code != "NOT_FOUND" {
+		t.Fatalf("code=%q body=%s", errBody.Error.Code, w.Body.String())
+	}
+	var n int
+	_ = pool.QueryRow(ctx, `SELECT COUNT(*) FROM course.course_checklist_item_state WHERE course_id = $1 AND item_id = 'not.a.real.item'`, courseID).Scan(&n)
+	if n != 0 {
+		t.Fatalf("unexpected state row for unknown item")
+	}
+
+	// Path injection / SQL metacharacters as item_id → 404 (validated via ResolveItemID).
+	for _, bad := range []string{"../../etc/passwd", "course.sections';DROP TABLE"} {
+		path := "/api/v1/courses/" + courseCode + "/checklist/items/" + url.PathEscape(bad) + "/dismiss"
+		req = httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{}`)))
+		req = req.WithContext(ctx)
+		req.Header.Set("Authorization", "Bearer "+instTok)
+		w = httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound && w.Code != http.StatusBadRequest {
+			t.Fatalf("bad item %q: %d %s", bad, w.Code, w.Body.String())
+		}
+	}
+
+	// Unrelated user same 404 body as missing course.
+	strangerEmail := "cc2-str-" + ts + "@e.com"
+	stranger, _ := user.InsertUser(ctx, pool, strangerEmail, ph, strPtr("Stranger"))
+	strTok, _ := signer.Sign(ctx, stranger.ID, strangerEmail, "", "", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+strTok)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("stranger: %d", w.Code)
+	}
+	if w.Body.String() != missingBody {
+		t.Fatalf("404 bodies differ:\nmissing=%s\nstranger=%s", missingBody, w.Body.String())
+	}
+}
+
+func TestCourseChecklist_SingleFlight_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	signer := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
+	ts := time.Now().Format("20060102150405.000")
+	email := "cc2-sf-" + ts + "@e.com"
+	ph, _ := auth.HashPassword("longpassword0")
+	u, _ := user.InsertUser(ctx, pool, email, ph, strPtr("Teacher"))
+	uid, _ := uuid.Parse(u.ID)
+	courseCode := "C-" + fmt.Sprintf("%06X", time.Now().UnixNano()%0xFFFFFF)
+	var courseID uuid.UUID
+	err = pool.QueryRow(ctx, `
+INSERT INTO course.courses (title, course_code, org_id, created_by_user_id)
+VALUES ('Checklist SF', $2, (SELECT id FROM tenant.organizations WHERE slug = 'default' LIMIT 1), $1)
+RETURNING id
+`, uid, courseCode).Scan(&courseID)
+	if err != nil {
+		t.Fatalf("course: %v", err)
+	}
+	tx, _ := pool.Begin(ctx)
+	_, _ = tx.Exec(ctx, `INSERT INTO course.course_enrollments (course_id, user_id, role) VALUES ($1, $2, 'teacher')`, courseID, uid)
+	_ = courseroles.RefreshManagedGrantsForCourseUser(ctx, tx, uid, courseID, courseCode)
+	_ = tx.Commit(ctx)
+	tok, _ := signer.Sign(ctx, u.ID, email, "", "", nil)
+
+	// Ensure cold by deleting any snapshot.
+	_, _ = pool.Exec(ctx, `DELETE FROM course.course_checklist_snapshots WHERE course_id = $1`, courseID)
+
+	h := NewHandler(Deps{Pool: pool, JWTSigner: signer, Config: config.Config{ChecklistSnapshotTTL: 15 * time.Minute}})
+	const n = 20
+	var wg sync.WaitGroup
+	computed := make([]string, n)
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode+"/checklist", nil)
+			req = req.WithContext(ctx)
+			req.Header.Set("Authorization", "Bearer "+tok)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				errs[i] = fmt.Errorf("status %d %s", w.Code, w.Body.String())
+				return
+			}
+			var resp coursechecklist.ChecklistResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				errs[i] = err
+				return
+			}
+			computed[i] = resp.ComputedAt.UTC().Format(time.RFC3339Nano)
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+	for i := 1; i < n; i++ {
+		if computed[i] != computed[0] {
+			t.Fatalf("computedAt mismatch: %s vs %s", computed[0], computed[i])
+		}
+	}
+}
+
+func TestCourseChecklist_Unauthenticated401_NoDB(t *testing.T) {
+	h := NewHandler(Deps{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/C-X/checklist", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d", w.Code)
+	}
+}

--- a/server/internal/httpserver/course_checklist_db_test.go
+++ b/server/internal/httpserver/course_checklist_db_test.go
@@ -384,7 +384,8 @@ RETURNING id
 				errs[i] = err
 				return
 			}
-			computed[i] = resp.ComputedAt.UTC().Format(time.RFC3339Nano)
+			// Truncate to milliseconds: JSON round-trip may drop sub-ms digits.
+			computed[i] = resp.ComputedAt.UTC().Truncate(time.Millisecond).Format(time.RFC3339Nano)
 		}()
 	}
 	wg.Wait()

--- a/server/internal/httpserver/course_checklist_state.go
+++ b/server/internal/httpserver/course_checklist_state.go
@@ -1,0 +1,204 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/service/coursechecklist"
+)
+
+func (d Deps) handleCourseChecklistGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseChecklistAccess(w, r)
+		if !ok {
+			coursechecklist.ObserveAPIRequest("get", "4xx")
+			return
+		}
+		includeNA := r.URL.Query().Get("includeNotApplicable") == "1"
+		resp, err := d.checklistService().GetChecklist(r.Context(), courseCode, includeNA)
+		if err != nil {
+			writeChecklistServiceError(w, err)
+			coursechecklist.ObserveAPIRequest("get", "4xx")
+			return
+		}
+		writeChecklistJSON(w, http.StatusOK, resp)
+		coursechecklist.ObserveAPIRequest("get", "2xx")
+	}
+}
+
+func (d Deps) handleCourseChecklistSummary() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseChecklistAccess(w, r)
+		if !ok {
+			coursechecklist.ObserveAPIRequest("summary", "4xx")
+			return
+		}
+		summary, err := d.checklistService().GetSummary(r.Context(), courseCode)
+		if err != nil {
+			writeChecklistServiceError(w, err)
+			coursechecklist.ObserveAPIRequest("summary", "4xx")
+			return
+		}
+		writeChecklistJSON(w, http.StatusOK, summary)
+		coursechecklist.ObserveAPIRequest("summary", "2xx")
+	}
+}
+
+func (d Deps) handleCourseChecklistRefresh() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseChecklistAccess(w, r)
+		if !ok {
+			coursechecklist.ObserveAPIRequest("refresh", "4xx")
+			return
+		}
+		limiter := d.buildRateLimiter()
+		key := limiter.UserKey(courseCode, "checklist_refresh")
+		if d.checklistRateLimited(w, r, key, 6) {
+			coursechecklist.ObserveAPIRequest("refresh", "4xx")
+			return
+		}
+		resp, err := d.checklistService().Refresh(r.Context(), courseCode)
+		if err != nil {
+			writeChecklistServiceError(w, err)
+			coursechecklist.ObserveAPIRequest("refresh", "4xx")
+			return
+		}
+		writeChecklistJSON(w, http.StatusOK, resp)
+		coursechecklist.ObserveAPIRequest("refresh", "2xx")
+	}
+}
+
+func (d Deps) handleCourseChecklistHistory() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseChecklistAccess(w, r)
+		if !ok {
+			coursechecklist.ObserveAPIRequest("history", "4xx")
+			return
+		}
+		resp, err := d.checklistService().History(r.Context(), courseCode)
+		if err != nil {
+			writeChecklistServiceError(w, err)
+			coursechecklist.ObserveAPIRequest("history", "4xx")
+			return
+		}
+		writeChecklistJSON(w, http.StatusOK, resp)
+		coursechecklist.ObserveAPIRequest("history", "2xx")
+	}
+}
+
+func (d Deps) handleCourseChecklistDismiss() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, userID, ok := d.requireCourseChecklistAccess(w, r)
+		if !ok {
+			coursechecklist.ObserveAPIRequest("dismiss", "4xx")
+			return
+		}
+		limiter := d.buildRateLimiter()
+		key := limiter.UserKey(userID.String(), "checklist_dismiss")
+		if d.checklistRateLimited(w, r, key, 60) {
+			coursechecklist.ObserveAPIRequest("dismiss", "4xx")
+			return
+		}
+		itemID := strings.TrimSpace(chi.URLParam(r, "item_id"))
+		var req coursechecklist.DismissRequest
+		body, _ := io.ReadAll(io.LimitReader(r.Body, 8<<10))
+		if len(strings.TrimSpace(string(body))) > 0 {
+			if err := json.Unmarshal(body, &req); err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+				coursechecklist.ObserveAPIRequest("dismiss", "4xx")
+				return
+			}
+		}
+		item, err := d.checklistService().Dismiss(r.Context(), courseCode, itemID, userID, req)
+		if err != nil {
+			writeChecklistServiceError(w, err)
+			coursechecklist.ObserveAPIRequest("dismiss", "4xx")
+			return
+		}
+		writeChecklistJSON(w, http.StatusOK, item)
+		coursechecklist.ObserveAPIRequest("dismiss", "2xx")
+	}
+}
+
+func (d Deps) handleCourseChecklistRestore() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, userID, ok := d.requireCourseChecklistAccess(w, r)
+		if !ok {
+			coursechecklist.ObserveAPIRequest("restore", "4xx")
+			return
+		}
+		limiter := d.buildRateLimiter()
+		key := limiter.UserKey(userID.String(), "checklist_restore")
+		if d.checklistRateLimited(w, r, key, 60) {
+			coursechecklist.ObserveAPIRequest("restore", "4xx")
+			return
+		}
+		itemID := strings.TrimSpace(chi.URLParam(r, "item_id"))
+		item, err := d.checklistService().Restore(r.Context(), courseCode, itemID, userID)
+		if err != nil {
+			writeChecklistServiceError(w, err)
+			coursechecklist.ObserveAPIRequest("restore", "4xx")
+			return
+		}
+		writeChecklistJSON(w, http.StatusOK, item)
+		coursechecklist.ObserveAPIRequest("restore", "2xx")
+	}
+}
+
+func (d Deps) handleCourseChecklistRecheck() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseChecklistAccess(w, r)
+		if !ok {
+			coursechecklist.ObserveAPIRequest("recheck", "4xx")
+			return
+		}
+		limiter := d.buildRateLimiter()
+		key := limiter.UserKey(courseCode, "checklist_recheck")
+		if d.checklistRateLimited(w, r, key, 30) {
+			coursechecklist.ObserveAPIRequest("recheck", "4xx")
+			return
+		}
+		itemID := strings.TrimSpace(chi.URLParam(r, "item_id"))
+		item, err := d.checklistService().Recheck(r.Context(), courseCode, itemID)
+		if err != nil {
+			writeChecklistServiceError(w, err)
+			coursechecklist.ObserveAPIRequest("recheck", "4xx")
+			return
+		}
+		writeChecklistJSON(w, http.StatusOK, item)
+		coursechecklist.ObserveAPIRequest("recheck", "2xx")
+	}
+}

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -55,6 +55,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	d.registerConditionalReleaseRoutes(r)
 	d.registerAdaptivePathRoutes(r)
 	d.registerPeerReviewRoutes(r)
+	d.registerCourseChecklistRoutes(r)
 	r.Post("/api/v1/courses/{course_code}/vibe-activities/generate", d.handleGenerateVibeActivityHTML())
 	r.Get("/api/v1/courses/{course_code}/vibe-activities/{item_id}", d.handleGetModuleVibeActivity())
 	r.Patch("/api/v1/courses/{course_code}/vibe-activities/{item_id}", d.handlePatchModuleVibeActivity())

--- a/server/internal/httpserver/testdata/route_inventory.golden
+++ b/server/internal/httpserver/testdata/route_inventory.golden
@@ -670,6 +670,13 @@ PATCH	/api/v1/courses/{course_code}/caption-policy	session
 GET	/api/v1/courses/{course_code}/catalog-info	anonymous
 GET	/api/v1/courses/{course_code}/catalog-listing	anonymous
 PUT	/api/v1/courses/{course_code}/catalog-listing	anonymous
+GET	/api/v1/courses/{course_code}/checklist	session
+GET	/api/v1/courses/{course_code}/checklist/history	session
+POST	/api/v1/courses/{course_code}/checklist/items/{item_id}/dismiss	session
+POST	/api/v1/courses/{course_code}/checklist/items/{item_id}/recheck	session
+POST	/api/v1/courses/{course_code}/checklist/items/{item_id}/restore	session
+POST	/api/v1/courses/{course_code}/checklist/refresh	session
+GET	/api/v1/courses/{course_code}/checklist/summary	session
 GET	/api/v1/courses/{course_code}/collab-docs	session
 POST	/api/v1/courses/{course_code}/collab-docs	session
 DELETE	/api/v1/courses/{course_code}/collab-docs/{doc_id}	session

--- a/server/internal/openapi/openapi.json
+++ b/server/internal/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "StudyDrift API",
-    "description": "Lextures LMS HTTP API. Generate TypeScript types: npx openapi-typescript http://localhost:8080/api/openapi.json -o src/lib/api-types.generated.ts (with the API running). AP.9 (0.2.0): Multi-provider AI GA. Deprecated: openRouterApiKey / clearOpenRouterApiKey on /api/v1/settings/ai and openRouterConfigured on /api/v1/platform/features \u2014 use /api/v1/settings/ai/providers and aiConfigured. Dual-read of platform_app_settings.openrouter_api_key continues for \u22651 minor release; see docs/api-changelog-ai-providers.md. TD.3 (0.2.1): Restored valid OpenAPI document (reattached components, fixed paths brace structure).",
+    "description": "Lextures LMS HTTP API. Generate TypeScript types: npx openapi-typescript http://localhost:8080/api/openapi.json -o src/lib/api-types.generated.ts (with the API running). AP.9 (0.2.0): Multi-provider AI GA. Deprecated: openRouterApiKey / clearOpenRouterApiKey on /api/v1/settings/ai and openRouterConfigured on /api/v1/platform/features — use /api/v1/settings/ai/providers and aiConfigured. Dual-read of platform_app_settings.openrouter_api_key continues for ≥1 minor release; see docs/api-changelog-ai-providers.md. TD.3 (0.2.1): Restored valid OpenAPI document (reattached components, fixed paths brace structure). CC.2: course checklist state API and dismissals.",
     "version": "0.2.1"
   },
   "tags": [
@@ -48,7 +48,7 @@
     },
     {
       "name": "transcripts",
-      "description": "Academic transcript preview, issuance, orders, lifecycle, fees, and electronic delivery (T01\u2013T06)"
+      "description": "Academic transcript preview, issuance, orders, lifecycle, fees, and electronic delivery (T01–T06)"
     },
     {
       "name": "content-tools",
@@ -2551,7 +2551,7 @@
         "tags": [
           "auth"
         ],
-        "summary": "Native Sign in with Apple (AuthenticationServices identity token \u2192 Lextures tokens)",
+        "summary": "Native Sign in with Apple (AuthenticationServices identity token → Lextures tokens)",
         "requestBody": {
           "required": true,
           "content": {
@@ -2604,7 +2604,7 @@
         "tags": [
           "auth"
         ],
-        "summary": "Native Google Sign-In (Credential Manager ID token \u2192 Lextures tokens)",
+        "summary": "Native Google Sign-In (Credential Manager ID token → Lextures tokens)",
         "requestBody": {
           "required": true,
           "content": {
@@ -3356,7 +3356,7 @@
         ],
         "responses": {
           "200": {
-            "description": "{ courses: PublicMarketplaceCourse[], total, nextCursor } \u2014 no owned field"
+            "description": "{ courses: PublicMarketplaceCourse[], total, nextCursor } — no owned field"
           },
           "400": {
             "description": "Invalid filter"
@@ -3536,7 +3536,7 @@
             "description": "Sign in required"
           },
           "402": {
-            "description": "Paid course \u2014 use checkout; body includes checkoutHint"
+            "description": "Paid course — use checkout; body includes checkoutHint"
           },
           "404": {
             "description": "Not listed or feature disabled"
@@ -3573,7 +3573,7 @@
             "description": "{ checkoutUrl, sessionId } or { alreadyOwned, courseCode, courseId }"
           },
           "400": {
-            "description": "Free course \u2014 use claim instead"
+            "description": "Free course — use claim instead"
           },
           "401": {
             "description": "Sign in required"
@@ -4298,7 +4298,7 @@
         "tags": [
           "accommodations"
         ],
-        "summary": "List a learner\u2019s accommodation records (coordinator perm)",
+        "summary": "List a learner’s accommodation records (coordinator perm)",
         "security": [
           {
             "bearerAuth": []
@@ -4465,7 +4465,7 @@
           "accommodations",
           "me"
         ],
-        "summary": "List this learner\u2019s active (by date range) accommodation summary entries",
+        "summary": "List this learner’s active (by date range) accommodation summary entries",
         "security": [
           {
             "bearerAuth": []
@@ -4486,7 +4486,7 @@
         "tags": [
           "admin"
         ],
-        "summary": "Start IRT 2PL calibration job (202 + jobId); fits a/b for active uncalibrated or pilot items with \u2265200 responses; optional conceptId scopes to one concept",
+        "summary": "Start IRT 2PL calibration job (202 + jobId); fits a/b for active uncalibrated or pilot items with ≥200 responses; optional conceptId scopes to one concept",
         "security": [
           {
             "bearerAuth": []
@@ -7744,7 +7744,7 @@
         "tags": [
           "courses"
         ],
-        "summary": "Force-rename a player (plan IQ.9); empty body \u2192 Player N",
+        "summary": "Force-rename a player (plan IQ.9); empty body → Player N",
         "security": [
           {
             "bearerAuth": []
@@ -8947,7 +8947,7 @@
           "courses"
         ],
         "summary": "Board realtime WebSocket (plan VC.4)",
-        "description": "Upgrades to a Y.js sync WebSocket. First text frame must be JSON {\"authToken\":\"\u2026\"}. Binary framing matches collab-docs: byte 0 = sync (persist+relay), byte 1 = awareness (relay only). Requires ffBoardsRealtime, per-course visualBoardsEnabled, enrollment, and a non-archived board. Oversized or flooding clients are disconnected.",
+        "description": "Upgrades to a Y.js sync WebSocket. First text frame must be JSON {\"authToken\":\"…\"}. Binary framing matches collab-docs: byte 0 = sync (persist+relay), byte 1 = awareness (relay only). Requires ffBoardsRealtime, per-course visualBoardsEnabled, enrollment, and a non-archived board. Oversized or flooding clients are disconnected.",
         "parameters": [
           {
             "name": "course_code",
@@ -14703,6 +14703,373 @@
           }
         }
       }
+    },
+    "/api/v1/courses/{course_code}/checklist": {
+      "get": {
+        "tags": [
+          "courses"
+        ],
+        "summary": "Course checklist (staff)",
+        "description": "CC.2: Full checklist with categories, evidence, and dismissed pile.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeNotApplicable",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "0",
+                "1"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Checklist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChecklistResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v1/courses/{course_code}/checklist/summary": {
+      "get": {
+        "tags": [
+          "courses"
+        ],
+        "summary": "Course checklist badge summary",
+        "description": "CC.2: Snapshot-served badge counts without a full evaluation when warm.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChecklistSummary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v1/courses/{course_code}/checklist/refresh": {
+      "post": {
+        "tags": [
+          "courses"
+        ],
+        "summary": "Force checklist recomputation",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fresh checklist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChecklistResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v1/courses/{course_code}/checklist/history": {
+      "get": {
+        "tags": [
+          "courses"
+        ],
+        "summary": "Checklist audit history",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChecklistHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v1/courses/{course_code}/checklist/items/{item_id}/dismiss": {
+      "post": {
+        "tags": [
+          "courses"
+        ],
+        "summary": "Dismiss a checklist item",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChecklistDismissBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChecklistItem"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v1/courses/{course_code}/checklist/items/{item_id}/restore": {
+      "post": {
+        "tags": [
+          "courses"
+        ],
+        "summary": "Restore a dismissed checklist item",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChecklistItem"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v1/courses/{course_code}/checklist/items/{item_id}/recheck": {
+      "post": {
+        "tags": [
+          "courses"
+        ],
+        "summary": "Re-evaluate one checklist item",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChecklistItem"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -15065,7 +15432,7 @@
           },
           "sourceRef": {
             "type": "object",
-            "description": "topic/passage text or contentId \u2014 never student data",
+            "description": "topic/passage text or contentId — never student data",
             "properties": {
               "topic": {
                 "type": "string"
@@ -17737,6 +18104,234 @@
                   "type": "integer"
                 }
               }
+            }
+          }
+        }
+      },
+      "ChecklistSummary": {
+        "type": "object",
+        "required": [
+          "outstandingEssential",
+          "outstandingTotal",
+          "done",
+          "total",
+          "dismissed",
+          "computedAt",
+          "stale"
+        ],
+        "properties": {
+          "outstandingEssential": {
+            "type": "integer"
+          },
+          "outstandingTotal": {
+            "type": "integer"
+          },
+          "done": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "dismissed": {
+            "type": "integer"
+          },
+          "computedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "stale": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ChecklistItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "titleKey",
+          "title",
+          "whyKey",
+          "why",
+          "tier",
+          "status",
+          "sources"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "titleKey": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "whyKey": {
+            "type": "string"
+          },
+          "why": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "essential",
+              "recommended"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "done",
+              "todo",
+              "in_progress",
+              "unknown",
+              "not_applicable"
+            ]
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "progress": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "done": {
+                "type": "integer"
+              },
+              "total": {
+                "type": "integer"
+              }
+            }
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "helpRef": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "evidence": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "dismissal": {
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        }
+      },
+      "ChecklistResponse": {
+        "type": "object",
+        "required": [
+          "courseCode",
+          "engineVersion",
+          "catalogVersion",
+          "computedAt",
+          "stale",
+          "evidenceTruncated",
+          "summary",
+          "categories",
+          "dismissed"
+        ],
+        "properties": {
+          "courseCode": {
+            "type": "string"
+          },
+          "engineVersion": {
+            "type": "integer"
+          },
+          "catalogVersion": {
+            "type": "string"
+          },
+          "computedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "stale": {
+            "type": "boolean"
+          },
+          "evidenceTruncated": {
+            "type": "boolean"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/ChecklistSummary"
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "dismissed": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChecklistItem"
+            }
+          }
+        }
+      },
+      "ChecklistDismissBody": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "enum": [
+              "not_applicable",
+              "done_elsewhere",
+              "disagree",
+              "later",
+              "other"
+            ]
+          },
+          "note": {
+            "type": "string",
+            "maxLength": 500
+          }
+        }
+      },
+      "ChecklistHistoryResponse": {
+        "type": "object",
+        "required": [
+          "courseCode",
+          "engineVersion",
+          "catalogVersion",
+          "events"
+        ],
+        "properties": {
+          "courseCode": {
+            "type": "string"
+          },
+          "engineVersion": {
+            "type": "integer"
+          },
+          "catalogVersion": {
+            "type": "string"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object"
             }
           }
         }

--- a/server/internal/repos/course/factory_reset.go
+++ b/server/internal/repos/course/factory_reset.go
@@ -97,6 +97,16 @@ func FactoryResetCourse(ctx context.Context, pool *pgxpool.Pool, courseCode stri
 	if err = execResetStep(ctx, tx, courseCode, "delete course_standards", `DELETE FROM course.course_standards WHERE course_id = $1`, *courseID); err != nil {
 		return nil, err
 	}
+	// CC.2: checklist dismissals/snapshots/events must not survive factory reset (FR-21 / AC-10).
+	if err = execResetStep(ctx, tx, courseCode, "delete course_checklist_events", `DELETE FROM course.course_checklist_events WHERE course_id = $1`, *courseID); err != nil {
+		return nil, err
+	}
+	if err = execResetStep(ctx, tx, courseCode, "delete course_checklist_item_state", `DELETE FROM course.course_checklist_item_state WHERE course_id = $1`, *courseID); err != nil {
+		return nil, err
+	}
+	if err = execResetStep(ctx, tx, courseCode, "delete course_checklist_snapshots", `DELETE FROM course.course_checklist_snapshots WHERE course_id = $1`, *courseID); err != nil {
+		return nil, err
+	}
 
 	if err = execResetStep(ctx, tx, courseCode, "insert default assignment_group", `
 		INSERT INTO course.assignment_groups (course_id, sort_order, name, weight_percent)

--- a/server/internal/repos/coursechecklist/dsar.go
+++ b/server/internal/repos/coursechecklist/dsar.go
@@ -1,0 +1,34 @@
+package coursechecklist
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ListDismissNotesForUser returns dismiss notes authored by the user (DSAR export).
+func ListDismissNotesForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) ([]DismissNoteExport, error) {
+	rows, err := pool.Query(ctx, `
+SELECT s.course_id, c.course_code, s.item_id, s.dismiss_reason, s.dismiss_note, s.dismissed_at
+FROM course.course_checklist_item_state s
+JOIN course.courses c ON c.id = s.course_id
+WHERE s.dismissed_by_user_id = $1
+  AND s.dismissed_at IS NOT NULL
+  AND s.dismiss_note <> ''
+ORDER BY s.dismissed_at DESC
+`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []DismissNoteExport
+	for rows.Next() {
+		var r DismissNoteExport
+		if err := rows.Scan(&r.CourseID, &r.CourseCode, &r.ItemID, &r.Reason, &r.Note, &r.DismissedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/server/internal/repos/coursechecklist/errors.go
+++ b/server/internal/repos/coursechecklist/errors.go
@@ -1,0 +1,12 @@
+package coursechecklist
+
+import "errors"
+
+var (
+	// ErrInvalidReason is returned when dismiss_reason is not in the allow-list.
+	ErrInvalidReason = errors.New("coursechecklist: invalid dismiss reason")
+	// ErrNoteTooLong is returned when dismiss_note exceeds MaxDismissNoteLen.
+	ErrNoteTooLong = errors.New("coursechecklist: dismiss note too long")
+	// ErrPayloadTooLarge is returned when a snapshot payload exceeds 256 KiB even after truncation.
+	ErrPayloadTooLarge = errors.New("coursechecklist: snapshot payload too large")
+)

--- a/server/internal/repos/coursechecklist/events.go
+++ b/server/internal/repos/coursechecklist/events.go
@@ -1,0 +1,56 @@
+package coursechecklist
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func insertEventTx(ctx context.Context, tx pgx.Tx, courseID uuid.UUID, itemID, action string, actor *uuid.UUID, reason string, at time.Time) error {
+	_, err := tx.Exec(ctx, `
+INSERT INTO course.course_checklist_events (course_id, item_id, action, actor_user_id, reason, occurred_at)
+VALUES ($1, $2, $3, $4, $5, $6)
+`, courseID, itemID, action, actor, reason, at)
+	return err
+}
+
+// ListEvents returns the most recent checklist events for a course (newest first).
+func ListEvents(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, limit int) ([]Event, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 100
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, course_id, item_id, action, actor_user_id, reason, occurred_at
+FROM course.course_checklist_events
+WHERE course_id = $1
+ORDER BY occurred_at DESC
+LIMIT $2
+`, courseID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Event
+	for rows.Next() {
+		var e Event
+		if err := rows.Scan(&e.ID, &e.CourseID, &e.ItemID, &e.Action, &e.ActorUserID, &e.Reason, &e.OccurredAt); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// DeleteEventsOlderThan removes audit rows older than cutoff (retention sweeper).
+func DeleteEventsOlderThan(ctx context.Context, pool *pgxpool.Pool, cutoff time.Time) (int64, error) {
+	tag, err := pool.Exec(ctx, `
+DELETE FROM course.course_checklist_events WHERE occurred_at < $1
+`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}

--- a/server/internal/repos/coursechecklist/snapshots.go
+++ b/server/internal/repos/coursechecklist/snapshots.go
@@ -1,0 +1,137 @@
+package coursechecklist
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// MaxPayloadBytes is the snapshot payload size ceiling (256 KiB).
+const MaxPayloadBytes = 262144
+
+// GetSnapshot returns the cached snapshot for a course, or nil if missing.
+func GetSnapshot(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (*Snapshot, error) {
+	row := pool.QueryRow(ctx, `
+SELECT course_id, computed_at, engine_version, catalog_version, payload,
+       total_count, done_count, outstanding_essential, outstanding_total, dismissed_count
+FROM course.course_checklist_snapshots
+WHERE course_id = $1
+`, courseID)
+	var s Snapshot
+	err := row.Scan(
+		&s.CourseID, &s.ComputedAt, &s.EngineVersion, &s.CatalogVersion, &s.Payload,
+		&s.TotalCount, &s.DoneCount, &s.OutstandingEssential, &s.OutstandingTotal, &s.DismissedCount,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// UpsertSnapshotInput is the write payload for a snapshot row.
+type UpsertSnapshotInput struct {
+	CourseID             uuid.UUID
+	ComputedAt           time.Time
+	EngineVersion        int
+	CatalogVersion       string
+	Payload              json.RawMessage
+	TotalCount           int
+	DoneCount            int
+	OutstandingEssential int
+	OutstandingTotal     int
+	DismissedCount       int
+}
+
+// UpsertSnapshot writes/replaces the snapshot. Returns ErrPayloadTooLarge when
+// the payload exceeds MaxPayloadBytes.
+func UpsertSnapshot(ctx context.Context, pool *pgxpool.Pool, in UpsertSnapshotInput) error {
+	if len(in.Payload) > MaxPayloadBytes {
+		return ErrPayloadTooLarge
+	}
+	if in.ComputedAt.IsZero() {
+		in.ComputedAt = time.Now().UTC()
+	}
+	_, err := pool.Exec(ctx, `
+INSERT INTO course.course_checklist_snapshots (
+    course_id, computed_at, engine_version, catalog_version, payload,
+    total_count, done_count, outstanding_essential, outstanding_total, dismissed_count
+) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10)
+ON CONFLICT (course_id) DO UPDATE SET
+    computed_at = EXCLUDED.computed_at,
+    engine_version = EXCLUDED.engine_version,
+    catalog_version = EXCLUDED.catalog_version,
+    payload = EXCLUDED.payload,
+    total_count = EXCLUDED.total_count,
+    done_count = EXCLUDED.done_count,
+    outstanding_essential = EXCLUDED.outstanding_essential,
+    outstanding_total = EXCLUDED.outstanding_total,
+    dismissed_count = EXCLUDED.dismissed_count
+`, in.CourseID, in.ComputedAt, in.EngineVersion, in.CatalogVersion, []byte(in.Payload),
+		in.TotalCount, in.DoneCount, in.OutstandingEssential, in.OutstandingTotal, in.DismissedCount)
+	return err
+}
+
+// UpdateSnapshotCounters patches denormalised counters without changing the payload.
+func UpdateSnapshotCounters(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, outstandingEssential, outstandingTotal, done, total, dismissed int) error {
+	_, err := pool.Exec(ctx, `
+UPDATE course.course_checklist_snapshots
+SET outstanding_essential = $2,
+    outstanding_total = $3,
+    done_count = $4,
+    total_count = $5,
+    dismissed_count = $6
+WHERE course_id = $1
+`, courseID, outstandingEssential, outstandingTotal, done, total, dismissed)
+	return err
+}
+
+// PatchSnapshotPayload replaces payload + counters (used by recheck).
+func PatchSnapshotPayload(ctx context.Context, pool *pgxpool.Pool, in UpsertSnapshotInput) error {
+	return UpsertSnapshot(ctx, pool, in)
+}
+
+// MutationFreshnessForCourse returns course.updated_at and max structure updated_at.
+func MutationFreshnessForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (MutationFreshness, error) {
+	var m MutationFreshness
+	err := pool.QueryRow(ctx, `
+SELECT c.updated_at,
+       (SELECT MAX(si.updated_at) FROM course.course_structure_items si WHERE si.course_id = c.id)
+FROM course.courses c
+WHERE c.id = $1
+`, courseID).Scan(&m.CourseUpdatedAt, &m.StructureMaxAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return MutationFreshness{}, pgx.ErrNoRows
+	}
+	return m, err
+}
+
+// DeleteSnapshotsUntouchedSince deletes snapshots for courses with no enrollment
+// activity and no course updates since cutoff (nightly sweeper).
+func DeleteSnapshotsUntouchedSince(ctx context.Context, pool *pgxpool.Pool, cutoff time.Time) (int64, error) {
+	tag, err := pool.Exec(ctx, `
+DELETE FROM course.course_checklist_snapshots s
+WHERE s.computed_at < $1
+  AND EXISTS (
+    SELECT 1 FROM course.courses c
+    WHERE c.id = s.course_id AND c.updated_at < $1
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM course.course_enrollments ce
+    WHERE ce.course_id = s.course_id
+      AND ce.active
+      AND ce.created_at >= $1
+  )
+`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}

--- a/server/internal/repos/coursechecklist/snapshots.go
+++ b/server/internal/repos/coursechecklist/snapshots.go
@@ -93,11 +93,6 @@ WHERE course_id = $1
 	return err
 }
 
-// PatchSnapshotPayload replaces payload + counters (used by recheck).
-func PatchSnapshotPayload(ctx context.Context, pool *pgxpool.Pool, in UpsertSnapshotInput) error {
-	return UpsertSnapshot(ctx, pool, in)
-}
-
 // MutationFreshnessForCourse returns course.updated_at and max structure updated_at.
 func MutationFreshnessForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (MutationFreshness, error) {
 	var m MutationFreshness

--- a/server/internal/repos/coursechecklist/state.go
+++ b/server/internal/repos/coursechecklist/state.go
@@ -1,0 +1,286 @@
+package coursechecklist
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ValidDismissReasons are the allowed dismiss_reason values (empty means unset).
+var ValidDismissReasons = map[string]struct{}{
+	"":               {},
+	"not_applicable": {},
+	"done_elsewhere": {},
+	"disagree":       {},
+	"later":          {},
+	"other":          {},
+}
+
+// MaxDismissNoteLen is the dismiss_note character cap (FR-15 / schema).
+const MaxDismissNoteLen = 500
+
+// ListDismissed returns currently dismissed item states for a course.
+func ListDismissed(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) ([]ItemState, error) {
+	rows, err := pool.Query(ctx, `
+SELECT course_id, item_id, dismissed_at, dismissed_by_user_id, dismiss_reason, dismiss_note,
+       snoozed_until, restored_at, restored_by_user_id, created_at, updated_at
+FROM course.course_checklist_item_state
+WHERE course_id = $1 AND dismissed_at IS NOT NULL
+ORDER BY item_id
+`, courseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanItemStates(rows)
+}
+
+// ListStates returns all item state rows for a course (including restored).
+func ListStates(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) ([]ItemState, error) {
+	rows, err := pool.Query(ctx, `
+SELECT course_id, item_id, dismissed_at, dismissed_by_user_id, dismiss_reason, dismiss_note,
+       snoozed_until, restored_at, restored_by_user_id, created_at, updated_at
+FROM course.course_checklist_item_state
+WHERE course_id = $1
+ORDER BY item_id
+`, courseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanItemStates(rows)
+}
+
+// GetState returns one item state row, or nil if absent.
+func GetState(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, itemID string) (*ItemState, error) {
+	row := pool.QueryRow(ctx, `
+SELECT course_id, item_id, dismissed_at, dismissed_by_user_id, dismiss_reason, dismiss_note,
+       snoozed_until, restored_at, restored_by_user_id, created_at, updated_at
+FROM course.course_checklist_item_state
+WHERE course_id = $1 AND item_id = $2
+`, courseID, itemID)
+	st, err := scanItemState(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+// DismissInput is the payload for an idempotent dismiss.
+type DismissInput struct {
+	CourseID uuid.UUID
+	ItemID   string
+	ActorID  uuid.UUID
+	Reason   string
+	Note     string
+}
+
+// Dismiss upserts a dismissal. Idempotent: if already dismissed, returns the
+// existing row without changing dismissed_at (FR-5).
+func Dismiss(ctx context.Context, pool *pgxpool.Pool, in DismissInput) (ItemState, bool, error) {
+	reason := strings.TrimSpace(in.Reason)
+	if _, ok := ValidDismissReasons[reason]; !ok {
+		return ItemState{}, false, ErrInvalidReason
+	}
+	note := strings.TrimSpace(in.Note)
+	if utf8.RuneCountInString(note) > MaxDismissNoteLen {
+		return ItemState{}, false, ErrNoteTooLong
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	existing, err := getStateTx(ctx, tx, in.CourseID, in.ItemID)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	if existing != nil && existing.DismissedAt != nil {
+		if err := tx.Commit(ctx); err != nil {
+			return ItemState{}, false, err
+		}
+		return *existing, false, nil
+	}
+
+	now := time.Now().UTC()
+	_, err = tx.Exec(ctx, `
+INSERT INTO course.course_checklist_item_state (
+    course_id, item_id, dismissed_at, dismissed_by_user_id, dismiss_reason, dismiss_note,
+    restored_at, restored_by_user_id, created_at, updated_at
+) VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, $3, $3)
+ON CONFLICT (course_id, item_id) DO UPDATE SET
+    dismissed_at = EXCLUDED.dismissed_at,
+    dismissed_by_user_id = EXCLUDED.dismissed_by_user_id,
+    dismiss_reason = EXCLUDED.dismiss_reason,
+    dismiss_note = EXCLUDED.dismiss_note,
+    restored_at = NULL,
+    restored_by_user_id = NULL,
+    updated_at = EXCLUDED.updated_at
+`, in.CourseID, in.ItemID, now, in.ActorID, reason, note)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	if err := insertEventTx(ctx, tx, in.CourseID, in.ItemID, "dismiss", &in.ActorID, reason, now); err != nil {
+		return ItemState{}, false, err
+	}
+	st, err := getStateTx(ctx, tx, in.CourseID, in.ItemID)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	if st == nil {
+		return ItemState{}, false, errors.New("coursechecklist: dismiss row missing after upsert")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ItemState{}, false, err
+	}
+	return *st, true, nil
+}
+
+// Restore clears a dismissal and stamps restored_* (FR-6). No-op when not dismissed.
+func Restore(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, itemID string, actorID uuid.UUID) (ItemState, bool, error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	existing, err := getStateTx(ctx, tx, courseID, itemID)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	if existing == nil || existing.DismissedAt == nil {
+		if existing == nil {
+			if err := tx.Commit(ctx); err != nil {
+				return ItemState{}, false, err
+			}
+			return ItemState{CourseID: courseID, ItemID: itemID}, false, nil
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return ItemState{}, false, err
+		}
+		return *existing, false, nil
+	}
+
+	now := time.Now().UTC()
+	_, err = tx.Exec(ctx, `
+UPDATE course.course_checklist_item_state
+SET dismissed_at = NULL,
+    dismissed_by_user_id = NULL,
+    dismiss_reason = '',
+    dismiss_note = '',
+    restored_at = $3,
+    restored_by_user_id = $4,
+    updated_at = $3
+WHERE course_id = $1 AND item_id = $2
+`, courseID, itemID, now, actorID)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	if err := insertEventTx(ctx, tx, courseID, itemID, "restore", &actorID, "", now); err != nil {
+		return ItemState{}, false, err
+	}
+	st, err := getStateTx(ctx, tx, courseID, itemID)
+	if err != nil {
+		return ItemState{}, false, err
+	}
+	if st == nil {
+		return ItemState{}, false, errors.New("coursechecklist: restore row missing after update")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ItemState{}, false, err
+	}
+	return *st, true, nil
+}
+
+// CountDismissed returns the number of currently dismissed items for a course.
+func CountDismissed(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (int, error) {
+	var n int
+	err := pool.QueryRow(ctx, `
+SELECT COUNT(*)::int FROM course.course_checklist_item_state
+WHERE course_id = $1 AND dismissed_at IS NOT NULL
+`, courseID).Scan(&n)
+	return n, err
+}
+
+// DeleteAllForCourse removes checklist state/snapshots/events for factory reset (FR-21).
+func DeleteAllForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_events WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_item_state WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_snapshots WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// DeleteAllForCourseTx is DeleteAllForCourse using an existing transaction.
+func DeleteAllForCourseTx(ctx context.Context, tx pgx.Tx, courseID uuid.UUID) error {
+	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_events WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_item_state WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_snapshots WHERE course_id = $1`, courseID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getStateTx(ctx context.Context, tx pgx.Tx, courseID uuid.UUID, itemID string) (*ItemState, error) {
+	row := tx.QueryRow(ctx, `
+SELECT course_id, item_id, dismissed_at, dismissed_by_user_id, dismiss_reason, dismiss_note,
+       snoozed_until, restored_at, restored_by_user_id, created_at, updated_at
+FROM course.course_checklist_item_state
+WHERE course_id = $1 AND item_id = $2
+`, courseID, itemID)
+	st, err := scanItemState(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+func scanItemStates(rows pgx.Rows) ([]ItemState, error) {
+	var out []ItemState
+	for rows.Next() {
+		st, err := scanItemState(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, st)
+	}
+	return out, rows.Err()
+}
+
+func scanItemState(row pgx.Row) (ItemState, error) {
+	var st ItemState
+	err := row.Scan(
+		&st.CourseID, &st.ItemID, &st.DismissedAt, &st.DismissedByUserID,
+		&st.DismissReason, &st.DismissNote, &st.SnoozedUntil,
+		&st.RestoredAt, &st.RestoredByUserID, &st.CreatedAt, &st.UpdatedAt,
+	)
+	return st, err
+}

--- a/server/internal/repos/coursechecklist/state.go
+++ b/server/internal/repos/coursechecklist/state.go
@@ -41,40 +41,6 @@ ORDER BY item_id
 	return scanItemStates(rows)
 }
 
-// ListStates returns all item state rows for a course (including restored).
-func ListStates(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) ([]ItemState, error) {
-	rows, err := pool.Query(ctx, `
-SELECT course_id, item_id, dismissed_at, dismissed_by_user_id, dismiss_reason, dismiss_note,
-       snoozed_until, restored_at, restored_by_user_id, created_at, updated_at
-FROM course.course_checklist_item_state
-WHERE course_id = $1
-ORDER BY item_id
-`, courseID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	return scanItemStates(rows)
-}
-
-// GetState returns one item state row, or nil if absent.
-func GetState(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, itemID string) (*ItemState, error) {
-	row := pool.QueryRow(ctx, `
-SELECT course_id, item_id, dismissed_at, dismissed_by_user_id, dismiss_reason, dismiss_note,
-       snoozed_until, restored_at, restored_by_user_id, created_at, updated_at
-FROM course.course_checklist_item_state
-WHERE course_id = $1 AND item_id = $2
-`, courseID, itemID)
-	st, err := scanItemState(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &st, nil
-}
-
 // DismissInput is the payload for an idempotent dismiss.
 type DismissInput struct {
 	CourseID uuid.UUID
@@ -211,39 +177,6 @@ SELECT COUNT(*)::int FROM course.course_checklist_item_state
 WHERE course_id = $1 AND dismissed_at IS NOT NULL
 `, courseID).Scan(&n)
 	return n, err
-}
-
-// DeleteAllForCourse removes checklist state/snapshots/events for factory reset (FR-21).
-func DeleteAllForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) error {
-	tx, err := pool.Begin(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_events WHERE course_id = $1`, courseID); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_item_state WHERE course_id = $1`, courseID); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_snapshots WHERE course_id = $1`, courseID); err != nil {
-		return err
-	}
-	return tx.Commit(ctx)
-}
-
-// DeleteAllForCourseTx is DeleteAllForCourse using an existing transaction.
-func DeleteAllForCourseTx(ctx context.Context, tx pgx.Tx, courseID uuid.UUID) error {
-	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_events WHERE course_id = $1`, courseID); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_item_state WHERE course_id = $1`, courseID); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM course.course_checklist_snapshots WHERE course_id = $1`, courseID); err != nil {
-		return err
-	}
-	return nil
 }
 
 func getStateTx(ctx context.Context, tx pgx.Tx, courseID uuid.UUID, itemID string) (*ItemState, error) {

--- a/server/internal/repos/coursechecklist/state_db_test.go
+++ b/server/internal/repos/coursechecklist/state_db_test.go
@@ -1,0 +1,100 @@
+package coursechecklist
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+func TestDismissRestoreIdempotentAndConstraints_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	ph, _ := auth.HashPassword("longpassword0")
+	email := fmt.Sprintf("cc2-repo-%d@e.com", time.Now().UnixNano())
+	u, err := user.InsertUser(ctx, pool, email, ph, strPtr("Teacher"))
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	uid, _ := uuid.Parse(u.ID)
+	var courseID uuid.UUID
+	code := fmt.Sprintf("C-%06X", time.Now().UnixNano()%0xFFFFFF)
+	err = pool.QueryRow(ctx, `
+INSERT INTO course.courses (title, course_code, org_id, created_by_user_id)
+VALUES ('Repo Checklist', $2, (SELECT id FROM tenant.organizations WHERE slug = 'default' LIMIT 1), $1)
+RETURNING id
+`, uid, code).Scan(&courseID)
+	if err != nil {
+		t.Fatalf("course: %v", err)
+	}
+
+	st, changed, err := Dismiss(ctx, pool, DismissInput{
+		CourseID: courseID, ItemID: "course.dates", ActorID: uid,
+		Reason: "not_applicable", Note: "first",
+	})
+	if err != nil || !changed || st.DismissedAt == nil {
+		t.Fatalf("dismiss1: changed=%v err=%v st=%+v", changed, err, st)
+	}
+	firstAt := *st.DismissedAt
+	st2, changed2, err := Dismiss(ctx, pool, DismissInput{
+		CourseID: courseID, ItemID: "course.dates", ActorID: uid,
+		Reason: "other", Note: "second",
+	})
+	if err != nil || changed2 {
+		t.Fatalf("idempotent dismiss should not change: changed=%v err=%v", changed2, err)
+	}
+	if st2.DismissedAt == nil || !st2.DismissedAt.Equal(firstAt) {
+		t.Fatalf("dismissed_at mutated: %v vs %v", st2.DismissedAt, firstAt)
+	}
+
+	_, _, err = Dismiss(ctx, pool, DismissInput{
+		CourseID: courseID, ItemID: "course.dates", ActorID: uid,
+		Reason: "nope", Note: "x",
+	})
+	if err != ErrInvalidReason {
+		t.Fatalf("want ErrInvalidReason got %v", err)
+	}
+	long := make([]rune, MaxDismissNoteLen+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	_, _, err = Dismiss(ctx, pool, DismissInput{
+		CourseID: courseID, ItemID: "course.dates", ActorID: uid,
+		Reason: "other", Note: string(long),
+	})
+	if err != ErrNoteTooLong {
+		t.Fatalf("want ErrNoteTooLong got %v", err)
+	}
+
+	_, changed, err = Restore(ctx, pool, courseID, "course.dates", uid)
+	if err != nil || !changed {
+		t.Fatalf("restore: %v changed=%v", err, changed)
+	}
+	events, err := ListEvents(ctx, pool, courseID, 10)
+	if err != nil || len(events) < 2 {
+		t.Fatalf("events: %v len=%d", err, len(events))
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/server/internal/repos/coursechecklist/types.go
+++ b/server/internal/repos/coursechecklist/types.go
@@ -1,0 +1,74 @@
+// Package coursechecklist persists checklist dismissals, evaluation snapshots, and audit events (CC.2).
+package coursechecklist
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ItemState is one row from course.course_checklist_item_state.
+type ItemState struct {
+	CourseID          uuid.UUID
+	ItemID            string
+	DismissedAt       *time.Time
+	DismissedByUserID *uuid.UUID
+	DismissReason     string
+	DismissNote       string
+	SnoozedUntil      *time.Time
+	RestoredAt        *time.Time
+	RestoredByUserID  *uuid.UUID
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+// Snapshot is one row from course.course_checklist_snapshots.
+type Snapshot struct {
+	CourseID             uuid.UUID
+	ComputedAt           time.Time
+	EngineVersion        int
+	CatalogVersion       string
+	Payload              json.RawMessage
+	TotalCount           int
+	DoneCount            int
+	OutstandingEssential int
+	OutstandingTotal     int
+	DismissedCount       int
+}
+
+// Event is one audit row from course.course_checklist_events.
+type Event struct {
+	ID          uuid.UUID
+	CourseID    uuid.UUID
+	ItemID      string
+	Action      string
+	ActorUserID *uuid.UUID
+	Reason      string
+	OccurredAt  time.Time
+}
+
+// DismissNoteExport is a DSAR export row for staff-authored dismiss notes.
+type DismissNoteExport struct {
+	CourseID     uuid.UUID
+	CourseCode   string
+	ItemID       string
+	Reason       string
+	Note         string
+	DismissedAt  time.Time
+}
+
+// MutationFreshness is the latest course/structure mutation time used for staleness.
+type MutationFreshness struct {
+	CourseUpdatedAt time.Time
+	StructureMaxAt  *time.Time
+}
+
+// LatestMutation returns the newest mutation timestamp among course and structure.
+func (m MutationFreshness) LatestMutation() time.Time {
+	latest := m.CourseUpdatedAt
+	if m.StructureMaxAt != nil && m.StructureMaxAt.After(latest) {
+		latest = *m.StructureMaxAt
+	}
+	return latest
+}

--- a/server/internal/scheduler/config.go
+++ b/server/internal/scheduler/config.go
@@ -26,6 +26,7 @@ const (
 	JobTypeContentToolResetPurge           = "scheduled.content_tool_reset_purge"
 	JobTypeContentToolDailyRollups         = "scheduled.content_tool_daily_rollups"
 	JobTypeContentToolSummaryRebuild       = "scheduled.content_tool_summary_rebuild"
+	JobTypeCourseChecklistRetention        = "scheduled.course_checklist_retention"
 )
 
 // ScheduledJob is one configuration-driven entry in the schedule list. New
@@ -209,6 +210,13 @@ func BuiltinJobs() []ScheduledJob {
 			Spec:           "0 */6 * * *", // every 6 hours
 			JobType:        JobTypeContentToolSummaryRebuild,
 			Description:    "Rebuild Content Tool state summaries when projection versions lag (CT.7).",
+			DefaultEnabled: true,
+		},
+		{
+			Name:           "course_checklist_retention",
+			Spec:           "15 3 * * *", // daily 03:15 UTC
+			JobType:        JobTypeCourseChecklistRetention,
+			Description:    "Purge untouched course checklist snapshots (90d) and aged audit events (400d) (CC.2).",
 			DefaultEnabled: true,
 		},
 	}

--- a/server/internal/scheduler/cron_test.go
+++ b/server/internal/scheduler/cron_test.go
@@ -99,8 +99,8 @@ func TestIsDue(t *testing.T) {
 
 func TestBuiltinJobsCompile(t *testing.T) {
 	jobs := BuiltinJobs()
-	if len(jobs) != 22 {
-		t.Fatalf("expected 22 builtin jobs, got %d", len(jobs))
+	if len(jobs) != 23 {
+		t.Fatalf("expected 23 builtin jobs, got %d", len(jobs))
 	}
 	seen := map[string]bool{}
 	for _, j := range jobs {

--- a/server/internal/service/coursechecklist/api_metrics.go
+++ b/server/internal/service/coursechecklist/api_metrics.go
@@ -1,0 +1,80 @@
+package coursechecklist
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	apiMetricsOnce sync.Once
+
+	apiRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lextures",
+		Name:      "coursechecklist_api_requests_total",
+		Help:      "Course checklist API requests by route and status class.",
+	}, []string{"route", "status"})
+
+	snapshotHits = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lextures",
+		Name:      "coursechecklist_snapshot_hits_total",
+		Help:      "Checklist snapshot cache outcomes (hit|stale|miss).",
+	}, []string{"result"})
+
+	dismissals = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lextures",
+		Name:      "coursechecklist_dismissals_total",
+		Help:      "Checklist dismissals by reason.",
+	}, []string{"reason"})
+
+	singleflightWaiters = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "lextures",
+		Name:      "coursechecklist_singleflight_waiters",
+		Help:      "Goroutines waiting on or holding checklist evaluation slots.",
+	})
+)
+
+func registerAPIMetrics() {
+	apiMetricsOnce.Do(func() {
+		prometheus.MustRegister(apiRequests, snapshotHits, dismissals, singleflightWaiters)
+	})
+}
+
+// ObserveAPIRequest increments the API request counter (route handlers).
+func ObserveAPIRequest(route, status string) {
+	registerAPIMetrics()
+	if route == "" {
+		route = "unknown"
+	}
+	if status == "" {
+		status = "unknown"
+	}
+	apiRequests.WithLabelValues(route, status).Inc()
+}
+
+func observeSnapshotHit(result string) {
+	registerAPIMetrics()
+	if result == "" {
+		result = "miss"
+	}
+	snapshotHits.WithLabelValues(result).Inc()
+}
+
+func observeDismissal(reason string) {
+	registerAPIMetrics()
+	if reason == "" {
+		reason = "unspecified"
+	}
+	dismissals.WithLabelValues(reason).Inc()
+}
+
+func setSingleflightWaiters(n float64) {
+	registerAPIMetrics()
+	singleflightWaiters.Set(n)
+}
+
+// SnapshotHitsCounter exposes the snapshot-hit counter for tests.
+func SnapshotHitsCounter() *prometheus.CounterVec {
+	registerAPIMetrics()
+	return snapshotHits
+}

--- a/server/internal/service/coursechecklist/api_types.go
+++ b/server/internal/service/coursechecklist/api_types.go
@@ -1,0 +1,113 @@
+package coursechecklist
+
+import "time"
+
+// ChecklistResponse is the GET /checklist wire shape (CC.2 §9).
+type ChecklistResponse struct {
+	CourseCode        string              `json:"courseCode"`
+	EngineVersion     int                 `json:"engineVersion"`
+	CatalogVersion    string              `json:"catalogVersion"`
+	ComputedAt        time.Time           `json:"computedAt"`
+	Stale             bool                `json:"stale"`
+	EvidenceTruncated bool                `json:"evidenceTruncated"`
+	Summary           ChecklistSummary    `json:"summary"`
+	Categories        []ChecklistCategory `json:"categories"`
+	Dismissed         []ChecklistItem     `json:"dismissed"`
+}
+
+// ChecklistCategory groups items for one registry category.
+type ChecklistCategory struct {
+	ID       string          `json:"id"`
+	TitleKey string          `json:"titleKey"`
+	Title    string          `json:"title"`
+	Items    []ChecklistItem `json:"items"`
+}
+
+// ChecklistItem is one checklist finding plus optional dismissal metadata.
+type ChecklistItem struct {
+	ID         string              `json:"id"`
+	TitleKey   string              `json:"titleKey"`
+	Title      string              `json:"title"`
+	WhyKey     string              `json:"whyKey"`
+	Why        string              `json:"why"`
+	Tier       Tier                `json:"tier"`
+	Status     Status              `json:"status"`
+	Detail     *string             `json:"detail"`
+	Progress   *Progress           `json:"progress"`
+	Sources    []string            `json:"sources"`
+	HelpRef    *string             `json:"helpRef"`
+	Target     *ChecklistNavTarget `json:"target"`
+	Evidence   *ChecklistEvidence  `json:"evidence"`
+	Dismissal  *ChecklistDismissal `json:"dismissal"`
+}
+
+// ChecklistNavTarget is the client navigation target for an item.
+type ChecklistNavTarget struct {
+	Route  string  `json:"route"`
+	Anchor *string `json:"anchor"`
+}
+
+// ChecklistEvidence is the expandable evidence table.
+type ChecklistEvidence struct {
+	Columns     []string              `json:"columns"`
+	Rows        []ChecklistEvidenceRow `json:"rows"`
+	TruncatedAt *int                  `json:"truncatedAt"`
+}
+
+// ChecklistEvidenceRow is one evidence table row.
+type ChecklistEvidenceRow struct {
+	Label    string              `json:"label"`
+	Sublabel *string             `json:"sublabel"`
+	Status   string              `json:"status"`
+	Target   *ChecklistNavTarget `json:"target"`
+}
+
+// ChecklistDismissal is course-scoped dismissal metadata.
+type ChecklistDismissal struct {
+	DismissedAt   time.Time `json:"dismissedAt"`
+	ByUserID      string    `json:"byUserId"`
+	ByDisplayName string    `json:"byDisplayName"`
+	Reason        string    `json:"reason"`
+	Note          string    `json:"note"`
+}
+
+// ChecklistSummary is the badge / progress counters (FR-14).
+type ChecklistSummary struct {
+	OutstandingEssential int       `json:"outstandingEssential"`
+	OutstandingTotal     int       `json:"outstandingTotal"`
+	Done                 int       `json:"done"`
+	Total                int       `json:"total"`
+	Dismissed            int       `json:"dismissed"`
+	ComputedAt           time.Time `json:"computedAt"`
+	Stale                bool      `json:"stale"`
+}
+
+// HistoryEvent is one checklist audit event for GET /history.
+type HistoryEvent struct {
+	ID          string    `json:"id"`
+	ItemID      string    `json:"itemId"`
+	Action      string    `json:"action"`
+	ActorUserID *string   `json:"actorUserId"`
+	Reason      string    `json:"reason"`
+	OccurredAt  time.Time `json:"occurredAt"`
+}
+
+// HistoryResponse is GET /checklist/history.
+type HistoryResponse struct {
+	CourseCode     string         `json:"courseCode"`
+	EngineVersion  int            `json:"engineVersion"`
+	CatalogVersion string         `json:"catalogVersion"`
+	Events         []HistoryEvent `json:"events"`
+}
+
+// DismissRequest is POST .../dismiss body.
+type DismissRequest struct {
+	Reason string `json:"reason"`
+	Note   string `json:"note"`
+}
+
+// snapshotPayload is the JSON stored in course_checklist_snapshots.payload.
+type snapshotPayload struct {
+	Result            Result `json:"result"`
+	EvidenceTruncated bool   `json:"evidenceTruncated"`
+}

--- a/server/internal/service/coursechecklist/assemble.go
+++ b/server/internal/service/coursechecklist/assemble.go
@@ -1,0 +1,216 @@
+package coursechecklist
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	ccrepo "github.com/lextures/lextures/server/internal/repos/coursechecklist"
+)
+
+// AssembleOptions controls response assembly from an evaluation Result.
+type AssembleOptions struct {
+	CourseCode            string
+	ComputedAt            time.Time
+	Stale                 bool
+	EvidenceTruncated     bool
+	IncludeNotApplicable  bool
+	Dismissed             []ccrepo.ItemState
+	DisplayNames          map[uuid.UUID]string
+}
+
+// AssembleChecklist builds the API response from Result + dismissals (FR-12/13).
+func AssembleChecklist(res Result, opt AssembleOptions) ChecklistResponse {
+	dismissedByID := make(map[string]ccrepo.ItemState, len(opt.Dismissed))
+	for _, st := range opt.Dismissed {
+		if st.DismissedAt != nil {
+			dismissedByID[st.ItemID] = st
+		}
+	}
+
+	byCat := make(map[CategoryID][]ChecklistItem, len(CategoryOrder))
+	var dismissedPile []ChecklistItem
+	for _, fr := range res.Findings {
+		item := itemFromFinding(fr, dismissedByID[string(fr.ID)], opt.DisplayNames)
+		if _, isDismissed := dismissedByID[string(fr.ID)]; isDismissed {
+			dismissedPile = append(dismissedPile, item)
+			continue
+		}
+		if fr.Finding.Status == StatusNotApplicable && !opt.IncludeNotApplicable {
+			continue
+		}
+		byCat[fr.Category] = append(byCat[fr.Category], item)
+	}
+
+	categories := make([]ChecklistCategory, 0, len(CategoryOrder))
+	for _, catID := range CategoryOrder {
+		items := byCat[catID]
+		if len(items) == 0 {
+			continue
+		}
+		meta := CategoryTitle(catID)
+		categories = append(categories, ChecklistCategory{
+			ID:       string(catID),
+			TitleKey: meta.TitleKey,
+			Title:    meta.Title,
+			Items:    items,
+		})
+	}
+	if dismissedPile == nil {
+		dismissedPile = []ChecklistItem{}
+	}
+
+	summary := DeriveSummary(res, dismissedByID, opt.ComputedAt, opt.Stale)
+	return ChecklistResponse{
+		CourseCode:        opt.CourseCode,
+		EngineVersion:     res.EngineVersion,
+		CatalogVersion:    res.CatalogVersion,
+		ComputedAt:        opt.ComputedAt,
+		Stale:             opt.Stale,
+		EvidenceTruncated: opt.EvidenceTruncated,
+		Summary:           summary,
+		Categories:        categories,
+		Dismissed:         dismissedPile,
+	}
+}
+
+// DeriveSummary computes badge counters excluding dismissed items (FR-14).
+func DeriveSummary(res Result, dismissedByID map[string]ccrepo.ItemState, computedAt time.Time, stale bool) ChecklistSummary {
+	var done, total, outstandingEssential, outstandingTotal int
+	for _, fr := range res.Findings {
+		if _, ok := dismissedByID[string(fr.ID)]; ok {
+			continue
+		}
+		switch fr.Finding.Status {
+		case StatusDone:
+			done++
+			total++
+		case StatusTodo, StatusInProgress:
+			total++
+			outstandingTotal++
+			if fr.Tier == TierEssential {
+				outstandingEssential++
+			}
+		case StatusUnknown:
+			// unknown excluded from total (same as Counts aggregation)
+		case StatusNotApplicable:
+			// N/A excluded from progress denominator
+		}
+	}
+	return ChecklistSummary{
+		OutstandingEssential: outstandingEssential,
+		OutstandingTotal:     outstandingTotal,
+		Done:                 done,
+		Total:                total,
+		Dismissed:            len(dismissedByID),
+		ComputedAt:           computedAt,
+		Stale:                stale,
+	}
+}
+
+func itemFromFinding(fr ItemResult, st ccrepo.ItemState, names map[uuid.UUID]string) ChecklistItem {
+	var detail *string
+	if strings.TrimSpace(fr.Finding.DetailDefault) != "" {
+		d := fr.Finding.DetailDefault
+		detail = &d
+	}
+	var help *string
+	if strings.TrimSpace(fr.HelpRef) != "" {
+		h := fr.HelpRef
+		help = &h
+	}
+	sources := fr.Sources
+	if sources == nil {
+		sources = []string{}
+	}
+	item := ChecklistItem{
+		ID:       string(fr.ID),
+		TitleKey: fr.TitleKey,
+		Title:    fr.TitleDefault,
+		WhyKey:   fr.WhyKey,
+		Why:      fr.WhyDefault,
+		Tier:     fr.Tier,
+		Status:   fr.Finding.Status,
+		Detail:   detail,
+		Progress: fr.Finding.Progress,
+		Sources:  sources,
+		HelpRef:  help,
+		Target:   navTargetPtr(fr.Target),
+		Evidence: evidenceFromFinding(fr),
+	}
+	if st.DismissedAt != nil {
+		byID := ""
+		byName := ""
+		if st.DismissedByUserID != nil {
+			byID = st.DismissedByUserID.String()
+			if names != nil {
+				byName = names[*st.DismissedByUserID]
+			}
+		}
+		item.Dismissal = &ChecklistDismissal{
+			DismissedAt:   st.DismissedAt.UTC(),
+			ByUserID:      byID,
+			ByDisplayName: byName,
+			Reason:        st.DismissReason,
+			Note:          st.DismissNote,
+		}
+	}
+	return item
+}
+
+func navTargetPtr(t NavTarget) *ChecklistNavTarget {
+	if strings.TrimSpace(t.Route) == "" {
+		return nil
+	}
+	out := &ChecklistNavTarget{Route: t.Route}
+	if strings.TrimSpace(t.Anchor) != "" {
+		a := t.Anchor
+		out.Anchor = &a
+	}
+	return out
+}
+
+func evidenceFromFinding(fr ItemResult) *ChecklistEvidence {
+	if len(fr.Finding.Evidence) == 0 && fr.EvidenceShape == nil {
+		return nil
+	}
+	cols := []string{}
+	if fr.EvidenceShape != nil {
+		cols = append(cols, fr.EvidenceShape.Columns...)
+	}
+	rows := make([]ChecklistEvidenceRow, 0, len(fr.Finding.Evidence))
+	for _, er := range fr.Finding.Evidence {
+		var sub *string
+		if strings.TrimSpace(er.Sublabel) != "" {
+			s := er.Sublabel
+			sub = &s
+		}
+		var tgt *ChecklistNavTarget
+		if er.TargetOverride != nil {
+			tgt = navTargetPtr(*er.TargetOverride)
+		}
+		rows = append(rows, ChecklistEvidenceRow{
+			Label:    er.Label,
+			Sublabel: sub,
+			Status:   string(er.Status),
+			Target:   tgt,
+		})
+	}
+	return &ChecklistEvidence{
+		Columns:     cols,
+		Rows:        rows,
+		TruncatedAt: fr.Finding.TruncatedAt,
+	}
+}
+
+// DropEvidence strips evidence from all findings (payload size fallback, AC-13).
+func DropEvidence(res Result) Result {
+	out := res
+	out.Findings = make([]ItemResult, len(res.Findings))
+	copy(out.Findings, res.Findings)
+	for i := range out.Findings {
+		out.Findings[i].Finding.Evidence = nil
+		out.Findings[i].Finding.TruncatedAt = nil
+	}
+	return out
+}

--- a/server/internal/service/coursechecklist/assemble_test.go
+++ b/server/internal/service/coursechecklist/assemble_test.go
@@ -1,0 +1,95 @@
+package coursechecklist
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	ccrepo "github.com/lextures/lextures/server/internal/repos/coursechecklist"
+)
+
+func TestAssembleChecklist_DismissedPileAndSummary(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	actor := uuid.New()
+	dismissedAt := now.Add(-time.Hour)
+	res := Result{
+		EngineVersion:  1,
+		CatalogVersion: "cat",
+		Findings: []ItemResult{
+			{
+				ID: ItemCourseDates, Category: CategoryReference, Tier: TierEssential,
+				TitleKey: "t", TitleDefault: "Dates", WhyKey: "w", WhyDefault: "why",
+				Sources: []string{"OSCQR 1"},
+				Finding: Finding{Status: StatusTodo},
+			},
+			{
+				ID: ItemCourseSections, Category: CategoryReference, Tier: TierEssential,
+				TitleKey: "t2", TitleDefault: "Sections", WhyKey: "w2", WhyDefault: "why2",
+				Sources: []string{"OSCQR 2"},
+				Finding: Finding{Status: StatusTodo},
+			},
+			{
+				ID: "course.na", Category: CategoryReference, Tier: TierRecommended,
+				TitleKey: "t3", TitleDefault: "NA", WhyKey: "w3", WhyDefault: "why3",
+				Sources: []string{"x"},
+				Finding: Finding{Status: StatusNotApplicable},
+			},
+		},
+	}
+	resp := AssembleChecklist(res, AssembleOptions{
+		CourseCode: "C-1",
+		ComputedAt: now,
+		Dismissed: []ccrepo.ItemState{{
+			ItemID: string(ItemCourseSections), DismissedAt: &dismissedAt,
+			DismissedByUserID: &actor, DismissReason: "not_applicable",
+		}},
+		DisplayNames: map[uuid.UUID]string{actor: "Teacher"},
+	})
+	if len(resp.Dismissed) != 1 || resp.Dismissed[0].ID != string(ItemCourseSections) {
+		t.Fatalf("dismissed pile: %+v", resp.Dismissed)
+	}
+	if resp.Dismissed[0].Dismissal == nil || resp.Dismissed[0].Dismissal.ByDisplayName != "Teacher" {
+		t.Fatalf("dismissal meta: %+v", resp.Dismissed[0].Dismissal)
+	}
+	if resp.Summary.Dismissed != 1 || resp.Summary.OutstandingEssential != 1 || resp.Summary.Total != 1 {
+		t.Fatalf("summary: %+v", resp.Summary)
+	}
+	// N/A omitted by default; dismissed not inline.
+	for _, cat := range resp.Categories {
+		for _, it := range cat.Items {
+			if it.ID == string(ItemCourseSections) || it.Status == StatusNotApplicable {
+				t.Fatalf("unexpected inline item %s", it.ID)
+			}
+		}
+	}
+}
+
+func TestDropEvidence_FitsPayload(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("x", 4000)
+	rows := make([]EvidenceRow, 0, 80)
+	for i := 0; i < 80; i++ {
+		rows = append(rows, EvidenceRow{Label: big})
+	}
+	res := Result{
+		EngineVersion: 1, CatalogVersion: "c",
+		Findings: []ItemResult{{
+			ID: ItemCourseDates, Category: CategoryReference, Tier: TierEssential,
+			TitleKey: "t", TitleDefault: "Dates", WhyKey: "w", WhyDefault: "why",
+			Sources: []string{"a"},
+			Finding: Finding{Status: StatusTodo, Evidence: rows},
+		}},
+	}
+	fitted, truncated := fitPayload(res)
+	if !truncated {
+		t.Fatal("expected truncation")
+	}
+	if len(fitted.Findings[0].Finding.Evidence) != 0 {
+		t.Fatal("evidence should be dropped")
+	}
+	if _, err := encodeSnapshotPayload(fitted, true); err != nil {
+		t.Fatalf("encode after drop: %v", err)
+	}
+}

--- a/server/internal/service/coursechecklist/categories.go
+++ b/server/internal/service/coursechecklist/categories.go
@@ -1,0 +1,31 @@
+package coursechecklist
+
+// CategoryMeta provides i18n keys and English defaults for category headings.
+type CategoryMeta struct {
+	TitleKey string
+	Title    string
+}
+
+// categoryMetaByID is the display metadata for CategoryOrder entries.
+var categoryMetaByID = map[CategoryID]CategoryMeta{
+	CategoryFoundations:   {TitleKey: "coursechecklist.category.foundations", Title: "Foundations"},
+	CategoryOrientation:   {TitleKey: "coursechecklist.category.orientation", Title: "Orientation"},
+	CategoryStructure:     {TitleKey: "coursechecklist.category.structure", Title: "Structure"},
+	CategoryOutcomes:      {TitleKey: "coursechecklist.category.outcomes", Title: "Outcomes"},
+	CategoryAssessment:    {TitleKey: "coursechecklist.category.assessment", Title: "Assessment"},
+	CategoryFeedback:      {TitleKey: "coursechecklist.category.feedback", Title: "Feedback"},
+	CategoryAccessibility: {TitleKey: "coursechecklist.category.accessibility", Title: "Accessibility"},
+	CategoryLaunch:        {TitleKey: "coursechecklist.category.launch", Title: "Launch readiness"},
+	CategoryReference:     {TitleKey: "coursechecklist.category.reference", Title: "Reference"},
+}
+
+// CategoryTitle returns title key + English default for a category.
+func CategoryTitle(id CategoryID) CategoryMeta {
+	if m, ok := categoryMetaByID[id]; ok {
+		return m
+	}
+	return CategoryMeta{
+		TitleKey: "coursechecklist.category." + string(id),
+		Title:    string(id),
+	}
+}

--- a/server/internal/service/coursechecklist/flight.go
+++ b/server/internal/service/coursechecklist/flight.go
@@ -1,0 +1,45 @@
+package coursechecklist
+
+import (
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// MaxConcurrentEvaluations caps in-flight evaluations per process (NFR).
+const MaxConcurrentEvaluations = 32
+
+var (
+	evalFlight     singleflight.Group
+	evalSemOnce    sync.Once
+	evalSem        chan struct{}
+	flightWaiters  int64
+	flightWaitersM sync.Mutex
+)
+
+func evaluationSemaphore() chan struct{} {
+	evalSemOnce.Do(func() {
+		evalSem = make(chan struct{}, MaxConcurrentEvaluations)
+	})
+	return evalSem
+}
+
+func acquireEvalSlot() {
+	flightWaitersM.Lock()
+	flightWaiters++
+	n := flightWaiters
+	flightWaitersM.Unlock()
+	setSingleflightWaiters(float64(n))
+	evaluationSemaphore() <- struct{}{}
+}
+
+func releaseEvalSlot() {
+	<-evaluationSemaphore()
+	flightWaitersM.Lock()
+	if flightWaiters > 0 {
+		flightWaiters--
+	}
+	n := flightWaiters
+	flightWaitersM.Unlock()
+	setSingleflightWaiters(float64(n))
+}

--- a/server/internal/service/coursechecklist/service.go
+++ b/server/internal/service/coursechecklist/service.go
@@ -1,0 +1,590 @@
+package coursechecklist
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/repos/course"
+	ccrepo "github.com/lextures/lextures/server/internal/repos/coursechecklist"
+	userrepo "github.com/lextures/lextures/server/internal/repos/user"
+)
+
+// Service orchestrates checklist evaluation, snapshot caching, and dismissals (CC.2).
+type Service struct {
+	Pool *pgxpool.Pool
+	TTL  time.Duration
+	Now  func() time.Time
+}
+
+// NewService builds a Service with the given snapshot TTL (0 → default).
+func NewService(pool *pgxpool.Pool, ttl time.Duration) *Service {
+	if ttl <= 0 {
+		ttl = SnapshotTTLDefault
+	}
+	return &Service{
+		Pool: pool,
+		TTL:  ttl,
+		Now:  func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (s *Service) now() time.Time {
+	if s != nil && s.Now != nil {
+		return s.Now()
+	}
+	return time.Now().UTC()
+}
+
+// GetChecklist returns the full checklist, recomputing when the snapshot is stale.
+func (s *Service) GetChecklist(ctx context.Context, courseCode string, includeNotApplicable bool) (ChecklistResponse, error) {
+	courseID, err := s.resolveCourseID(ctx, courseCode)
+	if err != nil {
+		return ChecklistResponse{}, err
+	}
+	res, computedAt, truncated, staleFlag, err := s.loadOrEvaluate(ctx, courseID, courseCode, false)
+	if err != nil {
+		return ChecklistResponse{}, err
+	}
+	dismissed, names, err := s.loadDismissals(ctx, courseID)
+	if err != nil {
+		return ChecklistResponse{}, err
+	}
+	return AssembleChecklist(res, AssembleOptions{
+		CourseCode:           courseCode,
+		ComputedAt:           computedAt,
+		Stale:                staleFlag,
+		EvidenceTruncated:    truncated,
+		IncludeNotApplicable: includeNotApplicable,
+		Dismissed:            dismissed,
+		DisplayNames:         names,
+	}), nil
+}
+
+// GetSummary returns badge counts from a warm snapshot without evaluating (FR-14).
+// When the snapshot is missing/stale it evaluates once (same as GetChecklist).
+func (s *Service) GetSummary(ctx context.Context, courseCode string) (ChecklistSummary, error) {
+	courseID, err := s.resolveCourseID(ctx, courseCode)
+	if err != nil {
+		return ChecklistSummary{}, err
+	}
+	snap, freshness, err := s.loadSnapshotAndFreshness(ctx, courseID)
+	if err != nil {
+		return ChecklistSummary{}, err
+	}
+	engineV := EngineVersion()
+	catalogV := CatalogVersion()
+	now := s.now()
+	if !IsSnapshotStale(snap, engineV, catalogV, s.TTL, freshness, now) {
+		observeSnapshotHit("hit")
+		dismissedCount := snap.DismissedCount
+		if n, err := ccrepo.CountDismissed(ctx, s.Pool, courseID); err == nil {
+			dismissedCount = n
+		}
+		return ChecklistSummary{
+			OutstandingEssential: snap.OutstandingEssential,
+			OutstandingTotal:     snap.OutstandingTotal,
+			Done:                 snap.DoneCount,
+			Total:                snap.TotalCount,
+			Dismissed:            dismissedCount,
+			ComputedAt:           snap.ComputedAt.UTC(),
+			Stale:                false,
+		}, nil
+	}
+	// Stale/miss: recompute via loadOrEvaluate (metrics recorded there).
+	res, computedAt, truncated, staleFlag, err := s.loadOrEvaluate(ctx, courseID, courseCode, false)
+	if err != nil {
+		return ChecklistSummary{}, err
+	}
+	dismissed, _, err := s.loadDismissals(ctx, courseID)
+	if err != nil {
+		return ChecklistSummary{}, err
+	}
+	dismissedByID := make(map[string]ccrepo.ItemState, len(dismissed))
+	for _, st := range dismissed {
+		dismissedByID[st.ItemID] = st
+	}
+	_ = truncated
+	_ = staleFlag
+	return DeriveSummary(res, dismissedByID, computedAt, false), nil
+}
+
+// Refresh forces recomputation bypassing TTL (FR-17).
+func (s *Service) Refresh(ctx context.Context, courseCode string) (ChecklistResponse, error) {
+	courseID, err := s.resolveCourseID(ctx, courseCode)
+	if err != nil {
+		return ChecklistResponse{}, err
+	}
+	res, computedAt, truncated, _, err := s.loadOrEvaluate(ctx, courseID, courseCode, true)
+	if err != nil {
+		return ChecklistResponse{}, err
+	}
+	dismissed, names, err := s.loadDismissals(ctx, courseID)
+	if err != nil {
+		return ChecklistResponse{}, err
+	}
+	return AssembleChecklist(res, AssembleOptions{
+		CourseCode:        courseCode,
+		ComputedAt:        computedAt,
+		Stale:             false,
+		EvidenceTruncated: truncated,
+		Dismissed:         dismissed,
+		DisplayNames:      names,
+	}), nil
+}
+
+// Dismiss marks an item dismissed for the course (FR-15).
+func (s *Service) Dismiss(ctx context.Context, courseCode, rawItemID string, actor uuid.UUID, req DismissRequest) (ChecklistItem, error) {
+	itemID, ok := ResolveItemID(rawItemID)
+	if !ok {
+		return ChecklistItem{}, ErrItemNotFound
+	}
+	courseID, err := s.resolveCourseID(ctx, courseCode)
+	if err != nil {
+		return ChecklistItem{}, err
+	}
+	st, changed, err := ccrepo.Dismiss(ctx, s.Pool, ccrepo.DismissInput{
+		CourseID: courseID,
+		ItemID:   string(itemID),
+		ActorID:  actor,
+		Reason:   req.Reason,
+		Note:     req.Note,
+	})
+	if err != nil {
+		return ChecklistItem{}, err
+	}
+	if changed {
+		observeDismissal(st.DismissReason)
+		slog.Info("coursechecklist.dismiss",
+			"course_id", courseID.String(),
+			"item_id", string(itemID),
+			"actor_user_id", actor.String(),
+			"action", "dismiss",
+		)
+	}
+	_ = s.refreshSnapshotCounters(ctx, courseID, courseCode)
+	return s.itemForID(ctx, courseID, courseCode, itemID, &st)
+}
+
+// Restore undoes a dismissal (FR-16).
+func (s *Service) Restore(ctx context.Context, courseCode, rawItemID string, actor uuid.UUID) (ChecklistItem, error) {
+	itemID, ok := ResolveItemID(rawItemID)
+	if !ok {
+		return ChecklistItem{}, ErrItemNotFound
+	}
+	courseID, err := s.resolveCourseID(ctx, courseCode)
+	if err != nil {
+		return ChecklistItem{}, err
+	}
+	st, changed, err := ccrepo.Restore(ctx, s.Pool, courseID, string(itemID), actor)
+	if err != nil {
+		return ChecklistItem{}, err
+	}
+	if changed {
+		slog.Info("coursechecklist.restore",
+			"course_id", courseID.String(),
+			"item_id", string(itemID),
+			"actor_user_id", actor.String(),
+			"action", "restore",
+		)
+	}
+	_ = s.refreshSnapshotCounters(ctx, courseID, courseCode)
+	return s.itemForID(ctx, courseID, courseCode, itemID, &st)
+}
+
+// Recheck re-evaluates one item and patches the stored snapshot (FR-18).
+func (s *Service) Recheck(ctx context.Context, courseCode, rawItemID string) (ChecklistItem, error) {
+	itemID, ok := ResolveItemID(rawItemID)
+	if !ok {
+		return ChecklistItem{}, ErrItemNotFound
+	}
+	courseID, err := s.resolveCourseID(ctx, courseCode)
+	if err != nil {
+		return ChecklistItem{}, err
+	}
+	res, computedAt, truncated, err := s.evaluateOnly(ctx, courseID, courseCode, itemID)
+	if err != nil {
+		return ChecklistItem{}, err
+	}
+	// Merge into existing snapshot payload when present.
+	if err := s.mergeRecheckIntoSnapshot(ctx, courseID, res, computedAt, truncated); err != nil {
+		slog.Warn("coursechecklist.recheck.snapshot_patch_failed",
+			"course_id", courseID.String(), "item_id", string(itemID), "err", err.Error())
+	}
+	dismissed, names, err := s.loadDismissals(ctx, courseID)
+	if err != nil {
+		return ChecklistItem{}, err
+	}
+	dismissedByID := map[string]ccrepo.ItemState{}
+	for _, st := range dismissed {
+		dismissedByID[st.ItemID] = st
+	}
+	for _, fr := range res.Findings {
+		if fr.ID == itemID {
+			return itemFromFinding(fr, dismissedByID[string(itemID)], names), nil
+		}
+	}
+	return ChecklistItem{}, ErrItemNotFound
+}
+
+// History returns recent checklist audit events (≤ 100).
+func (s *Service) History(ctx context.Context, courseCode string) (HistoryResponse, error) {
+	courseID, err := s.resolveCourseID(ctx, courseCode)
+	if err != nil {
+		return HistoryResponse{}, err
+	}
+	events, err := ccrepo.ListEvents(ctx, s.Pool, courseID, 100)
+	if err != nil {
+		return HistoryResponse{}, err
+	}
+	out := make([]HistoryEvent, 0, len(events))
+	for _, e := range events {
+		he := HistoryEvent{
+			ID:         e.ID.String(),
+			ItemID:     e.ItemID,
+			Action:     e.Action,
+			Reason:     e.Reason,
+			OccurredAt: e.OccurredAt.UTC(),
+		}
+		if e.ActorUserID != nil {
+			s := e.ActorUserID.String()
+			he.ActorUserID = &s
+		}
+		out = append(out, he)
+	}
+	return HistoryResponse{
+		CourseCode:     courseCode,
+		EngineVersion:  EngineVersion(),
+		CatalogVersion: CatalogVersion(),
+		Events:         out,
+	}, nil
+}
+
+// ErrItemNotFound is returned when item_id is unknown or retired.
+var ErrItemNotFound = errors.New("coursechecklist: item not found")
+
+// ErrCourseNotFound is returned when the course code does not resolve.
+var ErrCourseNotFound = errors.New("coursechecklist: course not found")
+
+func (s *Service) resolveCourseID(ctx context.Context, courseCode string) (uuid.UUID, error) {
+	if s == nil || s.Pool == nil {
+		return uuid.Nil, errors.New("coursechecklist: nil service pool")
+	}
+	id, err := course.GetIDByCourseCode(ctx, s.Pool, courseCode)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if id == nil {
+		return uuid.Nil, ErrCourseNotFound
+	}
+	return *id, nil
+}
+
+func (s *Service) loadDismissals(ctx context.Context, courseID uuid.UUID) ([]ccrepo.ItemState, map[uuid.UUID]string, error) {
+	dismissed, err := ccrepo.ListDismissed(ctx, s.Pool, courseID)
+	if err != nil {
+		return nil, nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(dismissed))
+	for _, st := range dismissed {
+		if st.DismissedByUserID != nil {
+			ids = append(ids, *st.DismissedByUserID)
+		}
+	}
+	names, err := userrepo.DisplayLabelsByIDs(ctx, s.Pool, ids)
+	if err != nil {
+		return dismissed, map[uuid.UUID]string{}, nil
+	}
+	return dismissed, names, nil
+}
+
+func (s *Service) loadSnapshotAndFreshness(ctx context.Context, courseID uuid.UUID) (*ccrepo.Snapshot, ccrepo.MutationFreshness, error) {
+	snap, err := ccrepo.GetSnapshot(ctx, s.Pool, courseID)
+	if err != nil {
+		return nil, ccrepo.MutationFreshness{}, err
+	}
+	freshness, err := ccrepo.MutationFreshnessForCourse(ctx, s.Pool, courseID)
+	if err != nil {
+		return nil, ccrepo.MutationFreshness{}, err
+	}
+	return snap, freshness, nil
+}
+
+func (s *Service) loadOrEvaluate(ctx context.Context, courseID uuid.UUID, courseCode string, force bool) (Result, time.Time, bool, bool, error) {
+	snap, freshness, err := s.loadSnapshotAndFreshness(ctx, courseID)
+	if err != nil {
+		return Result{}, time.Time{}, false, false, err
+	}
+	engineV := EngineVersion()
+	catalogV := CatalogVersion()
+	now := s.now()
+	stale := force || IsSnapshotStale(snap, engineV, catalogV, s.TTL, freshness, now)
+	if !stale {
+		observeSnapshotHit("hit")
+		res, truncated, err := decodeSnapshotPayload(snap.Payload)
+		if err != nil {
+			// Corrupt payload — recompute.
+			observeSnapshotHit("stale")
+		} else {
+			return res, snap.ComputedAt.UTC(), truncated, false, nil
+		}
+	} else if snap == nil {
+		observeSnapshotHit("miss")
+	} else {
+		observeSnapshotHit("stale")
+	}
+
+	res, computedAt, truncated, err := s.evaluateFull(ctx, courseID, courseCode)
+	if err != nil {
+		return Result{}, time.Time{}, false, false, err
+	}
+	if err := s.writeSnapshotBestEffort(ctx, courseID, res, computedAt, truncated); err != nil {
+		slog.Warn("coursechecklist.snapshot_write_failed",
+			"course_id", courseID.String(), "err", err.Error())
+	}
+	return res, computedAt, truncated, false, nil
+}
+
+func (s *Service) evaluateFull(ctx context.Context, courseID uuid.UUID, courseCode string) (Result, time.Time, bool, error) {
+	key := courseID.String()
+	type evalOut struct {
+		res       Result
+		at        time.Time
+		truncated bool
+	}
+	v, err, _ := evalFlight.Do(key, func() (any, error) {
+		acquireEvalSlot()
+		defer releaseEvalSlot()
+		needs := DataNeedsForEvaluate(MustDefault(), EvaluateOptions{})
+		snap, err := LoadSnapshot(ctx, s.Pool, courseCode, needs)
+		if err != nil {
+			return nil, err
+		}
+		res := Evaluate(ctx, snap, EvaluateOptions{})
+		truncated := false
+		res, truncated = fitPayload(res)
+		return evalOut{res: res, at: s.now(), truncated: truncated}, nil
+	})
+	if err != nil {
+		return Result{}, time.Time{}, false, err
+	}
+	out := v.(evalOut)
+	return out.res, out.at, out.truncated, nil
+}
+
+func (s *Service) evaluateOnly(ctx context.Context, courseID uuid.UUID, courseCode string, itemID ItemID) (Result, time.Time, bool, error) {
+	key := courseID.String() + ":only:" + string(itemID)
+	type evalOut struct {
+		res       Result
+		at        time.Time
+		truncated bool
+	}
+	v, err, _ := evalFlight.Do(key, func() (any, error) {
+		acquireEvalSlot()
+		defer releaseEvalSlot()
+		opt := EvaluateOptions{Only: []ItemID{itemID}}
+		needs := DataNeedsForEvaluate(MustDefault(), opt)
+		snap, err := LoadSnapshot(ctx, s.Pool, courseCode, needs)
+		if err != nil {
+			return nil, err
+		}
+		res := Evaluate(ctx, snap, opt)
+		truncated := false
+		res, truncated = fitPayload(res)
+		return evalOut{res: res, at: s.now(), truncated: truncated}, nil
+	})
+	if err != nil {
+		return Result{}, time.Time{}, false, err
+	}
+	out := v.(evalOut)
+	return out.res, out.at, out.truncated, nil
+}
+
+func (s *Service) writeSnapshotBestEffort(ctx context.Context, courseID uuid.UUID, res Result, computedAt time.Time, truncated bool) error {
+	dismissedCount, err := ccrepo.CountDismissed(ctx, s.Pool, courseID)
+	if err != nil {
+		dismissedCount = 0
+	}
+	dismissed, err := ccrepo.ListDismissed(ctx, s.Pool, courseID)
+	if err != nil {
+		dismissed = nil
+	}
+	dismissedByID := make(map[string]ccrepo.ItemState, len(dismissed))
+	for _, st := range dismissed {
+		dismissedByID[st.ItemID] = st
+	}
+	summary := DeriveSummary(res, dismissedByID, computedAt, false)
+	payload, err := encodeSnapshotPayload(res, truncated)
+	if err != nil {
+		return err
+	}
+	return ccrepo.UpsertSnapshot(ctx, s.Pool, ccrepo.UpsertSnapshotInput{
+		CourseID:             courseID,
+		ComputedAt:           computedAt,
+		EngineVersion:        res.EngineVersion,
+		CatalogVersion:       res.CatalogVersion,
+		Payload:              payload,
+		TotalCount:           summary.Total,
+		DoneCount:            summary.Done,
+		OutstandingEssential: summary.OutstandingEssential,
+		OutstandingTotal:     summary.OutstandingTotal,
+		DismissedCount:       dismissedCount,
+	})
+}
+
+func (s *Service) refreshSnapshotCounters(ctx context.Context, courseID uuid.UUID, courseCode string) error {
+	snap, err := ccrepo.GetSnapshot(ctx, s.Pool, courseID)
+	if err != nil || snap == nil {
+		return err
+	}
+	res, _, err := decodeSnapshotPayload(snap.Payload)
+	if err != nil {
+		return err
+	}
+	dismissed, err := ccrepo.ListDismissed(ctx, s.Pool, courseID)
+	if err != nil {
+		return err
+	}
+	dismissedByID := make(map[string]ccrepo.ItemState, len(dismissed))
+	for _, st := range dismissed {
+		dismissedByID[st.ItemID] = st
+	}
+	summary := DeriveSummary(res, dismissedByID, snap.ComputedAt.UTC(), false)
+	return ccrepo.UpdateSnapshotCounters(ctx, s.Pool, courseID,
+		summary.OutstandingEssential, summary.OutstandingTotal, summary.Done, summary.Total, summary.Dismissed)
+}
+
+func (s *Service) mergeRecheckIntoSnapshot(ctx context.Context, courseID uuid.UUID, partial Result, computedAt time.Time, truncated bool) error {
+	snap, err := ccrepo.GetSnapshot(ctx, s.Pool, courseID)
+	if err != nil {
+		return err
+	}
+	var base Result
+	baseTruncated := truncated
+	if snap != nil {
+		decoded, tr, err := decodeSnapshotPayload(snap.Payload)
+		if err == nil {
+			base = decoded
+			baseTruncated = baseTruncated || tr
+		}
+	}
+	if len(base.Findings) == 0 {
+		// No base — store partial as full (rare cold recheck).
+		return s.writeSnapshotBestEffort(ctx, courseID, partial, computedAt, truncated)
+	}
+	byID := make(map[ItemID]ItemResult, len(partial.Findings))
+	for _, fr := range partial.Findings {
+		byID[fr.ID] = fr
+	}
+	for i, fr := range base.Findings {
+		if repl, ok := byID[fr.ID]; ok {
+			base.Findings[i] = repl
+		}
+	}
+	base.Counts = aggregateCounts(base.Findings)
+	base.ByCategory = aggregateByCategory(base.Findings)
+	base.EngineVersion = EngineVersion()
+	base.CatalogVersion = CatalogVersion()
+	base, fitTrunc := fitPayload(base)
+	return s.writeSnapshotBestEffort(ctx, courseID, base, computedAt, baseTruncated || fitTrunc)
+}
+
+func (s *Service) itemForID(ctx context.Context, courseID uuid.UUID, courseCode string, itemID ItemID, st *ccrepo.ItemState) (ChecklistItem, error) {
+	// Prefer warm snapshot finding; fall back to single-item evaluate.
+	var fr *ItemResult
+	if snap, err := ccrepo.GetSnapshot(ctx, s.Pool, courseID); err == nil && snap != nil {
+		if res, _, err := decodeSnapshotPayload(snap.Payload); err == nil {
+			for i := range res.Findings {
+				if res.Findings[i].ID == itemID {
+					fr = &res.Findings[i]
+					break
+				}
+			}
+		}
+	}
+	if fr == nil {
+		res, _, _, err := s.evaluateOnly(ctx, courseID, courseCode, itemID)
+		if err != nil {
+			return ChecklistItem{}, err
+		}
+		for i := range res.Findings {
+			if res.Findings[i].ID == itemID {
+				fr = &res.Findings[i]
+				break
+			}
+		}
+	}
+	if fr == nil {
+		return ChecklistItem{}, ErrItemNotFound
+	}
+	names := map[uuid.UUID]string{}
+	state := ccrepo.ItemState{}
+	if st != nil {
+		state = *st
+		if st.DismissedByUserID != nil {
+			if m, err := userrepo.DisplayLabelsByIDs(ctx, s.Pool, []uuid.UUID{*st.DismissedByUserID}); err == nil {
+				names = m
+			}
+		}
+	}
+	return itemFromFinding(*fr, state, names), nil
+}
+
+func encodeSnapshotPayload(res Result, truncated bool) (json.RawMessage, error) {
+	b, err := json.Marshal(snapshotPayload{Result: res, EvidenceTruncated: truncated})
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > ccrepo.MaxPayloadBytes {
+		return nil, ccrepo.ErrPayloadTooLarge
+	}
+	return b, nil
+}
+
+func decodeSnapshotPayload(raw json.RawMessage) (Result, bool, error) {
+	var p snapshotPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return Result{}, false, err
+	}
+	return p.Result, p.EvidenceTruncated, nil
+}
+
+// fitPayload drops evidence when the serialized snapshot would exceed 256 KiB (AC-13).
+func fitPayload(res Result) (Result, bool) {
+	if _, err := encodeSnapshotPayload(res, false); err == nil {
+		return res, false
+	}
+	stripped := DropEvidence(res)
+	if _, err := encodeSnapshotPayload(stripped, true); err != nil {
+		// Still too large — return stripped anyway; write will fail best-effort.
+		slog.Warn("coursechecklist.payload_still_too_large", "err", err.Error())
+	}
+	return stripped, true
+}
+
+// SweepRetention deletes aged snapshots and audit events (nightly sweeper).
+func SweepRetention(ctx context.Context, pool *pgxpool.Pool, now time.Time) (snapshotsDeleted, eventsDeleted int64, err error) {
+	if pool == nil {
+		return 0, 0, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	snapCutoff := now.AddDate(0, 0, -90)
+	eventCutoff := now.AddDate(0, 0, -400)
+	snapshotsDeleted, err = ccrepo.DeleteSnapshotsUntouchedSince(ctx, pool, snapCutoff)
+	if err != nil {
+		return 0, 0, fmt.Errorf("sweep snapshots: %w", err)
+	}
+	eventsDeleted, err = ccrepo.DeleteEventsOlderThan(ctx, pool, eventCutoff)
+	if err != nil {
+		return snapshotsDeleted, 0, fmt.Errorf("sweep events: %w", err)
+	}
+	return snapshotsDeleted, eventsDeleted, nil
+}

--- a/server/internal/service/coursechecklist/staleness.go
+++ b/server/internal/service/coursechecklist/staleness.go
@@ -1,0 +1,40 @@
+package coursechecklist
+
+import (
+	"time"
+
+	ccrepo "github.com/lextures/lextures/server/internal/repos/coursechecklist"
+)
+
+// SnapshotTTLDefault is the default CHECKLIST_SNAPSHOT_TTL (FR-9).
+const SnapshotTTLDefault = 15 * time.Minute
+
+// IsSnapshotStale reports whether a stored snapshot must be recomputed (FR-9).
+func IsSnapshotStale(
+	snap *ccrepo.Snapshot,
+	engineVersion int,
+	catalogVersion string,
+	ttl time.Duration,
+	freshness ccrepo.MutationFreshness,
+	now time.Time,
+) bool {
+	if snap == nil {
+		return true
+	}
+	if snap.EngineVersion != engineVersion {
+		return true
+	}
+	if snap.CatalogVersion != catalogVersion {
+		return true
+	}
+	if ttl <= 0 {
+		ttl = SnapshotTTLDefault
+	}
+	if now.Sub(snap.ComputedAt) > ttl {
+		return true
+	}
+	if freshness.LatestMutation().After(snap.ComputedAt) {
+		return true
+	}
+	return false
+}

--- a/server/internal/service/coursechecklist/staleness_test.go
+++ b/server/internal/service/coursechecklist/staleness_test.go
@@ -1,0 +1,47 @@
+package coursechecklist
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	ccrepo "github.com/lextures/lextures/server/internal/repos/coursechecklist"
+)
+
+func TestIsSnapshotStale_TruthTable(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	base := &ccrepo.Snapshot{
+		CourseID:       uuid.New(),
+		ComputedAt:     now.Add(-5 * time.Minute),
+		EngineVersion:  1,
+		CatalogVersion: "abc",
+	}
+	fresh := ccrepo.MutationFreshness{CourseUpdatedAt: now.Add(-1 * time.Hour)}
+
+	cases := []struct {
+		name    string
+		snap    *ccrepo.Snapshot
+		engine  int
+		catalog string
+		ttl     time.Duration
+		mut     ccrepo.MutationFreshness
+		want    bool
+	}{
+		{"nil", nil, 1, "abc", SnapshotTTLDefault, fresh, true},
+		{"engine bump", base, 2, "abc", SnapshotTTLDefault, fresh, true},
+		{"catalog bump", base, 1, "xyz", SnapshotTTLDefault, fresh, true},
+		{"ttl expired", base, 1, "abc", 2 * time.Minute, fresh, true},
+		{"course mutated", base, 1, "abc", SnapshotTTLDefault, ccrepo.MutationFreshness{CourseUpdatedAt: now.Add(-1 * time.Minute)}, true},
+		{"warm hit", base, 1, "abc", SnapshotTTLDefault, fresh, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsSnapshotStale(tc.snap, tc.engine, tc.catalog, tc.ttl, tc.mut, now)
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/service/coursechecklist/warmup.go
+++ b/server/internal/service/coursechecklist/warmup.go
@@ -38,6 +38,7 @@ func WarmStart(ctx context.Context, pool *pgxpool.Pool) {
 	}
 	// Touch metrics registration so Prometheus series exist before first eval.
 	_ = ruleErrorsCounter()
+	_ = SnapshotHitsCounter()
 	slog.Info("coursechecklist.ready",
 		"items", reg.Size(),
 		"catalog_version", catalogVersionFor(reg),

--- a/server/internal/service/coursechecklist/warmup.go
+++ b/server/internal/service/coursechecklist/warmup.go
@@ -7,9 +7,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// WarmStart validates the builtin registry at process start and keeps the
-// public evaluation/load surface reachable from cmd/server (CC.1; deadcode keep-alive
-// until CC.2 HTTP handlers land).
+// WarmStart validates the builtin registry at process start (CC.1) so a bad
+// catalog fails fast before HTTP traffic (CC.2) hits Evaluate/LoadSnapshot.
 func WarmStart(ctx context.Context, pool *pgxpool.Pool) {
 	reg := MustDefault()
 	_ = CatalogVersion()

--- a/server/internal/service/coursecopy/copy.go
+++ b/server/internal/service/coursecopy/copy.go
@@ -31,6 +31,8 @@ type Options struct {
 }
 
 // CopyFromCourse copies selected content from source into target. Target must be empty (no structure rows).
+// Course checklist dismissals/snapshots/events (CC.2) are intentionally not copied — a new course
+// starts with a clean checklist (FR-21 / AC-11).
 func CopyFromCourse(ctx context.Context, pool *pgxpool.Pool, opts Options) error {
 	include := opts.Include.WithDefaults()
 

--- a/server/internal/service/gdpr/service.go
+++ b/server/internal/service/gdpr/service.go
@@ -20,6 +20,7 @@ import (
 	acrepo "github.com/lextures/lextures/server/internal/repos/adaptivecontent"
 	"github.com/lextures/lextures/server/internal/repos/board"
 	ctrepo "github.com/lextures/lextures/server/internal/repos/contenttools"
+	ccrepo "github.com/lextures/lextures/server/internal/repos/coursechecklist"
 	repo "github.com/lextures/lextures/server/internal/repos/gdpr"
 	icrepo "github.com/lextures/lextures/server/internal/repos/introcourse"
 	lprepo "github.com/lextures/lextures/server/internal/repos/learnerprofile"
@@ -324,6 +325,7 @@ SELECT email, display_name, first_name, last_name, timezone, created_at, custom_
 		AdaptiveContent  acrepo.UserACEExport           `json:"adaptiveContent,omitempty"`
 		ContentTools     ctrepo.UserContentToolsExport  `json:"contentTools,omitempty"`
 		PinnedSettings   []map[string]any               `json:"pinnedSettings,omitempty"`
+		CourseChecklist  []map[string]any               `json:"courseChecklist,omitempty"`
 		ExportedAt       string                         `json:"exportedAt"`
 	}
 
@@ -359,6 +361,7 @@ SELECT email, display_name, first_name, last_name, timezone, created_at, custom_
 		return "", fmt.Errorf("gdpr: content tools export: %w", err)
 	}
 	pinnedExport := dsarPinnedSettingsExport(ctx, pool, userID)
+	checklistExport := dsarCourseChecklistExport(ctx, pool, userID)
 
 	var customFields map[string]any
 	if len(customRaw) > 0 {
@@ -378,6 +381,7 @@ SELECT email, display_name, first_name, last_name, timezone, created_at, custom_
 		AdaptiveContent: aceExport,
 		ContentTools:    ctExport,
 		PinnedSettings:  pinnedExport,
+		CourseChecklist: checklistExport,
 		ExportedAt:      time.Now().UTC().Format(time.RFC3339),
 	}
 	b, err := json.Marshal(doc)
@@ -431,6 +435,26 @@ func dsarPinnedSettingsExport(ctx context.Context, pool *pgxpool.Pool, userID uu
 			"surface":     r.Surface,
 			"settingKeys": r.SettingKeys,
 			"updatedAt":   r.UpdatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	return out
+}
+
+// dsarCourseChecklistExport includes staff-authored checklist dismiss notes (CC.2).
+func dsarCourseChecklistExport(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) []map[string]any {
+	rows, err := ccrepo.ListDismissNotesForUser(ctx, pool, userID)
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, map[string]any{
+			"courseId":    r.CourseID.String(),
+			"courseCode":  r.CourseCode,
+			"itemId":      r.ItemID,
+			"reason":      r.Reason,
+			"note":        r.Note,
+			"dismissedAt": r.DismissedAt.UTC().Format(time.RFC3339),
 		})
 	}
 	return out

--- a/server/migrations/461_course_checklist.down.sql
+++ b/server/migrations/461_course_checklist.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS course.course_checklist_events;
+DROP TABLE IF EXISTS course.course_checklist_snapshots;
+DROP TABLE IF EXISTS course.course_checklist_item_state;

--- a/server/migrations/461_course_checklist.sql
+++ b/server/migrations/461_course_checklist.sql
@@ -1,0 +1,60 @@
+-- CC.2: Course checklist dismissals, evaluation snapshots, and audit events.
+
+CREATE TABLE IF NOT EXISTS course.course_checklist_item_state (
+    course_id            UUID NOT NULL REFERENCES course.courses (id) ON DELETE CASCADE,
+    item_id              TEXT NOT NULL,
+    dismissed_at         TIMESTAMPTZ,
+    dismissed_by_user_id UUID REFERENCES "user".users (id) ON DELETE SET NULL,
+    dismiss_reason       TEXT NOT NULL DEFAULT '',
+    dismiss_note         TEXT NOT NULL DEFAULT '',
+    snoozed_until        TIMESTAMPTZ,
+    restored_at          TIMESTAMPTZ,
+    restored_by_user_id  UUID REFERENCES "user".users (id) ON DELETE SET NULL,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (course_id, item_id),
+    CONSTRAINT course_checklist_item_id_format CHECK (item_id ~ '^[a-z][a-z0-9]*(\.[a-z0-9-]+){1,3}$'),
+    CONSTRAINT course_checklist_reason_check CHECK (
+        dismiss_reason IN ('', 'not_applicable', 'done_elsewhere', 'disagree', 'later', 'other')),
+    CONSTRAINT course_checklist_note_len CHECK (length(dismiss_note) <= 500)
+);
+
+CREATE INDEX IF NOT EXISTS idx_course_checklist_state_dismissed
+    ON course.course_checklist_item_state (course_id) WHERE dismissed_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS course.course_checklist_snapshots (
+    course_id             UUID PRIMARY KEY REFERENCES course.courses (id) ON DELETE CASCADE,
+    computed_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    engine_version        INT NOT NULL,
+    catalog_version       TEXT NOT NULL,
+    payload               JSONB NOT NULL,
+    total_count           INT NOT NULL DEFAULT 0,
+    done_count            INT NOT NULL DEFAULT 0,
+    outstanding_essential INT NOT NULL DEFAULT 0,
+    outstanding_total     INT NOT NULL DEFAULT 0,
+    dismissed_count       INT NOT NULL DEFAULT 0,
+    CONSTRAINT course_checklist_payload_size CHECK (pg_column_size(payload) <= 262144)
+);
+
+CREATE INDEX IF NOT EXISTS idx_course_checklist_snapshots_computed
+    ON course.course_checklist_snapshots (computed_at);
+
+CREATE TABLE IF NOT EXISTS course.course_checklist_events (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    course_id     UUID NOT NULL REFERENCES course.courses (id) ON DELETE CASCADE,
+    item_id       TEXT NOT NULL,
+    action        TEXT NOT NULL CHECK (action IN ('dismiss', 'restore', 'complete', 'regress')),
+    actor_user_id UUID REFERENCES "user".users (id) ON DELETE SET NULL,
+    reason        TEXT NOT NULL DEFAULT '',
+    occurred_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_course_checklist_events_course_time
+    ON course.course_checklist_events (course_id, occurred_at DESC);
+
+COMMENT ON TABLE course.course_checklist_item_state IS
+    'CC.2: Per-course checklist item dismissals (course-scoped, not per-user).';
+COMMENT ON TABLE course.course_checklist_snapshots IS
+    'CC.2: Cached checklist evaluation Result plus denormalised badge counters.';
+COMMENT ON TABLE course.course_checklist_events IS
+    'CC.2: Audit trail for checklist dismiss/restore/status transitions.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **CC.2** — checklist persistence, staff-only HTTP API, and dismissals on top of the CC.1 evaluation engine.

- Migration `461`: `course_checklist_item_state`, `course_checklist_snapshots`, `course_checklist_events`
- Staff guard (`item:create` / org admin / global admin); students & TAs get `403`
- Routes: `GET /checklist`, `GET /summary`, `POST /refresh`, `GET /history`, dismiss/restore/recheck
- Snapshot cache with TTL + mutation staleness, per-course single-flight, best-effort writes
- Factory reset clears checklist state; course copy does not carry dismissals; DSAR exports dismiss notes
- Nightly retention sweeper; OpenAPI + route inventory; Playwright API smoke + Go DB tests

Plan moved to `docs/completed/checklist/CC.2-checklist-state-api-and-dismissals.md`.

## Checklist

- [x] Tests added/updated as appropriate
- [x] Structure: new/changed code follows ARCHITECTURE_CONVENTIONS (`make lint-structure`)
- [x] Disposition in `e2e/coverage/completed-feature-manifest.json` + `npm run e2e:coverage:check`
- [x] No feature flag (always on for staff)

## Test plan

- [x] `go test ./internal/service/coursechecklist/ ./internal/repos/coursechecklist/ -count=1`
- [x] `go test ./internal/httpserver/ -run TestCourseChecklist_ -count=1` (needs `DATABASE_URL`)
- [x] `make openapi-check` / route inventory update
- [x] `make lint-structure` (including deadcode)
- [x] `e2e/tests/course-checklist.spec.ts` against local API
- [x] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcb23-08bb-73b1-bfe0-ccbba8bb3a4e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcb23-08bb-73b1-bfe0-ccbba8bb3a4e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

