### PR TITLE
feat(web): CC.7 course checklist page, nav badge, and dashboard card

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -154,6 +154,7 @@ export default function App() {
               <Route path="gradebook" element={<Pages.CourseGradebook />} />
               <Route path="reports" element={<Pages.CourseStudentReportsPage />} />
               <Route path="at-risk" element={<Pages.CourseAtRiskPage />} />
+              <Route path="checklist" element={<Pages.CourseChecklistPage />} />
               <Route path="event-log" element={<Pages.CourseEventLogPage />} />
               <Route path="students/:enrollmentId/progress" element={<Pages.StudentProgressPage />} />
               <Route path="standards-gradebook" element={<Pages.CourseStandardsGradebook />} />

--- a/clients/web/src/components/checklist/__tests__/checklist-badge.test.tsx
+++ b/clients/web/src/components/checklist/__tests__/checklist-badge.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ChecklistBadge } from '../checklist-badge'
+
+describe('ChecklistBadge', () => {
+  it('renders nothing when outstanding is zero', () => {
+    const { container } = render(<ChecklistBadge outstandingEssential={0} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('caps display at 99+ but aria-label uses the true count', () => {
+    render(<ChecklistBadge outstandingEssential={137} />)
+    expect(screen.getByText('99+')).toBeInTheDocument()
+    expect(screen.getByLabelText('137 checklist items need attention')).toBeInTheDocument()
+  })
+
+  it('shows the exact count under 100', () => {
+    render(<ChecklistBadge outstandingEssential={8} />)
+    expect(screen.getByText('8')).toBeInTheDocument()
+    expect(screen.getByLabelText('8 checklist items need attention')).toBeInTheDocument()
+  })
+})

--- a/clients/web/src/components/checklist/__tests__/checklist-item-row.test.tsx
+++ b/clients/web/src/components/checklist/__tests__/checklist-item-row.test.tsx
@@ -41,7 +41,9 @@ describe('ChecklistItemRow', () => {
         </ul>
       </MemoryRouter>,
     )
-    expect(screen.getByText('Completed')).toHaveClass('sr-only')
+    const completed = screen.getAllByText('Completed')
+    expect(completed.length).toBeGreaterThanOrEqual(1)
+    expect(completed.every((el) => el.classList.contains('sr-only'))).toBe(true)
     expect(screen.getByText('Post a welcome announcement').className).toMatch(/line-through/)
   })
 

--- a/clients/web/src/components/checklist/__tests__/checklist-item-row.test.tsx
+++ b/clients/web/src/components/checklist/__tests__/checklist-item-row.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import type { ChecklistItem } from '../../../lib/course-checklist-api-schemas'
+import { ChecklistItemRow } from '../../../pages/lms/course-checklist/checklist-item-row'
+
+vi.mock('../../../context/platform-features-context', () => ({
+  usePlatformFeatures: () => ({ ffMotionOverlays: false }),
+}))
+
+function baseItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
+  return {
+    id: 'orientation.welcome-message',
+    titleKey: 'k',
+    title: 'Post a welcome announcement',
+    whyKey: 'w',
+    why: 'Students need a welcome',
+    tier: 'essential',
+    status: 'todo',
+    detail: 'Missing announcement',
+    progress: null,
+    sources: ['QM 1.2'],
+    helpRef: null,
+    target: { route: '/courses/C1/feed' },
+    evidence: null,
+    dismissal: null,
+    ...overrides,
+  }
+}
+
+describe('ChecklistItemRow', () => {
+  it('shows completed label and strikethrough for done items', () => {
+    render(
+      <MemoryRouter>
+        <ul>
+          <ChecklistItemRow
+            item={baseItem({ status: 'done' })}
+            onDismiss={vi.fn()}
+            onRecheck={vi.fn()}
+          />
+        </ul>
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Completed')).toHaveClass('sr-only')
+    expect(screen.getByText('Post a welcome announcement').className).toMatch(/line-through/)
+  })
+
+  it('expands evidence table when evidence rows exist', () => {
+    render(
+      <MemoryRouter>
+        <ul>
+          <ChecklistItemRow
+            item={baseItem({
+              target: null,
+              evidence: {
+                columns: ['Item', 'Type'],
+                rows: [
+                  {
+                    label: 'Essay 1',
+                    sublabel: 'Assign.',
+                    status: 'unmapped',
+                    target: { route: '/courses/C1/modules/assignment/a1' },
+                  },
+                ],
+                truncatedAt: null,
+              },
+            })}
+            onDismiss={vi.fn()}
+            onRecheck={vi.fn()}
+          />
+        </ul>
+      </MemoryRouter>,
+    )
+    const toggle = screen.getByRole('button', { name: /show the 1/i })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('columnheader', { name: 'Item' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Essay 1' })).toHaveAttribute(
+      'href',
+      '/courses/C1/modules/assignment/a1',
+    )
+  })
+
+  it('links directly to target when there is no evidence', () => {
+    render(
+      <MemoryRouter>
+        <ul>
+          <ChecklistItemRow item={baseItem()} onDismiss={vi.fn()} onRecheck={vi.fn()} />
+        </ul>
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('link', { name: /post a welcome announcement/i })).toHaveAttribute(
+      'href',
+      '/courses/C1/feed',
+    )
+  })
+
+  it('offers re-check for unknown items', () => {
+    const onRecheck = vi.fn()
+    render(
+      <MemoryRouter>
+        <ul>
+          <ChecklistItemRow
+            item={baseItem({ status: 'unknown', detail: null })}
+            onDismiss={vi.fn()}
+            onRecheck={onRecheck}
+          />
+        </ul>
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/couldn't check this right now/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^re-check$/i }))
+    expect(onRecheck).toHaveBeenCalled()
+  })
+})

--- a/clients/web/src/components/checklist/checklist-badge.tsx
+++ b/clients/web/src/components/checklist/checklist-badge.tsx
@@ -1,0 +1,19 @@
+import { courseChecklistI18n } from '../../lib/course-checklist-i18n'
+
+type ChecklistBadgeProps = {
+  outstandingEssential: number
+}
+
+/** Nav badge for outstanding essential checklist items (FR-4 / FR-5). */
+export function ChecklistBadge({ outstandingEssential }: ChecklistBadgeProps) {
+  if (outstandingEssential <= 0) return null
+  const display = outstandingEssential > 99 ? '99+' : String(outstandingEssential)
+  return (
+    <span
+      className="inline-flex min-h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-amber-600 px-1.5 text-[11px] font-semibold tabular-nums leading-none text-white"
+      aria-label={courseChecklistI18n.badgeAria(outstandingEssential)}
+    >
+      {display}
+    </span>
+  )
+}

--- a/clients/web/src/components/checklist/checklist-dashboard-card-container.tsx
+++ b/clients/web/src/components/checklist/checklist-dashboard-card-container.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+import { useCourseChecklistSummary } from '../../context/course-checklist-summary-context'
+import { usePermissions } from '../../context/use-permissions'
+import { fetchCourseChecklist } from '../../lib/course-checklist-api'
+import type { ChecklistItem } from '../../lib/course-checklist-api-schemas'
+import { isOutstandingStatus } from '../../lib/course-checklist-api-schemas'
+import { courseItemCreatePermission } from '../../lib/courses-api'
+import { useCourseViewAs } from '../../lib/course-view-as'
+import { ChecklistDashboardCard } from './checklist-dashboard-card'
+
+type Props = {
+  courseCode: string
+}
+
+/** Staff-only compact checklist card for the course dashboard (CC.7 FR-7). */
+export function ChecklistDashboardCardContainer({ courseCode }: Props) {
+  const { allows, loading: permLoading } = usePermissions()
+  const viewAs = useCourseViewAs(courseCode)
+  const canManage =
+    !permLoading && allows(courseItemCreatePermission(courseCode)) && viewAs !== 'student'
+  const { summary, loading: summaryLoading } = useCourseChecklistSummary()
+  const [topItems, setTopItems] = useState<ChecklistItem[]>([])
+  const [itemsLoading, setItemsLoading] = useState(false)
+
+  useEffect(() => {
+    if (!canManage) {
+      setTopItems([])
+      return
+    }
+    let cancelled = false
+    setItemsLoading(true)
+    void fetchCourseChecklist(courseCode)
+      .then((res) => {
+        if (cancelled) return
+        const outstanding: ChecklistItem[] = []
+        for (const cat of res.categories) {
+          for (const item of cat.items) {
+            if (item.tier === 'essential' && isOutstandingStatus(item.status)) {
+              outstanding.push(item)
+              if (outstanding.length >= 3) break
+            }
+          }
+          if (outstanding.length >= 3) break
+        }
+        setTopItems(outstanding)
+      })
+      .catch(() => {
+        if (!cancelled) setTopItems([])
+      })
+      .finally(() => {
+        if (!cancelled) setItemsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [canManage, courseCode])
+
+  if (!canManage) return null
+
+  return (
+    <ChecklistDashboardCard
+      courseCode={courseCode}
+      summary={summary}
+      topItems={topItems}
+      loading={summaryLoading || itemsLoading}
+    />
+  )
+}

--- a/clients/web/src/components/checklist/checklist-dashboard-card.tsx
+++ b/clients/web/src/components/checklist/checklist-dashboard-card.tsx
@@ -32,8 +32,8 @@ export function ChecklistDashboardCard({
 
       {loading && !summary ? (
         <div className="mt-3 space-y-2" aria-busy="true">
-          <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200 dark:bg-neutral-700" />
-          <div className="h-3 w-full animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
+          <div className="h-4 w-2/3 motion-safe:animate-pulse rounded bg-slate-200 dark:bg-neutral-700" />
+          <div className="h-3 w-full motion-safe:animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
         </div>
       ) : outstanding <= 0 ? (
         <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">

--- a/clients/web/src/components/checklist/checklist-dashboard-card.tsx
+++ b/clients/web/src/components/checklist/checklist-dashboard-card.tsx
@@ -1,0 +1,67 @@
+import { ClipboardCheck } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import type { ChecklistItem, ChecklistSummary } from '../../lib/course-checklist-api-schemas'
+import { isOutstandingStatus } from '../../lib/course-checklist-api-schemas'
+import { courseChecklistI18n } from '../../lib/course-checklist-i18n'
+
+type ChecklistDashboardCardProps = {
+  courseCode: string
+  summary: ChecklistSummary | null
+  topItems: ChecklistItem[]
+  loading?: boolean
+}
+
+export function ChecklistDashboardCard({
+  courseCode,
+  summary,
+  topItems,
+  loading,
+}: ChecklistDashboardCardProps) {
+  const href = `/courses/${encodeURIComponent(courseCode)}/checklist`
+  const outstanding = summary?.outstandingEssential ?? 0
+  const outstandingItems = topItems.filter((i) => isOutstandingStatus(i.status)).slice(0, 3)
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900 sm:col-span-2 lg:col-span-1">
+      <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+        <ClipboardCheck className="h-5 w-5 shrink-0" aria-hidden />
+        <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">
+          {courseChecklistI18n.dashboardTitle}
+        </span>
+      </div>
+
+      {loading && !summary ? (
+        <div className="mt-3 space-y-2" aria-busy="true">
+          <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200 dark:bg-neutral-700" />
+          <div className="h-3 w-full animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
+        </div>
+      ) : outstanding <= 0 ? (
+        <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
+          {courseChecklistI18n.dashboardComplete}
+        </p>
+      ) : (
+        <>
+          <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
+            {courseChecklistI18n.dashboardProgress(summary?.done ?? 0, summary?.total ?? 0)}
+          </p>
+          {outstandingItems.length > 0 ? (
+            <ul className="mt-3 space-y-1.5 text-sm text-slate-800 dark:text-neutral-200">
+              {outstandingItems.map((item) => (
+                <li key={item.id} className="truncate">
+                  · {item.title}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </>
+      )}
+
+      <Link
+        to={href}
+        className="mt-4 inline-flex text-xs font-semibold text-amber-800 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200"
+      >
+        {courseChecklistI18n.dashboardViewAll} →
+      </Link>
+    </div>
+  )
+}

--- a/clients/web/src/components/checklist/checklist-progress.tsx
+++ b/clients/web/src/components/checklist/checklist-progress.tsx
@@ -38,7 +38,7 @@ export function ChecklistProgressBar({
         aria-label={label}
       >
         <div
-          className="h-full rounded-full bg-emerald-600 transition-[width] duration-300 motion-reduce:transition-none dark:bg-emerald-500"
+          className="h-full rounded-full bg-emerald-600 motion-safe:transition-[width] motion-safe:duration-300 dark:bg-emerald-500"
           style={{ width: `${pct}%` }}
         />
       </div>

--- a/clients/web/src/components/checklist/checklist-progress.tsx
+++ b/clients/web/src/components/checklist/checklist-progress.tsx
@@ -1,0 +1,47 @@
+import { courseChecklistI18n } from '../../lib/course-checklist-i18n'
+
+type ChecklistProgressProps = {
+  done: number
+  total: number
+  outstandingTotal?: number
+  checkedLabel?: string
+  className?: string
+}
+
+export function ChecklistProgressBar({
+  done,
+  total,
+  outstandingTotal,
+  checkedLabel,
+  className = '',
+}: ChecklistProgressProps) {
+  const safeTotal = Math.max(total, 0)
+  const safeDone = Math.min(Math.max(done, 0), safeTotal || done)
+  const pct = safeTotal > 0 ? Math.round((safeDone / safeTotal) * 100) : 0
+  const label = courseChecklistI18n.progressDoneOfTotal(safeDone, safeTotal)
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm text-slate-600 dark:text-neutral-400">
+        <span className="font-medium text-slate-800 dark:text-neutral-200">{label}</span>
+        {outstandingTotal != null && outstandingTotal > 0 ? (
+          <span>· {courseChecklistI18n.needAttention(outstandingTotal)}</span>
+        ) : null}
+        {checkedLabel ? <span>· {checkedLabel}</span> : null}
+      </div>
+      <div
+        className="mt-2 h-2 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-neutral-700"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={safeTotal || 100}
+        aria-valuenow={safeDone}
+        aria-label={label}
+      >
+        <div
+          className="h-full rounded-full bg-emerald-600 transition-[width] duration-300 motion-reduce:transition-none dark:bg-emerald-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/components/checklist/checklist-status-affordance.tsx
+++ b/clients/web/src/components/checklist/checklist-status-affordance.tsx
@@ -1,0 +1,53 @@
+import { Check, Circle, CircleDot, HelpCircle } from 'lucide-react'
+import {
+  normalizeChecklistStatus,
+  type ChecklistStatus,
+} from '../../lib/course-checklist-api-schemas'
+import { courseChecklistI18n } from '../../lib/course-checklist-i18n'
+
+const iconClass = 'h-4 w-4 shrink-0'
+
+export function ChecklistStatusAffordance({ status }: { status: string }) {
+  const s: ChecklistStatus = normalizeChecklistStatus(status)
+  switch (s) {
+    case 'done':
+      return (
+        <span className="inline-flex items-center text-emerald-600 dark:text-emerald-400">
+          <Check className={iconClass} aria-hidden />
+          <span className="sr-only">{courseChecklistI18n.completedLabel}</span>
+        </span>
+      )
+    case 'in_progress':
+      return (
+        <span className="inline-flex items-center text-amber-600 dark:text-amber-400">
+          <CircleDot className={iconClass} aria-hidden />
+          <span className="sr-only">In progress</span>
+        </span>
+      )
+    case 'unknown':
+      return (
+        <span className="inline-flex items-center text-slate-400 dark:text-neutral-500">
+          <HelpCircle className={iconClass} aria-hidden />
+          <span className="sr-only">Unknown</span>
+        </span>
+      )
+    case 'not_applicable':
+      return (
+        <span className="inline-flex items-center text-slate-400 dark:text-neutral-500">
+          <Circle className={`${iconClass} opacity-40`} aria-hidden />
+          <span className="sr-only">Not applicable</span>
+        </span>
+      )
+    case 'todo':
+      return (
+        <span className="inline-flex items-center text-slate-500 dark:text-neutral-400">
+          <Circle className={iconClass} aria-hidden />
+          <span className="sr-only">To do</span>
+        </span>
+      )
+    default: {
+      const _exhaustive: never = s
+      return _exhaustive
+    }
+  }
+}

--- a/clients/web/src/components/layout/__tests__/side-nav-course-checklist.test.tsx
+++ b/clients/web/src/components/layout/__tests__/side-nav-course-checklist.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ShellNavProvider } from '../shell-nav-context'
+import { SideNavCourseLinks } from '../side-nav-course-links'
+
+const allowsMock = vi.fn()
+const viewAsMock = vi.fn((): 'teacher' | 'student' => 'teacher')
+const summaryMock = vi.fn(() => ({
+  summary: { outstandingEssential: 8 } as { outstandingEssential: number } | null,
+  loading: false,
+  refresh: async () => {},
+  canManageCourse: true,
+}))
+
+vi.mock('../../../context/use-permissions', () => ({
+  usePermissions: () => ({
+    allows: allowsMock,
+    loading: false,
+  }),
+}))
+
+vi.mock('../../../lib/course-view-as', () => ({
+  useCourseViewAs: () => viewAsMock(),
+}))
+
+vi.mock('../../../lib/use-viewer-enrollment-roles', () => ({
+  useViewerEnrollmentRoles: () => ['teacher'],
+}))
+
+vi.mock('../../../context/course-checklist-summary-context', () => ({
+  useCourseChecklistSummary: () => summaryMock(),
+}))
+
+vi.mock('../../../context/course-nav-features-context', () => ({
+  useCourseNavFeatures: () => ({
+    notebookEnabled: true,
+    feedEnabled: true,
+    calendarEnabled: true,
+    questionBankEnabled: false,
+    standardsAlignmentEnabled: false,
+    discussionsEnabled: false,
+    collabDocsEnabled: false,
+    sbgEnabled: false,
+    liveSessionsEnabled: false,
+    groupSpacesEnabled: false,
+    officeHoursEnabled: false,
+    filesEnabled: true,
+    attendanceEnabled: false,
+    whiteboardEnabled: false,
+    reportCardsEnabled: false,
+    visualBoardsEnabled: false,
+    interactiveQuizzesEnabled: false,
+    screenShareEnabled: false,
+    contentToolsEnabled: true,
+  }),
+}))
+
+vi.mock('../../../context/platform-features-context', () => ({
+  usePlatformFeatures: () => ({
+    instructorInsightsEnabled: false,
+    ffLibrary: false,
+    ffCourseEvaluations: false,
+    ffGradeSubmission: false,
+    ffClassroomSignals: false,
+  }),
+}))
+
+function renderNav() {
+  return render(
+    <MemoryRouter initialEntries={['/courses/DEMO']}>
+      <ShellNavProvider>
+        <SideNavCourseLinks courseCode="DEMO" />
+      </ShellNavProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('SideNavCourseLinks checklist entry', () => {
+  beforeEach(() => {
+    allowsMock.mockImplementation((p: string) => p === 'course:DEMO:item:create')
+    viewAsMock.mockReturnValue('teacher')
+    summaryMock.mockReturnValue({
+      summary: { outstandingEssential: 8 },
+      loading: false,
+      refresh: async () => {},
+      canManageCourse: true,
+    })
+  })
+
+  it('renders Checklist under Dashboard with badge for teachers', () => {
+    renderNav()
+    const dashboard = screen.getByRole('link', { name: /^dashboard$/i })
+    const checklist = screen.getByRole('link', { name: /checklist/i })
+    expect(checklist).toHaveAttribute('href', '/courses/DEMO/checklist')
+    expect(
+      dashboard.compareDocumentPosition(checklist) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(screen.getByLabelText('8 checklist items need attention')).toBeInTheDocument()
+  })
+
+  it('hides Checklist for students (no manage permission)', () => {
+    allowsMock.mockReturnValue(false)
+    renderNav()
+    expect(screen.queryByRole('link', { name: /checklist/i })).not.toBeInTheDocument()
+  })
+
+  it('hides Checklist when View as Student is active', () => {
+    viewAsMock.mockReturnValue('student')
+    renderNav()
+    expect(screen.queryByRole('link', { name: /checklist/i })).not.toBeInTheDocument()
+  })
+
+  it('omits badge when outstandingEssential is 0', () => {
+    summaryMock.mockReturnValue({
+      summary: { outstandingEssential: 0 },
+      loading: false,
+      refresh: async () => {},
+      canManageCourse: true,
+    })
+    renderNav()
+    expect(screen.getByRole('link', { name: /^checklist$/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/checklist items need attention/i)).not.toBeInTheDocument()
+  })
+})

--- a/clients/web/src/components/layout/app-shell.tsx
+++ b/clients/web/src/components/layout/app-shell.tsx
@@ -8,6 +8,7 @@ import { CourseHiddenProvider } from '../../context/course-hidden-context'
 import { InboxNotificationsProvider } from '../../context/inbox-notifications-provider'
 import { CanvasImportProvider } from '../../context/canvas-import-context'
 import { InboxUnreadProvider } from '../../context/inbox-unread-provider'
+import { CourseChecklistSummaryProvider } from '../../context/course-checklist-summary-context'
 import { CourseNavFeaturesProvider } from '../../context/course-nav-features-context'
 import { ContentFilterProvider } from '../../context/content-filter-context'
 import { PlatformFeaturesProvider } from '../../context/platform-features-context'
@@ -57,6 +58,7 @@ function AppShellLayout() {
 
   return (
     <CourseNavFeaturesProvider>
+      <CourseChecklistSummaryProvider>
       <LmsExperienceRoot>
       <UiThemeSync />
       <LocaleBootstrapSync />
@@ -94,6 +96,7 @@ function AppShellLayout() {
         </ImpersonationChrome>
       </Suspense>
       </LmsExperienceRoot>
+      </CourseChecklistSummaryProvider>
     </CourseNavFeaturesProvider>
   )
 }

--- a/clients/web/src/components/layout/side-nav-course-links.tsx
+++ b/clients/web/src/components/layout/side-nav-course-links.tsx
@@ -14,6 +14,7 @@ import {
   LayoutDashboard,
   Lightbulb,
   ListChecks,
+  ListTodo,
   Library,
   MessageSquare,
   MessagesSquare,
@@ -39,9 +40,12 @@ import {
   studentProgressFeatureEnabled,
   xapiEmissionFeatureEnabled,
 } from '../../lib/platform-features'
+import { ChecklistBadge } from '../checklist/checklist-badge'
+import { useCourseChecklistSummary } from '../../context/course-checklist-summary-context'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { usePlatformFeatures } from '../../context/platform-features-context'
 import { usePermissions } from '../../context/use-permissions'
+import { courseChecklistI18n } from '../../lib/course-checklist-i18n'
 import {
   courseEnrollmentsReadPermission,
   courseGradebookViewPermission,
@@ -106,6 +110,17 @@ export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
   const canViewMyGrades = viewerShouldShowMyGradesNav(viewerEnrollmentRoles, courseViewPreview)
   const canManageCourse = !permLoading && allows(courseItemCreatePermission(courseCode))
   const canManageQuestionBank = !permLoading && allows(courseItemsCreatePermission(courseCode))
+  const showChecklist = canManageCourse && courseViewPreview !== 'student'
+  const { summary: checklistSummary } = useCourseChecklistSummary()
+  const checklistOutstanding = checklistSummary?.outstandingEssential ?? 0
+  const checklistBadge =
+    showChecklist && checklistOutstanding > 0 ? (
+      <ChecklistBadge outstandingEssential={checklistOutstanding} />
+    ) : undefined
+  const checklistTooltip =
+    checklistOutstanding > 0
+      ? `${courseChecklistI18n.navLabel} (${checklistOutstanding > 99 ? '99+' : checklistOutstanding})`
+      : courseChecklistI18n.navLabel
 
   const boardsNavVisible = visualBoardsEnabled
   const liveQuizzesNavVisible = interactiveQuizzesEnabled
@@ -137,6 +152,16 @@ export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
       <SideNavLink to={base} end icon={<LayoutDashboard className="h-5 w-5" />}>
         Dashboard
       </SideNavLink>
+      {showChecklist ? (
+        <SideNavLink
+          to={`${base}/checklist`}
+          icon={<ListTodo className="h-5 w-5" />}
+          badge={checklistBadge}
+          tooltip={checklistTooltip}
+        >
+          {courseChecklistI18n.navLabel}
+        </SideNavLink>
+      ) : null}
 
       <SideNavSectionLabel first>Content</SideNavSectionLabel>
       {filesEnabled && canManageCourse ? (

--- a/clients/web/src/components/layout/side-nav-link.tsx
+++ b/clients/web/src/components/layout/side-nav-link.tsx
@@ -14,6 +14,8 @@ interface SideNavLinkProps extends NavLinkProps {
   children: ReactNode
   badge?: ReactNode
   nested?: boolean
+  /** Override collapsed-nav tooltip (defaults to string children). */
+  tooltip?: string
 }
 
 export function SideNavLink({
@@ -21,12 +23,13 @@ export function SideNavLink({
   children,
   badge,
   nested = false,
+  tooltip,
   className,
   ...props
 }: SideNavLinkProps) {
   const { sideNavCollapsed } = useShellNav()
 
-  const label = typeof children === 'string' ? children : ''
+  const label = tooltip ?? (typeof children === 'string' ? children : '')
 
   return (
     <SideNavTooltip content={label}>

--- a/clients/web/src/context/course-checklist-summary-context.tsx
+++ b/clients/web/src/context/course-checklist-summary-context.tsx
@@ -1,0 +1,189 @@
+/* eslint-disable react-refresh/only-export-components -- context module exports provider + hooks */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { matchPath, useLocation } from 'react-router-dom'
+import { fetchCourseChecklistSummary } from '../lib/course-checklist-api'
+import type { ChecklistSummary } from '../lib/course-checklist-api-schemas'
+import { subscribeChecklistInvalidation } from '../lib/course-checklist-invalidate'
+import { courseItemCreatePermission } from '../lib/courses-api'
+import { useCourseViewAs } from '../lib/course-view-as'
+import { usePermissions } from './use-permissions'
+
+const MEMO_MS = 60_000
+
+type CourseChecklistSummaryContextValue = {
+  summary: ChecklistSummary | null
+  loading: boolean
+  refresh: () => Promise<void>
+  canManageCourse: boolean
+}
+
+const CourseChecklistSummaryContext = createContext<CourseChecklistSummaryContextValue>({
+  summary: null,
+  loading: false,
+  refresh: async () => {},
+  canManageCourse: false,
+})
+
+type MemoEntry = {
+  summary: ChecklistSummary
+  fetchedAt: number
+  catalogVersion: string
+}
+
+const memoByCourse = new Map<string, MemoEntry>()
+
+function activeCourseCodeFromPath(pathname: string): string | null {
+  const m = matchPath({ path: '/courses/:courseCode/*', end: false }, pathname)
+  const raw = m?.params.courseCode
+  if (!raw || raw === 'create') return null
+  return raw
+}
+
+export function CourseChecklistSummaryProvider({ children }: { children: ReactNode }) {
+  const location = useLocation()
+  const courseCode = activeCourseCodeFromPath(location.pathname)
+  const { allows, loading: permLoading } = usePermissions()
+  const courseViewPreview = useCourseViewAs(courseCode ?? undefined)
+  const canManageCourse =
+    !!courseCode && !permLoading && allows(courseItemCreatePermission(courseCode))
+  const showChecklist = canManageCourse && courseViewPreview !== 'student'
+
+  const [summary, setSummary] = useState<ChecklistSummary | null>(null)
+  const [loading, setLoading] = useState(false)
+  const lastFocusIdleAt = useRef(Date.now())
+  const inFlight = useRef<Promise<void> | null>(null)
+
+  const load = useCallback(
+    async (code: string, opts?: { force?: boolean }) => {
+      if (!opts?.force) {
+        const cached = memoByCourse.get(code)
+        if (cached && Date.now() - cached.fetchedAt < MEMO_MS) {
+          setSummary(cached.summary)
+          setLoading(false)
+          return
+        }
+      }
+
+      if (inFlight.current) {
+        await inFlight.current
+        return
+      }
+
+      setLoading(true)
+      const run = (async () => {
+        try {
+          const next = await fetchCourseChecklistSummary(code)
+          memoByCourse.set(code, {
+            summary: next,
+            fetchedAt: Date.now(),
+            catalogVersion: `${next.outstandingEssential}:${next.done}:${next.total}:${next.computedAt}`,
+          })
+          setSummary(next)
+        } catch (err) {
+          if (import.meta.env.DEV) {
+            console.warn('[course-checklist] summary fetch failed', err)
+          }
+          // Silent failure: no badge, no toast (FR-11).
+          setSummary(null)
+        } finally {
+          setLoading(false)
+          inFlight.current = null
+        }
+      })()
+      inFlight.current = run
+      await run
+    },
+    [],
+  )
+
+  const refresh = useCallback(async () => {
+    if (!courseCode || !showChecklist) return
+    memoByCourse.delete(courseCode)
+    await load(courseCode, { force: true })
+  }, [courseCode, load, showChecklist])
+
+  useEffect(() => {
+    if (!courseCode || !showChecklist) {
+      setSummary(null)
+      setLoading(false)
+      return
+    }
+    void load(courseCode)
+  }, [courseCode, showChecklist, load])
+
+  useEffect(() => {
+    function onFocus() {
+      if (!courseCode || !showChecklist) return
+      const idle = Date.now() - lastFocusIdleAt.current
+      if (idle > MEMO_MS) {
+        void load(courseCode, { force: true })
+      }
+    }
+    function onBlur() {
+      lastFocusIdleAt.current = Date.now()
+    }
+    window.addEventListener('focus', onFocus)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [courseCode, showChecklist, load])
+
+  useEffect(() => {
+    return subscribeChecklistInvalidation((code) => {
+      memoByCourse.delete(code)
+      if (code === courseCode && showChecklist) {
+        void load(code, { force: true })
+      }
+    })
+  }, [courseCode, showChecklist, load])
+
+  const value = useMemo(
+    () => ({
+      summary: showChecklist ? summary : null,
+      loading: showChecklist && (permLoading || loading),
+      refresh,
+      canManageCourse: showChecklist,
+    }),
+    [summary, loading, permLoading, refresh, showChecklist],
+  )
+
+  return (
+    <CourseChecklistSummaryContext.Provider value={value}>
+      {children}
+    </CourseChecklistSummaryContext.Provider>
+  )
+}
+
+export function useCourseChecklistSummary(): CourseChecklistSummaryContextValue {
+  return useContext(CourseChecklistSummaryContext)
+}
+
+/** Bust the in-memory memo and refresh when the viewer can manage the course. */
+export function useInvalidateChecklist(): (courseCode?: string) => void {
+  const { refresh } = useCourseChecklistSummary()
+  const location = useLocation()
+  return useCallback(
+    (courseCode?: string) => {
+      const code = courseCode ?? activeCourseCodeFromPath(location.pathname)
+      if (!code) return
+      memoByCourse.delete(code)
+      void refresh()
+    },
+    [location.pathname, refresh],
+  )
+}
+
+export function clearChecklistSummaryMemoForTests(): void {
+  memoByCourse.clear()
+}

--- a/clients/web/src/lazy-pages.ts
+++ b/clients/web/src/lazy-pages.ts
@@ -26,6 +26,7 @@ export const CourseFilesPage = lazy(() => import('./pages/lms/course-files-page'
 export const CourseGroupsPage = lazy(() => import('./pages/lms/course-groups-page'))
 export const CourseGradebook = lazy(() => import('./pages/lms/course-gradebook'))
 export const CourseAtRiskPage = lazy(() => import('./pages/lms/course-at-risk'))
+export const CourseChecklistPage = lazy(() => import('./pages/lms/course-checklist'))
 export const StudentProgressPage = lazy(() => import('./pages/lms/student-progress-page'))
 export const CourseStudentReportsPage = lazy(() => import('./pages/lms/course-student-reports-page'))
 export const CourseMyGrades = lazy(() => import('./pages/lms/course-my-grades'))

--- a/clients/web/src/lib/__tests__/api-surface.golden.json
+++ b/clients/web/src/lib/__tests__/api-surface.golden.json
@@ -517,6 +517,15 @@
     "putCourseCatalogSettings",
     "putCourseKanbanBoard"
   ],
+  "course-checklist-api.ts": [
+    "CourseChecklistApiError",
+    "dismissChecklistItem",
+    "fetchCourseChecklist",
+    "fetchCourseChecklistSummary",
+    "recheckChecklistItem",
+    "refreshCourseChecklist",
+    "restoreChecklistItem"
+  ],
   "course-evaluations-api.ts": [
     "AdminReportRow",
     "EvaluationQuestion",

--- a/clients/web/src/lib/__tests__/build-search-items.test.ts
+++ b/clients/web/src/lib/__tests__/build-search-items.test.ts
@@ -503,6 +503,19 @@ describe('granular builders', () => {
     )).toBe(false)
   })
 
+  it('buildCoursePageItems includes Course checklist for item:create', () => {
+    const allowsCreate = (p: string) => p === courseItemCreatePermission('C')
+    const pages = buildCoursePageItems([{ courseCode: 'C', title: 'Chem' }], allowsCreate)
+    expect(pages.some((i) => i.path === '/courses/C/checklist' && i.title === 'Course checklist')).toBe(
+      true,
+    )
+    expect(
+      buildCoursePageItems([{ courseCode: 'C', title: 'Chem' }], allowsNone).some(
+        (i) => i.path === '/courses/C/checklist',
+      ),
+    ).toBe(false)
+  })
+
   it('buildCourseActionItems requires roster permission', () => {
     const allowsRoster = (p: string) => p === courseEnrollmentsReadPermission('Z')
     expect(buildCourseActionItems([{ courseCode: 'Z', title: 'W' }], allowsRoster).length).toBe(1)

--- a/clients/web/src/lib/__tests__/course-checklist-api-schemas.test.ts
+++ b/clients/web/src/lib/__tests__/course-checklist-api-schemas.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  checklistResponseSchema,
+  checklistSummarySchema,
+  isOutstandingStatus,
+  normalizeChecklistStatus,
+} from '../course-checklist-api-schemas'
+
+describe('course-checklist-api-schemas', () => {
+  it('normalizes unknown status values to unknown', () => {
+    expect(normalizeChecklistStatus('done')).toBe('done')
+    expect(normalizeChecklistStatus('weird')).toBe('unknown')
+  })
+
+  it('detects outstanding statuses', () => {
+    expect(isOutstandingStatus('todo')).toBe(true)
+    expect(isOutstandingStatus('in_progress')).toBe(true)
+    expect(isOutstandingStatus('unknown')).toBe(true)
+    expect(isOutstandingStatus('done')).toBe(false)
+  })
+
+  it('parses a summary payload', () => {
+    const parsed = checklistSummarySchema.parse({
+      outstandingEssential: 2,
+      outstandingTotal: 5,
+      done: 10,
+      total: 15,
+      dismissed: 1,
+      computedAt: '2026-08-04T12:00:00Z',
+      stale: false,
+    })
+    expect(parsed.outstandingEssential).toBe(2)
+  })
+
+  it('parses a checklist response with evidence and dismissal', () => {
+    const parsed = checklistResponseSchema.parse({
+      courseCode: 'C1',
+      engineVersion: 1,
+      catalogVersion: 'v1',
+      computedAt: '2026-08-04T12:00:00Z',
+      stale: false,
+      evidenceTruncated: false,
+      summary: {
+        outstandingEssential: 1,
+        outstandingTotal: 1,
+        done: 0,
+        total: 1,
+        dismissed: 0,
+        computedAt: '2026-08-04T12:00:00Z',
+        stale: false,
+      },
+      categories: [
+        {
+          id: 'foundations',
+          titleKey: 'cat.foundations',
+          title: 'Foundations',
+          items: [
+            {
+              id: 'orientation.welcome-message',
+              titleKey: 'item.welcome',
+              title: 'Post a welcome',
+              whyKey: 'why.welcome',
+              why: 'Students need orientation',
+              tier: 'essential',
+              status: 'todo',
+              detail: 'Missing announcement',
+              progress: null,
+              sources: ['QM 1.2'],
+              helpRef: null,
+              target: { route: '/courses/C1/feed' },
+              evidence: {
+                columns: ['Item', 'Type'],
+                rows: [
+                  {
+                    label: 'Essay 1',
+                    sublabel: 'Assign.',
+                    status: 'unmapped',
+                    target: { route: '/courses/C1/modules/assignment/a1' },
+                  },
+                ],
+                truncatedAt: null,
+              },
+              dismissal: null,
+            },
+          ],
+        },
+      ],
+      dismissed: [],
+    })
+    expect(parsed.categories[0]?.items[0]?.evidence?.rows).toHaveLength(1)
+  })
+})

--- a/clients/web/src/lib/__tests__/course-checklist-api.test.ts
+++ b/clients/web/src/lib/__tests__/course-checklist-api.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  CourseChecklistApiError,
+  dismissChecklistItem,
+  fetchCourseChecklist,
+  fetchCourseChecklistSummary,
+} from '../course-checklist-api'
+
+const authorizedFetch = vi.fn()
+
+vi.mock('../api', () => ({
+  authorizedFetch: (...args: unknown[]) => authorizedFetch(...args),
+}))
+
+afterEach(() => {
+  authorizedFetch.mockReset()
+})
+
+describe('course-checklist-api', () => {
+  it('fetches and validates summary', async () => {
+    authorizedFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        outstandingEssential: 1,
+        outstandingTotal: 2,
+        done: 3,
+        total: 5,
+        dismissed: 0,
+        computedAt: '2026-08-04T12:00:00Z',
+        stale: false,
+      }),
+    })
+    const summary = await fetchCourseChecklistSummary('C1')
+    expect(summary.outstandingEssential).toBe(1)
+    expect(authorizedFetch).toHaveBeenCalledWith('/api/v1/courses/C1/checklist/summary')
+  })
+
+  it('maps 403 to CourseChecklistApiError', async () => {
+    authorizedFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'forbidden' }),
+    })
+    await expect(fetchCourseChecklist('C1')).rejects.toBeInstanceOf(CourseChecklistApiError)
+    await expect(fetchCourseChecklist('C1')).rejects.toMatchObject({ status: 403 })
+  })
+
+  it('posts dismiss body', async () => {
+    authorizedFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'orientation.welcome-message',
+        titleKey: 't',
+        title: 'Welcome',
+        whyKey: 'w',
+        why: 'Why',
+        tier: 'essential',
+        status: 'todo',
+        sources: [],
+        dismissal: {
+          dismissedAt: '2026-08-04T12:00:00Z',
+          byUserId: 'u1',
+          byDisplayName: 'Teacher',
+          reason: 'not_applicable',
+          note: 'n/a',
+        },
+      }),
+    })
+    const item = await dismissChecklistItem('C1', 'orientation.welcome-message', {
+      reason: 'not_applicable',
+      note: 'n/a',
+    })
+    expect(item.dismissal?.reason).toBe('not_applicable')
+    expect(authorizedFetch).toHaveBeenCalledWith(
+      '/api/v1/courses/C1/checklist/items/orientation.welcome-message/dismiss',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+})

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -456,6 +456,12 @@ type CoursePageDef = {
 const coursePageDefs: CoursePageDef[] = [
   { suffix: '', title: 'Course dashboard', hint: 'dashboard overview' },
   {
+    suffix: '/checklist',
+    title: 'Course checklist',
+    hint: 'checklist course quality outstanding items dismiss',
+    requiredPermission: courseItemCreatePermission,
+  },
+  {
     suffix: '/feed',
     title: 'Feed',
     hint: 'feed chat channels messages discussion',

--- a/clients/web/src/lib/course-checklist-api-schemas.ts
+++ b/clients/web/src/lib/course-checklist-api-schemas.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod'
+
+export const dismissReasonSchema = z.enum([
+  'not_applicable',
+  'done_elsewhere',
+  'disagree',
+  'later',
+  'other',
+])
+
+export type DismissReason = z.infer<typeof dismissReasonSchema>
+
+export const checklistStatusSchema = z.enum([
+  'done',
+  'todo',
+  'in_progress',
+  'unknown',
+  'not_applicable',
+])
+
+export type ChecklistStatus = z.infer<typeof checklistStatusSchema>
+
+const checklistNavTargetSchema = z
+  .object({
+    route: z.string(),
+    anchor: z.string().nullish(),
+  })
+  .passthrough()
+
+export type ChecklistNavTarget = z.infer<typeof checklistNavTargetSchema>
+
+const checklistEvidenceRowSchema = z
+  .object({
+    label: z.string(),
+    sublabel: z.string().nullish(),
+    status: z.string(),
+    target: checklistNavTargetSchema.nullish(),
+  })
+  .passthrough()
+
+export type ChecklistEvidenceRow = z.infer<typeof checklistEvidenceRowSchema>
+
+const checklistEvidenceSchema = z
+  .object({
+    columns: z.array(z.string()),
+    rows: z.array(checklistEvidenceRowSchema),
+    truncatedAt: z.number().int().nullish(),
+  })
+  .passthrough()
+
+export type ChecklistEvidence = z.infer<typeof checklistEvidenceSchema>
+
+const checklistDismissalSchema = z
+  .object({
+    dismissedAt: z.string(),
+    byUserId: z.string(),
+    byDisplayName: z.string(),
+    reason: z.string(),
+    note: z.string(),
+  })
+  .passthrough()
+
+export type ChecklistDismissal = z.infer<typeof checklistDismissalSchema>
+
+const checklistProgressSchema = z
+  .object({
+    done: z.number().int(),
+    total: z.number().int(),
+  })
+  .passthrough()
+
+export const checklistItemSchema = z
+  .object({
+    id: z.string(),
+    titleKey: z.string(),
+    title: z.string(),
+    whyKey: z.string(),
+    why: z.string(),
+    tier: z.enum(['essential', 'recommended']),
+    status: z.string(),
+    detail: z.string().nullish(),
+    progress: checklistProgressSchema.nullish(),
+    sources: z.array(z.string()),
+    helpRef: z.string().nullish(),
+    target: checklistNavTargetSchema.nullish(),
+    evidence: checklistEvidenceSchema.nullish(),
+    dismissal: checklistDismissalSchema.nullish(),
+  })
+  .passthrough()
+
+export type ChecklistItem = z.infer<typeof checklistItemSchema>
+
+const checklistCategorySchema = z
+  .object({
+    id: z.string(),
+    titleKey: z.string(),
+    title: z.string(),
+    items: z.array(checklistItemSchema),
+  })
+  .passthrough()
+
+export type ChecklistCategory = z.infer<typeof checklistCategorySchema>
+
+export const checklistSummarySchema = z
+  .object({
+    outstandingEssential: z.number().int(),
+    outstandingTotal: z.number().int(),
+    done: z.number().int(),
+    total: z.number().int(),
+    dismissed: z.number().int(),
+    computedAt: z.string(),
+    stale: z.boolean(),
+  })
+  .passthrough()
+
+export type ChecklistSummary = z.infer<typeof checklistSummarySchema>
+
+export const checklistResponseSchema = z
+  .object({
+    courseCode: z.string(),
+    engineVersion: z.number().int(),
+    catalogVersion: z.string(),
+    computedAt: z.string(),
+    stale: z.boolean(),
+    evidenceTruncated: z.boolean(),
+    summary: checklistSummarySchema,
+    categories: z.array(checklistCategorySchema),
+    dismissed: z.array(checklistItemSchema),
+  })
+  .passthrough()
+
+export type ChecklistResponse = z.infer<typeof checklistResponseSchema>
+
+export const dismissRequestSchema = z
+  .object({
+    reason: dismissReasonSchema,
+    note: z.string().max(500).optional(),
+  })
+  .strict()
+
+export type DismissRequest = z.infer<typeof dismissRequestSchema>
+
+/** Normalize unknown status values to `unknown` for rendering (CC.7 §6). */
+export function normalizeChecklistStatus(status: string): ChecklistStatus {
+  const parsed = checklistStatusSchema.safeParse(status)
+  return parsed.success ? parsed.data : 'unknown'
+}
+
+export function isOutstandingStatus(status: string): boolean {
+  const s = normalizeChecklistStatus(status)
+  return s === 'todo' || s === 'in_progress' || s === 'unknown'
+}

--- a/clients/web/src/lib/course-checklist-api.ts
+++ b/clients/web/src/lib/course-checklist-api.ts
@@ -1,0 +1,105 @@
+import { authorizedFetch } from './api'
+import {
+  checklistItemSchema,
+  checklistResponseSchema,
+  checklistSummarySchema,
+  type ChecklistItem,
+  type ChecklistResponse,
+  type ChecklistSummary,
+  type DismissReason,
+} from './course-checklist-api-schemas'
+import { parseApiResponse } from './courses-api-schemas'
+import { readApiErrorMessage } from './errors'
+
+function checklistBase(courseCode: string): string {
+  return `/api/v1/courses/${encodeURIComponent(courseCode)}/checklist`
+}
+
+export class CourseChecklistApiError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'CourseChecklistApiError'
+    this.status = status
+  }
+}
+
+async function throwApiError(res: Response, fallback: string): Promise<never> {
+  const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+  throw new CourseChecklistApiError(res.status, readApiErrorMessage(raw) || fallback)
+}
+
+export async function fetchCourseChecklist(courseCode: string): Promise<ChecklistResponse> {
+  const res = await authorizedFetch(checklistBase(courseCode))
+  if (!res.ok) {
+    await throwApiError(res, 'Could not load course checklist.')
+  }
+  return parseApiResponse('fetchCourseChecklist', checklistResponseSchema, await res.json())
+}
+
+export async function fetchCourseChecklistSummary(courseCode: string): Promise<ChecklistSummary> {
+  const res = await authorizedFetch(`${checklistBase(courseCode)}/summary`)
+  if (!res.ok) {
+    await throwApiError(res, 'Could not load checklist summary.')
+  }
+  return parseApiResponse('fetchCourseChecklistSummary', checklistSummarySchema, await res.json())
+}
+
+export async function refreshCourseChecklist(courseCode: string): Promise<ChecklistResponse> {
+  const res = await authorizedFetch(`${checklistBase(courseCode)}/refresh`, { method: 'POST' })
+  if (!res.ok) {
+    await throwApiError(res, 'Could not re-check the course checklist.')
+  }
+  return parseApiResponse('refreshCourseChecklist', checklistResponseSchema, await res.json())
+}
+
+export async function dismissChecklistItem(
+  courseCode: string,
+  itemId: string,
+  body: { reason: DismissReason; note?: string },
+): Promise<ChecklistItem> {
+  const res = await authorizedFetch(
+    `${checklistBase(courseCode)}/items/${encodeURIComponent(itemId)}/dismiss`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        reason: body.reason,
+        note: body.note ?? '',
+      }),
+    },
+  )
+  if (!res.ok) {
+    await throwApiError(res, 'Could not dismiss checklist item.')
+  }
+  return parseApiResponse('dismissChecklistItem', checklistItemSchema, await res.json())
+}
+
+export async function restoreChecklistItem(
+  courseCode: string,
+  itemId: string,
+): Promise<ChecklistItem> {
+  const res = await authorizedFetch(
+    `${checklistBase(courseCode)}/items/${encodeURIComponent(itemId)}/restore`,
+    { method: 'POST' },
+  )
+  if (!res.ok) {
+    await throwApiError(res, 'Could not restore checklist item.')
+  }
+  return parseApiResponse('restoreChecklistItem', checklistItemSchema, await res.json())
+}
+
+export async function recheckChecklistItem(
+  courseCode: string,
+  itemId: string,
+): Promise<ChecklistItem> {
+  const res = await authorizedFetch(
+    `${checklistBase(courseCode)}/items/${encodeURIComponent(itemId)}/recheck`,
+    { method: 'POST' },
+  )
+  if (!res.ok) {
+    await throwApiError(res, 'Could not re-check checklist item.')
+  }
+  return parseApiResponse('recheckChecklistItem', checklistItemSchema, await res.json())
+}

--- a/clients/web/src/lib/course-checklist-category-state.ts
+++ b/clients/web/src/lib/course-checklist-category-state.ts
@@ -1,0 +1,44 @@
+const storageKey = (courseCode: string) => `checklist:categories:${courseCode}`
+
+export type CategoryCollapseMap = Record<string, boolean>
+
+export function readCategoryCollapseState(
+  courseCode: string,
+  catalogVersion: string,
+): CategoryCollapseMap | null {
+  try {
+    const raw = sessionStorage.getItem(storageKey(courseCode))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as {
+      catalogVersion?: string
+      collapsed?: CategoryCollapseMap
+    }
+    if (parsed.catalogVersion !== catalogVersion || !parsed.collapsed) return null
+    return parsed.collapsed
+  } catch {
+    return null
+  }
+}
+
+export function writeCategoryCollapseState(
+  courseCode: string,
+  catalogVersion: string,
+  collapsed: CategoryCollapseMap,
+): void {
+  try {
+    sessionStorage.setItem(
+      storageKey(courseCode),
+      JSON.stringify({ catalogVersion, collapsed }),
+    )
+  } catch {
+    // sessionStorage may be unavailable; ignore.
+  }
+}
+
+export function clearCategoryCollapseState(courseCode: string): void {
+  try {
+    sessionStorage.removeItem(storageKey(courseCode))
+  } catch {
+    // ignore
+  }
+}

--- a/clients/web/src/lib/course-checklist-i18n.ts
+++ b/clients/web/src/lib/course-checklist-i18n.ts
@@ -1,0 +1,64 @@
+import type { DismissReason } from './course-checklist-api-schemas'
+
+/** UI copy for the course checklist (CC.7). Server title/why used when no client key. */
+export const courseChecklistI18n = {
+  navLabel: 'Checklist',
+  pageTitle: 'Course checklist',
+  commandPaletteTitle: 'Course checklist',
+  recheck: 'Re-check',
+  rechecking: 'Re-checking…',
+  progressDoneOfTotal: (done: number, total: number) => `${done} of ${total} done`,
+  needAttention: (n: number) => (n === 1 ? '1 needs attention' : `${n} need attention`),
+  checkedAgo: (relative: string) => `checked ${relative}`,
+  outstandingCount: (n: number) => (n === 1 ? '1 outstanding' : `${n} outstanding`),
+  completedLabel: 'Completed',
+  essentialTier: 'Essential',
+  showEvidence: (n: number) => `Show the ${n}`,
+  hideEvidence: 'Hide evidence',
+  evidenceTruncated: (shown: number, total: number) => `Showing first ${shown} of ${total}`,
+  unknownDetail: "Couldn't check this right now",
+  dismiss: 'Dismiss',
+  restore: 'Restore',
+  restoring: 'Restoring…',
+  dismissedSection: (n: number) => `Dismissed (${n})`,
+  dismissedBy: (name: string, when: string) => `Dismissed by ${name} · ${when}`,
+  dismissDialogTitle: 'Dismiss checklist item',
+  dismissDialogHelp: 'Explain why this item does not apply so your co-teachers can see it.',
+  dismissReasonLabel: 'Reason',
+  dismissNoteLabel: 'Note (optional)',
+  dismissNotePlaceholder: 'Optional context for your co-teachers (max 500 characters)',
+  dismissConfirm: 'Dismiss item',
+  dismissCancel: 'Cancel',
+  dismissReasons: {
+    not_applicable: 'Not applicable',
+    done_elsewhere: 'Done elsewhere',
+    disagree: 'Disagree with this check',
+    later: 'Later',
+    other: 'Other',
+  } satisfies Record<DismissReason, string>,
+  allDoneTitle: 'Everything on the checklist is done',
+  allDoneBody: 'Your course meets every active checklist item.',
+  showCompleted: 'Show completed',
+  hideCompleted: 'Hide completed',
+  catalogEmpty: 'Nothing to check right now.',
+  noAccess: "You don't have access to this page.",
+  loadError: 'Could not load the course checklist.',
+  retry: 'Retry',
+  itemDismissedLive: 'Item dismissed',
+  itemRestoredLive: 'Item restored',
+  itemRecheckedLive: 'Re-checked',
+  badgeAria: (n: number) =>
+    n === 1 ? '1 checklist item needs attention' : `${n} checklist items need attention`,
+  dashboardTitle: 'Course checklist',
+  dashboardComplete: 'Your course checklist is complete',
+  dashboardViewAll: 'Open checklist',
+  dashboardProgress: (done: number, total: number) => `${done} of ${total} done`,
+  whyExpand: 'Why this matters',
+  overflowMenu: 'Item actions',
+  aiActionSlot: '', // reserved for CC.10
+} as const
+
+export function dismissReasonLabel(reason: string): string {
+  const key = reason as DismissReason
+  return courseChecklistI18n.dismissReasons[key] ?? reason
+}

--- a/clients/web/src/lib/course-checklist-invalidate.ts
+++ b/clients/web/src/lib/course-checklist-invalidate.ts
@@ -1,0 +1,22 @@
+type Listener = (courseCode: string) => void
+
+const listeners = new Set<Listener>()
+
+/**
+ * Notify the checklist summary provider that course data changed on a known
+ * checklist target path (settings, modules, outcomes, enrollments).
+ */
+export function invalidateChecklist(courseCode: string): void {
+  const code = courseCode.trim()
+  if (!code) return
+  for (const listener of listeners) {
+    listener(code)
+  }
+}
+
+export function subscribeChecklistInvalidation(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/clients/web/src/lib/course-page-title.ts
+++ b/clients/web/src/lib/course-page-title.ts
@@ -30,6 +30,7 @@ const EXACT_SUBPATH_TITLES: Record<string, string> = {
   gradebook: 'Gradebook',
   reports: 'Reports',
   'at-risk': 'At-risk students',
+  checklist: 'Checklist',
   'event-log': 'Event log',
   'standards-gradebook': 'Standards gradebook',
   'standards-coverage': 'Standards coverage',

--- a/clients/web/src/pages/lms/course-checklist/checklist-category-section.tsx
+++ b/clients/web/src/pages/lms/course-checklist/checklist-category-section.tsx
@@ -1,0 +1,76 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import type { ChecklistCategory, ChecklistItem } from '../../../lib/course-checklist-api-schemas'
+import { isOutstandingStatus } from '../../../lib/course-checklist-api-schemas'
+import { courseChecklistI18n } from '../../../lib/course-checklist-i18n'
+import { ChecklistItemRow } from './checklist-item-row'
+
+type ChecklistCategorySectionProps = {
+  category: ChecklistCategory
+  expanded: boolean
+  onToggle: () => void
+  itemErrors: Record<string, string>
+  busyItemId: string | null
+  highlightItemId: string | null
+  onDismiss: (item: ChecklistItem) => void
+  onRecheck: (item: ChecklistItem) => void
+}
+
+export function ChecklistCategorySection({
+  category,
+  expanded,
+  onToggle,
+  itemErrors,
+  busyItemId,
+  highlightItemId,
+  onDismiss,
+  onRecheck,
+}: ChecklistCategorySectionProps) {
+  const outstanding = category.items.filter((i) => isOutstandingStatus(i.status)).length
+  const panelId = `checklist-cat-${category.id}`
+
+  return (
+    <section aria-labelledby={`${panelId}-heading`} className="border-b border-slate-200 py-4 last:border-0 dark:border-neutral-800">
+      <h2
+        id={`${panelId}-heading`}
+        className="sticky top-0 z-10 -mx-1 bg-[var(--lx-page-bg,theme(colors.slate.50))] px-1 py-1 dark:bg-[var(--lx-page-bg,theme(colors.neutral.950))] md:static md:bg-transparent"
+      >
+        <button
+          type="button"
+          className="flex w-full min-h-11 items-center justify-between gap-3 text-start"
+          aria-expanded={expanded}
+          aria-controls={panelId}
+          onClick={onToggle}
+        >
+          <span className="inline-flex items-center gap-2 text-base font-semibold text-slate-900 dark:text-neutral-50">
+            {expanded ? (
+              <ChevronDown className="h-4 w-4 shrink-0" aria-hidden />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" aria-hidden />
+            )}
+            {category.title}
+          </span>
+          <span className="shrink-0 text-xs font-medium text-slate-500 dark:text-neutral-400">
+            {courseChecklistI18n.outstandingCount(outstanding)}
+          </span>
+        </button>
+      </h2>
+      {expanded ? (
+        <ul id={panelId} className="mt-2 divide-y divide-slate-100 dark:divide-neutral-800">
+          {category.items.map((item) => (
+            <ChecklistItemRow
+              key={item.id}
+              item={item}
+              busy={busyItemId === item.id}
+              error={itemErrors[item.id] ?? null}
+              highlighted={highlightItemId === item.id}
+              onDismiss={onDismiss}
+              onRecheck={onRecheck}
+            />
+          ))}
+        </ul>
+      ) : (
+        <div id={panelId} hidden />
+      )}
+    </section>
+  )
+}

--- a/clients/web/src/pages/lms/course-checklist/checklist-dismiss-dialog.tsx
+++ b/clients/web/src/pages/lms/course-checklist/checklist-dismiss-dialog.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useId, useRef, useState, type CSSProperties, type FormEvent } from 'react'
+import { usePlatformFeatures } from '../../../context/platform-features-context'
+import {
+  dismissReasonSchema,
+  type DismissReason,
+} from '../../../lib/course-checklist-api-schemas'
+import { courseChecklistI18n } from '../../../lib/course-checklist-i18n'
+import { overlayClassNames } from '../../../lib/overlay-motion'
+import { useOverlayPresence } from '../../../lib/use-overlay-presence'
+
+const REASONS = dismissReasonSchema.options
+
+type ChecklistDismissDialogProps = {
+  open: boolean
+  itemTitle: string
+  busy?: boolean
+  error?: string | null
+  onConfirm: (body: { reason: DismissReason; note?: string }) => void
+  onClose: () => void
+}
+
+export function ChecklistDismissDialog({
+  open,
+  itemTitle,
+  busy,
+  error,
+  onConfirm,
+  onClose,
+}: ChecklistDismissDialogProps) {
+  const titleId = useId()
+  const descId = useId()
+  const reasonId = useId()
+  const noteId = useId()
+  const firstFieldRef = useRef<HTMLSelectElement>(null)
+  const triggerReturnRef = useRef<Element | null>(null)
+  const { ffMotionOverlays } = usePlatformFeatures()
+  const presence = useOverlayPresence({
+    open,
+    kind: 'dialog',
+    enabled: ffMotionOverlays !== false,
+  })
+  const [reason, setReason] = useState<DismissReason>('not_applicable')
+  const [note, setNote] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      triggerReturnRef.current = document.activeElement
+      setReason('not_applicable')
+      setNote('')
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!presence.entered) return
+    const t = window.setTimeout(() => firstFieldRef.current?.focus(), 0)
+    return () => window.clearTimeout(t)
+  }, [presence.entered])
+
+  useEffect(() => {
+    if (presence.phase === 'closed' && !open && triggerReturnRef.current instanceof HTMLElement) {
+      triggerReturnRef.current.focus()
+      triggerReturnRef.current = null
+    }
+  }, [presence.phase, open])
+
+  useEffect(() => {
+    if (!presence.mounted) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !busy) {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [presence.mounted, busy, onClose])
+
+  if (!presence.mounted) return null
+
+  const classes = overlayClassNames({
+    kind: 'dialog',
+    phase: presence.phase,
+    enabled: presence.enabled,
+    reduceMotion: presence.reducedMotion,
+  })
+  const durationStyle = {
+    '--lx-overlay-duration': `${classes.durationMs}ms`,
+  } as CSSProperties
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault()
+    const trimmed = note.trim()
+    onConfirm({
+      reason,
+      note: trimmed ? trimmed.slice(0, 500) : undefined,
+    })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[400] flex items-center justify-center p-4"
+      role="presentation"
+      style={durationStyle}
+    >
+      <button
+        type="button"
+        className={`absolute inset-0 bg-slate-950/50 ${classes.scrim}`}
+        aria-label={courseChecklistI18n.dismissCancel}
+        disabled={busy}
+        onClick={() => {
+          if (!busy) onClose()
+        }}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className={`relative z-10 w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl dark:border-neutral-700 dark:bg-neutral-900 ${classes.panel}`}
+      >
+        <h2 id={titleId} className="text-lg font-semibold text-slate-900 dark:text-neutral-50">
+          {courseChecklistI18n.dismissDialogTitle}
+        </h2>
+        <p id={descId} className="mt-1 text-sm text-slate-600 dark:text-neutral-400">
+          {courseChecklistI18n.dismissDialogHelp}
+        </p>
+        <p className="mt-2 text-sm font-medium text-slate-800 dark:text-neutral-200">{itemTitle}</p>
+        <form className="mt-4 space-y-4" onSubmit={submit}>
+          <div>
+            <label htmlFor={reasonId} className="block text-sm font-medium text-slate-700 dark:text-neutral-300">
+              {courseChecklistI18n.dismissReasonLabel}
+            </label>
+            <select
+              ref={firstFieldRef}
+              id={reasonId}
+              value={reason}
+              disabled={busy}
+              onChange={(e) => setReason(e.target.value as DismissReason)}
+              className="mt-1 w-full min-h-11 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100"
+            >
+              {REASONS.map((r) => (
+                <option key={r} value={r}>
+                  {courseChecklistI18n.dismissReasons[r]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor={noteId} className="block text-sm font-medium text-slate-700 dark:text-neutral-300">
+              {courseChecklistI18n.dismissNoteLabel}
+            </label>
+            <textarea
+              id={noteId}
+              value={note}
+              maxLength={500}
+              disabled={busy}
+              rows={3}
+              placeholder={courseChecklistI18n.dismissNotePlaceholder}
+              onChange={(e) => setNote(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100"
+            />
+            <p className="mt-1 text-xs text-slate-500">{note.length}/500</p>
+          </div>
+          {error ? (
+            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={onClose}
+              className="inline-flex min-h-11 items-center rounded-lg border border-slate-300 px-4 text-sm font-semibold text-slate-800 dark:border-neutral-600 dark:text-neutral-100"
+            >
+              {courseChecklistI18n.dismissCancel}
+            </button>
+            <button
+              type="submit"
+              disabled={busy}
+              className="inline-flex min-h-11 items-center rounded-lg bg-amber-700 px-4 text-sm font-semibold text-white hover:bg-amber-600 disabled:opacity-60"
+            >
+              {busy ? courseChecklistI18n.rechecking : courseChecklistI18n.dismissConfirm}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/course-checklist/checklist-dismissed-section.tsx
+++ b/clients/web/src/pages/lms/course-checklist/checklist-dismissed-section.tsx
@@ -1,0 +1,97 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import type { ChecklistItem } from '../../../lib/course-checklist-api-schemas'
+import { courseChecklistI18n, dismissReasonLabel } from '../../../lib/course-checklist-i18n'
+import { formatTimeAgoFromIso } from '../../../lib/format-time-ago'
+
+type ChecklistDismissedSectionProps = {
+  items: ChecklistItem[]
+  expanded: boolean
+  onToggle: () => void
+  busyItemId: string | null
+  itemErrors: Record<string, string>
+  onRestore: (item: ChecklistItem) => void
+}
+
+export function ChecklistDismissedSection({
+  items,
+  expanded,
+  onToggle,
+  busyItemId,
+  itemErrors,
+  onRestore,
+}: ChecklistDismissedSectionProps) {
+  if (items.length === 0) return null
+  const panelId = 'checklist-dismissed'
+
+  return (
+    <section aria-labelledby={`${panelId}-heading`} className="mt-6 border-t border-slate-200 pt-4 dark:border-neutral-800">
+      <h2 id={`${panelId}-heading`}>
+        <button
+          type="button"
+          className="flex w-full min-h-11 items-center justify-between gap-3 text-start"
+          aria-expanded={expanded}
+          aria-controls={panelId}
+          onClick={onToggle}
+        >
+          <span className="inline-flex items-center gap-2 text-base font-semibold text-slate-700 dark:text-neutral-300">
+            {expanded ? (
+              <ChevronDown className="h-4 w-4 shrink-0" aria-hidden />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" aria-hidden />
+            )}
+            {courseChecklistI18n.dismissedSection(items.length)}
+          </span>
+        </button>
+      </h2>
+      {expanded ? (
+        <ul id={panelId} className="mt-2 space-y-3">
+          {items.map((item) => {
+            const d = item.dismissal
+            return (
+              <li
+                key={item.id}
+                className="rounded-lg border border-slate-200 bg-slate-50/80 p-3 dark:border-neutral-700 dark:bg-neutral-900/60"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-slate-800 dark:text-neutral-200">
+                      {item.title}
+                    </p>
+                    {d ? (
+                      <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+                        {courseChecklistI18n.dismissedBy(
+                          d.byDisplayName || 'Someone',
+                          formatTimeAgoFromIso(d.dismissedAt),
+                        )}
+                        {' · '}
+                        {dismissReasonLabel(d.reason)}
+                        {d.note ? ` — ${d.note}` : ''}
+                      </p>
+                    ) : null}
+                    {itemErrors[item.id] ? (
+                      <p className="mt-1 text-sm text-red-600" role="alert">
+                        {itemErrors[item.id]}
+                      </p>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    disabled={busyItemId === item.id}
+                    onClick={() => onRestore(item)}
+                    className="inline-flex min-h-11 items-center rounded-lg border border-slate-300 px-3 text-xs font-semibold text-slate-800 hover:border-amber-300 dark:border-neutral-600 dark:text-neutral-100"
+                  >
+                    {busyItemId === item.id
+                      ? courseChecklistI18n.restoring
+                      : courseChecklistI18n.restore}
+                  </button>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      ) : (
+        <div id={panelId} hidden />
+      )}
+    </section>
+  )
+}

--- a/clients/web/src/pages/lms/course-checklist/checklist-evidence-table.tsx
+++ b/clients/web/src/pages/lms/course-checklist/checklist-evidence-table.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useRef, useState, useEffect, type UIEvent } from 'react'
+import { Link } from 'react-router-dom'
+import type {
+  ChecklistEvidence,
+  ChecklistNavTarget,
+} from '../../../lib/course-checklist-api-schemas'
+import { courseChecklistI18n } from '../../../lib/course-checklist-i18n'
+
+const VIRTUALIZE_THRESHOLD = 100
+const ROW_HEIGHT = 44
+const VIEWPORT_ROWS = 12
+
+type ChecklistEvidenceTableProps = {
+  evidence: ChecklistEvidence
+  fallbackTarget?: ChecklistNavTarget | null
+  onRowNavigate?: (route: string) => void
+}
+
+function resolveRoute(
+  rowTarget: ChecklistNavTarget | null | undefined,
+  fallback: ChecklistNavTarget | null | undefined,
+): string | null {
+  return rowTarget?.route || fallback?.route || null
+}
+
+export function ChecklistEvidenceTable({
+  evidence,
+  fallbackTarget,
+  onRowNavigate,
+}: ChecklistEvidenceTableProps) {
+  const rows = evidence.rows
+  const virtualize = rows.length > VIRTUALIZE_THRESHOLD
+  const [scrollTop, setScrollTop] = useState(0)
+  const scrollerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    setScrollTop(0)
+    if (scrollerRef.current) scrollerRef.current.scrollTop = 0
+  }, [rows.length])
+
+  const windowed = useMemo(() => {
+    if (!virtualize) return { start: 0, end: rows.length, offsetY: 0, totalH: 0 }
+    const start = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - 2)
+    const end = Math.min(rows.length, start + VIEWPORT_ROWS + 4)
+    return {
+      start,
+      end,
+      offsetY: start * ROW_HEIGHT,
+      totalH: rows.length * ROW_HEIGHT,
+    }
+  }, [virtualize, scrollTop, rows.length])
+
+  const visibleRows = virtualize ? rows.slice(windowed.start, windowed.end) : rows
+  const truncatedAt = evidence.truncatedAt ?? null
+
+  const onScroll = (e: UIEvent<HTMLDivElement>) => {
+    setScrollTop(e.currentTarget.scrollTop)
+  }
+
+  const table = (
+    <table className="w-full min-w-[20rem] border-collapse text-sm">
+      <thead>
+        <tr className="border-b border-slate-200 text-start dark:border-neutral-700">
+          {evidence.columns.map((col) => (
+            <th
+              key={col}
+              scope="col"
+              className="px-3 py-2 text-start text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400"
+            >
+              {col}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {virtualize ? <tr style={{ height: windowed.offsetY }} aria-hidden><td colSpan={evidence.columns.length} /></tr> : null}
+        {visibleRows.map((row, idx) => {
+          const route = resolveRoute(row.target, fallbackTarget)
+          const cells = [row.label, row.sublabel ?? '', row.status, '']
+          const key = `${row.label}-${windowed.start + idx}`
+          return (
+            <tr
+              key={key}
+              className="border-b border-slate-100 last:border-0 dark:border-neutral-800 max-sm:block max-sm:border max-sm:rounded-lg max-sm:mb-2 max-sm:p-2"
+            >
+              {evidence.columns.map((col, colIdx) => {
+                const value = cells[colIdx] ?? ''
+                const isFirst = colIdx === 0
+                return (
+                  <td
+                    key={col}
+                    className="px-3 py-2 text-slate-800 dark:text-neutral-200 max-sm:block max-sm:px-0 max-sm:py-1"
+                    data-label={col}
+                  >
+                    {isFirst && route ? (
+                      <Link
+                        to={route}
+                        className="inline-flex min-h-11 items-center font-medium text-amber-800 underline-offset-2 hover:underline dark:text-amber-300"
+                        onClick={() => onRowNavigate?.(route)}
+                      >
+                        {row.label}
+                      </Link>
+                    ) : isFirst ? (
+                      <span className="font-medium">{row.label}</span>
+                    ) : (
+                      <span className="max-sm:before:content-[attr(data-label)_':_'] max-sm:before:font-semibold max-sm:before:text-slate-500">
+                        {value}
+                      </span>
+                    )}
+                  </td>
+                )
+              })}
+            </tr>
+          )
+        })}
+        {virtualize ? (
+          <tr style={{ height: Math.max(0, windowed.totalH - windowed.offsetY - visibleRows.length * ROW_HEIGHT) }} aria-hidden>
+            <td colSpan={evidence.columns.length} />
+          </tr>
+        ) : null}
+      </tbody>
+    </table>
+  )
+
+  return (
+    <div className="mt-3 overflow-x-auto rounded-lg border border-slate-200 dark:border-neutral-700">
+      {truncatedAt != null ? (
+        <p className="border-b border-slate-200 px-3 py-2 text-xs text-slate-500 dark:border-neutral-700 dark:text-neutral-400">
+          {courseChecklistI18n.evidenceTruncated(rows.length, truncatedAt)}
+        </p>
+      ) : null}
+      {virtualize ? (
+        <div
+          ref={scrollerRef}
+          className="max-h-[528px] overflow-y-auto"
+          onScroll={onScroll}
+        >
+          {table}
+        </div>
+      ) : (
+        table
+      )}
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/course-checklist/checklist-item-row.tsx
+++ b/clients/web/src/pages/lms/course-checklist/checklist-item-row.tsx
@@ -1,0 +1,221 @@
+import { useId, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { MoreHorizontal, RefreshCw } from 'lucide-react'
+import { ChecklistStatusAffordance } from '../../../components/checklist/checklist-status-affordance'
+import type { ChecklistItem } from '../../../lib/course-checklist-api-schemas'
+import {
+  isOutstandingStatus,
+  normalizeChecklistStatus,
+} from '../../../lib/course-checklist-api-schemas'
+import { courseChecklistI18n } from '../../../lib/course-checklist-i18n'
+import { ChecklistEvidenceTable } from './checklist-evidence-table'
+
+type ChecklistItemRowProps = {
+  item: ChecklistItem
+  busy?: boolean
+  error?: string | null
+  onDismiss: (item: ChecklistItem) => void
+  onRecheck: (item: ChecklistItem) => void
+  highlighted?: boolean
+}
+
+function interactionMode(item: ChecklistItem): 'evidence' | 'link' | 'static' {
+  if (item.evidence && item.evidence.rows.length >= 1) return 'evidence'
+  if (item.target?.route) return 'link'
+  return 'static'
+}
+
+export function ChecklistItemRow({
+  item,
+  busy,
+  error,
+  onDismiss,
+  onRecheck,
+  highlighted,
+}: ChecklistItemRowProps) {
+  const navigate = useNavigate()
+  const status = normalizeChecklistStatus(item.status)
+  const done = status === 'done'
+  const unknown = status === 'unknown'
+  const mode = interactionMode(item)
+  const evidenceId = useId()
+  const whyId = useId()
+  const [expanded, setExpanded] = useState(false)
+  const [whyOpen, setWhyOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const interactive = isOutstandingStatus(item.status) || unknown
+
+  const titleClass = done
+    ? 'line-through text-slate-500 dark:text-neutral-500'
+    : unknown
+      ? 'text-slate-500 dark:text-neutral-400'
+      : 'text-slate-900 dark:text-neutral-50'
+
+  const titleNode = (
+    <span className={`text-sm font-medium ${titleClass}`}>
+      {item.title}
+      {done ? <span className="sr-only"> {courseChecklistI18n.completedLabel}</span> : null}
+    </span>
+  )
+
+  return (
+    <li
+      id={`item-${item.id}`}
+      className={`rounded-lg border border-transparent px-2 py-3 transition-colors ${
+        highlighted ? 'border-amber-300 bg-amber-50/60 dark:border-amber-700 dark:bg-amber-950/30' : ''
+      } ${unknown ? 'opacity-80' : ''}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5">
+          <ChecklistStatusAffordance status={item.status} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              {mode === 'link' && interactive && item.target?.route ? (
+                <Link
+                  to={item.target.route}
+                  className="inline-flex min-h-11 items-center hover:underline"
+                >
+                  {titleNode}
+                </Link>
+              ) : mode === 'evidence' && interactive ? (
+                <button
+                  type="button"
+                  className="inline-flex min-h-11 items-center text-start hover:underline"
+                  aria-expanded={expanded}
+                  aria-controls={evidenceId}
+                  onClick={() => setExpanded((v) => !v)}
+                >
+                  {titleNode}
+                </button>
+              ) : (
+                <div className="inline-flex min-h-11 items-center">{titleNode}</div>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {item.progress ? (
+                <span className="text-xs tabular-nums text-slate-500 dark:text-neutral-400">
+                  {item.progress.done} / {item.progress.total}
+                </span>
+              ) : null}
+              {item.tier === 'essential' ? (
+                <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-900 dark:bg-amber-950 dark:text-amber-200">
+                  {courseChecklistI18n.essentialTier}
+                </span>
+              ) : null}
+              {unknown ? (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => onRecheck(item)}
+                  className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-slate-300 px-2 text-xs font-semibold text-slate-700 dark:border-neutral-600 dark:text-neutral-200"
+                >
+                  <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+                  {courseChecklistI18n.recheck}
+                </button>
+              ) : null}
+              <div className="relative">
+                <button
+                  type="button"
+                  aria-label={courseChecklistI18n.overflowMenu}
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 dark:hover:bg-neutral-800"
+                  onClick={() => setMenuOpen((v) => !v)}
+                >
+                  <MoreHorizontal className="h-4 w-4" aria-hidden />
+                </button>
+                {menuOpen ? (
+                  <div
+                    role="menu"
+                    className="absolute end-0 z-20 mt-1 min-w-[10rem] rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
+                  >
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="block w-full px-3 py-2 text-start text-sm text-slate-800 hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                      onClick={() => {
+                        setMenuOpen(false)
+                        onDismiss(item)
+                      }}
+                    >
+                      {courseChecklistI18n.dismiss}
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className="mt-1 max-w-full truncate text-start text-xs text-slate-500 hover:text-slate-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+            aria-expanded={whyOpen}
+            aria-controls={whyId}
+            onClick={() => setWhyOpen((v) => !v)}
+          >
+            {whyOpen ? item.why : item.why}
+          </button>
+          {whyOpen ? (
+            <p id={whyId} className="mt-1 text-xs text-slate-600 dark:text-neutral-400">
+              {item.why}
+            </p>
+          ) : null}
+
+          {item.detail || unknown ? (
+            <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">
+              {unknown && !item.detail ? courseChecklistI18n.unknownDetail : item.detail}
+            </p>
+          ) : null}
+
+          {item.sources.length > 0 ? (
+            <ul className="mt-2 flex flex-wrap gap-1.5">
+              {item.sources.map((src) => (
+                <li
+                  key={src}
+                  className="rounded bg-slate-100 px-1.5 py-0.5 text-[11px] font-medium text-slate-700 dark:bg-neutral-800 dark:text-neutral-300"
+                >
+                  {src}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          {mode === 'evidence' && interactive ? (
+            <div className="mt-2">
+              <button
+                type="button"
+                className="inline-flex min-h-11 items-center text-xs font-semibold text-amber-800 dark:text-amber-300"
+                aria-expanded={expanded}
+                aria-controls={evidenceId}
+                onClick={() => setExpanded((v) => !v)}
+              >
+                {expanded
+                  ? courseChecklistI18n.hideEvidence
+                  : courseChecklistI18n.showEvidence(item.evidence!.rows.length)}
+              </button>
+              {expanded && item.evidence ? (
+                <div id={evidenceId}>
+                  <ChecklistEvidenceTable
+                    evidence={item.evidence}
+                    fallbackTarget={item.target}
+                    onRowNavigate={(route) => navigate(route)}
+                  />
+                </div>
+              ) : (
+                <div id={evidenceId} hidden />
+              )}
+            </div>
+          ) : null}
+
+          {error ? (
+            <p className="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  )
+}

--- a/clients/web/src/pages/lms/course-checklist/index.tsx
+++ b/clients/web/src/pages/lms/course-checklist/index.tsx
@@ -15,9 +15,9 @@ function ChecklistSkeleton() {
     <div className="space-y-4" aria-busy="true" aria-label="Loading checklist">
       {Array.from({ length: 4 }).map((_, i) => (
         <div key={i} className="space-y-2 rounded-lg border border-slate-200 p-4 dark:border-neutral-700">
-          <div className="h-5 w-1/3 animate-pulse rounded bg-slate-200 dark:bg-neutral-700" />
-          <div className="h-4 w-full animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
-          <div className="h-4 w-5/6 animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
+          <div className="h-5 w-1/3 motion-safe:animate-pulse rounded bg-slate-200 dark:bg-neutral-700" />
+          <div className="h-4 w-full motion-safe:animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
+          <div className="h-4 w-5/6 motion-safe:animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
         </div>
       ))}
     </div>

--- a/clients/web/src/pages/lms/course-checklist/index.tsx
+++ b/clients/web/src/pages/lms/course-checklist/index.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react'
+import { RefreshCw } from 'lucide-react'
+import { useLocation, useParams } from 'react-router-dom'
+import { ChecklistProgressBar } from '../../../components/checklist/checklist-progress'
+import { courseChecklistI18n } from '../../../lib/course-checklist-i18n'
+import { formatTimeAgoFromIso } from '../../../lib/format-time-ago'
+import { LmsPage } from '../lms-page'
+import { ChecklistCategorySection } from './checklist-category-section'
+import { ChecklistDismissDialog } from './checklist-dismiss-dialog'
+import { ChecklistDismissedSection } from './checklist-dismissed-section'
+import { useChecklistPage } from './use-checklist-page'
+
+function ChecklistSkeleton() {
+  return (
+    <div className="space-y-4" aria-busy="true" aria-label="Loading checklist">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="space-y-2 rounded-lg border border-slate-200 p-4 dark:border-neutral-700">
+          <div className="h-5 w-1/3 animate-pulse rounded bg-slate-200 dark:bg-neutral-700" />
+          <div className="h-4 w-full animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
+          <div className="h-4 w-5/6 animate-pulse rounded bg-slate-100 dark:bg-neutral-800" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function CourseChecklistPage() {
+  const { courseCode: raw } = useParams<{ courseCode: string }>()
+  const courseCode = raw ? decodeURIComponent(raw) : undefined
+  const location = useLocation()
+  const [highlightItemId, setHighlightItemId] = useState<string | null>(null)
+  const page = useChecklistPage(courseCode)
+
+  useEffect(() => {
+    const hash = location.hash.replace(/^#/, '')
+    if (!hash.startsWith('item-') || !page.data) return
+    const itemId = hash.slice('item-'.length)
+    for (const cat of page.data.categories) {
+      if (cat.items.some((i) => i.id === itemId)) {
+        page.ensureCategoryExpanded(cat.id)
+        setHighlightItemId(itemId)
+        break
+      }
+    }
+    const t = window.setTimeout(() => {
+      document.getElementById(`item-${itemId}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }, 50)
+    return () => window.clearTimeout(t)
+    // intentionally only when data/hash change
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ensureCategoryExpanded identity changes often
+  }, [location.hash, page.data])
+
+  if (page.loadState === 'forbidden') {
+    return (
+      <LmsPage title={courseChecklistI18n.pageTitle}>
+        <p className="text-sm text-slate-600 dark:text-neutral-400">{courseChecklistI18n.noAccess}</p>
+      </LmsPage>
+    )
+  }
+
+  const summary = page.data?.summary
+  const checkedLabel = summary
+    ? courseChecklistI18n.checkedAgo(formatTimeAgoFromIso(summary.computedAt).toLowerCase())
+    : undefined
+
+  return (
+    <LmsPage
+      title={courseChecklistI18n.pageTitle}
+      actions={
+        <button
+          type="button"
+          disabled={page.refreshing || page.loadState === 'loading'}
+          onClick={() => void page.onRefresh()}
+          className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-amber-700 px-4 text-sm font-semibold text-white hover:bg-amber-600 disabled:opacity-60"
+        >
+          <RefreshCw className={`h-4 w-4 ${page.refreshing ? 'animate-spin' : ''}`} aria-hidden />
+          {page.refreshing ? courseChecklistI18n.rechecking : courseChecklistI18n.recheck}
+        </button>
+      }
+    >
+      <div className="sr-only" aria-live="polite">
+        {page.liveMessage}
+      </div>
+
+      {page.loadState === 'loading' || page.loadState === 'idle' ? <ChecklistSkeleton /> : null}
+
+      {page.loadState === 'error' ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950/40">
+          <p className="text-sm text-red-800 dark:text-red-200">{page.error ?? courseChecklistI18n.loadError}</p>
+          <button
+            type="button"
+            className="mt-3 inline-flex min-h-11 items-center rounded-lg border border-red-300 px-3 text-sm font-semibold text-red-800 dark:border-red-800 dark:text-red-200"
+            onClick={() => void page.load()}
+          >
+            {courseChecklistI18n.retry}
+          </button>
+        </div>
+      ) : null}
+
+      {page.loadState === 'ready' && page.data && summary ? (
+        <>
+          <ChecklistProgressBar
+            done={summary.done}
+            total={summary.total}
+            outstandingTotal={summary.outstandingTotal}
+            checkedLabel={checkedLabel}
+            className="mb-6"
+          />
+
+          {page.catalogEmpty ? (
+            <p className="text-sm text-slate-600 dark:text-neutral-400">{courseChecklistI18n.catalogEmpty}</p>
+          ) : null}
+
+          {page.allDone ? (
+            <div className="mb-6 rounded-xl border border-emerald-200 bg-emerald-50/80 p-5 dark:border-emerald-900 dark:bg-emerald-950/30">
+              <p className="text-base font-semibold text-emerald-900 dark:text-emerald-100">
+                {courseChecklistI18n.allDoneTitle}
+              </p>
+              <p className="mt-1 text-sm text-emerald-800 dark:text-emerald-200">
+                {courseChecklistI18n.allDoneBody}
+              </p>
+              <button
+                type="button"
+                className="mt-3 inline-flex min-h-11 items-center text-sm font-semibold text-emerald-900 underline-offset-2 hover:underline dark:text-emerald-200"
+                onClick={() => page.setShowCompletedWhenAllDone((v) => !v)}
+              >
+                {page.showCompletedWhenAllDone
+                  ? courseChecklistI18n.hideCompleted
+                  : courseChecklistI18n.showCompleted}
+              </button>
+            </div>
+          ) : null}
+
+          {(!page.allDone || page.showCompletedWhenAllDone) &&
+            page.data.categories.map((cat) => (
+              <ChecklistCategorySection
+                key={cat.id}
+                category={cat}
+                expanded={!page.collapsed[cat.id]}
+                onToggle={() => page.toggleCategory(cat.id)}
+                itemErrors={page.itemErrors}
+                busyItemId={page.busyItemId}
+                highlightItemId={highlightItemId}
+                onDismiss={(item) => page.setDismissTarget(item)}
+                onRecheck={(item) => void page.onRecheck(item)}
+              />
+            ))}
+
+          <ChecklistDismissedSection
+            items={page.data.dismissed}
+            expanded={page.dismissedOpen}
+            onToggle={() => page.setDismissedOpen((v) => !v)}
+            busyItemId={page.busyItemId}
+            itemErrors={page.itemErrors}
+            onRestore={(item) => void page.onRestore(item)}
+          />
+        </>
+      ) : null}
+
+      <ChecklistDismissDialog
+        open={!!page.dismissTarget}
+        itemTitle={page.dismissTarget?.title ?? ''}
+        busy={page.dismissBusy}
+        error={page.dismissError}
+        onClose={() => page.setDismissTarget(null)}
+        onConfirm={(body) => void page.onDismissConfirm(body)}
+      />
+    </LmsPage>
+  )
+}

--- a/clients/web/src/pages/lms/course-checklist/index.tsx
+++ b/clients/web/src/pages/lms/course-checklist/index.tsx
@@ -73,7 +73,7 @@ export default function CourseChecklistPage() {
           onClick={() => void page.onRefresh()}
           className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-amber-700 px-4 text-sm font-semibold text-white hover:bg-amber-600 disabled:opacity-60"
         >
-          <RefreshCw className={`h-4 w-4 ${page.refreshing ? 'animate-spin' : ''}`} aria-hidden />
+          <RefreshCw className={`h-4 w-4 ${page.refreshing ? 'motion-safe:animate-spin' : ''}`} aria-hidden />
           {page.refreshing ? courseChecklistI18n.rechecking : courseChecklistI18n.recheck}
         </button>
       }

--- a/clients/web/src/pages/lms/course-checklist/use-checklist-page.ts
+++ b/clients/web/src/pages/lms/course-checklist/use-checklist-page.ts
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  CourseChecklistApiError,
+  dismissChecklistItem,
+  fetchCourseChecklist,
+  recheckChecklistItem,
+  refreshCourseChecklist,
+  restoreChecklistItem,
+} from '../../../lib/course-checklist-api'
+import type {
+  ChecklistItem,
+  ChecklistResponse,
+  DismissReason,
+} from '../../../lib/course-checklist-api-schemas'
+import { isOutstandingStatus } from '../../../lib/course-checklist-api-schemas'
+import {
+  readCategoryCollapseState,
+  writeCategoryCollapseState,
+  type CategoryCollapseMap,
+} from '../../../lib/course-checklist-category-state'
+import { courseChecklistI18n } from '../../../lib/course-checklist-i18n'
+import { useCourseChecklistSummary } from '../../../context/course-checklist-summary-context'
+
+type LoadState = 'idle' | 'loading' | 'ready' | 'error' | 'forbidden'
+
+export function useChecklistPage(courseCode: string | undefined) {
+  const { refresh: refreshSummary, canManageCourse } = useCourseChecklistSummary()
+  const [data, setData] = useState<ChecklistResponse | null>(null)
+  const [loadState, setLoadState] = useState<LoadState>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const [collapsed, setCollapsed] = useState<CategoryCollapseMap>({})
+  const [dismissedOpen, setDismissedOpen] = useState(false)
+  const [showCompletedWhenAllDone, setShowCompletedWhenAllDone] = useState(false)
+  const [busyItemId, setBusyItemId] = useState<string | null>(null)
+  const [itemErrors, setItemErrors] = useState<Record<string, string>>({})
+  const [liveMessage, setLiveMessage] = useState('')
+  const [refreshing, setRefreshing] = useState(false)
+  const [dismissTarget, setDismissTarget] = useState<ChecklistItem | null>(null)
+  const [dismissBusy, setDismissBusy] = useState(false)
+  const [dismissError, setDismissError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!courseCode) return
+    setLoadState('loading')
+    setError(null)
+    try {
+      const res = await fetchCourseChecklist(courseCode)
+      setData(res)
+      const stored = readCategoryCollapseState(courseCode, res.catalogVersion)
+      if (stored) {
+        setCollapsed(stored)
+      } else {
+        const initial: CategoryCollapseMap = {}
+        for (const cat of res.categories) {
+          const outstanding = cat.items.some((i) => isOutstandingStatus(i.status))
+          initial[cat.id] = !outstanding
+        }
+        setCollapsed(initial)
+        writeCategoryCollapseState(courseCode, res.catalogVersion, initial)
+      }
+      setLoadState('ready')
+    } catch (err) {
+      if (err instanceof CourseChecklistApiError && err.status === 403) {
+        setLoadState('forbidden')
+      } else {
+        setError(err instanceof Error ? err.message : courseChecklistI18n.loadError)
+        setLoadState('error')
+      }
+      setData(null)
+    }
+  }, [courseCode])
+
+  useEffect(() => {
+    if (!courseCode) return
+    if (!canManageCourse) {
+      // Still attempt load so direct URL hits get server 403 (FR-27).
+    }
+    void load()
+  }, [courseCode, canManageCourse, load])
+
+  const persistCollapse = useCallback(
+    (next: CategoryCollapseMap) => {
+      setCollapsed(next)
+      if (courseCode && data) {
+        writeCategoryCollapseState(courseCode, data.catalogVersion, next)
+      }
+    },
+    [courseCode, data],
+  )
+
+  const toggleCategory = useCallback(
+    (categoryId: string) => {
+      persistCollapse({ ...collapsed, [categoryId]: !collapsed[categoryId] })
+    },
+    [collapsed, persistCollapse],
+  )
+
+  const ensureCategoryExpanded = useCallback(
+    (categoryId: string) => {
+      if (collapsed[categoryId]) {
+        persistCollapse({ ...collapsed, [categoryId]: false })
+      }
+    },
+    [collapsed, persistCollapse],
+  )
+
+  const onRefresh = useCallback(async () => {
+    if (!courseCode) return
+    setRefreshing(true)
+    setError(null)
+    try {
+      const res = await refreshCourseChecklist(courseCode)
+      setData(res)
+      setLoadState('ready')
+      await refreshSummary()
+      setLiveMessage(courseChecklistI18n.itemRecheckedLive)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : courseChecklistI18n.loadError)
+    } finally {
+      setRefreshing(false)
+    }
+  }, [courseCode, refreshSummary])
+
+  const onDismissConfirm = useCallback(
+    async (body: { reason: DismissReason; note?: string }) => {
+      if (!courseCode || !dismissTarget || !data) return
+      const item = dismissTarget
+      setDismissBusy(true)
+      setDismissError(null)
+      const prev = data
+      // Optimistic: move to dismissed
+      setData({
+        ...data,
+        categories: data.categories.map((c) => ({
+          ...c,
+          items: c.items.filter((i) => i.id !== item.id),
+        })),
+        dismissed: [
+          {
+            ...item,
+            dismissal: {
+              dismissedAt: new Date().toISOString(),
+              byUserId: '',
+              byDisplayName: 'You',
+              reason: body.reason,
+              note: body.note ?? '',
+            },
+          },
+          ...data.dismissed,
+        ],
+        summary: {
+          ...data.summary,
+          dismissed: data.summary.dismissed + 1,
+          outstandingEssential:
+            item.tier === 'essential' && isOutstandingStatus(item.status)
+              ? Math.max(0, data.summary.outstandingEssential - 1)
+              : data.summary.outstandingEssential,
+          outstandingTotal: isOutstandingStatus(item.status)
+            ? Math.max(0, data.summary.outstandingTotal - 1)
+            : data.summary.outstandingTotal,
+        },
+      })
+      try {
+        const updated = await dismissChecklistItem(courseCode, item.id, body)
+        setData((cur) =>
+          cur
+            ? {
+                ...cur,
+                dismissed: cur.dismissed.map((d) => (d.id === item.id ? updated : d)),
+              }
+            : cur,
+        )
+        setDismissTarget(null)
+        setLiveMessage(courseChecklistI18n.itemDismissedLive)
+        await refreshSummary()
+      } catch (err) {
+        setData(prev)
+        setDismissError(err instanceof Error ? err.message : 'Dismiss failed')
+      } finally {
+        setDismissBusy(false)
+      }
+    },
+    [courseCode, data, dismissTarget, refreshSummary],
+  )
+
+  const onRestore = useCallback(
+    async (item: ChecklistItem) => {
+      if (!courseCode || !data) return
+      setBusyItemId(item.id)
+      setItemErrors((e) => {
+        const next = { ...e }
+        delete next[item.id]
+        return next
+      })
+      const prev = data
+      setData({
+        ...data,
+        dismissed: data.dismissed.filter((d) => d.id !== item.id),
+        categories: data.categories.map((c) => {
+          // Put restored item back into first category as placeholder; server will correct.
+          if (c.id === data.categories[0]?.id) {
+            return { ...c, items: [{ ...item, dismissal: null }, ...c.items] }
+          }
+          return c
+        }),
+      })
+      try {
+        await restoreChecklistItem(courseCode, item.id)
+        const fresh = await fetchCourseChecklist(courseCode)
+        setData(fresh)
+        setLiveMessage(courseChecklistI18n.itemRestoredLive)
+        await refreshSummary()
+      } catch (err) {
+        setData(prev)
+        setItemErrors((e) => ({
+          ...e,
+          [item.id]: err instanceof Error ? err.message : 'Restore failed',
+        }))
+      } finally {
+        setBusyItemId(null)
+      }
+    },
+    [courseCode, data, refreshSummary],
+  )
+
+  const onRecheck = useCallback(
+    async (item: ChecklistItem) => {
+      if (!courseCode || !data) return
+      setBusyItemId(item.id)
+      try {
+        const updated = await recheckChecklistItem(courseCode, item.id)
+        setData({
+          ...data,
+          categories: data.categories.map((c) => ({
+            ...c,
+            items: c.items.map((i) => (i.id === item.id ? updated : i)),
+          })),
+        })
+        setLiveMessage(courseChecklistI18n.itemRecheckedLive)
+        await refreshSummary()
+      } catch (err) {
+        setItemErrors((e) => ({
+          ...e,
+          [item.id]: err instanceof Error ? err.message : 'Re-check failed',
+        }))
+      } finally {
+        setBusyItemId(null)
+      }
+    },
+    [courseCode, data, refreshSummary],
+  )
+
+  const allDone = useMemo(() => {
+    if (!data) return false
+    return data.summary.outstandingTotal === 0 && data.summary.total > 0
+  }, [data])
+
+  const catalogEmpty = useMemo(() => {
+    if (!data) return false
+    return data.summary.total === 0 && data.dismissed.length === 0
+  }, [data])
+
+  return {
+    data,
+    loadState,
+    error,
+    load,
+    collapsed,
+    toggleCategory,
+    ensureCategoryExpanded,
+    dismissedOpen,
+    setDismissedOpen,
+    showCompletedWhenAllDone,
+    setShowCompletedWhenAllDone,
+    busyItemId,
+    itemErrors,
+    liveMessage,
+    refreshing,
+    onRefresh,
+    dismissTarget,
+    setDismissTarget,
+    dismissBusy,
+    dismissError,
+    onDismissConfirm,
+    onRestore,
+    onRecheck,
+    allDone,
+    catalogEmpty,
+  }
+}

--- a/clients/web/src/pages/lms/course-detail.tsx
+++ b/clients/web/src/pages/lms/course-detail.tsx
@@ -50,6 +50,7 @@ import {
   GradingBacklogList,
   type GradingBacklogItem,
 } from '../../components/dashboard/grading-backlog-list'
+import { ChecklistDashboardCardContainer } from '../../components/checklist/checklist-dashboard-card-container'
 import { CourseHeroBanner } from '../../components/course-hero-banner'
 import { LeaderboardWidget } from './LeaderboardWidget'
 
@@ -825,6 +826,8 @@ export default function CourseDetail() {
                       </Link>
                     </div>
                   ) : null}
+
+                  {courseCode ? <ChecklistDashboardCardContainer courseCode={courseCode} /> : null}
 
                   {staff ? (
                     <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900 sm:col-span-2 lg:col-span-1">

--- a/clients/web/src/pages/lms/course-enrollments.tsx
+++ b/clients/web/src/pages/lms/course-enrollments.tsx
@@ -20,6 +20,7 @@ import { LmsPage } from './lms-page'
 import { usePermission, usePermissions } from '../../context/use-permissions'
 import { authorizedFetch } from '../../lib/api'
 import { getJwtSubject } from '../../lib/auth'
+import { invalidateChecklist } from '../../lib/course-checklist-invalidate'
 import {
   courseEnrollmentsReadPermission,
   courseEnrollmentsUpdatePermission,
@@ -780,6 +781,7 @@ export default function CourseEnrollments() {
       setEmailListText('')
       await loadEnrollments()
       await refreshPermissions()
+      invalidateChecklist(courseCode)
     } catch {
       setAddStatus('error')
       setAddMessage('Request failed.')

--- a/clients/web/src/pages/lms/course-features-section.tsx
+++ b/clients/web/src/pages/lms/course-features-section.tsx
@@ -16,6 +16,7 @@ import {
   type ContentToolsCatalogTool,
   type ContentToolsSettings,
 } from '../../lib/courses-api'
+import { invalidateChecklist } from '../../lib/course-checklist-invalidate'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
 import type { CoursePublic } from '../../lib/courses-api'
 
@@ -302,6 +303,7 @@ export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: P
         const updated = await patchCourseFeatures(courseCode, body)
         onCourseUpdated(updated)
         await refresh()
+        invalidateChecklist(courseCode)
         setMessage('Saved.')
         toastSaveOk('Course tools updated')
       } catch (e) {

--- a/clients/web/src/pages/lms/course-grading-settings.tsx
+++ b/clients/web/src/pages/lms/course-grading-settings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Plus, Trash2 } from 'lucide-react'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { usePermissions } from '../../context/use-permissions'
+import { invalidateChecklist } from '../../lib/course-checklist-invalidate'
 import { toastSaveOk } from '../../lib/lms-toast'
 import { UnsavedChangesBanner } from '../../components/ui/unsaved-changes-banner'
 import {
@@ -349,6 +350,7 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
       await Promise.all(promises)
       await load()
       void refreshCourseNav()
+      invalidateChecklist(courseCode)
       setSaveStatus('saved')
       if (savedScheme) {
         toastSaveOk('Grading scheme saved.')

--- a/clients/web/src/pages/lms/course-outcomes-section.tsx
+++ b/clients/web/src/pages/lms/course-outcomes-section.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import { usePermissions } from '../../context/use-permissions'
 import { usePlatformFeatures } from '../../context/platform-features-context'
+import { invalidateChecklist } from '../../lib/course-checklist-invalidate'
 import {
   addCourseOutcomeLink,
   courseItemCreatePermission,
@@ -275,6 +276,7 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
 
       await load()
       setDrafts({})
+      invalidateChecklist(courseCode)
       setSaveStatus('saved')
     } catch (e) {
       setSaveStatus('error')

--- a/docs/completed/checklist/CC.7-web-checklist-page-and-nav-badge.md
+++ b/docs/completed/checklist/CC.7-web-checklist-page-and-nav-badge.md
@@ -10,7 +10,7 @@
 | **Section** | Course Checklist |
 | **Severity** | MAJOR |
 | **Markets** | K12 / HE / HS |
-| **Status (today)** | MISSING |
+| **Status (today)** | DONE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Web client team |
 | **Depends on** | CC.2 (API), CC.3 (real items to render) |

--- a/docs/completed/checklist/README.md
+++ b/docs/completed/checklist/README.md
@@ -8,5 +8,6 @@
 | **CC.4** | [Rule pack B — structure, content & outcome alignment](CC.4-rule-pack-structure-outcomes-alignment.md) |
 | **CC.5** | [Rule pack C — assessment, grading, feedback & interaction](CC.5-rule-pack-assessment-feedback-interaction.md) |
 | **CC.6** | [Rule pack D — accessibility, inclusive design & launch readiness](CC.6-rule-pack-accessibility-and-launch-readiness.md) |
+| **CC.7** | [Web: checklist page, nav entry & badge](CC.7-web-checklist-page-and-nav-badge.md) |
 
 Remaining plans live under [`docs/plan/checklist/`](../../plan/checklist/README.md).

--- a/docs/plan/checklist/README.md
+++ b/docs/plan/checklist/README.md
@@ -21,7 +21,7 @@ Every plan follows [_TEMPLATE.md](../_TEMPLATE.md).
 | CC.4 | [Rule pack B — structure, content & outcome alignment](../../completed/checklist/CC.4-rule-pack-structure-outcomes-alignment.md) ✅ (22 rules) | Server | M | CC.1, CC.2 |
 | CC.5 | [Rule pack C — assessment, grading, feedback & interaction](../../completed/checklist/CC.5-rule-pack-assessment-feedback-interaction.md) ✅ (26 rules) | Server | M | CC.1, CC.2 |
 | CC.6 | [Rule pack D — accessibility, inclusive design & launch readiness](../../completed/checklist/CC.6-rule-pack-accessibility-and-launch-readiness.md) ✅ (20 rules) | Server | M | CC.1, CC.2 |
-| CC.7 | [Web: checklist page, nav entry & badge](CC.7-web-checklist-page-and-nav-badge.md) | Web | M | CC.2, CC.3 |
+| CC.7 | [Web: checklist page, nav entry & badge](../../completed/checklist/CC.7-web-checklist-page-and-nav-badge.md) ✅ | Web | M | CC.2, CC.3 |
 | CC.8 | [Deep-link & highlight targeting](CC.8-deep-link-and-highlight-targeting.md) | Web (+ shared) | M | CC.1, CC.7 |
 | CC.9 | [Mobile: checklist on iOS & Android](CC.9-mobile-checklist-ios-and-android.md) | iOS + Android | M | CC.2, CC.7, CC.8 |
 | CC.10 | [Guidance, assisted fixes, analytics & rollout](CC.10-analytics-guidance-and-rollout.md) | Cross-cutting | M | CC.2–CC.7 |
@@ -34,8 +34,8 @@ for all **101 rules**, and the sources they come from.
 ```
 CC.1 ──▶ CC.2 ──┬──▶ CC.3 ─┐
                 ├──▶ CC.4 ─┤
-                ├──▶ CC.5 ─┼──▶ CC.7 ──▶ CC.8 ──▶ CC.9
-                └──▶ CC.6 ─┘        └──────────────┴──▶ CC.10
+                ├──▶ CC.5 ─┼──▶ CC.7 ✅ ──▶ CC.8 ──▶ CC.9
+                └──▶ CC.6 ─┘              └──────────────┴──▶ CC.10
 ```
 
 CC.1 and CC.2 are the critical path. The four rule packs are independent of each other and can be worked in

--- a/e2e/coverage/completed-feature-manifest.json
+++ b/e2e/coverage/completed-feature-manifest.json
@@ -5236,6 +5236,38 @@
       }
     },
     {
+      "id": "CC.7",
+      "path": "docs/completed/checklist/CC.7-web-checklist-page-and-nav-badge.md",
+      "markets": [
+        "K12",
+        "HE",
+        "HS"
+      ],
+      "risk": "major",
+      "client": "web",
+      "coverage": "journey",
+      "rationale": "Staff-only Checklist nav under Dashboard with outstanding-essential badge, full checklist page (categories, evidence table, dismiss/restore, re-check), dashboard card, and command-palette destination. Playwright covers teacher nav+page, dismiss/restore, and student no-access (no item titles).",
+      "owner": "Learning Platform",
+      "reviewed": true,
+      "specs": [
+        {
+          "path": "e2e/tests/course-checklist-ui.spec.ts"
+        },
+        {
+          "path": "e2e/tests/course-checklist.spec.ts"
+        }
+      ],
+      "flags": {
+        "settingsToggle": false,
+        "disabledState": "n/a",
+        "enabledJourney": true,
+        "authorization": true,
+        "dependency": "n/a",
+        "rollback": true,
+        "notes": "No feature flag. Client gating is UX-only; server enforces item:create (CC.2). Unblocks CC.8–CC.10."
+      }
+    },
+    {
       "id": "mb-1-in-app-browser",
       "path": "docs/completed/mobile/MB.1-in-app-browser.md",
       "markets": [

--- a/e2e/tests/course-checklist-ui.spec.ts
+++ b/e2e/tests/course-checklist-ui.spec.ts
@@ -35,7 +35,8 @@ test.describe('Course checklist UI (CC.7)', () => {
     await expect(page.getByRole('heading', { name: /course checklist/i })).toBeVisible({
       timeout: 15_000,
     })
-    await expect(page.getByRole('button', { name: /re-check/i })).toBeVisible()
+    // Page header re-check; item rows may also expose re-check for unknown status.
+    await expect(page.getByRole('button', { name: /re-check/i }).first()).toBeVisible()
     // Bare course should surface foundation items (CC.3).
     await expect(page.getByText(/welcome/i).first()).toBeVisible({ timeout: 15_000 })
   })

--- a/e2e/tests/course-checklist-ui.spec.ts
+++ b/e2e/tests/course-checklist-ui.spec.ts
@@ -21,12 +21,15 @@ test.describe('Course checklist UI (CC.7)', () => {
 
     await injectToken(page, token)
     await page.goto(`/courses/${encodeURIComponent(course.courseCode)}`)
-    await expect(mainNav(page)).toBeVisible()
+    const courseNav = page.getByRole('navigation', { name: 'Course menu' })
+    await expect(courseNav).toBeVisible()
 
-    const checklistNav = mainNav(page).locator(
-      `a[href="/courses/${encodeURIComponent(course.courseCode)}/checklist"]`,
-    )
+    const checklistNav = courseNav.getByRole('link', { name: /^checklist$/i })
     await expect(checklistNav).toBeVisible()
+    await expect(checklistNav).toHaveAttribute(
+      'href',
+      `/courses/${encodeURIComponent(course.courseCode)}/checklist`,
+    )
 
     await checklistNav.click()
     await expect(page.getByRole('heading', { name: /course checklist/i })).toBeVisible({
@@ -97,10 +100,9 @@ test.describe('Course checklist UI (CC.7)', () => {
 
     await injectToken(page, studentTok)
     await page.goto(`/courses/${encodeURIComponent(course.courseCode)}`)
-    await expect(mainNav(page)).toBeVisible()
-    await expect(
-      mainNav(page).locator(`a[href="/courses/${encodeURIComponent(course.courseCode)}/checklist"]`),
-    ).toHaveCount(0)
+    const courseNav = page.getByRole('navigation', { name: 'Course menu' })
+    await expect(courseNav).toBeVisible()
+    await expect(courseNav.getByRole('link', { name: /^checklist$/i })).toHaveCount(0)
 
     await page.goto(`/courses/${encodeURIComponent(course.courseCode)}/checklist`)
     await expect(page.getByText(/don't have access/i)).toBeVisible({ timeout: 15_000 })

--- a/e2e/tests/course-checklist-ui.spec.ts
+++ b/e2e/tests/course-checklist-ui.spec.ts
@@ -23,12 +23,10 @@ test.describe('Course checklist UI (CC.7)', () => {
     await page.goto(`/courses/${encodeURIComponent(course.courseCode)}`)
     await expect(mainNav(page)).toBeVisible()
 
-    const checklistNav = page.getByRole('link', { name: /checklist/i })
-    await expect(checklistNav).toBeVisible()
-    await expect(checklistNav).toHaveAttribute(
-      'href',
-      `/courses/${encodeURIComponent(course.courseCode)}/checklist`,
+    const checklistNav = mainNav(page).locator(
+      `a[href="/courses/${encodeURIComponent(course.courseCode)}/checklist"]`,
     )
+    await expect(checklistNav).toBeVisible()
 
     await checklistNav.click()
     await expect(page.getByRole('heading', { name: /course checklist/i })).toBeVisible({
@@ -100,7 +98,9 @@ test.describe('Course checklist UI (CC.7)', () => {
     await injectToken(page, studentTok)
     await page.goto(`/courses/${encodeURIComponent(course.courseCode)}`)
     await expect(mainNav(page)).toBeVisible()
-    await expect(page.getByRole('link', { name: /checklist/i })).toHaveCount(0)
+    await expect(
+      mainNav(page).locator(`a[href="/courses/${encodeURIComponent(course.courseCode)}/checklist"]`),
+    ).toHaveCount(0)
 
     await page.goto(`/courses/${encodeURIComponent(course.courseCode)}/checklist`)
     await expect(page.getByText(/don't have access/i)).toBeVisible({ timeout: 15_000 })

--- a/e2e/tests/course-checklist-ui.spec.ts
+++ b/e2e/tests/course-checklist-ui.spec.ts
@@ -35,13 +35,8 @@ test.describe('Course checklist UI (CC.7)', () => {
     await expect(page.getByRole('heading', { name: /course checklist/i })).toBeVisible({
       timeout: 15_000,
     })
-<<<<<<< HEAD
-    // Page header re-check; item rows may also expose re-check for unknown status.
-    await expect(page.getByRole('button', { name: /re-check/i }).first()).toBeVisible()
-=======
     // Header action — item-level "Re-check" buttons for unknown rows may also be present.
     await expect(page.getByRole('button', { name: /^re-check$/i }).first()).toBeVisible()
->>>>>>> ad190461 (test(e2e): disambiguate checklist Re-check button locator)
     // Bare course should surface foundation items (CC.3).
     await expect(page.getByText(/welcome/i).first()).toBeVisible({ timeout: 15_000 })
   })

--- a/e2e/tests/course-checklist-ui.spec.ts
+++ b/e2e/tests/course-checklist-ui.spec.ts
@@ -3,7 +3,7 @@
  */
 import { expect, test } from '@playwright/test'
 import { apiSignup, apiCreateCourse, apiEnroll } from '../fixtures/api.js'
-import { injectToken, mainNav, uniqueEmail } from '../fixtures/test.js'
+import { injectToken, uniqueEmail } from '../fixtures/test.js'
 
 const PASSWORD = 'E2eTestPass1!'
 const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'

--- a/e2e/tests/course-checklist-ui.spec.ts
+++ b/e2e/tests/course-checklist-ui.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Course Checklist web UI (CC.7) — nav badge, page, dismiss/restore, student no-access.
+ */
+import { expect, test } from '@playwright/test'
+import { apiSignup, apiCreateCourse, apiEnroll } from '../fixtures/api.js'
+import { injectToken, mainNav, uniqueEmail } from '../fixtures/test.js'
+
+const PASSWORD = 'E2eTestPass1!'
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+
+test.describe('Course checklist UI (CC.7)', () => {
+  test('teacher sees nav entry and can open checklist page', async ({ page }) => {
+    const email = uniqueEmail('cc7-teacher')
+    const { access_token: token } = await apiSignup({
+      email,
+      password: PASSWORD,
+      displayName: 'CC7 Teacher',
+    })
+    const course = await apiCreateCourse(token, { title: `CC7 UI ${Date.now()}` })
+    await apiEnroll(token, course.courseCode, email, 'teacher')
+
+    await injectToken(page, token)
+    await page.goto(`/courses/${encodeURIComponent(course.courseCode)}`)
+    await expect(mainNav(page)).toBeVisible()
+
+    const checklistNav = page.getByRole('link', { name: /checklist/i })
+    await expect(checklistNav).toBeVisible()
+    await expect(checklistNav).toHaveAttribute(
+      'href',
+      `/courses/${encodeURIComponent(course.courseCode)}/checklist`,
+    )
+
+    await checklistNav.click()
+    await expect(page.getByRole('heading', { name: /course checklist/i })).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(page.getByRole('button', { name: /re-check/i })).toBeVisible()
+    // Bare course should surface foundation items (CC.3).
+    await expect(page.getByText(/welcome/i).first()).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('teacher can dismiss and restore an item', async ({ page }) => {
+    const email = uniqueEmail('cc7-dismiss')
+    const { access_token: token } = await apiSignup({
+      email,
+      password: PASSWORD,
+      displayName: 'CC7 Dismiss',
+    })
+    const course = await apiCreateCourse(token, { title: `CC7 Dismiss ${Date.now()}` })
+    await apiEnroll(token, course.courseCode, email, 'teacher')
+
+    await injectToken(page, token)
+    await page.goto(`/courses/${encodeURIComponent(course.courseCode)}/checklist`)
+    await expect(page.getByRole('heading', { name: /course checklist/i })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    const firstActions = page.getByRole('button', { name: /item actions/i }).first()
+    await expect(firstActions).toBeVisible({ timeout: 15_000 })
+    await firstActions.click()
+    await page.getByRole('menuitem', { name: /^dismiss$/i }).click()
+    await expect(page.getByRole('dialog', { name: /dismiss checklist item/i })).toBeVisible()
+    await page.getByLabel(/^reason$/i).selectOption('not_applicable')
+    await page.getByRole('button', { name: /dismiss item/i }).click()
+    await expect(page.getByText(/item dismissed/i)).toBeVisible({ timeout: 10_000 })
+
+    await page.getByRole('button', { name: /dismissed \(/i }).click()
+    await expect(page.getByRole('button', { name: /^restore$/i }).first()).toBeVisible()
+    await page.getByRole('button', { name: /^restore$/i }).first().click()
+    await expect(page.getByText(/item restored/i)).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('student has no nav item and sees no-access on direct URL', async ({ page }) => {
+    const teacherEmail = uniqueEmail('cc7-t')
+    const studentEmail = uniqueEmail('cc7-s')
+    const { access_token: teacherTok } = await apiSignup({
+      email: teacherEmail,
+      password: PASSWORD,
+    })
+    const { access_token: studentTok } = await apiSignup({
+      email: studentEmail,
+      password: PASSWORD,
+    })
+    const course = await apiCreateCourse(teacherTok, { title: `CC7 Student ${Date.now()}` })
+    await apiEnroll(teacherTok, course.courseCode, teacherEmail, 'teacher')
+    await apiEnroll(teacherTok, course.courseCode, studentEmail, 'student', studentTok)
+
+    // Confirm API still returns items for teacher so the course is not empty.
+    const teacherRes = await fetch(
+      `${API_BASE}/api/v1/courses/${encodeURIComponent(course.courseCode)}/checklist`,
+      { headers: { Authorization: `Bearer ${teacherTok}` } },
+    )
+    expect(teacherRes.status).toBe(200)
+    const teacherBody = (await teacherRes.json()) as {
+      categories?: Array<{ items?: Array<{ title?: string }> }>
+    }
+    const sampleTitle = teacherBody.categories?.[0]?.items?.[0]?.title
+    expect(sampleTitle).toBeTruthy()
+
+    await injectToken(page, studentTok)
+    await page.goto(`/courses/${encodeURIComponent(course.courseCode)}`)
+    await expect(mainNav(page)).toBeVisible()
+    await expect(page.getByRole('link', { name: /checklist/i })).toHaveCount(0)
+
+    await page.goto(`/courses/${encodeURIComponent(course.courseCode)}/checklist`)
+    await expect(page.getByText(/don't have access/i)).toBeVisible({ timeout: 15_000 })
+    if (sampleTitle) {
+      await expect(page.getByText(sampleTitle)).toHaveCount(0)
+    }
+  })
+})

--- a/e2e/tests/course-checklist-ui.spec.ts
+++ b/e2e/tests/course-checklist-ui.spec.ts
@@ -35,8 +35,13 @@ test.describe('Course checklist UI (CC.7)', () => {
     await expect(page.getByRole('heading', { name: /course checklist/i })).toBeVisible({
       timeout: 15_000,
     })
+<<<<<<< HEAD
     // Page header re-check; item rows may also expose re-check for unknown status.
     await expect(page.getByRole('button', { name: /re-check/i }).first()).toBeVisible()
+=======
+    // Header action — item-level "Re-check" buttons for unknown rows may also be present.
+    await expect(page.getByRole('button', { name: /^re-check$/i }).first()).toBeVisible()
+>>>>>>> ad190461 (test(e2e): disambiguate checklist Re-check button locator)
     // Bare course should surface foundation items (CC.3).
     await expect(page.getByText(/welcome/i).first()).toBeVisible({ timeout: 15_000 })
   })

--- a/server/internal/service/coursechecklist/load_snapshot.go
+++ b/server/internal/service/coursechecklist/load_snapshot.go
@@ -497,9 +497,9 @@ FROM course.module_prerequisites mp
 INNER JOIN course.course_structure_items m ON m.id = mp.module_id
 WHERE m.course_id = $1
 UNION ALL
-SELECT 'rule'::text AS kind, r.structure_item_id, r.structure_item_id
+SELECT 'rule'::text AS kind, r.item_id, r.item_id
 FROM course.item_completion_rules r
-INNER JOIN course.course_structure_items i ON i.id = r.structure_item_id
+INNER JOIN course.course_structure_items i ON i.id = r.item_id
 WHERE i.course_id = $1
 LIMIT 5000
 `, courseID)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **CC.7** — staff-only Course Checklist UI on web:

- **Nav**: Checklist link immediately under Dashboard (teachers with `item:create`, hidden for students and View as Student), with outstanding-essential badge (`99+` cap, accessible name).
- **Summary provider**: 60s memoized `GET .../checklist/summary`, silent failure, refresh on focus/idle, dismiss/restore, and `invalidateChecklist()` from settings/enrollments/outcomes/grading saves.
- **Page** (`/courses/:courseCode/checklist`): progress bar, collapsible categories, done strikethrough + sr-only Completed, evidence tables, dismiss/restore dialog, dismissed section, re-check, deep-link `#item-{id}`, loading/error/no-access states.
- **Dashboard card**: compact staff card above Teaching/grading backlog.
- **Command palette**: “Course checklist” destination for staff.
- Dedicated `course-checklist-api.ts` (+ schemas) per TD.12 — not added to `courses-api.ts`.
- Plan moved to `docs/completed/checklist/`; E2E.4 disposition + Playwright UI coverage added.

## Checklist

- [x] Tests added/updated as appropriate
- [x] Structure: new/changed code follows [ARCHITECTURE_CONVENTIONS.md](docs/ARCHITECTURE_CONVENTIONS.md) (`make lint-structure`)
- [x] If moving a plan into `docs/completed/`, added a disposition in `e2e/coverage/completed-feature-manifest.json` and ran `npm run e2e:coverage:check` (E2E.4)
- [x] Flagged features link settings-toggle / disabled / enabled / authz / dependency / rollback coverage (or an E2E.1–E2E.3 family)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6d365cc-2056-481e-b20a-76bfda498d94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6d365cc-2056-481e-b20a-76bfda498d94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

