### PR TITLE
feat(server): CC.5 assessment, grading, feedback & interaction checklist rules

### DIFF
--- a/docs/completed/checklist/CC.5-rule-pack-assessment-feedback-interaction.md
+++ b/docs/completed/checklist/CC.5-rule-pack-assessment-feedback-interaction.md
@@ -1,7 +1,7 @@
 # CC.5 — Rule Pack C: Assessment, Grading, Feedback & Interaction
 
 > Implementation plan. Source: Course Checklist product request. Folder overview: [README](README.md).
-> Rubric mapping: [course-design-research.md](course-design-research.md).
+> Rubric mapping: [course-design-research.md](../../plan/checklist/course-design-research.md).
 
 ## Metadata
 
@@ -330,7 +330,7 @@ wires the checklist item's action button to it. No new model, prompt or cost bud
 
 ## 17. Documentation & Training
 
-- [course-design-research.md](course-design-research.md) C-sections.
+- [course-design-research.md](../../plan/checklist/course-design-research.md) C-sections.
 - Help-centre: "Why do my weights need to total 100%?", "Writing grading criteria students can use",
   "Formative checks: what counts".
 - Accommodations doc note explaining exactly what the checklist can and cannot see (privacy transparency).
@@ -360,5 +360,5 @@ wires the checklist item's action button to it. No new model, prompt or cost bud
   GS3 (Assessment and Measurement) and GS5 (Course Activities and Learner Interaction);
   [NSQ](https://nsqol.org/the-standards/quality-online-courses/) Standard D (Learner Assessment).
 - Related plans: [CC.4](CC.4-rule-pack-structure-outcomes-alignment.md),
-  [CC.6](CC.6-rule-pack-accessibility-and-launch-readiness.md),
-  [CC.10](CC.10-analytics-guidance-and-rollout.md).
+  [CC.6](../../plan/checklist/CC.6-rule-pack-accessibility-and-launch-readiness.md),
+  [CC.10](../../plan/checklist/CC.10-analytics-guidance-and-rollout.md).

--- a/docs/completed/checklist/README.md
+++ b/docs/completed/checklist/README.md
@@ -6,5 +6,6 @@
 | **CC.2** | [Checklist state, API & dismissals](CC.2-checklist-state-api-and-dismissals.md) |
 | **CC.3** | [Rule pack A — foundations, orientation, policies & people](CC.3-rule-pack-foundations-and-orientation.md) |
 | **CC.4** | [Rule pack B — structure, content & outcome alignment](CC.4-rule-pack-structure-outcomes-alignment.md) |
+| **CC.5** | [Rule pack C — assessment, grading, feedback & interaction](CC.5-rule-pack-assessment-feedback-interaction.md) |
 
 Remaining plans live under [`docs/plan/checklist/`](../../plan/checklist/README.md).

--- a/docs/plan/checklist/README.md
+++ b/docs/plan/checklist/README.md
@@ -19,7 +19,7 @@ Every plan follows [_TEMPLATE.md](../_TEMPLATE.md).
 | CC.2 | [Checklist state, API & dismissals](../../completed/checklist/CC.2-checklist-state-api-and-dismissals.md) ✅ | Server | M | CC.1 |
 | CC.3 | [Rule pack A — foundations, orientation, policies & people](../../completed/checklist/CC.3-rule-pack-foundations-and-orientation.md) ✅ (33 rules) | Server | M | CC.1, CC.2 |
 | CC.4 | [Rule pack B — structure, content & outcome alignment](../../completed/checklist/CC.4-rule-pack-structure-outcomes-alignment.md) ✅ (22 rules) | Server | M | CC.1, CC.2 |
-| CC.5 | [Rule pack C — assessment, grading, feedback & interaction](CC.5-rule-pack-assessment-feedback-interaction.md) (26 rules) | Server | M | CC.1, CC.2 |
+| CC.5 | [Rule pack C — assessment, grading, feedback & interaction](../../completed/checklist/CC.5-rule-pack-assessment-feedback-interaction.md) ✅ (26 rules) | Server | M | CC.1, CC.2 |
 | CC.6 | [Rule pack D — accessibility, inclusive design & launch readiness](CC.6-rule-pack-accessibility-and-launch-readiness.md) (20 rules) | Server | M | CC.1, CC.2 |
 | CC.7 | [Web: checklist page, nav entry & badge](CC.7-web-checklist-page-and-nav-badge.md) | Web | M | CC.2, CC.3 |
 | CC.8 | [Deep-link & highlight targeting](CC.8-deep-link-and-highlight-targeting.md) | Web (+ shared) | M | CC.1, CC.7 |

--- a/e2e/coverage/REPORT.md
+++ b/e2e/coverage/REPORT.md
@@ -1,17 +1,17 @@
 # Completed feature E2E coverage report
 
-Total stories: **545**
+Total stories: **560**
 
 ## Coverage levels
 
 | Level | Count |
 |---|---:|
 | journey | 108 |
-| smoke | 178 |
+| smoke | 182 |
 | api-contract | 1 |
 | covered-by-parent | 11 |
 | manual | 8 |
-| not-applicable | 171 |
+| not-applicable | 182 |
 | missing | 68 |
 
 ## By client
@@ -20,18 +20,18 @@ Total stories: **545**
 |---|---:|
 | cli | 48 |
 | docs | 18 |
-| mobile | 92 |
-| ops | 16 |
+| mobile | 102 |
+| ops | 21 |
 | web | 371 |
 
 ## By market tag
 
 | Market | Count |
 |---|---:|
-| ALL | 498 |
-| HE | 15 |
-| HS | 19 |
-| K12 | 13 |
+| ALL | 508 |
+| HE | 20 |
+| HS | 24 |
+| K12 | 18 |
 
 ## Missing journeys (severity / owner / milestone)
 
@@ -117,9 +117,16 @@ Total stories: **545**
 | AC.1 | enabledJourney, rollback | [docs/completed/adaptive/AC.1-foundations-flag-and-data-model.md](../../docs/completed/adaptive/AC.1-foundations-flag-and-data-model.md) |
 | AC.7 | rollback | [docs/completed/adaptive/AC.7-post-assessment-and-effectiveness.md](../../docs/completed/adaptive/AC.7-post-assessment-and-effectiveness.md) |
 | AC.9 | rollback | [docs/completed/adaptive/AC.9-analytics-reporting-and-operability.md](../../docs/completed/adaptive/AC.9-analytics-reporting-and-operability.md) |
+| CC.1 | settingsToggle | [docs/completed/checklist/CC.1-checklist-registry-and-evaluation-engine.md](../../docs/completed/checklist/CC.1-checklist-registry-and-evaluation-engine.md) |
+| CC.2 | settingsToggle | [docs/completed/checklist/CC.2-checklist-state-api-and-dismissals.md](../../docs/completed/checklist/CC.2-checklist-state-api-and-dismissals.md) |
+| CC.3 | settingsToggle | [docs/completed/checklist/CC.3-rule-pack-foundations-and-orientation.md](../../docs/completed/checklist/CC.3-rule-pack-foundations-and-orientation.md) |
+| CC.4 | settingsToggle | [docs/completed/checklist/CC.4-rule-pack-structure-outcomes-alignment.md](../../docs/completed/checklist/CC.4-rule-pack-structure-outcomes-alignment.md) |
+| CC.5 | settingsToggle | [docs/completed/checklist/CC.5-rule-pack-assessment-feedback-interaction.md](../../docs/completed/checklist/CC.5-rule-pack-assessment-feedback-interaction.md) |
 | CT.1 | enabledJourney, rollback | [docs/completed/content_tools/CT.1-foundations-registry-and-data-model.md](../../docs/completed/content_tools/CT.1-foundations-registry-and-data-model.md) |
 | CT.2 | rollback | [docs/completed/content_tools/CT.2-authoring-tools-dropdown-and-config.md](../../docs/completed/content_tools/CT.2-authoring-tools-dropdown-and-config.md) |
+| ct-m9-mobile-tools-governance-a11y-telemetry | settingsToggle | [docs/completed/content_tools/CT.M9-mobile-tools-governance-a11y-telemetry.md](../../docs/completed/content_tools/CT.M9-mobile-tools-governance-a11y-telemetry.md) |
 | IQ.1 | disabledState, authorization, dependency, rollback | [docs/completed/interactive-quizzes/IQ.1-foundation-and-feature-flag.md](../../docs/completed/interactive-quizzes/IQ.1-foundation-and-feature-flag.md) |
+| mb-1-in-app-browser | dependency | [docs/completed/mobile/MB.1-in-app-browser.md](../../docs/completed/mobile/MB.1-in-app-browser.md) |
 | PS.4 | disabledState, enabledJourney, rollback | [docs/completed/settings/PS.4-suggested-pins-telemetry-and-rollout.md](../../docs/completed/settings/PS.4-suggested-pins-telemetry-and-rollout.md) |
 | T01 | disabledState, authorization, dependency, rollback | [docs/completed/transcripts/T01-official-transcript-generation.md](../../docs/completed/transcripts/T01-official-transcript-generation.md) |
 | VC.1 | disabledState, authorization, dependency, rollback | [docs/completed/visual-collaboration/VC.1-foundation-and-feature-flag.md](../../docs/completed/visual-collaboration/VC.1-foundation-and-feature-flag.md) |
@@ -155,8 +162,9 @@ Total stories: **545**
 | ai-providers | 0 | 8 | 0 | 0 | 0 | 0 | 1 |
 | animations | 0 | 4 | 0 | 0 | 0 | 0 | 3 |
 | badges | 0 | 0 | 0 | 0 | 0 | 0 | 1 |
+| checklist | 0 | 4 | 0 | 0 | 0 | 1 | 0 |
 | cli | 0 | 0 | 0 | 0 | 0 | 40 | 0 |
-| content_tools | 22 | 1 | 0 | 0 | 0 | 0 | 0 |
+| content_tools | 22 | 1 | 0 | 0 | 0 | 9 | 0 |
 | e2e | 3 | 0 | 1 | 0 | 0 | 0 | 0 |
 | emails | 0 | 0 | 0 | 0 | 0 | 3 | 0 |
 | feedback | 0 | 5 | 0 | 0 | 0 | 0 | 0 |
@@ -168,7 +176,7 @@ Total stories: **545**
 | lighthouse | 0 | 3 | 0 | 0 | 0 | 0 | 0 |
 | marketplace | 1 | 9 | 0 | 1 | 0 | 0 | 0 |
 | marketplace-courses | 0 | 2 | 0 | 2 | 0 | 0 | 0 |
-| mobile | 0 | 0 | 0 | 0 | 0 | 84 | 0 |
+| mobile | 0 | 0 | 0 | 0 | 0 | 85 | 0 |
 | parent-portal | 1 | 0 | 0 | 0 | 0 | 0 | 0 |
 | screenshare | 0 | 1 | 0 | 0 | 0 | 0 | 0 |
 | settings | 0 | 0 | 0 | 0 | 0 | 3 | 4 |

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -5178,6 +5178,35 @@
       }
     },
     {
+      "id": "CC.5",
+      "path": "docs/completed/checklist/CC.5-rule-pack-assessment-feedback-interaction.md",
+      "markets": [
+        "K12",
+        "HE",
+        "HS"
+      ],
+      "risk": "major",
+      "client": "ops",
+      "coverage": "smoke",
+      "rationale": "26 assessment/grading/feedback/interaction checklist rules (recommended tier) evaluated server-side. Playwright covers grading.group-weights (87%→todo, 100%→done) and feedback.rubrics-on-high-stakes evidence targeting assignment.rubric; accommodations privacy asserted in Go tests. UI lands with CC.7/CC.8.",
+      "owner": "Learning Platform",
+      "reviewed": true,
+      "specs": [
+        {
+          "path": "e2e/tests/course-checklist.spec.ts"
+        }
+      ],
+      "flags": {
+        "settingsToggle": false,
+        "disabledState": "n/a",
+        "enabledJourney": true,
+        "authorization": "n/a",
+        "dependency": "n/a",
+        "rollback": true,
+        "notes": "All 26 rules ship recommended (FR-27); promote arithmetic essentials after dogfood (CC.10). Accommodations rules are count/type-only (no PII). Retire via RETIRED_ITEM_IDS. No feature flag."
+      }
+    },
+    {
       "id": "mb-1-in-app-browser",
       "path": "docs/completed/mobile/MB.1-in-app-browser.md",
       "markets": [

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -538,7 +538,16 @@ export async function apiGetGradingScheme(
 export async function apiGetCourseGrading(
   token: string,
   courseCode: string,
-): Promise<{ gradingScale: string; sbgEnabled?: boolean }> {
+): Promise<{
+  gradingScale: string
+  sbgEnabled?: boolean
+  assignmentGroups?: Array<{
+    id: string
+    name: string
+    sortOrder: number
+    weightPercent: number
+  }>
+}> {
   const res = await fetch(
     `${apiBase}/api/v1/courses/${encodeURIComponent(courseCode)}/grading`,
     { headers: { Authorization: `Bearer ${token}` } },
@@ -547,7 +556,16 @@ export async function apiGetCourseGrading(
     const body = await res.text()
     throw new Error(`Get course grading failed (${res.status}): ${body}`)
   }
-  return res.json() as Promise<{ gradingScale: string; sbgEnabled?: boolean }>
+  return res.json() as Promise<{
+    gradingScale: string
+    sbgEnabled?: boolean
+    assignmentGroups?: Array<{
+      id: string
+      name: string
+      sortOrder: number
+      weightPercent: number
+    }>
+  }>
 }
 
 export async function apiPutCourseGrading(

--- a/e2e/tests/course-checklist.spec.ts
+++ b/e2e/tests/course-checklist.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Course Checklist state API (CC.2) + foundation rule pack (CC.3) + structure/outcomes (CC.4).
+ * Course Checklist state API (CC.2) + foundation rule pack (CC.3) + structure/outcomes (CC.4)
+ * + assessment/grading/feedback (CC.5).
  *
  * Checklist coverage:
  *   [x] Unauthenticated GET /checklist returns 401
@@ -11,6 +12,8 @@
  *   [x] Enroll a student → people.students-enrolled becomes done
  *   [x] CC.4: 5 assignments / 2 mapped → outcomes.assessment-mapping shows 3 evidence rows
  *   [x] CC.4: map a third assignment → evidence shrinks after refresh
+ *   [x] CC.5: weights 40/30/17 → grading.group-weights todo with 87% detail; fix to 100% → done
+ *   [x] CC.5: 30% assignment without rubric → feedback.rubrics-on-high-stakes evidence targets rubric
  */
 
 import { test, expect } from '@playwright/test'
@@ -25,6 +28,8 @@ import {
   apiPatchAssignment,
   apiCreateOutcome,
   apiCreateOutcomeLink,
+  apiPutCourseGrading,
+  apiGetCourseGrading,
 } from '../fixtures/api.js'
 
 const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
@@ -38,7 +43,8 @@ function uniqueEmail(prefix = 'cc3') {
 type ChecklistItem = {
   id: string
   status: string
-  finding?: { status?: string }
+  detail?: string | null
+  finding?: { status?: string; detailDefault?: string }
   progress?: { done: number; total: number }
   evidence?: {
     columns?: string[]
@@ -245,4 +251,85 @@ test('Course checklist CC.4: assessment-mapping evidence rows shrink after mappi
   expect(itemStatus(after)).toBe('in_progress')
   expect(after!.progress).toEqual({ done: 3, total: 5 })
   expect(after!.evidence?.rows?.length).toBe(2)
+})
+
+test('Course checklist CC.5: group weights 87% → todo, then 100% → done', async () => {
+  const teacherEmail = uniqueEmail('cc5-weights-teacher')
+  const { access_token: teacherTok } = await apiSignup({ email: teacherEmail, password: PASSWORD })
+  const course = await apiCreateCourse(teacherTok, { title: 'CC5 Weights Course' })
+  await apiEnroll(teacherTok, course.courseCode, teacherEmail, 'teacher')
+
+  async function refreshChecklist(token: string, courseCode: string): Promise<ChecklistResponse> {
+    const res = await fetch(`${API_BASE}/api/v1/courses/${courseCode}/checklist/refresh`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(200)
+    return res.json() as Promise<ChecklistResponse>
+  }
+
+  await apiPutCourseGrading(teacherTok, course.courseCode, {
+    gradingScale: 'percent',
+    assignmentGroups: [
+      { name: 'Essays', sortOrder: 0, weightPercent: 40 },
+      { name: 'Quizzes', sortOrder: 1, weightPercent: 30 },
+      { name: 'Participation', sortOrder: 2, weightPercent: 17 },
+    ],
+  })
+
+  let list = await refreshChecklist(teacherTok, course.courseCode)
+  const weights = findItem(list, 'grading.group-weights')
+  expect(weights, 'grading.group-weights should be present').toBeTruthy()
+  expect(itemStatus(weights)).toBe('todo')
+  const detail = weights!.detail ?? weights!.finding?.detailDefault ?? ''
+  expect(detail).toMatch(/87%/)
+  expect(detail).toMatch(/100%/)
+
+  const current = await apiGetCourseGrading(teacherTok, course.courseCode)
+  const groups = current.assignmentGroups ?? []
+  expect(groups.length).toBeGreaterThanOrEqual(3)
+  await apiPutCourseGrading(teacherTok, course.courseCode, {
+    gradingScale: 'percent',
+    assignmentGroups: groups.map((g) => ({
+      id: g.id,
+      name: g.name,
+      sortOrder: g.sortOrder,
+      weightPercent: g.name === 'Participation' ? 30 : g.weightPercent,
+    })),
+  })
+  list = await refreshChecklist(teacherTok, course.courseCode)
+  expect(itemStatus(findItem(list, 'grading.group-weights'))).toBe('done')
+})
+
+test('Course checklist CC.5: high-stakes assignment without rubric targets rubric section', async () => {
+  const teacherEmail = uniqueEmail('cc5-rubric-teacher')
+  const { access_token: teacherTok } = await apiSignup({ email: teacherEmail, password: PASSWORD })
+  const course = await apiCreateCourse(teacherTok, { title: 'CC5 Rubric Course' })
+  await apiEnroll(teacherTok, course.courseCode, teacherEmail, 'teacher')
+
+  const mod = await apiCreateModule(teacherTok, course.courseCode, 'Unit 1')
+  const capstone = await apiCreateAssignment(teacherTok, course.courseCode, mod.id, 'Capstone Essay')
+  await apiPatchAssignment(teacherTok, course.courseCode, capstone.id, {
+    pointsWorth: 30,
+    markdown: '',
+  })
+  const filler = await apiCreateAssignment(teacherTok, course.courseCode, mod.id, 'Weekly quiz points')
+  await apiPatchAssignment(teacherTok, course.courseCode, filler.id, {
+    pointsWorth: 70,
+    markdown: 'Complete the weekly work.',
+  })
+
+  const res = await fetch(`${API_BASE}/api/v1/courses/${course.courseCode}/checklist/refresh`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${teacherTok}` },
+  })
+  expect(res.status).toBe(200)
+  const list = (await res.json()) as ChecklistResponse
+  const item = findItem(list, 'feedback.rubrics-on-high-stakes')
+  expect(item, 'feedback.rubrics-on-high-stakes should be present').toBeTruthy()
+  expect(itemStatus(item)).toBe('todo')
+  const row = item!.evidence?.rows?.find((r) => (r.label ?? '').includes('Capstone'))
+  expect(row, 'capstone should appear in evidence').toBeTruthy()
+  expect(row!.target?.route).toContain(`/modules/assignment/${capstone.id}`)
+  expect(row!.target?.anchor).toBe('assignment.rubric')
 })

--- a/server/internal/httpserver/module_assignment.go
+++ b/server/internal/httpserver/module_assignment.go
@@ -460,6 +460,8 @@ func (d Deps) handlePatchModuleAssignment() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Not found.")
 			return
 		}
+		// CC.5: saving assignment settings (incl. originality) stamps integrity review marker.
+		_ = course.StampIntegritySettingsReviewed(r.Context(), d.Pool, *cid)
 		if d.readingLevelEnabled() && req.Markdown != "" {
 			_ = rlrepo.ScoreAndPersist(r.Context(), d.Pool, itemID, rlrepo.TypeAssignment, req.Markdown)
 		}

--- a/server/internal/httpserver/module_quiz.go
+++ b/server/internal/httpserver/module_quiz.go
@@ -359,6 +359,8 @@ func (d Deps) handlePatchModuleQuiz() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Not found.")
 			return
 		}
+		// CC.5: saving quiz settings (incl. lockdown/shuffle) stamps integrity review marker.
+		_ = course.StampIntegritySettingsReviewed(r.Context(), d.Pool, *cid)
 		row, err := coursemodulequizzes.GetForCourseItem(r.Context(), d.Pool, *cid, itemID)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load quiz.")

--- a/server/internal/repos/course/checklist_markers.go
+++ b/server/internal/repos/course/checklist_markers.go
@@ -1,0 +1,21 @@
+package course
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// StampIntegritySettingsReviewed sets integrity_settings_reviewed_at = NOW() for a course.
+// Drives checklist item integrity.high-stakes-settings (CC.5).
+// Accommodations review is stamped inline from studentaccommodations writes (same table)
+// to avoid an import cycle with this package.
+func StampIntegritySettingsReviewed(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) error {
+	_, err := pool.Exec(ctx, `
+UPDATE course.courses
+SET integrity_settings_reviewed_at = NOW(), updated_at = NOW()
+WHERE id = $1
+`, courseID)
+	return err
+}

--- a/server/internal/repos/studentaccommodations/counts.go
+++ b/server/internal/repos/studentaccommodations/counts.go
@@ -2,6 +2,7 @@ package studentaccommodations
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -18,4 +19,58 @@ WHERE sa.active = true
   AND (sa.course_id = $1 OR sa.course_id IS NULL)
 `, courseID).Scan(&n)
 	return n, err
+}
+
+// TypeAggregate is a privacy-safe count of active accommodations of one type.
+// Never includes user identifiers (CC.5 FR-21 / AC-10).
+type TypeAggregate struct {
+	Type  string
+	Count int
+}
+
+// AggregateActiveTypesForCourse returns counts by accommodation type for the course
+// (course-scoped or global). Types with zero count are omitted.
+func AggregateActiveTypesForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) ([]TypeAggregate, *time.Time, error) {
+	rows, err := pool.Query(ctx, `
+SELECT typ, COUNT(*)::int AS n, MAX(created_at) AS latest
+FROM (
+  SELECT 'extended_time' AS typ, created_at
+  FROM course.student_accommodations
+  WHERE active = true AND (course_id = $1 OR course_id IS NULL) AND time_multiplier > 1.0
+  UNION ALL
+  SELECT 'extra_attempts', created_at
+  FROM course.student_accommodations
+  WHERE active = true AND (course_id = $1 OR course_id IS NULL) AND extra_attempts > 0
+  UNION ALL
+  SELECT 'reduced_distraction', created_at
+  FROM course.student_accommodations
+  WHERE active = true AND (course_id = $1 OR course_id IS NULL) AND reduced_distraction_mode
+  UNION ALL
+  SELECT 'separate_setting', created_at
+  FROM course.student_accommodations
+  WHERE active = true AND (course_id = $1 OR course_id IS NULL) AND separate_setting
+) t
+GROUP BY typ
+ORDER BY typ
+`, courseID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var out []TypeAggregate
+	var latest *time.Time
+	for rows.Next() {
+		var typ string
+		var n int
+		var created time.Time
+		if err := rows.Scan(&typ, &n, &created); err != nil {
+			return nil, nil, err
+		}
+		out = append(out, TypeAggregate{Type: typ, Count: n})
+		if latest == nil || created.After(*latest) {
+			t := created
+			latest = &t
+		}
+	}
+	return out, latest, rows.Err()
 }

--- a/server/internal/repos/studentaccommodations/counts_test.go
+++ b/server/internal/repos/studentaccommodations/counts_test.go
@@ -1,0 +1,75 @@
+package studentaccommodations
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Guard: AggregateActiveTypesForCourse SQL must never SELECT user identifiers (CC.5 AC-10).
+func TestAggregateActiveTypesSQLHasNoPII(t *testing.T) {
+	src, err := os.ReadFile("counts.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(src)
+	fn := "func AggregateActiveTypesForCourse"
+	idx := strings.Index(text, fn)
+	if idx < 0 {
+		t.Fatalf("%s missing", fn)
+	}
+	chunk := strings.ToLower(text[idx:])
+	if end := strings.Index(chunk, "\nfunc "); end > 0 {
+		chunk = chunk[:end]
+	}
+	for _, banned := range []string{
+		"user_id", "sa.user_id", "email", "display_name", "created_by", "updated_by",
+	} {
+		if strings.Contains(chunk, banned) {
+			t.Fatalf("%s must not reference %q (privacy)", fn, banned)
+		}
+	}
+}
+
+func TestTypeAggregateExportedFields(t *testing.T) {
+	fset := token.NewFileSet()
+	path := filepath.Join("counts.go")
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != "TypeAggregate" {
+				continue
+			}
+			found = true
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				t.Fatal("TypeAggregate not a struct")
+			}
+			for _, field := range st.Fields.List {
+				for _, name := range field.Names {
+					switch name.Name {
+					case "Type", "Count":
+					default:
+						t.Fatalf("unexpected field %s on TypeAggregate (privacy)", name.Name)
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("TypeAggregate missing")
+	}
+}

--- a/server/internal/repos/studentaccommodations/studentaccommodations.go
+++ b/server/internal/repos/studentaccommodations/studentaccommodations.go
@@ -218,6 +218,13 @@ RETURNING id, user_id, course_id,` + rowSelectCols
 	r.EffectiveFrom = effF
 	r.EffectiveUntil = effU
 	r.AlternativeFormat = strptr(alt)
+	if courseID != nil {
+		_, _ = pool.Exec(ctx, `
+UPDATE course.courses
+SET accommodations_reviewed_at = NOW(), updated_at = NOW()
+WHERE id = $1
+`, *courseID)
+	}
 	return &r, nil
 }
 
@@ -276,6 +283,13 @@ RETURNING id, user_id, course_id,` + rowSelectCols
 	r.EffectiveFrom = effF
 	r.EffectiveUntil = effU
 	r.AlternativeFormat = strptr(alt)
+	if courseID != nil {
+		_, _ = pool.Exec(ctx, `
+UPDATE course.courses
+SET accommodations_reviewed_at = NOW(), updated_at = NOW()
+WHERE id = $1
+`, *courseID)
+	}
 	return &r, nil
 }
 

--- a/server/internal/service/coursechecklist/builtin.go
+++ b/server/internal/service/coursechecklist/builtin.go
@@ -1,7 +1,7 @@
 package coursechecklist
 
-// BuildBuiltinRegistry returns the CC.3 foundation packs plus CC.4 structure/outcomes
-// packs (55 recommended items). Reference rules from CC.1 remain helpers for engine tests only.
+// BuildBuiltinRegistry returns the CC.3–CC.5 rule packs (81 recommended items).
+// Reference rules from CC.1 remain helpers for engine tests only.
 func BuildBuiltinRegistry() (*Registry, error) {
 	items := []ItemDescriptor{}
 	items = append(items, foundationsRules()...)
@@ -10,5 +10,9 @@ func BuildBuiltinRegistry() (*Registry, error) {
 	items = append(items, peopleRules()...)
 	items = append(items, structureRules()...)
 	items = append(items, outcomesRules()...)
+	items = append(items, assessmentRules()...)
+	items = append(items, gradingRules()...)
+	items = append(items, feedbackRules()...)
+	items = append(items, interactionRules()...)
 	return NewRegistry(items)
 }

--- a/server/internal/service/coursechecklist/dataneed.go
+++ b/server/internal/service/coursechecklist/dataneed.go
@@ -15,10 +15,17 @@ const (
 	DataNeedFeed                DataNeed = "feed"                 // channels + latest message per channel
 	DataNeedFiles               DataNeed = "files"                // course file metadata
 	DataNeedSections            DataNeed = "sections"             // course sections
-	DataNeedAccommodations      DataNeed = "accommodations"       // accommodation counts
+	DataNeedAccommodations      DataNeed = "accommodations"       // accommodation counts (+ type aggregates, CC.5)
 	DataNeedStandards           DataNeed = "standards"            // K-12 standards + item alignments (optional)
 	DataNeedContentTools        DataNeed = "content_tool_counts"  // content tool instance item IDs
 	DataNeedModulePrerequisites DataNeed = "module_prerequisites" // gating prerequisite edges
+	// CC.5 assessment / interaction slices
+	DataNeedAssessmentItems   DataNeed = "assessment_items"    // assignment/quiz availability, rubrics, quiz settings
+	DataNeedPeerReview        DataNeed = "peer_review_configs" // peer-review configs
+	DataNeedDiscussions       DataNeed = "discussions"         // forums / structured discussions
+	DataNeedOfficeHours       DataNeed = "office_hours"        // future appointment slots
+	DataNeedEnrollmentGroups  DataNeed = "enrollment_groups"   // group sets + unassigned student count
+	DataNeedAnnouncementCadence DataNeed = "announcement_cadence" // announcement timestamps for presence plan
 )
 
 // AllDataNeeds is the full set loaded for a complete evaluation.
@@ -37,6 +44,12 @@ var AllDataNeeds = []DataNeed{
 	DataNeedStandards,
 	DataNeedContentTools,
 	DataNeedModulePrerequisites,
+	DataNeedAssessmentItems,
+	DataNeedPeerReview,
+	DataNeedDiscussions,
+	DataNeedOfficeHours,
+	DataNeedEnrollmentGroups,
+	DataNeedAnnouncementCadence,
 }
 
 func unionDataNeeds(items []ItemDescriptor) []DataNeed {

--- a/server/internal/service/coursechecklist/item_ids.go
+++ b/server/internal/service/coursechecklist/item_ids.go
@@ -71,4 +71,40 @@ const (
 	ItemOutcomesMasteryScale       ItemID = "outcomes.mastery-scale"
 	ItemOutcomesStandardsAlignment ItemID = "outcomes.standards-alignment"
 	ItemOutcomesSyllabusPublished  ItemID = "outcomes.syllabus-published"
+
+	// C1 — Gradable item configuration (CC.5)
+	ItemAssessmentGradableItems       ItemID = "assessment.gradable-items"
+	ItemAssessmentDueDates            ItemID = "assessment.due-dates"
+	ItemAssessmentPoints              ItemID = "assessment.points"
+	ItemAssessmentDatesWithinTerm     ItemID = "assessment.dates-within-term"
+	ItemAssessmentAvailabilityWindows ItemID = "assessment.availability-windows"
+	ItemAssessmentSpread              ItemID = "assessment.spread"
+
+	// C2 — Grading model integrity (CC.5)
+	ItemGradingGroupWeights         ItemID = "grading.group-weights"
+	ItemGradingEmptyGroups          ItemID = "grading.empty-groups"
+	ItemGradingDropRules            ItemID = "grading.drop-rules"
+	ItemGradingSchemeCoverage       ItemID = "grading.scheme-coverage"
+	ItemGradingPostingPolicy        ItemID = "grading.posting-policy"
+	ItemGradingLatePolicyConfigured ItemID = "grading.late-policy-configured"
+
+	// C3 — Criteria & feedback (CC.5)
+	ItemFeedbackRubricsOnHighStakes ItemID = "feedback.rubrics-on-high-stakes"
+	ItemFeedbackCriteriaPublished   ItemID = "feedback.criteria-published"
+	ItemFeedbackFormativePerModule  ItemID = "feedback.formative-per-module"
+	ItemFeedbackQuizReviewSettings  ItemID = "feedback.quiz-review-settings"
+	ItemFeedbackAttemptsPolicy      ItemID = "feedback.attempts-policy"
+	ItemFeedbackPeerReviewConfig    ItemID = "feedback.peer-review-config"
+
+	// C4 — Integrity & accommodations (CC.5)
+	ItemIntegrityHighStakesSettings ItemID = "integrity.high-stakes-settings"
+	ItemIntegrityAIPolicyAlignment  ItemID = "integrity.ai-policy-alignment"
+	ItemAccommodationsHonored       ItemID = "accommodations.honored"
+	ItemAccommodationsReviewed      ItemID = "accommodations.reviewed"
+
+	// C5 — Interaction & community (CC.5)
+	ItemInteractionDiscussionExists       ItemID = "interaction.discussion-exists"
+	ItemInteractionInstructorPresencePlan ItemID = "interaction.instructor-presence-plan"
+	ItemInteractionOfficeHours            ItemID = "interaction.office-hours"
+	ItemInteractionGroupsConfigured       ItemID = "interaction.groups-configured"
 )

--- a/server/internal/service/coursechecklist/load_snapshot.go
+++ b/server/internal/service/coursechecklist/load_snapshot.go
@@ -13,20 +13,18 @@ import (
 
 	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/coursefeed"
-	"github.com/lextures/lextures/server/internal/repos/coursegrading"
 	"github.com/lextures/lextures/server/internal/repos/courseoutcomes"
 	"github.com/lextures/lextures/server/internal/repos/coursesections"
 	"github.com/lextures/lextures/server/internal/repos/coursestructure"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
 	"github.com/lextures/lextures/server/internal/repos/filemanager"
-	"github.com/lextures/lextures/server/internal/repos/studentaccommodations"
 	"github.com/lextures/lextures/server/internal/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 )
 
 // MaxSnapshotQueries is the hard budget for a full snapshot load (NFR / AC-9).
-// CC.4 adds ≤ 4 queries (content tools, prerequisites/rules, enriched standards).
-const MaxSnapshotQueries = 20
+// CC.5 adds ≤ 5 queries (assessment items, peer review, interaction, cadence, scheme).
+const MaxSnapshotQueries = 25
 
 // queryCounter tallies logical SQL round-trips during LoadSnapshot (tests / AC-9).
 type queryCounter struct {
@@ -157,29 +155,42 @@ func loadSnapshot(ctx context.Context, pool *pgxpool.Pool, courseCode string, ne
 			VisualBoardsEnabled:       pub.VisualBoardsEnabled,
 			AiTutorEnabled:            pub.AiTutorEnabled,
 			ModulesAiAssistantEnabled: pub.ModulesAiAssistantEnabled,
+			OfficeHoursEnabled:        pub.OfficeHoursEnabled,
+			AdaptiveContentEnabled:    pub.AdaptiveContentEnabled,
 		},
 		Lazy: make(map[LazyLoaderID]any),
 	}
 
 	// Extra course markers not on CoursePublic (features_reviewed_at, grading_scheme_id,
-	// catalog_language, created_by_user_id) — one query (CC.3).
+	// catalog_language, created_by_user_id, CC.5 review markers) — one query.
 	{
 		var featuresReviewedAt *time.Time
+		var accommodationsReviewedAt *time.Time
+		var integrityReviewedAt *time.Time
 		var gradingSchemeID *uuid.UUID
 		var catalogLanguage *string
 		var creatorID *uuid.UUID
+		var enrollmentGroupsEnabled bool
 		err := pool.QueryRow(ctx, `
-SELECT features_reviewed_at, grading_scheme_id, NULLIF(TRIM(catalog_language), ''), created_by_user_id
+SELECT features_reviewed_at, accommodations_reviewed_at, integrity_settings_reviewed_at,
+       grading_scheme_id, NULLIF(TRIM(catalog_language), ''), created_by_user_id,
+       COALESCE(enrollment_groups_enabled, false)
 FROM course.courses
 WHERE id = $1
-`, courseID).Scan(&featuresReviewedAt, &gradingSchemeID, &catalogLanguage, &creatorID)
+`, courseID).Scan(
+			&featuresReviewedAt, &accommodationsReviewedAt, &integrityReviewedAt,
+			&gradingSchemeID, &catalogLanguage, &creatorID, &enrollmentGroupsEnabled,
+		)
 		count(1)
 		if err != nil {
 			return CourseSnapshot{}, err
 		}
 		snap.FeaturesReviewedAt = featuresReviewedAt
+		snap.AccommodationsReviewedAt = accommodationsReviewedAt
+		snap.IntegritySettingsReviewedAt = integrityReviewedAt
 		snap.GradingSchemeID = gradingSchemeID
 		snap.CreatorUserID = creatorID
+		snap.EnrollmentGroupsEnabled = enrollmentGroupsEnabled
 		if catalogLanguage != nil {
 			snap.CatalogLanguage = *catalogLanguage
 		}
@@ -315,21 +326,8 @@ WHERE id = $1
 	}
 
 	if hasDataNeed(needs, DataNeedGrading) {
-		settings, err := coursegrading.GetSettingsForCourseCode(ctx, pool, courseCode)
-		count(2) // settings query + groups query inside helper
-		if err != nil {
+		if err := loadGradingSlice(ctx, pool, courseCode, &snap, count); err != nil {
 			return CourseSnapshot{}, err
-		}
-		if settings != nil {
-			snap.GradingScale = settings.GradingScale
-			for _, g := range settings.AssignmentGroups {
-				w := g.WeightPercent
-				snap.AssignmentGroups = append(snap.AssignmentGroups, AssignmentGroupSnap{
-					ID:     g.ID,
-					Name:   g.Name,
-					Weight: &w,
-				})
-			}
 		}
 	}
 
@@ -441,15 +439,13 @@ WHERE id = $1
 	}
 
 	if hasDataNeed(needs, DataNeedAccommodations) {
-		n, err := studentaccommodations.CountActiveForCourse(ctx, pool, courseID)
-		count(1)
-		if err != nil {
-			if !isUndefinedTable(err) {
-				return CourseSnapshot{}, err
-			}
-		} else {
-			snap.AccommodationCount = n
+		if err := loadAccommodationsSlice(ctx, pool, courseID, &snap, count); err != nil {
+			return CourseSnapshot{}, err
 		}
+	}
+
+	if err := loadAssessmentCC5Slices(ctx, pool, courseID, needs, &snap, count); err != nil {
+		return CourseSnapshot{}, err
 	}
 
 	if hasDataNeed(needs, DataNeedStandards) {

--- a/server/internal/service/coursechecklist/load_snapshot_assessment.go
+++ b/server/internal/service/coursechecklist/load_snapshot_assessment.go
@@ -1,0 +1,287 @@
+package coursechecklist
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/repos/coursegrading"
+	"github.com/lextures/lextures/server/internal/repos/studentaccommodations"
+)
+
+func loadGradingSlice(ctx context.Context, pool *pgxpool.Pool, courseCode string, snap *CourseSnapshot, count func(int)) error {
+	settings, err := coursegrading.GetSettingsForCourseCode(ctx, pool, courseCode)
+	count(2) // settings query + groups query inside helper
+	if err != nil {
+		return err
+	}
+	if settings != nil {
+		snap.GradingScale = settings.GradingScale
+		for _, g := range settings.AssignmentGroups {
+			w := g.WeightPercent
+			snap.AssignmentGroups = append(snap.AssignmentGroups, AssignmentGroupSnap{
+				ID:          g.ID,
+				Name:        g.Name,
+				Weight:      &w,
+				DropLowest:  g.DropLowest,
+				DropHighest: g.DropHighest,
+			})
+		}
+	}
+	// Active grading scheme bands (CC.5 FR-10) — fold into grading need.
+	if snap.GradingSchemeID != nil {
+		var scale []byte
+		err := pool.QueryRow(ctx, `
+SELECT scale_json FROM course.grading_schemes WHERE id = $1
+`, *snap.GradingSchemeID).Scan(&scale)
+		count(1)
+		if err != nil {
+			if !isUndefinedTable(err) && !strings.Contains(strings.ToLower(err.Error()), "no rows") {
+				return err
+			}
+		} else if len(scale) > 0 {
+			snap.GradingSchemeScaleJSON = append(json.RawMessage(nil), scale...)
+		}
+	}
+	return nil
+}
+
+func loadAccommodationsSlice(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, snap *CourseSnapshot, count func(int)) error {
+	n, err := studentaccommodations.CountActiveForCourse(ctx, pool, courseID)
+	count(1)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil
+		}
+		return err
+	}
+	snap.AccommodationCount = n
+	types, latest, err := studentaccommodations.AggregateActiveTypesForCourse(ctx, pool, courseID)
+	count(1)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil
+		}
+		return err
+	}
+	for _, t := range types {
+		snap.AccommodationTypeCounts = append(snap.AccommodationTypeCounts, AccommodationTypeCount{
+			Type: t.Type, Count: t.Count,
+		})
+	}
+	snap.LatestAccommodationAt = latest
+	return nil
+}
+
+// loadAssessmentCC5Slices loads CC.5 assessment/interaction DataNeeds in ≤ 5 queries.
+func loadAssessmentCC5Slices(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	needs []DataNeed,
+	snap *CourseSnapshot,
+	count func(int),
+) error {
+	if hasDataNeed(needs, DataNeedAssessmentItems) {
+		if err := loadAssessmentItems(ctx, pool, courseID, snap, count); err != nil {
+			return err
+		}
+	}
+	if hasDataNeed(needs, DataNeedPeerReview) {
+		if err := loadPeerReviewConfigs(ctx, pool, courseID, snap, count); err != nil {
+			return err
+		}
+	}
+	if hasDataNeed(needs, DataNeedDiscussions) || hasDataNeed(needs, DataNeedOfficeHours) || hasDataNeed(needs, DataNeedEnrollmentGroups) {
+		if err := loadInteractionSlice(ctx, pool, courseID, needs, snap, count); err != nil {
+			return err
+		}
+	}
+	if hasDataNeed(needs, DataNeedAnnouncementCadence) {
+		if err := loadAnnouncementCadence(ctx, pool, courseID, snap, count); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadAssessmentItems(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, snap *CourseSnapshot, count func(int)) error {
+	rows, err := pool.Query(ctx, `
+SELECT
+  c.id, c.kind, c.title, c.parent_id, COALESCE(parent.title, ''),
+  c.sort_order, c.published, c.archived, c.due_at, c.assignment_group_id,
+  COALESCE(m.available_from, q.available_from) AS available_from,
+  COALESCE(m.available_until, q.available_until) AS available_until,
+  COALESCE(m.points_worth, q.points_worth) AS points_worth,
+	(COALESCE(LENGTH(TRIM(m.markdown)), 0) > 0 OR COALESCE(LENGTH(TRIM(q.markdown)), 0) > 0) AS has_body,
+  (m.rubric_json IS NOT NULL AND m.rubric_json::text NOT IN ('', 'null', '[]', '{}')) AS has_rubric,
+  COALESCE(m.late_submission_policy, q.late_submission_policy, '') AS late_policy,
+  COALESCE(m.posting_policy, '') AS posting_policy,
+  COALESCE(m.originality_detection, 'disabled') AS originality,
+  COALESCE(q.unlimited_attempts, false) AS unlimited_attempts,
+  COALESCE(q.max_attempts, 0) AS max_attempts,
+  COALESCE(q.grade_attempt_policy, '') AS grade_attempt_policy,
+  COALESCE(q.show_score_timing, '') AS show_score_timing,
+  COALESCE(q.review_visibility, '') AS review_visibility,
+  COALESCE(q.review_when, '') AS review_when,
+  q.time_limit_minutes,
+  COALESCE(q.shuffle_questions, false) AS shuffle_questions,
+  COALESCE(q.shuffle_choices, false) AS shuffle_choices,
+  COALESCE(q.lockdown_mode::text, 'standard') AS lockdown_mode
+FROM course.course_structure_items c
+LEFT JOIN course.course_structure_items parent ON parent.id = c.parent_id
+LEFT JOIN course.module_assignments m ON m.structure_item_id = c.id AND c.kind = 'assignment'
+LEFT JOIN course.module_quizzes q ON q.structure_item_id = c.id AND c.kind = 'quiz'
+WHERE c.course_id = $1
+  AND c.kind IN ('assignment', 'quiz')
+  AND c.archived = false
+ORDER BY c.sort_order ASC, c.title ASC
+LIMIT 5000
+`, courseID)
+	count(1)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var it AssessmentItemSnap
+		var points *int
+		var timeLimit *int32
+		if err := rows.Scan(
+			&it.ID, &it.Kind, &it.Title, &it.ParentID, &it.ModuleTitle,
+			&it.SortOrder, &it.Published, &it.Archived, &it.DueAt, &it.AssignmentGroupID,
+			&it.AvailableFrom, &it.AvailableUntil, &points,
+			&it.HasBody, &it.HasRubric, &it.LateSubmissionPolicy, &it.PostingPolicy, &it.OriginalityDetection,
+			&it.UnlimitedAttempts, &it.MaxAttempts, &it.GradeAttemptPolicy,
+			&it.ShowScoreTiming, &it.ReviewVisibility, &it.ReviewWhen,
+			&timeLimit, &it.ShuffleQuestions, &it.ShuffleChoices, &it.LockdownMode,
+		); err != nil {
+			return err
+		}
+		it.Points = points
+		if timeLimit != nil {
+			v := int(*timeLimit)
+			it.TimeLimitMinutes = &v
+		}
+		snap.AssessmentItems = append(snap.AssessmentItems, it)
+	}
+	return rows.Err()
+}
+
+func loadPeerReviewConfigs(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, snap *CourseSnapshot, count func(int)) error {
+	rows, err := pool.Query(ctx, `
+SELECT c.assignment_id, si.title, c.reviews_per_reviewer, c.opens_at, c.closes_at, si.due_at,
+       (m.rubric_json IS NOT NULL AND m.rubric_json::text NOT IN ('', 'null', '[]', '{}')) AS has_rubric
+FROM course.peer_review_configs c
+INNER JOIN course.course_structure_items si ON si.id = c.assignment_id
+LEFT JOIN course.module_assignments m ON m.structure_item_id = si.id
+WHERE si.course_id = $1
+ORDER BY si.title ASC
+LIMIT 500
+`, courseID)
+	count(1)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var p PeerReviewConfigSnap
+		if err := rows.Scan(
+			&p.AssignmentID, &p.AssignmentTitle, &p.ReviewsPerReviewer,
+			&p.OpensAt, &p.ClosesAt, &p.DueAt, &p.HasRubric,
+		); err != nil {
+			return err
+		}
+		snap.PeerReviewConfigs = append(snap.PeerReviewConfigs, p)
+	}
+	return rows.Err()
+}
+
+func loadInteractionSlice(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	needs []DataNeed,
+	snap *CourseSnapshot,
+	count func(int),
+) error {
+	// One round-trip: discussions + office hours + enrollment groups.
+	row := pool.QueryRow(ctx, `
+SELECT
+  (SELECT COUNT(*)::int FROM course.discussion_forums WHERE course_id = $1),
+  (SELECT COUNT(*)::int FROM course.discussion_threads t
+     INNER JOIN course.discussion_forums f ON f.id = t.forum_id
+    WHERE f.course_id = $1),
+	(SELECT COUNT(*)::int FROM course.appointment_slots s
+     INNER JOIN course.availability_windows w ON w.id = s.window_id
+    WHERE w.course_id = $1 AND s.status <> 'cancelled' AND w.status = 'active'
+      AND s.slot_start > NOW()),
+  (SELECT COUNT(*)::int FROM course.enrollment_group_sets WHERE course_id = $1),
+  (SELECT COUNT(*)::int FROM course.course_enrollments ce
+     INNER JOIN course.enrollment_roles er ON er.role_key = ce.role AND er.is_student_equivalent
+    WHERE ce.course_id = $1 AND ce.active
+      AND NOT EXISTS (
+        SELECT 1 FROM course.enrollment_group_memberships m
+        WHERE m.enrollment_id = ce.id
+      ))
+`, courseID)
+	count(1)
+	var forums, prompts, slots, sets, unassigned int
+	if err := row.Scan(&forums, &prompts, &slots, &sets, &unassigned); err != nil {
+		if isUndefinedTable(err) {
+			return nil
+		}
+		return err
+	}
+	if hasDataNeed(needs, DataNeedDiscussions) {
+		snap.DiscussionForumCount = forums
+		snap.DiscussionPromptCount = prompts
+	}
+	if hasDataNeed(needs, DataNeedOfficeHours) {
+		snap.FutureOfficeHourSlots = slots
+	}
+	if hasDataNeed(needs, DataNeedEnrollmentGroups) {
+		snap.EnrollmentGroupSetCount = sets
+		snap.UnassignedStudentCount = unassigned
+	}
+	return nil
+}
+
+func loadAnnouncementCadence(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, snap *CourseSnapshot, count func(int)) error {
+	rows, err := pool.Query(ctx, `
+SELECT m.created_at
+FROM course.feed_messages m
+INNER JOIN course.feed_channels c ON c.id = m.channel_id
+WHERE c.course_id = $1
+  AND LOWER(c.name) = 'announcements'
+	AND m.parent_message_id IS NULL
+ORDER BY m.created_at ASC
+LIMIT 500
+`, courseID)
+	count(1)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var t time.Time
+		if err := rows.Scan(&t); err != nil {
+			return err
+		}
+		snap.AnnouncementTimes = append(snap.AnnouncementTimes, t)
+	}
+	return rows.Err()
+}

--- a/server/internal/service/coursechecklist/registry_test.go
+++ b/server/internal/service/coursechecklist/registry_test.go
@@ -18,8 +18,8 @@ func TestRegistryIntegrity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildBuiltinRegistry: %v", err)
 	}
-	if reg.Size() != 55 {
-		t.Fatalf("expected 55 rules, got %d", reg.Size())
+	if reg.Size() != 81 {
+		t.Fatalf("expected 81 rules, got %d", reg.Size())
 	}
 
 	routes, err := loadWebRoutesFixture()

--- a/server/internal/service/coursechecklist/rules_assessment.go
+++ b/server/internal/service/coursechecklist/rules_assessment.go
@@ -1,0 +1,435 @@
+package coursechecklist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func assessmentRules() []ItemDescriptor {
+	return []ItemDescriptor{
+		ruleAssessmentGradableItems(),
+		ruleAssessmentDueDates(),
+		ruleAssessmentPoints(),
+		ruleAssessmentDatesWithinTerm(),
+		ruleAssessmentAvailabilityWindows(),
+		ruleAssessmentSpread(),
+	}
+}
+
+func ruleAssessmentGradableItems() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAssessmentGradableItems,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.assessment.gradable-items.title",
+		TitleDefault: "Add something to grade",
+		WhyKey:       "coursechecklist.item.assessment.gradable-items.why",
+		WhyDefault:   "Learners need at least one graded activity so the gradebook has meaning.",
+		HelpRef:      "course-checklist#assessment-gradable-items",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.1", "OSCQR 45"},
+		DataNeeds:    []DataNeed{DataNeedStructure, DataNeedItemMeta, DataNeedAssessmentItems},
+		Evaluate:     evalAssessmentGradableItems,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+		},
+	}
+}
+
+func evalAssessmentGradableItems(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	// Non-graded mode: SBG-only courses with no traditional items stay N/A when SBG is on
+	// and there are no assignment groups / points items expected.
+	if snap.SbgEnabled && len(snap.AssignmentGroups) == 0 && len(assessmentItemsFor(snap)) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.assessment.gradable-items.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	items := assessmentItemsFor(snap)
+	if len(items) >= 1 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.assessment.gradable-items.detail.done",
+			DetailDefault: fmt.Sprintf("%d graded items are ready.", len(items)),
+			DetailFields:  map[string]any{"count": len(items)},
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.assessment.gradable-items.detail.todo",
+		DetailDefault: "Add at least one assignment or quiz to grade.",
+	}, nil
+}
+
+func ruleAssessmentDueDates() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAssessmentDueDates,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.assessment.due-dates.title",
+		TitleDefault: "Give every assessment a due date",
+		WhyKey:       "coursechecklist.item.assessment.due-dates.why",
+		WhyDefault:   "Due dates keep the gradebook predictable and help learners plan.",
+		HelpRef:      "course-checklist#assessment-due-dates",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 1.2", "OSCQR 44"},
+		DataNeeds:    []DataNeed{DataNeedStructure, DataNeedItemMeta, DataNeedAssessmentItems, DataNeedCourse},
+		Applies: func(snap CourseSnapshot) bool {
+			return !strings.EqualFold(snap.ScheduleMode, "relative")
+		},
+		Evaluate: evalAssessmentDueDates,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "assignment.scheduling",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalAssessmentDueDates(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := sortAssessmentItems(assessmentItemsFor(snap))
+	if len(items) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.assessment.due-dates.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	var evidence []EvidenceRow
+	for _, it := range items {
+		if it.DueAt == nil {
+			evidence = append(evidence, assessmentEvidenceRow(it, "No due date", "assignment.scheduling"))
+		}
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.assessment.due-dates.detail.done",
+			DetailDefault: "Every assessment has a due date.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.assessment.due-dates.detail.todo",
+		DetailDefault: fmt.Sprintf("%d assessments have no due date.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleAssessmentPoints() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAssessmentPoints,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.assessment.points.title",
+		TitleDefault: "Give every assessment points",
+		WhyKey:       "coursechecklist.item.assessment.points.why",
+		WhyDefault:   "Zero-point items in a weighted group silently distort the gradebook.",
+		HelpRef:      "course-checklist#assessment-points",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 44", "OSCQR 46"},
+		DataNeeds:    []DataNeed{DataNeedStructure, DataNeedItemMeta, DataNeedAssessmentItems, DataNeedGrading},
+		Evaluate:     evalAssessmentPoints,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "assignment.grading",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalAssessmentPoints(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := sortAssessmentItems(assessmentItemsFor(snap))
+	weightedIDs := map[string]bool{}
+	for _, g := range snap.AssignmentGroups {
+		if g.Weight != nil && *g.Weight > 0 {
+			weightedIDs[g.ID.String()] = true
+		}
+	}
+	var evidence []EvidenceRow
+	for _, it := range items {
+		inWeighted := it.AssignmentGroupID != nil && weightedIDs[it.AssignmentGroupID.String()]
+		if !inWeighted && !usesWeightedGrading(snap) {
+			// Unweighted: flag null/zero points on any gradable item.
+			if it.Points == nil || *it.Points == 0 {
+				evidence = append(evidence, assessmentEvidenceRow(it, "Missing or zero points", "assignment.grading"))
+			}
+			continue
+		}
+		if inWeighted && (it.Points == nil || *it.Points == 0) {
+			evidence = append(evidence, assessmentEvidenceRow(it, "Missing or zero points in weighted group", "assignment.grading"))
+		}
+	}
+	if len(items) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.assessment.points.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.assessment.points.detail.done",
+			DetailDefault: "Graded items have points set.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.assessment.points.detail.todo",
+		DetailDefault: fmt.Sprintf("%d items need points.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleAssessmentDatesWithinTerm() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAssessmentDatesWithinTerm,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.assessment.dates-within-term.title",
+		TitleDefault: "Move due dates inside the term",
+		WhyKey:       "coursechecklist.item.assessment.dates-within-term.why",
+		WhyDefault:   "Due dates outside the term are a common copy-forward defect.",
+		HelpRef:      "course-checklist#assessment-dates-within-term",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 7"},
+		DataNeeds:    []DataNeed{DataNeedStructure, DataNeedAssessmentItems, DataNeedCourse},
+		Applies: func(snap CourseSnapshot) bool {
+			return snap.StartsAt != nil && snap.EndsAt != nil && !strings.EqualFold(snap.ScheduleMode, "relative")
+		},
+		Evaluate: evalAssessmentDatesWithinTerm,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "assignment.scheduling",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalAssessmentDatesWithinTerm(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	if snap.StartsAt == nil || snap.EndsAt == nil {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.assessment.dates-within-term.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	start, end := *snap.StartsAt, *snap.EndsAt
+	var evidence []EvidenceRow
+	for _, it := range sortAssessmentItems(assessmentItemsFor(snap)) {
+		if it.DueAt == nil {
+			continue
+		}
+		d := it.DueAt.UTC()
+		if d.Before(start.UTC()) || d.After(end.UTC()) {
+			evidence = append(evidence, assessmentEvidenceRow(it, "Due date outside the term", "assignment.scheduling"))
+		}
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.assessment.dates-within-term.detail.done",
+			DetailDefault: "All due dates fall inside the term.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.assessment.dates-within-term.detail.todo",
+		DetailDefault: fmt.Sprintf("%d due dates fall outside the term.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleAssessmentAvailabilityWindows() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAssessmentAvailabilityWindows,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.assessment.availability-windows.title",
+		TitleDefault: "Fix contradictory availability windows",
+		WhyKey:       "coursechecklist.item.assessment.availability-windows.why",
+		WhyDefault:   "Available-from after due, or available-until before due, locks learners out.",
+		HelpRef:      "course-checklist#assessment-availability-windows",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 44"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems},
+		Evaluate:     evalAssessmentAvailabilityWindows,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "assignment.scheduling",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalAssessmentAvailabilityWindows(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	var evidence []EvidenceRow
+	for _, it := range sortAssessmentItems(assessmentItemsFor(snap)) {
+		if it.DueAt == nil {
+			continue
+		}
+		due := it.DueAt.UTC()
+		issue := ""
+		if it.AvailableFrom != nil && it.AvailableFrom.UTC().After(due) {
+			issue = "Available from is after the due date"
+		}
+		if it.AvailableUntil != nil && it.AvailableUntil.UTC().Before(due) {
+			if issue != "" {
+				issue += "; "
+			}
+			issue += "Available until is before the due date"
+		}
+		if issue != "" {
+			evidence = append(evidence, assessmentEvidenceRow(it, issue, "assignment.scheduling"))
+		}
+	}
+	if len(assessmentItemsFor(snap)) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.assessment.availability-windows.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.assessment.availability-windows.detail.done",
+			DetailDefault: "Availability windows are consistent with due dates.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.assessment.availability-windows.detail.todo",
+		DetailDefault: fmt.Sprintf("%d items have contradictory availability windows.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleAssessmentSpread() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAssessmentSpread,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.assessment.spread.title",
+		TitleDefault: "Spread assessments across the term",
+		WhyKey:       "coursechecklist.item.assessment.spread.why",
+		WhyDefault:   "Stacking most points in one week overwhelms learners.",
+		HelpRef:      "course-checklist#assessment-spread",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.4", "OSCQR 47"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems, DataNeedCourse},
+		Evaluate:     evalAssessmentSpread,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+		},
+	}
+}
+
+func evalAssessmentSpread(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := assessmentItemsFor(snap)
+	total := totalCoursePoints(items)
+	if total <= 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.assessment.spread.detail.na",
+			DetailDefault: "Does not apply when the course has no points.",
+		}, nil
+	}
+	byWeek := map[string]int{}
+	var keys []string
+	for _, it := range items {
+		if it.DueAt == nil || it.Points == nil || *it.Points <= 0 {
+			continue
+		}
+		k := weekKey(*it.DueAt)
+		if _, ok := byWeek[k]; !ok {
+			keys = append(keys, k)
+		}
+		byWeek[k] += *it.Points
+	}
+	if len(byWeek) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.assessment.spread.detail.na-dates",
+			DetailDefault: "Does not apply until assessments have due dates.",
+		}, nil
+	}
+	// Cap pathological buckets (NFR: 520 weeks).
+	if len(byWeek) > 520 {
+		return Finding{
+			Status:        StatusUnknown,
+			DetailKey:     "coursechecklist.item.assessment.spread.detail.unknown",
+			DetailDefault: "Too many distinct due-date weeks to evaluate.",
+		}, nil
+	}
+
+	var overloaded []string
+	var maxPct float64
+	var maxWeek string
+	for _, k := range keys {
+		pct := 100.0 * float64(byWeek[k]) / float64(total)
+		if pct > maxPct {
+			maxPct = pct
+			maxWeek = k
+		}
+		if pct > 40.0 {
+			overloaded = append(overloaded, fmt.Sprintf("%s (%.0f%%)", k, pct))
+		}
+	}
+
+	finalWeekPct := 0.0
+	if snap.EndsAt != nil {
+		fk := weekKey(*snap.EndsAt)
+		finalWeekPct = 100.0 * float64(byWeek[fk]) / float64(total)
+	} else {
+		// Last due week by calendar.
+		var last time.Time
+		var lastKey string
+		for _, it := range items {
+			if it.DueAt == nil {
+				continue
+			}
+			if last.IsZero() || it.DueAt.After(last) {
+				last = *it.DueAt
+				lastKey = weekKey(last)
+			}
+		}
+		if lastKey != "" {
+			finalWeekPct = 100.0 * float64(byWeek[lastKey]) / float64(total)
+		}
+	}
+
+	if len(overloaded) == 0 && finalWeekPct < 50.0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.assessment.spread.detail.done",
+			DetailDefault: fmt.Sprintf("Heaviest week holds %.0f%% of points.", maxPct),
+			DetailFields:  map[string]any{"maxWeekPct": maxPct, "maxWeek": maxWeek, "finalWeekPct": finalWeekPct},
+		}, nil
+	}
+	detail := fmt.Sprintf("Heaviest week holds %.0f%% of points", maxPct)
+	if finalWeekPct >= 50.0 {
+		detail += fmt.Sprintf("; final week holds %.0f%%", finalWeekPct)
+	}
+	detail += " (limits: 40% any week, 50% final week)."
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.assessment.spread.detail.todo",
+		DetailDefault: detail,
+		DetailFields: map[string]any{
+			"maxWeekPct":    maxPct,
+			"maxWeek":       maxWeek,
+			"finalWeekPct":  finalWeekPct,
+			"overloaded":    overloaded,
+			"totalPoints":   total,
+		},
+	}, nil
+}

--- a/server/internal/service/coursechecklist/rules_assessment_helpers.go
+++ b/server/internal/service/coursechecklist/rules_assessment_helpers.go
@@ -1,0 +1,150 @@
+package coursechecklist
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// assessmentEvidenceColumns is the shared evidence shape for assessment rules (CC.5 §10).
+var assessmentEvidenceColumns = []string{"Item", "Type", "Module", "Points", "Issue"}
+
+// gradingEvidenceColumns is the shared evidence shape for grading-group rules.
+var gradingEvidenceColumns = []string{"Group", "Weight", "Items"}
+
+func usesWeightedGrading(snap CourseSnapshot) bool {
+	if len(snap.AssignmentGroups) == 0 {
+		return false
+	}
+	for _, g := range snap.AssignmentGroups {
+		if g.Weight != nil && math.Abs(*g.Weight) > 0.0001 {
+			return true
+		}
+	}
+	return false
+}
+
+func assessmentItemsFor(snap CourseSnapshot) []AssessmentItemSnap {
+	if len(snap.AssessmentItems) > 0 {
+		return snap.AssessmentItems
+	}
+	// Fallback for unit tests that only populate StructureItems / ItemMeta.
+	var out []AssessmentItemSnap
+	byID := structureByID(snap)
+	for _, it := range snap.StructureItems {
+		if it.Archived || !isGradableKind(it.Kind) {
+			continue
+		}
+		meta := snap.ItemMeta[it.ID]
+		modTitle := ""
+		if it.ParentID != nil {
+			if m, ok := byID[*it.ParentID]; ok {
+				modTitle = m.Title
+			}
+		}
+		out = append(out, AssessmentItemSnap{
+			ID:                   it.ID,
+			Kind:                 it.Kind,
+			Title:                it.Title,
+			ParentID:             it.ParentID,
+			ModuleTitle:          modTitle,
+			SortOrder:            it.SortOrder,
+			Published:            it.Published,
+			Archived:             it.Archived,
+			DueAt:                it.DueAt,
+			Points:               meta.PointsWorth,
+			AssignmentGroupID:    it.AssignmentGroupID,
+			HasBody:              meta.HasBody,
+			LateSubmissionPolicy: meta.LateSubmissionPolicy,
+		})
+	}
+	return out
+}
+
+func totalCoursePoints(items []AssessmentItemSnap) int {
+	total := 0
+	for _, it := range items {
+		if it.Points != nil && *it.Points > 0 {
+			total += *it.Points
+		}
+	}
+	return total
+}
+
+func formatPoints(p *int) string {
+	if p == nil {
+		return "—"
+	}
+	return fmt.Sprintf("%d", *p)
+}
+
+func assessmentEvidenceRow(it AssessmentItemSnap, issue, anchor string) EvidenceRow {
+	route := itemEditorRoute(it.Kind)
+	route = strings.ReplaceAll(route, "{itemId}", it.ID.String())
+	return EvidenceRow{
+		Label:    it.Title,
+		Sublabel: fmt.Sprintf("%s · %s · %s pts · %s", humanKind(it.Kind), it.ModuleTitle, formatPoints(it.Points), issue),
+		TargetOverride: &NavTarget{
+			Surface:   "web",
+			Route:     route,
+			Anchor:    anchor,
+			EntityKey: it.ID.String(),
+		},
+	}
+}
+
+func groupItemCounts(snap CourseSnapshot) map[uuid.UUID]int {
+	counts := map[uuid.UUID]int{}
+	for _, it := range assessmentItemsFor(snap) {
+		if it.AssignmentGroupID == nil {
+			continue
+		}
+		counts[*it.AssignmentGroupID]++
+	}
+	return counts
+}
+
+func isHighStakes(it AssessmentItemSnap, total int, weighted bool) bool {
+	if it.Points == nil || *it.Points <= 0 {
+		return false
+	}
+	if total <= 0 {
+		return false
+	}
+	pct := 100.0 * float64(*it.Points) / float64(total)
+	if weighted {
+		return pct >= 10.0
+	}
+	return *it.Points >= 100 || pct >= 10.0
+}
+
+func weekKey(t time.Time) string {
+	y, w := t.UTC().ISOWeek()
+	return fmt.Sprintf("%04d-W%02d", y, w)
+}
+
+func sortAssessmentItems(items []AssessmentItemSnap) []AssessmentItemSnap {
+	out := append([]AssessmentItemSnap(nil), items...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].SortOrder == out[j].SortOrder {
+			return out[i].Title < out[j].Title
+		}
+		return out[i].SortOrder < out[j].SortOrder
+	})
+	return out
+}
+
+func formatWeight(w *float64) string {
+	if w == nil {
+		return "—"
+	}
+	return fmt.Sprintf("%.2f%%", *w)
+}
+
+func almostEqual(a, b, eps float64) bool {
+	return math.Abs(a-b) <= eps
+}

--- a/server/internal/service/coursechecklist/rules_assessment_test.go
+++ b/server/internal/service/coursechecklist/rules_assessment_test.go
@@ -1,0 +1,307 @@
+package coursechecklist
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+var (
+	uuidPattern  = regexp.MustCompile(`(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`)
+	emailPattern = regexp.MustCompile(`(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b`)
+)
+
+func evidenceLooksPrivate(rows []EvidenceRow) bool {
+	for _, r := range rows {
+		blob := r.Label + " " + r.Sublabel
+		if uuidPattern.MatchString(blob) || emailPattern.MatchString(blob) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAssessmentCopyContract(t *testing.T) {
+	for _, it := range append(assessmentRules(), append(gradingRules(), append(feedbackRules(), interactionRules()...)...)...) {
+		if utf8.RuneCountInString(it.TitleDefault) > 60 {
+			t.Errorf("%s title too long", it.ID)
+		}
+		low := strings.ToLower(it.TitleDefault + " " + it.WhyDefault)
+		for _, ban := range []string{"failed", "should have", "!"} {
+			if strings.Contains(low, ban) {
+				t.Errorf("%s contains banned %q", it.ID, ban)
+			}
+		}
+	}
+}
+
+func TestGradingGroupWeightsAC1(t *testing.T) {
+	// AC-1: 40/30/17 → todo with "Weights add up to 87%, not 100%"
+	w1, w2, w3 := 40.0, 30.0, 17.0
+	f, err := findRule(t, ItemGradingGroupWeights).Evaluate(context.Background(), CourseSnapshot{
+		AssignmentGroups: []AssignmentGroupSnap{
+			{ID: uuid.New(), Name: "A", Weight: &w1},
+			{ID: uuid.New(), Name: "B", Weight: &w2},
+			{ID: uuid.New(), Name: "C", Weight: &w3},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo {
+		t.Fatalf("status=%s", f.Status)
+	}
+	if !strings.Contains(f.DetailDefault, "87%") || !strings.Contains(f.DetailDefault, "100%") {
+		t.Fatalf("detail=%q", f.DetailDefault)
+	}
+}
+
+func TestGradingGroupWeightsAC2(t *testing.T) {
+	// AC-2: sum 100 → done; unweighted → N/A
+	w1, w2 := 60.0, 40.0
+	f, err := findRule(t, ItemGradingGroupWeights).Evaluate(context.Background(), CourseSnapshot{
+		AssignmentGroups: []AssignmentGroupSnap{
+			{ID: uuid.New(), Name: "A", Weight: &w1},
+			{ID: uuid.New(), Name: "B", Weight: &w2},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusDone {
+		t.Fatalf("status=%s detail=%q", f.Status, f.DetailDefault)
+	}
+
+	reg := MustDefault()
+	res := Evaluate(context.Background(), CourseSnapshot{
+		AssignmentGroups: []AssignmentGroupSnap{{ID: uuid.New(), Name: "A", Weight: floatPtr(0)}},
+	}, EvaluateOptions{Registry: reg, Only: []ItemID{ItemGradingGroupWeights}})
+	if len(res.Findings) != 1 || res.Findings[0].Finding.Status != StatusNotApplicable {
+		t.Fatalf("unweighted should be N/A: %+v", res.Findings)
+	}
+}
+
+func TestGradingEmptyGroupsAC3(t *testing.T) {
+	gid := uuid.New()
+	w := 20.0
+	f, err := findRule(t, ItemGradingEmptyGroups).Evaluate(context.Background(), CourseSnapshot{
+		AssignmentGroups: []AssignmentGroupSnap{{ID: gid, Name: "Essays", Weight: &w}},
+		AssessmentItems:  []AssessmentItemSnap{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo || len(f.Evidence) != 1 || f.Evidence[0].Label != "Essays" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestGradingDropRulesAC4(t *testing.T) {
+	gid := uuid.New()
+	w := 100.0
+	items := make([]AssessmentItemSnap, 3)
+	for i := range items {
+		items[i] = AssessmentItemSnap{
+			ID: uuid.New(), Kind: "assignment", Title: "A", AssignmentGroupID: &gid, Points: intPtr(10),
+		}
+	}
+	f, err := findRule(t, ItemGradingDropRules).Evaluate(context.Background(), CourseSnapshot{
+		AssignmentGroups: []AssignmentGroupSnap{
+			{ID: gid, Name: "Quizzes", Weight: &w, DropLowest: 2, DropHighest: 1},
+		},
+		AssessmentItems: items,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo || len(f.Evidence) != 1 || f.Evidence[0].Label != "Quizzes" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestFeedbackRubricsOnHighStakesAC5(t *testing.T) {
+	// AC-5: 30% assignment, no rubric, empty description
+	id := uuid.New()
+	pts := 30
+	other := 70
+	f, err := findRule(t, ItemFeedbackRubricsOnHighStakes).Evaluate(context.Background(), CourseSnapshot{
+		AssessmentItems: []AssessmentItemSnap{
+			{ID: id, Kind: "assignment", Title: "Capstone", Points: &pts, HasRubric: false, HasBody: false},
+			{ID: uuid.New(), Kind: "quiz", Title: "Quiz", Points: &other, HasBody: true},
+		},
+		AssignmentGroups: []AssignmentGroupSnap{{ID: uuid.New(), Name: "All", Weight: floatPtr(100)}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo || len(f.Evidence) != 1 {
+		t.Fatalf("got %+v", f)
+	}
+	if f.Evidence[0].TargetOverride == nil || f.Evidence[0].TargetOverride.Anchor != "assignment.rubric" {
+		t.Fatalf("target=%+v", f.Evidence[0].TargetOverride)
+	}
+}
+
+func TestFeedbackFormativePerModuleAC6(t *testing.T) {
+	mod := uuid.New()
+	quiz := uuid.New()
+	zero := 0
+	f, err := findRule(t, ItemFeedbackFormativePerModule).Evaluate(context.Background(), CourseSnapshot{
+		StructureItems: []StructureItem{
+			{ID: mod, Kind: "module", Title: "M1", SortOrder: 0},
+			{ID: quiz, Kind: "quiz", Title: "Practice", ParentID: &mod, SortOrder: 1},
+		},
+		ItemMeta: map[uuid.UUID]ItemMeta{
+			quiz: {Kind: "quiz", PointsWorth: &zero, HasBody: true},
+		},
+		AssessmentItems: []AssessmentItemSnap{}, // practice excluded from gradable set
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusDone {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestAssessmentDatesWithinTermAC7(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	late := end.Add(14 * 24 * time.Hour)
+	f, err := findRule(t, ItemAssessmentDatesWithinTerm).Evaluate(context.Background(), CourseSnapshot{
+		StartsAt: &start, EndsAt: &end, ScheduleMode: "fixed",
+		AssessmentItems: []AssessmentItemSnap{
+			{ID: uuid.New(), Kind: "assignment", Title: "Late", DueAt: &late, Points: intPtr(10)},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo || len(f.Evidence) != 1 {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestAssessmentSpreadAC8(t *testing.T) {
+	// AC-8: 60% of points in final week
+	end := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	finalDue := end.Add(-24 * time.Hour)
+	early := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	f, err := findRule(t, ItemAssessmentSpread).Evaluate(context.Background(), CourseSnapshot{
+		EndsAt: &end,
+		AssessmentItems: []AssessmentItemSnap{
+			{ID: uuid.New(), Kind: "assignment", Title: "Final", DueAt: &finalDue, Points: intPtr(60)},
+			{ID: uuid.New(), Kind: "quiz", Title: "Mid", DueAt: &early, Points: intPtr(40)},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo {
+		t.Fatalf("status=%s detail=%q", f.Status, f.DetailDefault)
+	}
+	if !strings.Contains(f.DetailDefault, "60%") && !strings.Contains(f.DetailDefault, "final week") {
+		t.Fatalf("detail should include computed %%: %q", f.DetailDefault)
+	}
+}
+
+func TestFeedbackQuizReviewSettingsAC9(t *testing.T) {
+	until := time.Now().UTC().Add(7 * 24 * time.Hour)
+	f, err := findRule(t, ItemFeedbackQuizReviewSettings).Evaluate(context.Background(), CourseSnapshot{
+		AssessmentItems: []AssessmentItemSnap{{
+			ID: uuid.New(), Kind: "quiz", Title: "Q1", Points: intPtr(10),
+			ReviewVisibility: "correct_answers", ReviewWhen: "after_submit",
+			ShowScoreTiming: "immediate", AvailableUntil: &until,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo || len(f.Evidence) != 1 {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestAccommodationsHonoredAC10(t *testing.T) {
+	limit := 30
+	f, err := findRule(t, ItemAccommodationsHonored).Evaluate(context.Background(), CourseSnapshot{
+		AccommodationCount: 1,
+		AccommodationTypeCounts: []AccommodationTypeCount{
+			{Type: "extended_time", Count: 1},
+		},
+		AssessmentItems: []AssessmentItemSnap{{
+			ID: uuid.New(), Kind: "quiz", Title: "Timed Quiz", Points: intPtr(10),
+			TimeLimitMinutes: &limit,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Status != StatusTodo {
+		t.Fatalf("status=%s", f.Status)
+	}
+	if evidenceLooksPrivate(f.Evidence) {
+		t.Fatalf("evidence leaked identifiers: %+v", f.Evidence)
+	}
+	blob := f.DetailDefault
+	for _, row := range f.Evidence {
+		blob += row.Label + row.Sublabel
+	}
+	if uuidPattern.MatchString(blob) || emailPattern.MatchString(blob) {
+		t.Fatalf("serialized evidence contains id/email: %q", blob)
+	}
+}
+
+func TestInteractionNAAC11AC12(t *testing.T) {
+	// AC-11: 1 student → discussion + groups N/A
+	reg := MustDefault()
+	snap := CourseSnapshot{
+		EnrollmentCounts: map[string]int{"student": 1},
+		Features:         CourseFeatures{DiscussionsEnabled: true, GroupSpacesEnabled: true},
+		EnrollmentGroupsEnabled: true,
+	}
+	res := Evaluate(context.Background(), snap, EvaluateOptions{
+		Registry: reg,
+		Only:     []ItemID{ItemInteractionDiscussionExists, ItemInteractionGroupsConfigured},
+	})
+	for _, it := range res.Findings {
+		if it.Finding.Status != StatusNotApplicable {
+			t.Fatalf("%s status=%s want N/A", it.ID, it.Finding.Status)
+		}
+	}
+
+	// AC-12: office_hours_enabled=false → N/A
+	res2 := Evaluate(context.Background(), CourseSnapshot{
+		Features: CourseFeatures{OfficeHoursEnabled: false},
+	}, EvaluateOptions{Registry: reg, Only: []ItemID{ItemInteractionOfficeHours}})
+	if len(res2.Findings) != 1 || res2.Findings[0].Finding.Status != StatusNotApplicable {
+		t.Fatalf("office hours: %+v", res2.Findings)
+	}
+}
+
+func TestZeroPointsNANAC13(t *testing.T) {
+	// AC-13: 0 total points → spread + rubrics N/A, no panic
+	reg := MustDefault()
+	snap := CourseSnapshot{
+		AssessmentItems: []AssessmentItemSnap{
+			{ID: uuid.New(), Kind: "assignment", Title: "A", Points: intPtr(0)},
+		},
+	}
+	res := Evaluate(context.Background(), snap, EvaluateOptions{
+		Registry: reg,
+		Only:     []ItemID{ItemAssessmentSpread, ItemFeedbackRubricsOnHighStakes},
+	})
+	for _, it := range res.Findings {
+		if it.Finding.Status != StatusNotApplicable {
+			t.Fatalf("%s status=%s want N/A", it.ID, it.Finding.Status)
+		}
+	}
+}
+
+func floatPtr(v float64) *float64 { return &v }
+func intPtr(v int) *int           { return &v }

--- a/server/internal/service/coursechecklist/rules_feedback.go
+++ b/server/internal/service/coursechecklist/rules_feedback.go
@@ -1,0 +1,433 @@
+package coursechecklist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func feedbackRules() []ItemDescriptor {
+	return []ItemDescriptor{
+		ruleFeedbackRubricsOnHighStakes(),
+		ruleFeedbackCriteriaPublished(),
+		ruleFeedbackFormativePerModule(),
+		ruleFeedbackQuizReviewSettings(),
+		ruleFeedbackAttemptsPolicy(),
+		ruleFeedbackPeerReviewConfig(),
+	}
+}
+
+func ruleFeedbackRubricsOnHighStakes() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemFeedbackRubricsOnHighStakes,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.feedback.rubrics-on-high-stakes.title",
+		TitleDefault: "Add criteria to high-stakes work",
+		WhyKey:       "coursechecklist.item.feedback.rubrics-on-high-stakes.why",
+		WhyDefault:   "High-stakes work needs published criteria so grading is defensible.",
+		HelpRef:      "course-checklist#feedback-rubrics-on-high-stakes",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.3", "OSCQR 46"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems, DataNeedGrading, DataNeedStructure},
+		Evaluate:     evalFeedbackRubricsOnHighStakes,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "assignment.rubric",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalFeedbackRubricsOnHighStakes(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := sortAssessmentItems(assessmentItemsFor(snap))
+	total := totalCoursePoints(items)
+	if total <= 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.feedback.rubrics-on-high-stakes.detail.na",
+			DetailDefault: "Does not apply when the course has no points.",
+		}, nil
+	}
+	weighted := usesWeightedGrading(snap)
+	var evidence []EvidenceRow
+	for _, it := range items {
+		if !isHighStakes(it, total, weighted) {
+			continue
+		}
+		if it.HasRubric || it.HasBody {
+			continue
+		}
+		pct := 100.0 * float64(*it.Points) / float64(total)
+		evidence = append(evidence, assessmentEvidenceRow(it,
+			fmt.Sprintf("%.0f%% of course with no criteria", pct), "assignment.rubric"))
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.feedback.rubrics-on-high-stakes.detail.done",
+			DetailDefault: "High-stakes work has rubrics or written criteria.",
+			DetailFields:  map[string]any{"totalPoints": total},
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.feedback.rubrics-on-high-stakes.detail.todo",
+		DetailDefault: fmt.Sprintf("%d high-stakes items need rubrics or written criteria.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence), "totalPoints": total},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleFeedbackCriteriaPublished() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemFeedbackCriteriaPublished,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.feedback.criteria-published.title",
+		TitleDefault: "Write instructions for every assessment",
+		WhyKey:       "coursechecklist.item.feedback.criteria-published.why",
+		WhyDefault:   "Learners need instructions before they can complete the work.",
+		HelpRef:      "course-checklist#feedback-criteria-published",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.3", "OSCQR 46"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems},
+		Evaluate:     evalFeedbackCriteriaPublished,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalFeedbackCriteriaPublished(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := sortAssessmentItems(assessmentItemsFor(snap))
+	if len(items) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.feedback.criteria-published.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	var evidence []EvidenceRow
+	for _, it := range items {
+		if !it.HasBody {
+			evidence = append(evidence, assessmentEvidenceRow(it, "No instructions", ""))
+		}
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.feedback.criteria-published.detail.done",
+			DetailDefault: "Every assessment has instructions.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.feedback.criteria-published.detail.todo",
+		DetailDefault: fmt.Sprintf("%d assessments have no instructions.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleFeedbackFormativePerModule() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemFeedbackFormativePerModule,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.feedback.formative-per-module.title",
+		TitleDefault: "Add a low-stakes check to each module",
+		WhyKey:       "coursechecklist.item.feedback.formative-per-module.why",
+		WhyDefault:   "Formative checks keep courses from being all high-stakes finals.",
+		HelpRef:      "course-checklist#feedback-formative-per-module",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.4", "OSCQR 47", "NSQ D"},
+		DataNeeds:    []DataNeed{DataNeedStructure, DataNeedAssessmentItems, DataNeedItemMeta, DataNeedContentTools},
+		Evaluate:     evalFeedbackFormativePerModule,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+		},
+		EvidenceShape: &EvidenceShape{Columns: []string{"Module", "Issue"}},
+	}
+}
+
+func evalFeedbackFormativePerModule(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	mods := listModules(snap)
+	if len(mods) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.feedback.formative-per-module.detail.na",
+			DetailDefault: "Does not apply until the course has modules.",
+		}, nil
+	}
+	items := assessmentItemsFor(snap)
+	total := totalCoursePoints(items)
+	children := childrenByParent(snap)
+	var evidence []EvidenceRow
+	for _, mod := range mods {
+		if moduleHasFormative(snap, mod, children[mod.ID], items, total) {
+			continue
+		}
+		evidence = append(evidence, EvidenceRow{
+			Label:    mod.Title,
+			Sublabel: "No low-stakes formative check",
+		})
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.feedback.formative-per-module.detail.done",
+			DetailDefault: "Every module has a low-stakes formative check.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.feedback.formative-per-module.detail.todo",
+		DetailDefault: fmt.Sprintf("%d modules need a formative check.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func moduleHasFormative(snap CourseSnapshot, mod StructureItem, kids []StructureItem, assessments []AssessmentItemSnap, total int) bool {
+	byID := map[string]AssessmentItemSnap{}
+	for _, a := range assessments {
+		byID[a.ID.String()] = a
+	}
+	for _, kid := range kids {
+		if kid.Archived {
+			continue
+		}
+		// Survey / practice quiz / content tool / SRS-ish interactive.
+		if kid.Kind == "survey" {
+			return true
+		}
+		if snap.ContentToolItemIDs != nil {
+			if _, ok := snap.ContentToolItemIDs[kid.ID]; ok {
+				return true
+			}
+		}
+		a, ok := byID[kid.ID.String()]
+		if !ok {
+			// Ungraded practice: assignment/quiz with 0 points via ItemMeta.
+			if meta, has := snap.ItemMeta[kid.ID]; has && isGradableKind(kid.Kind) {
+				if meta.PointsWorth != nil && *meta.PointsWorth <= 0 {
+					return true
+				}
+			}
+			continue
+		}
+		if a.Points == nil || *a.Points <= 0 {
+			return true
+		}
+		if total > 0 {
+			pct := 100.0 * float64(*a.Points) / float64(total)
+			if pct < 2.0 {
+				return true
+			}
+		}
+	}
+	_ = mod
+	return false
+}
+
+func ruleFeedbackQuizReviewSettings() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemFeedbackQuizReviewSettings,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.feedback.quiz-review-settings.title",
+		TitleDefault: "Review what quizzes reveal, and when",
+		WhyKey:       "coursechecklist.item.feedback.quiz-review-settings.why",
+		WhyDefault:   "Revealing correct answers while others can still take the quiz is an integrity defect.",
+		HelpRef:      "course-checklist#feedback-quiz-review-settings",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.5", "OSCQR 45"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems},
+		Evaluate:     evalFeedbackQuizReviewSettings,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "quiz.scores-review",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalFeedbackQuizReviewSettings(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	var quizzes []AssessmentItemSnap
+	for _, it := range assessmentItemsFor(snap) {
+		if it.Kind == "quiz" {
+			quizzes = append(quizzes, it)
+		}
+	}
+	if len(quizzes) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.feedback.quiz-review-settings.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	now := time.Now().UTC()
+	var evidence []EvidenceRow
+	for _, q := range sortAssessmentItems(quizzes) {
+		// Graded quiz revealing correct answers immediately while availability still open.
+		graded := q.Points != nil && *q.Points > 0
+		revealsCorrect := strings.EqualFold(q.ReviewVisibility, "correct_answers") ||
+			strings.EqualFold(q.ReviewVisibility, "full")
+		immediate := strings.EqualFold(q.ReviewWhen, "after_submit") ||
+			strings.EqualFold(q.ShowScoreTiming, "immediate")
+		windowOpen := q.AvailableUntil == nil || q.AvailableUntil.After(now)
+		if graded && revealsCorrect && immediate && windowOpen {
+			evidence = append(evidence, assessmentEvidenceRow(q,
+				"Reveals correct answers while still available", "quiz.scores-review"))
+		}
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.feedback.quiz-review-settings.detail.done",
+			DetailDefault: "Quiz review settings look consistent.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.feedback.quiz-review-settings.detail.todo",
+		DetailDefault: fmt.Sprintf("%d quizzes reveal answers while still available.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleFeedbackAttemptsPolicy() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemFeedbackAttemptsPolicy,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.feedback.attempts-policy.title",
+		TitleDefault: "Make attempts and scoring consistent",
+		WhyKey:       "coursechecklist.item.feedback.attempts-policy.why",
+		WhyDefault:   "One attempt cannot use highest-of-attempts scoring.",
+		HelpRef:      "course-checklist#feedback-attempts-policy",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 45"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems},
+		Evaluate:     evalFeedbackAttemptsPolicy,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "quiz.attempts-grading",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalFeedbackAttemptsPolicy(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	var evidence []EvidenceRow
+	var quizCount int
+	for _, q := range sortAssessmentItems(assessmentItemsFor(snap)) {
+		if q.Kind != "quiz" {
+			continue
+		}
+		quizCount++
+		if q.UnlimitedAttempts {
+			continue
+		}
+		if q.MaxAttempts <= 1 {
+			pol := strings.ToLower(strings.TrimSpace(q.GradeAttemptPolicy))
+			if pol == "highest" || pol == "average" {
+				evidence = append(evidence, assessmentEvidenceRow(q,
+					fmt.Sprintf("1 attempt with %s-of-attempts scoring", pol), "quiz.attempts-grading"))
+			}
+		}
+	}
+	if quizCount == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.feedback.attempts-policy.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.feedback.attempts-policy.detail.done",
+			DetailDefault: "Quiz attempts and scoring policies are consistent.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.feedback.attempts-policy.detail.todo",
+		DetailDefault: fmt.Sprintf("%d quizzes have inconsistent attempt policies.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleFeedbackPeerReviewConfig() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemFeedbackPeerReviewConfig,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.feedback.peer-review-config.title",
+		TitleDefault: "Complete your peer-review setup",
+		WhyKey:       "coursechecklist.item.feedback.peer-review-config.why",
+		WhyDefault:   "Peer review needs an allocation strategy, a review window after the due date, and a rubric.",
+		HelpRef:      "course-checklist#feedback-peer-review-config",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 5.2"},
+		DataNeeds:    []DataNeed{DataNeedPeerReview},
+		Applies: func(snap CourseSnapshot) bool {
+			return len(snap.PeerReviewConfigs) > 0
+		},
+		Evaluate: evalFeedbackPeerReviewConfig,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalFeedbackPeerReviewConfig(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	var evidence []EvidenceRow
+	for _, p := range snap.PeerReviewConfigs {
+		var issues []string
+		if p.ReviewsPerReviewer < 1 {
+			issues = append(issues, "no allocation strategy")
+		}
+		if p.OpensAt == nil || (p.DueAt != nil && p.OpensAt.Before(*p.DueAt)) {
+			issues = append(issues, "review window should open after the due date")
+		}
+		if !p.HasRubric {
+			issues = append(issues, "missing rubric")
+		}
+		if len(issues) == 0 {
+			continue
+		}
+		route := "/courses/{courseCode}/modules/assignment/{itemId}"
+		route = strings.ReplaceAll(route, "{itemId}", p.AssignmentID.String())
+		evidence = append(evidence, EvidenceRow{
+			Label:    p.AssignmentTitle,
+			Sublabel: strings.Join(issues, "; "),
+			TargetOverride: &NavTarget{
+				Surface:   "web",
+				Route:     route,
+				EntityKey: p.AssignmentID.String(),
+			},
+		})
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.feedback.peer-review-config.detail.done",
+			DetailDefault: "Peer-review configurations look complete.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.feedback.peer-review-config.detail.todo",
+		DetailDefault: fmt.Sprintf("%d peer-reviewed assignments need setup.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}

--- a/server/internal/service/coursechecklist/rules_grading.go
+++ b/server/internal/service/coursechecklist/rules_grading.go
@@ -1,0 +1,376 @@
+package coursechecklist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/lextures/lextures/server/internal/gradingdisplay"
+)
+
+func gradingRules() []ItemDescriptor {
+	return []ItemDescriptor{
+		ruleGradingGroupWeights(),
+		ruleGradingEmptyGroups(),
+		ruleGradingDropRules(),
+		ruleGradingSchemeCoverage(),
+		ruleGradingPostingPolicy(),
+		ruleGradingLatePolicyConfigured(),
+	}
+}
+
+func ruleGradingGroupWeights() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemGradingGroupWeights,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.grading.group-weights.title",
+		TitleDefault: "Make weights total 100%",
+		WhyKey:       "coursechecklist.item.grading.group-weights.why",
+		WhyDefault:   "Weights that do not sum to 100% silently produce the wrong final grade.",
+		HelpRef:      "course-checklist#grading-group-weights",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.2", "OSCQR 44"},
+		DataNeeds:    []DataNeed{DataNeedGrading},
+		Applies:      usesWeightedGrading,
+		Evaluate:     evalGradingGroupWeights,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/settings/grading",
+			Anchor:  "grading.groups",
+		},
+	}
+}
+
+func evalGradingGroupWeights(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	sum := assignmentGroupWeightSum(snap.AssignmentGroups)
+	if almostEqual(sum, 100.0, 0.01) {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.grading.group-weights.detail.done",
+			DetailDefault: "Weights add up to 100%.",
+			DetailFields:  map[string]any{"sum": sum},
+		}, nil
+	}
+	// Format without trailing noise for common cases.
+	sumStr := fmt.Sprintf("%.0f", sum)
+	if !almostEqual(sum, float64(int(sum+0.5)), 0.01) {
+		sumStr = fmt.Sprintf("%.2f", sum)
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.grading.group-weights.detail.todo",
+		DetailDefault: fmt.Sprintf("Weights add up to %s%%, not 100%%", sumStr),
+		DetailFields:  map[string]any{"sum": sum},
+	}, nil
+}
+
+func ruleGradingEmptyGroups() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemGradingEmptyGroups,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.grading.empty-groups.title",
+		TitleDefault: "Fill or remove empty weighted groups",
+		WhyKey:       "coursechecklist.item.grading.empty-groups.why",
+		WhyDefault:   "A weighted group with no items silently redistributes the grade.",
+		HelpRef:      "course-checklist#grading-empty-groups",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 44"},
+		DataNeeds:    []DataNeed{DataNeedGrading, DataNeedAssessmentItems, DataNeedStructure},
+		Applies:      usesWeightedGrading,
+		Evaluate:     evalGradingEmptyGroups,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/settings/grading",
+			Anchor:  "grading.groups",
+		},
+		EvidenceShape: &EvidenceShape{Columns: gradingEvidenceColumns},
+	}
+}
+
+func evalGradingEmptyGroups(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	counts := groupItemCounts(snap)
+	var evidence []EvidenceRow
+	for _, g := range snap.AssignmentGroups {
+		if g.Weight == nil || *g.Weight <= 0 {
+			continue
+		}
+		n := counts[g.ID]
+		if n == 0 {
+			evidence = append(evidence, EvidenceRow{
+				Label:    g.Name,
+				Sublabel: fmt.Sprintf("%s · 0 items", formatWeight(g.Weight)),
+			})
+		}
+	}
+	sortEvidenceByLabel(evidence)
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.grading.empty-groups.detail.done",
+			DetailDefault: "Every weighted group has at least one item.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.grading.empty-groups.detail.todo",
+		DetailDefault: fmt.Sprintf("%d weighted groups have no items.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleGradingDropRules() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemGradingDropRules,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.grading.drop-rules.title",
+		TitleDefault: "Fix impossible drop rules",
+		WhyKey:       "coursechecklist.item.grading.drop-rules.why",
+		WhyDefault:   "Dropping more items than a group contains cannot be applied.",
+		HelpRef:      "course-checklist#grading-drop-rules",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 44"},
+		DataNeeds:    []DataNeed{DataNeedGrading, DataNeedAssessmentItems, DataNeedStructure},
+		Evaluate:     evalGradingDropRules,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/settings/grading",
+			Anchor:  "grading.groups",
+		},
+		EvidenceShape: &EvidenceShape{Columns: gradingEvidenceColumns},
+	}
+}
+
+func evalGradingDropRules(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	if len(snap.AssignmentGroups) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.grading.drop-rules.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	counts := groupItemCounts(snap)
+	var evidence []EvidenceRow
+	for _, g := range snap.AssignmentGroups {
+		drops := g.DropLowest + g.DropHighest
+		if drops <= 0 {
+			continue
+		}
+		n := counts[g.ID]
+		if drops >= n {
+			evidence = append(evidence, EvidenceRow{
+				Label: g.Name,
+				Sublabel: fmt.Sprintf("drop %d of %d items (lowest %d, highest %d)",
+					drops, n, g.DropLowest, g.DropHighest),
+			})
+		}
+	}
+	sortEvidenceByLabel(evidence)
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.grading.drop-rules.detail.done",
+			DetailDefault: "Drop rules fit within each group's item count.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.grading.drop-rules.detail.todo",
+		DetailDefault: fmt.Sprintf("%d groups have impossible drop rules.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func ruleGradingSchemeCoverage() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemGradingSchemeCoverage,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.grading.scheme-coverage.title",
+		TitleDefault: "Close gaps in your grading scale",
+		WhyKey:       "coursechecklist.item.grading.scheme-coverage.why",
+		WhyDefault:   "Letter bands should cover 0–100 with no gaps or overlaps.",
+		HelpRef:      "course-checklist#grading-scheme-coverage",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 44"},
+		DataNeeds:    []DataNeed{DataNeedGrading, DataNeedCourse},
+		Applies: func(snap CourseSnapshot) bool {
+			return snap.GradingSchemeID != nil || strings.EqualFold(snap.GradingScale, "letter") ||
+				strings.EqualFold(snap.GradingScale, "gpa")
+		},
+		Evaluate: evalGradingSchemeCoverage,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/settings/grading",
+		},
+	}
+}
+
+func evalGradingSchemeCoverage(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	scale := snap.GradingSchemeScaleJSON
+	if len(scale) == 0 {
+		// No custom scheme bands — treat platform defaults as covering 0–100.
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.grading.scheme-coverage.detail.done-default",
+			DetailDefault: "Using the default grading scale.",
+		}, nil
+	}
+	kind, ok := gradingdisplay.ParseKind(snap.GradingScale)
+	if !ok {
+		kind = gradingdisplay.Letter
+	}
+	raw := json.RawMessage(scale)
+	parsed, err := gradingdisplay.ParseScale(kind, &raw)
+	if err != nil {
+		return Finding{
+			Status:        StatusTodo,
+			DetailKey:     "coursechecklist.item.grading.scheme-coverage.detail.todo",
+			DetailDefault: "Grading scale has gaps or overlaps: " + err.Error(),
+			DetailFields:  map[string]any{"error": err.Error()},
+		}, nil
+	}
+	if kind == gradingdisplay.Letter || kind == gradingdisplay.Gpa {
+		if len(parsed.LetterTiers) == 0 {
+			return Finding{
+				Status:        StatusTodo,
+				DetailKey:     "coursechecklist.item.grading.scheme-coverage.detail.todo-empty",
+				DetailDefault: "Grading scale has no letter bands.",
+			}, nil
+		}
+	}
+	return Finding{
+		Status:        StatusDone,
+		DetailKey:     "coursechecklist.item.grading.scheme-coverage.detail.done",
+		DetailDefault: "Grading scale covers 0–100 with no gaps.",
+	}, nil
+}
+
+func ruleGradingPostingPolicy() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemGradingPostingPolicy,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.grading.posting-policy.title",
+		TitleDefault: "Choose when grades are posted",
+		WhyKey:       "coursechecklist.item.grading.posting-policy.why",
+		WhyDefault:   "Learners should know whether grades appear automatically or after review.",
+		HelpRef:      "course-checklist#grading-posting-policy",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.5", "OSCQR 38"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems, DataNeedSyllabus},
+		Evaluate:     evalGradingPostingPolicy,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/settings/grading",
+		},
+	}
+}
+
+func evalGradingPostingPolicy(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := assessmentItemsFor(snap)
+	assignments := 0
+	manual := 0
+	for _, it := range items {
+		if it.Kind != "assignment" {
+			continue
+		}
+		assignments++
+		if strings.EqualFold(it.PostingPolicy, "manual") {
+			manual++
+		}
+	}
+	if assignments == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.grading.posting-policy.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	if manual == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.grading.posting-policy.detail.done-auto",
+			DetailDefault: "Grades post automatically.",
+		}, nil
+	}
+	// Manual posting: syllabus should state when grades are released.
+	text, _ := SyllabusPlainText(snap)
+	if containsAny(strings.ToLower(text),
+		[]string{"grade release", "grades are released", "grades will be posted", "posting grades", "when grades"}) {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.grading.posting-policy.detail.done-manual",
+			DetailDefault: "Manual posting is set and the syllabus explains grade release.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.grading.posting-policy.detail.todo",
+		DetailDefault: fmt.Sprintf("%d assignments use manual posting; add when grades are released to the syllabus.", manual),
+		DetailFields:  map[string]any{"manualCount": manual},
+	}, nil
+}
+
+func ruleGradingLatePolicyConfigured() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemGradingLatePolicyConfigured,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.grading.late-policy-configured.title",
+		TitleDefault: "Configure late-work handling",
+		WhyKey:       "coursechecklist.item.grading.late-policy-configured.why",
+		WhyDefault:   "Every graded item should say whether late work is allowed, penalized, or blocked.",
+		HelpRef:      "course-checklist#grading-late-policy-configured",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 44"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems, DataNeedItemMeta},
+		Evaluate:     evalGradingLatePolicyConfigured,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+			Anchor:  "assignment.grading",
+		},
+		EvidenceShape: &EvidenceShape{Columns: assessmentEvidenceColumns},
+	}
+}
+
+func evalGradingLatePolicyConfigured(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := sortAssessmentItems(assessmentItemsFor(snap))
+	if len(items) == 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.grading.late-policy-configured.detail.na",
+			DetailDefault: "Does not apply to this course.",
+		}, nil
+	}
+	var evidence []EvidenceRow
+	for _, it := range items {
+		p := strings.TrimSpace(strings.ToLower(it.LateSubmissionPolicy))
+		if p == "" || (p != "allow" && p != "penalty" && p != "block") {
+			evidence = append(evidence, assessmentEvidenceRow(it, "Late policy not set", "assignment.grading"))
+		}
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.grading.late-policy-configured.detail.done",
+			DetailDefault: "Late-work policy is set on every graded item.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.grading.late-policy-configured.detail.todo",
+		DetailDefault: fmt.Sprintf("%d items need a late-work policy.", len(evidence)),
+		DetailFields:  map[string]any{"count": len(evidence)},
+		Evidence:      evidence,
+	}, nil
+}
+
+func containsAny(text string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(text, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/service/coursechecklist/rules_interaction.go
+++ b/server/internal/service/coursechecklist/rules_interaction.go
@@ -1,0 +1,467 @@
+package coursechecklist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func interactionRules() []ItemDescriptor {
+	return []ItemDescriptor{
+		ruleIntegrityHighStakesSettings(),
+		ruleIntegrityAIPolicyAlignment(),
+		ruleAccommodationsHonored(),
+		ruleAccommodationsReviewed(),
+		ruleInteractionDiscussionExists(),
+		ruleInteractionInstructorPresencePlan(),
+		ruleInteractionOfficeHours(),
+		ruleInteractionGroupsConfigured(),
+	}
+}
+
+func ruleIntegrityHighStakesSettings() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemIntegrityHighStakesSettings,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.integrity.high-stakes-settings.title",
+		TitleDefault: "Review integrity settings on major assessments",
+		WhyKey:       "coursechecklist.item.integrity.high-stakes-settings.why",
+		WhyDefault:   "Items worth 20% or more deserve an intentional integrity review.",
+		HelpRef:      "course-checklist#integrity-high-stakes-settings",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 3.x", "OSCQR 45"},
+		DataNeeds:    []DataNeed{DataNeedAssessmentItems, DataNeedCourse},
+		Evaluate:     evalIntegrityHighStakesSettings,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/modules",
+		},
+	}
+}
+
+func evalIntegrityHighStakesSettings(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	items := assessmentItemsFor(snap)
+	total := totalCoursePoints(items)
+	if total <= 0 {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.integrity.high-stakes-settings.detail.na",
+			DetailDefault: "Does not apply when no item crosses the 20% threshold.",
+		}, nil
+	}
+	hasMajor := false
+	for _, it := range items {
+		if it.Points == nil || *it.Points <= 0 {
+			continue
+		}
+		if 100.0*float64(*it.Points)/float64(total) >= 20.0 {
+			hasMajor = true
+			break
+		}
+	}
+	if !hasMajor {
+		return Finding{
+			Status:        StatusNotApplicable,
+			DetailKey:     "coursechecklist.item.integrity.high-stakes-settings.detail.na",
+			DetailDefault: "Does not apply when no item crosses the 20% threshold.",
+		}, nil
+	}
+	if snap.IntegritySettingsReviewedAt != nil {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.integrity.high-stakes-settings.detail.done",
+			DetailDefault: "Integrity settings have been reviewed.",
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.integrity.high-stakes-settings.detail.todo",
+		DetailDefault: "Review integrity settings on assessments worth 20% or more.",
+	}, nil
+}
+
+func ruleIntegrityAIPolicyAlignment() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemIntegrityAIPolicyAlignment,
+		Category:     CategoryAssessment,
+		TitleKey:     "coursechecklist.item.integrity.ai-policy-alignment.title",
+		TitleDefault: "Say how AI may be used",
+		WhyKey:       "coursechecklist.item.integrity.ai-policy-alignment.why",
+		WhyDefault:   "When AI features are on for learners, the syllabus should say how AI may be used.",
+		HelpRef:      "course-checklist#integrity-ai-policy-alignment",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 1.3"},
+		DataNeeds:    []DataNeed{DataNeedCourse, DataNeedSyllabus},
+		Applies: func(snap CourseSnapshot) bool {
+			return snap.Features.AiTutorEnabled || snap.Features.AdaptiveContentEnabled ||
+				snap.Features.ModulesAiAssistantEnabled || snap.Features.ContentToolsEnabled
+		},
+		Evaluate: evalIntegrityAIPolicyAlignment,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/syllabus",
+		},
+	}
+}
+
+func evalIntegrityAIPolicyAlignment(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	if snap.SyllabusMalformed {
+		return syllabusUnknownFinding(ItemIntegrityAIPolicyAlignment), nil
+	}
+	lx := lexiconForSnap(snap)
+	text, trunc := SyllabusPlainText(snap)
+	if lx != nil && lx.AcademicIntegrity != nil && lx.AcademicIntegrity.Match(text) &&
+		containsAny(strings.ToLower(text), []string{"ai", "artificial intelligence", "generative", "chatgpt", "llm"}) {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.integrity.ai-policy-alignment.detail.done",
+			DetailDefault: truncatedDetail("Syllabus covers AI use alongside academic integrity.", trunc),
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.integrity.ai-policy-alignment.detail.todo",
+		DetailDefault: truncatedDetail("Add how learners may use AI to the academic-integrity section.", trunc),
+	}, nil
+}
+
+func ruleAccommodationsHonored() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAccommodationsHonored,
+		Category:     CategoryAccessibility,
+		TitleKey:     "coursechecklist.item.accommodations.honored.title",
+		TitleDefault: "Check timed work against accommodations",
+		WhyKey:       "coursechecklist.item.accommodations.honored.why",
+		WhyDefault:   "Timed quizzes may conflict with extended-time accommodations the platform cannot auto-apply.",
+		HelpRef:      "course-checklist#accommodations-honored",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 48", "ADA/§504"},
+		DataNeeds:    []DataNeed{DataNeedAccommodations, DataNeedAssessmentItems},
+		Applies: func(snap CourseSnapshot) bool {
+			return snap.AccommodationCount >= 1
+		},
+		Evaluate: evalAccommodationsHonored,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/settings/accessibility",
+		},
+		EvidenceShape: &EvidenceShape{Columns: []string{"Item", "Type", "Accommodation", "Issue"}},
+	}
+}
+
+func evalAccommodationsHonored(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	extended := 0
+	for _, t := range snap.AccommodationTypeCounts {
+		if t.Type == "extended_time" {
+			extended = t.Count
+		}
+	}
+	if extended == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.accommodations.honored.detail.done-no-extended",
+			DetailDefault: "No extended-time accommodations conflict with timed quizzes.",
+		}, nil
+	}
+	var timedQuizzes int
+	var evidence []EvidenceRow
+	for _, it := range sortAssessmentItems(assessmentItemsFor(snap)) {
+		if it.Kind != "quiz" || it.TimeLimitMinutes == nil || *it.TimeLimitMinutes <= 0 {
+			continue
+		}
+		timedQuizzes++
+		// Privacy: counts and accommodation type only — never user IDs or names (FR-21 / AC-10).
+		evidence = append(evidence, EvidenceRow{
+			Label:    it.Title,
+			Sublabel: fmt.Sprintf("Quiz · extended_time · hard time limit (%d min)", *it.TimeLimitMinutes),
+			TargetOverride: &NavTarget{
+				Surface: "web",
+				Route:   "/courses/{courseCode}/settings/accessibility",
+			},
+		})
+	}
+	if len(evidence) == 0 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.accommodations.honored.detail.done",
+			DetailDefault: "No timed quizzes conflict with extended-time accommodations.",
+		}, nil
+	}
+	noun := "timed quiz"
+	if len(evidence) != 1 {
+		noun = "timed quizzes"
+	}
+	return Finding{
+		Status:    StatusTodo,
+		DetailKey: "coursechecklist.item.accommodations.honored.detail.todo",
+		DetailDefault: fmt.Sprintf(
+			"%d %s may conflict with an extended-time accommodation",
+			len(evidence), noun,
+		),
+		DetailFields: map[string]any{
+			"timedQuizCount":    len(evidence),
+			"extendedTimeCount": extended,
+			"accommodationType": "extended_time",
+		},
+		Evidence: evidence,
+	}, nil
+}
+
+func ruleAccommodationsReviewed() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemAccommodationsReviewed,
+		Category:     CategoryAccessibility,
+		TitleKey:     "coursechecklist.item.accommodations.reviewed.title",
+		TitleDefault: "Review new accommodations",
+		WhyKey:       "coursechecklist.item.accommodations.reviewed.why",
+		WhyDefault:   "Open the accommodations surface after new accommodations are added.",
+		HelpRef:      "course-checklist#accommodations-reviewed",
+		Tier:         TierRecommended,
+		Sources:      []string{"OSCQR 48"},
+		DataNeeds:    []DataNeed{DataNeedAccommodations, DataNeedCourse},
+		Applies: func(snap CourseSnapshot) bool {
+			return snap.AccommodationCount >= 1
+		},
+		Evaluate: evalAccommodationsReviewed,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/settings/accessibility",
+		},
+	}
+}
+
+func evalAccommodationsReviewed(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	if snap.AccommodationsReviewedAt != nil {
+		if snap.LatestAccommodationAt == nil || !snap.LatestAccommodationAt.After(*snap.AccommodationsReviewedAt) {
+			return Finding{
+				Status:        StatusDone,
+				DetailKey:     "coursechecklist.item.accommodations.reviewed.detail.done",
+				DetailDefault: "Accommodations have been reviewed since the latest addition.",
+			}, nil
+		}
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.accommodations.reviewed.detail.todo",
+		DetailDefault: "Review accommodations for this course.",
+	}, nil
+}
+
+func ruleInteractionDiscussionExists() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemInteractionDiscussionExists,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.interaction.discussion-exists.title",
+		TitleDefault: "Add a discussion or collaborative activity",
+		WhyKey:       "coursechecklist.item.interaction.discussion-exists.why",
+		WhyDefault:   "Courses with multiple learners benefit from a structured discussion prompt.",
+		HelpRef:      "course-checklist#interaction-discussion-exists",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 5.2", "OSCQR 39", "OSCQR 42", "NSQ C"},
+		DataNeeds:    []DataNeed{DataNeedCourse, DataNeedEnrollments, DataNeedDiscussions},
+		Applies: func(snap CourseSnapshot) bool {
+			students := snap.EnrollmentCounts["student"]
+			if students == 0 {
+				for _, p := range snap.People {
+					if p.Active && isStudentRole(p.Role) {
+						students++
+					}
+				}
+			}
+			if students < 2 {
+				return false
+			}
+			return snap.Features.DiscussionsEnabled || snap.Features.FeedEnabled ||
+				snap.Features.GroupSpacesEnabled || snap.Features.VisualBoardsEnabled
+		},
+		Evaluate: evalInteractionDiscussionExists,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/discussions",
+		},
+	}
+}
+
+func evalInteractionDiscussionExists(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	if snap.DiscussionForumCount >= 1 || snap.DiscussionPromptCount >= 1 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.interaction.discussion-exists.detail.done",
+			DetailDefault: "A discussion or collaborative activity is set up.",
+			DetailFields: map[string]any{
+				"forums":  snap.DiscussionForumCount,
+				"threads": snap.DiscussionPromptCount,
+			},
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.interaction.discussion-exists.detail.todo",
+		DetailDefault: "Add a structured discussion prompt, forum, or graded discussion.",
+	}, nil
+}
+
+func ruleInteractionInstructorPresencePlan() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemInteractionInstructorPresencePlan,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.interaction.instructor-presence-plan.title",
+		TitleDefault: "Plan your announcements",
+		WhyKey:       "coursechecklist.item.interaction.instructor-presence-plan.why",
+		WhyDefault:   "A steady announcement cadence signals instructor presence.",
+		HelpRef:      "course-checklist#interaction-instructor-presence-plan",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 5.3", "OSCQR 40"},
+		DataNeeds:    []DataNeed{DataNeedCourse, DataNeedAnnouncementCadence, DataNeedFeed},
+		Evaluate:     evalInteractionInstructorPresencePlan,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/feed",
+		},
+	}
+}
+
+func evalInteractionInstructorPresencePlan(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	weeks := courseDurationWeeks(snap)
+	if weeks <= 0 {
+		weeks = 1
+	}
+	needed := (weeks + 1) / 2 // ≥ 1 per 2 weeks
+	if needed < 1 {
+		needed = 1
+	}
+	have := len(snap.AnnouncementTimes)
+	if have >= needed {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.interaction.instructor-presence-plan.detail.done",
+			DetailDefault: fmt.Sprintf("%d announcements for a %d-week course (need %d).", have, weeks, needed),
+			DetailFields:  map[string]any{"have": have, "needed": needed, "weeks": weeks},
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.interaction.instructor-presence-plan.detail.todo",
+		DetailDefault: fmt.Sprintf("%d of %d planned announcements for a %d-week course.", have, needed, weeks),
+		DetailFields:  map[string]any{"have": have, "needed": needed, "weeks": weeks},
+		Progress:      &Progress{Done: have, Total: needed},
+	}, nil
+}
+
+func courseDurationWeeks(snap CourseSnapshot) int {
+	if snap.StartsAt == nil || snap.EndsAt == nil {
+		return 0
+	}
+	d := snap.EndsAt.Sub(*snap.StartsAt)
+	if d <= 0 {
+		return 0
+	}
+	weeks := int(d.Hours() / (24 * 7))
+	if weeks < 1 {
+		weeks = 1
+	}
+	return weeks
+}
+
+func ruleInteractionOfficeHours() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemInteractionOfficeHours,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.interaction.office-hours.title",
+		TitleDefault: "Publish office hours",
+		WhyKey:       "coursechecklist.item.interaction.office-hours.why",
+		WhyDefault:   "When office hours are enabled, publish at least one upcoming slot.",
+		HelpRef:      "course-checklist#interaction-office-hours",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 1.7", "OSCQR 40"},
+		DataNeeds:    []DataNeed{DataNeedCourse, DataNeedOfficeHours},
+		Applies: func(snap CourseSnapshot) bool {
+			return snap.Features.OfficeHoursEnabled
+		},
+		Evaluate: evalInteractionOfficeHours,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/office-hours",
+		},
+	}
+}
+
+func evalInteractionOfficeHours(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	if snap.FutureOfficeHourSlots >= 1 {
+		return Finding{
+			Status:        StatusDone,
+			DetailKey:     "coursechecklist.item.interaction.office-hours.detail.done",
+			DetailDefault: fmt.Sprintf("%d upcoming office-hour slots.", snap.FutureOfficeHourSlots),
+			DetailFields:  map[string]any{"slots": snap.FutureOfficeHourSlots},
+		}, nil
+	}
+	return Finding{
+		Status:        StatusTodo,
+		DetailKey:     "coursechecklist.item.interaction.office-hours.detail.todo",
+		DetailDefault: "Publish at least one upcoming office-hour slot.",
+	}, nil
+}
+
+func ruleInteractionGroupsConfigured() ItemDescriptor {
+	return ItemDescriptor{
+		ID:           ItemInteractionGroupsConfigured,
+		Category:     CategoryFeedback,
+		TitleKey:     "coursechecklist.item.interaction.groups-configured.title",
+		TitleDefault: "Put every student in a group",
+		WhyKey:       "coursechecklist.item.interaction.groups-configured.why",
+		WhyDefault:   "When groups are enabled, every student should belong to a group.",
+		HelpRef:      "course-checklist#interaction-groups-configured",
+		Tier:         TierRecommended,
+		Sources:      []string{"QM 5.2"},
+		DataNeeds:    []DataNeed{DataNeedCourse, DataNeedEnrollments, DataNeedEnrollmentGroups},
+		Applies: func(snap CourseSnapshot) bool {
+			students := studentCount(snap)
+			if students < 2 {
+				return false
+			}
+			return snap.EnrollmentGroupsEnabled || snap.Features.GroupSpacesEnabled || snap.EnrollmentGroupSetCount > 0
+		},
+		Evaluate: evalInteractionGroupsConfigured,
+		Target: NavTarget{
+			Surface: "web",
+			Route:   "/courses/{courseCode}/groups",
+		},
+	}
+}
+
+func evalInteractionGroupsConfigured(_ context.Context, snap CourseSnapshot) (Finding, error) {
+	if snap.EnrollmentGroupSetCount < 1 {
+		return Finding{
+			Status:        StatusTodo,
+			DetailKey:     "coursechecklist.item.interaction.groups-configured.detail.todo-sets",
+			DetailDefault: "Create at least one group set.",
+		}, nil
+	}
+	if snap.UnassignedStudentCount > 0 {
+		return Finding{
+			Status:        StatusTodo,
+			DetailKey:     "coursechecklist.item.interaction.groups-configured.detail.todo",
+			// Count only — never names (FR-26).
+			DetailDefault: fmt.Sprintf("%d students are not in a group.", snap.UnassignedStudentCount),
+			DetailFields:  map[string]any{"unassignedCount": snap.UnassignedStudentCount},
+		}, nil
+	}
+	return Finding{
+		Status:        StatusDone,
+		DetailKey:     "coursechecklist.item.interaction.groups-configured.detail.done",
+		DetailDefault: "Every student belongs to a group.",
+	}, nil
+}
+
+func studentCount(snap CourseSnapshot) int {
+	if n, ok := snap.EnrollmentCounts["student"]; ok && n > 0 {
+		return n
+	}
+	n := 0
+	for _, p := range snap.People {
+		if p.Active && isStudentRole(p.Role) {
+			n++
+		}
+	}
+	return n
+}

--- a/server/internal/service/coursechecklist/snapshot.go
+++ b/server/internal/service/coursechecklist/snapshot.go
@@ -36,14 +36,18 @@ type CourseSnapshot struct {
 	CourseHomeLanding       string
 	CourseHomeContentItemID *string
 	CreatedAt               time.Time
-	FeaturesReviewedAt      *time.Time
-	GradingSchemeID         *uuid.UUID
-	CatalogLanguage         string
-	HomeschoolMode          bool // true when OrgID is nil (personal / single-instructor)
-	ParentPortalEnabled     bool
-	OrgIsK12                bool
-	CreatorUserID           *uuid.UUID
-	Features                CourseFeatures
+	FeaturesReviewedAt             *time.Time
+	AccommodationsReviewedAt       *time.Time
+	IntegritySettingsReviewedAt    *time.Time
+	GradingSchemeID                *uuid.UUID
+	GradingSchemeScaleJSON         json.RawMessage
+	CatalogLanguage                string
+	HomeschoolMode                 bool // true when OrgID is nil (personal / single-instructor)
+	ParentPortalEnabled            bool
+	OrgIsK12                       bool
+	CreatorUserID                  *uuid.UUID
+	EnrollmentGroupsEnabled        bool
+	Features                       CourseFeatures
 
 	// Structure (DataNeedStructure)
 	StructureItems []StructureItem
@@ -86,8 +90,30 @@ type CourseSnapshot struct {
 	// Sections (DataNeedSections)
 	Sections []SectionSnap
 
-	// Accommodations (DataNeedAccommodations)
-	AccommodationCount int
+	// Accommodations (DataNeedAccommodations) — counts/types only; never student IDs (CC.5)
+	AccommodationCount       int
+	AccommodationTypeCounts  []AccommodationTypeCount
+	LatestAccommodationAt    *time.Time
+
+	// Assessment item details (DataNeedAssessmentItems)
+	AssessmentItems []AssessmentItemSnap
+
+	// Peer review (DataNeedPeerReview)
+	PeerReviewConfigs []PeerReviewConfigSnap
+
+	// Discussions (DataNeedDiscussions)
+	DiscussionForumCount int
+	DiscussionPromptCount int
+
+	// Office hours (DataNeedOfficeHours)
+	FutureOfficeHourSlots int
+
+	// Enrollment groups (DataNeedEnrollmentGroups)
+	EnrollmentGroupSetCount int
+	UnassignedStudentCount  int
+
+	// Announcement cadence (DataNeedAnnouncementCadence)
+	AnnouncementTimes []time.Time
 
 	// Standards (DataNeedStandards)
 	StandardsCount         int
@@ -124,6 +150,8 @@ type CourseFeatures struct {
 	VisualBoardsEnabled       bool
 	AiTutorEnabled            bool
 	ModulesAiAssistantEnabled bool
+	OfficeHoursEnabled        bool
+	AdaptiveContentEnabled    bool
 }
 
 // StructureItem is a course structure row subset for checklist rules.
@@ -197,9 +225,61 @@ type PrerequisiteEdge struct {
 
 // AssignmentGroupSnap is an assignment group.
 type AssignmentGroupSnap struct {
-	ID     uuid.UUID
-	Name   string
-	Weight *float64
+	ID          uuid.UUID
+	Name        string
+	Weight      *float64
+	DropLowest  int
+	DropHighest int
+}
+
+// AssessmentItemSnap is assignment/quiz detail for assessment rules (CC.5).
+type AssessmentItemSnap struct {
+	ID                   uuid.UUID
+	Kind                 string // assignment | quiz | survey
+	Title                string
+	ParentID             *uuid.UUID
+	ModuleTitle          string
+	SortOrder            int
+	Published            bool
+	Archived             bool
+	DueAt                *time.Time
+	AvailableFrom        *time.Time
+	AvailableUntil       *time.Time
+	Points               *int
+	AssignmentGroupID    *uuid.UUID
+	HasBody              bool
+	HasRubric            bool
+	LateSubmissionPolicy string
+	PostingPolicy        string
+	OriginalityDetection string
+	// Quiz behaviour
+	UnlimitedAttempts  bool
+	MaxAttempts        int
+	GradeAttemptPolicy string
+	ShowScoreTiming    string
+	ReviewVisibility   string
+	ReviewWhen         string
+	TimeLimitMinutes   *int
+	ShuffleQuestions   bool
+	ShuffleChoices     bool
+	LockdownMode       string
+}
+
+// PeerReviewConfigSnap is a peer-review configuration row (CC.5).
+type PeerReviewConfigSnap struct {
+	AssignmentID       uuid.UUID
+	AssignmentTitle    string
+	ReviewsPerReviewer int
+	OpensAt            *time.Time
+	ClosesAt           *time.Time
+	HasRubric          bool
+	DueAt              *time.Time
+}
+
+// AccommodationTypeCount is a privacy-safe aggregate (CC.5 FR-21).
+type AccommodationTypeCount struct {
+	Type  string
+	Count int
 }
 
 // PersonSnap is a privacy-safe enrollment stub (display name + opaque ID only).

--- a/server/internal/service/coursechecklist/testdata/web_routes.json
+++ b/server/internal/service/coursechecklist/testdata/web_routes.json
@@ -24,6 +24,9 @@
     "/courses/{courseCode}/enrollments",
     "/courses/{courseCode}/gradebook",
     "/courses/{courseCode}/people",
-    "/courses/{courseCode}/standards-coverage"
+    "/courses/{courseCode}/standards-coverage",
+    "/courses/{courseCode}/discussions",
+    "/courses/{courseCode}/office-hours",
+    "/courses/{courseCode}/groups"
   ]
 }

--- a/server/migrations/463_course_checklist_review_markers_2.down.sql
+++ b/server/migrations/463_course_checklist_review_markers_2.down.sql
@@ -1,0 +1,5 @@
+-- Companion to: 463_course_checklist_review_markers_2.sql
+
+ALTER TABLE course.courses
+    DROP COLUMN IF EXISTS accommodations_reviewed_at,
+    DROP COLUMN IF EXISTS integrity_settings_reviewed_at;

--- a/server/migrations/463_course_checklist_review_markers_2.sql
+++ b/server/migrations/463_course_checklist_review_markers_2.sql
@@ -1,0 +1,10 @@
+-- CC.5: Review markers for accommodations and integrity settings.
+
+ALTER TABLE course.courses
+    ADD COLUMN IF NOT EXISTS accommodations_reviewed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS integrity_settings_reviewed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN course.courses.accommodations_reviewed_at IS
+    'Set when course staff open/save the course accommodations surface; drives accommodations.reviewed.';
+COMMENT ON COLUMN course.courses.integrity_settings_reviewed_at IS
+    'Set when course staff save integrity settings; drives integrity.high-stakes-settings.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **CC.5 — Rule Pack C**: 26 course-checklist rules covering assessment configuration, grading integrity, criteria/feedback, accommodations (privacy-safe), and learner interaction. All ship as `recommended`.

## Changes

- Migration `463`: `accommodations_reviewed_at` / `integrity_settings_reviewed_at` on `course.courses`, stamped on accommodations writes and assignment/quiz settings saves
- Snapshot loaders for assessment items, peer review, discussions/office hours/groups, announcement cadence, and accommodation type aggregates (counts/types only — never student IDs)
- New evaluators: `rules_assessment.go`, `rules_grading.go`, `rules_feedback.go`, `rules_interaction.go` (registry now **81** rules)
- Arithmetic rules put computed numbers in `Detail` (e.g. “Weights add up to 87%, not 100%”)
- Unit tests for AC-1–AC-13 including privacy assertions for accommodations evidence
- Playwright: weights 87% → todo → 100% → done; high-stakes assignment without rubric targets `#assignment.rubric`
- E2E.4 coverage manifest entry for the completed CC.5 plan
- Plan moved to `docs/completed/checklist/`

## Test plan

- [x] `go test ./internal/service/coursechecklist/` (short + DB)
- [x] `make lint-structure`
- [x] `golangci-lint` on touched packages
- [x] Playwright `e2e/tests/course-checklist.spec.ts` against local API
- [x] `npm run e2e:coverage:check`
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcdc2-d007-7a7f-a926-5b5268f4b964?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcdc2-d007-7a7f-a926-5b5268f4b964&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

