### PR TITLE
fix: overlay exit hit-testing, cross-module moves, and editor cleanup

### DIFF
--- a/clients/web/src/components/__tests__/confirm-dialog.test.tsx
+++ b/clients/web/src/components/__tests__/confirm-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { ConfirmDialog } from '../confirm-dialog'
@@ -9,6 +9,29 @@ describe('ConfirmDialog — accessibility', () => {
       <ConfirmDialog open={false} title="Delete?" onConfirm={() => {}} onClose={() => {}} />,
     )
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('disables pointer events while exit animation is in progress', async () => {
+    vi.useFakeTimers()
+    try {
+      const { rerender } = render(
+        <ConfirmDialog open title="Delete?" onConfirm={() => {}} onClose={() => {}} />,
+      )
+      const root = screen.getByTestId('confirm-dialog-root')
+      expect(root.className).not.toContain('pointer-events-none')
+
+      rerender(
+        <ConfirmDialog open={false} title="Delete?" onConfirm={() => {}} onClose={() => {}} />,
+      )
+      expect(screen.getByTestId('confirm-dialog-root').className).toContain('pointer-events-none')
+
+      await act(async () => {
+        vi.runAllTimers()
+      })
+      expect(screen.queryByTestId('confirm-dialog-root')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('renders dialog with title and focus-trapped cancel on open', async () => {

--- a/clients/web/src/components/command-palette/command-palette-dialog.tsx
+++ b/clients/web/src/components/command-palette/command-palette-dialog.tsx
@@ -395,11 +395,14 @@ export function CommandPaletteDialog({
 
   if (!presence.mounted) return null
 
+  // Exit keeps the portal mounted at opacity 0 — do not block shell nav / Links.
+  const exiting = presence.phase === 'closing'
+
   const palette = (
     <div
-      className="fixed inset-0 z-[100] flex items-start justify-center px-3 pt-12 pb-[env(safe-area-inset-bottom)] sm:px-4 sm:pt-[min(12vh,8rem)]"
+      className={`fixed inset-0 z-[100] flex items-start justify-center px-3 pt-12 pb-[env(safe-area-inset-bottom)] sm:px-4 sm:pt-[min(12vh,8rem)] ${exiting ? 'pointer-events-none' : ''}`}
       role="dialog"
-      aria-modal="true"
+      aria-modal={!exiting}
       aria-label="Command Palette"
       ref={dialogRef}
       style={durationStyle}
@@ -410,7 +413,10 @@ export function CommandPaletteDialog({
         className={`absolute inset-0 cursor-default bg-slate-950/55 backdrop-blur-md dark:bg-neutral-950/75 ${motion.scrim}`}
         aria-label="Close search"
         tabIndex={-1}
-        onClick={() => close()}
+        disabled={exiting}
+        onClick={() => {
+          if (!exiting) close()
+        }}
       />
       <div className={`relative z-10 w-full max-w-xl overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-2xl shadow-slate-900/20 dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-black/50 ${motion.panel}`}>
         <div className="flex items-center gap-3 border-b border-slate-200 px-4 py-3 dark:border-neutral-700">

--- a/clients/web/src/components/confirm-dialog.tsx
+++ b/clients/web/src/components/confirm-dialog.tsx
@@ -94,9 +94,13 @@ export function ConfirmDialog({
     requireTypedPhrase == null || typedPhrase.trim() === requireTypedPhrase.trim()
   const disableConfirm = Boolean(busy || confirmDisabled || !phraseOk)
 
+  // While exiting, opacity goes to 0 but the layer stays mounted for the animation.
+  // Disable pointer events so an invisible scrim cannot swallow nav Link clicks.
+  const exiting = presence.phase === 'closing'
+
   return (
     <div
-      className="fixed inset-0 z-[400] flex items-center justify-center p-4"
+      className={`fixed inset-0 z-[400] flex items-center justify-center p-4 ${exiting ? 'pointer-events-none' : ''}`}
       role="presentation"
       style={durationStyle}
       data-overlay-phase={presence.phase}
@@ -105,15 +109,15 @@ export function ConfirmDialog({
       <button
         type="button"
         aria-label="Close dialog"
-        disabled={busy}
+        disabled={busy || exiting}
         className={`lex-btn-static absolute inset-0 cursor-default border-0 bg-black/45 p-0 disabled:cursor-not-allowed ${classes.scrim}`}
         onClick={() => {
-          if (!busy) onClose()
+          if (!busy && !exiting) onClose()
         }}
       />
       <div
         role="dialog"
-        aria-modal="true"
+        aria-modal={!exiting}
         aria-labelledby={titleId}
         aria-describedby={description ? descId : undefined}
         className={`relative z-10 w-full max-w-md rounded-2xl border border-slate-200 bg-white p-5 shadow-xl dark:border-neutral-700 dark:bg-neutral-900 ${classes.panel}`}

--- a/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
+++ b/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
@@ -36,6 +36,15 @@ function CourseImageNodeView(props: NodeViewProps) {
     aspect: number
   } | null>(null)
   const latestDragSize = useRef<{ w: number; h: number } | null>(null)
+  /** Clears window listeners if the node view unmounts mid-resize (e.g. host page save). */
+  const dragCleanupRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    return () => {
+      dragCleanupRef.current?.()
+      dragCleanupRef.current = null
+    }
+  }, [])
 
   const [url, setUrl] = useState<string | null>(() =>
     src && !needsAuthenticatedCourseImageSrc(src) ? src : null,
@@ -89,6 +98,10 @@ function CourseImageNodeView(props: NodeViewProps) {
       e.stopPropagation()
       const img = imgRef.current
       if (!img || !url) return
+      // End any prior drag before starting another.
+      dragCleanupRef.current?.()
+      dragCleanupRef.current = null
+
       const rect = img.getBoundingClientRect()
       const w0 = typeof widthAttr === 'number' && widthAttr > 0 ? widthAttr : rect.width
       const h0 = typeof heightAttr === 'number' && heightAttr > 0 ? heightAttr : rect.height
@@ -102,7 +115,8 @@ function CourseImageNodeView(props: NodeViewProps) {
       )
       dragRef.current = { startDist, baseW: w0, baseH: h0, aspect }
       latestDragSize.current = { w: w0, h: h0 }
-      ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+      const target = e.target as HTMLElement
+      target.setPointerCapture(e.pointerId)
 
       const onMove = (ev: PointerEvent) => {
         const d = dragRef.current
@@ -117,27 +131,37 @@ function CourseImageNodeView(props: NodeViewProps) {
         setDragSize(next)
       }
 
-      const onUp = (ev: PointerEvent) => {
+      const finish = (ev?: PointerEvent, commit = true) => {
         dragRef.current = null
         try {
-          ;(e.target as HTMLElement).releasePointerCapture(ev.pointerId)
+          if (ev) target.releasePointerCapture(ev.pointerId)
         } catch {
           /* ignore */
         }
         window.removeEventListener('pointermove', onMove)
         window.removeEventListener('pointerup', onUp)
-        window.removeEventListener('pointercancel', onUp)
+        window.removeEventListener('pointercancel', onCancel)
+        dragCleanupRef.current = null
         const fin = latestDragSize.current
         latestDragSize.current = null
-        if (fin) {
-          updateAttributes({ width: fin.w, height: fin.h })
+        if (commit && fin) {
+          try {
+            updateAttributes({ width: fin.w, height: fin.h })
+          } catch {
+            /* editor may already be destroyed (host save) */
+          }
         }
         setDragSize(null)
       }
 
+      const onUp = (ev: PointerEvent) => finish(ev, true)
+      const onCancel = (ev: PointerEvent) => finish(ev, false)
+
+      dragCleanupRef.current = () => finish(undefined, false)
+
       window.addEventListener('pointermove', onMove)
       window.addEventListener('pointerup', onUp)
-      window.addEventListener('pointercancel', onUp)
+      window.addEventListener('pointercancel', onCancel)
     },
     [heightAttr, updateAttributes, url, widthAttr],
   )

--- a/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
@@ -908,6 +908,15 @@ export function MarkdownBodyEditor({
     if (editor) editor.setEditable(!disabled)
   }, [disabled, editor])
 
+  // Host page save disables the editor then unmounts it — clear floating UI so a
+  // portaled link popover cannot outlive the intentional close transition.
+  useEffect(() => {
+    if (!disabled) return
+    setLinkPopover(null)
+    setMentionUi(null)
+    setSlashUi(null)
+  }, [disabled])
+
   useEffect(() => {
     setNotebookTaskContext(notebookTaskContext)
     if (!editor) return

--- a/clients/web/src/components/input-dialog.tsx
+++ b/clients/web/src/components/input-dialog.tsx
@@ -81,9 +81,12 @@ export function InputDialog({
     '--lx-overlay-duration': `${classes.durationMs}ms`,
   } as CSSProperties
 
+  // Exit animation keeps the layer mounted at opacity 0 — do not block underlying Links.
+  const exiting = presence.phase === 'closing'
+
   return (
     <div
-      className="fixed inset-0 z-[400] flex items-center justify-center p-4"
+      className={`fixed inset-0 z-[400] flex items-center justify-center p-4 ${exiting ? 'pointer-events-none' : ''}`}
       role="presentation"
       style={durationStyle}
       data-overlay-phase={presence.phase}
@@ -91,15 +94,15 @@ export function InputDialog({
       <button
         type="button"
         aria-label={t('dialogs.close')}
-        disabled={busy}
+        disabled={busy || exiting}
         className={`lex-btn-static absolute inset-0 cursor-default border-0 bg-black/45 p-0 disabled:cursor-not-allowed ${classes.scrim}`}
         onClick={() => {
-          if (!busy) onClose()
+          if (!busy && !exiting) onClose()
         }}
       />
       <form
         role="dialog"
-        aria-modal="true"
+        aria-modal={!exiting}
         aria-labelledby={titleId}
         aria-describedby={description ? descId : undefined}
         className={`relative z-10 w-full max-w-md rounded-2xl border border-slate-200 bg-white p-5 shadow-xl dark:border-neutral-700 dark:bg-neutral-900 ${classes.panel}`}

--- a/clients/web/src/components/layout/notifications-drawer.tsx
+++ b/clients/web/src/components/layout/notifications-drawer.tsx
@@ -313,14 +313,19 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
     transitionTimingFunction: overlayMotionOn && !reducedMotion ? activeEase : 'linear',
   } as const
 
+  // While closing, `entered` is false so the scrim is invisible but still hit-tests
+  // unless we drop pointer events — that looks like “router links are dead”.
+  const closing = !open
+
   return createPortal(
     <div
-      className="fixed inset-0 z-[60] flex justify-end"
+      className={`fixed inset-0 z-[60] flex justify-end ${closing ? 'pointer-events-none' : ''}`}
       data-overlay-phase={entered ? (open ? 'open' : 'closing') : open ? 'opening' : 'closed'}
     >
       <button
         type="button"
         aria-label="Close notifications"
+        disabled={closing}
         style={{
           ...transitionStyle,
           transitionProperty: 'opacity',
@@ -330,7 +335,9 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
         className={`lex-btn-static absolute inset-0 bg-slate-900/45 backdrop-blur-[1px] ${
           entered ? 'opacity-100' : 'opacity-0'
         }`}
-        onClick={onClose}
+        onClick={() => {
+          if (!closing) onClose()
+        }}
       />
       <div
         role="dialog"

--- a/clients/web/src/components/syllabus/__tests__/syllabus-section-markdown.test.ts
+++ b/clients/web/src/components/syllabus/__tests__/syllabus-section-markdown.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { markdownToSectionsForEditor, sectionsToMarkdown } from '../syllabus-section-markdown'
+import {
+  EDITOR_SECTION_BOUNDARY,
+  markdownToSectionsForEditor,
+  sectionsToMarkdown,
+  stripEditorSectionBoundaries,
+} from '../syllabus-section-markdown'
 
 describe('sectionsToMarkdown', () => {
   it('joins sections with ## headings and double newlines', () => {
@@ -10,12 +15,33 @@ describe('sectionsToMarkdown', () => {
     expect(md).toBe('## A\n\nBody one.\n\n## B\n\nBody two.')
   })
 
-  it('trims trailing body whitespace only and skips empty heading in output', () => {
+  it('trims trailing body whitespace and keeps untitled sections separate', () => {
     const md = sectionsToMarkdown([
       { id: '1', heading: '', markdown: '  solo  \n' },
       { id: '2', heading: '  ', markdown: 'x' },
     ])
-    expect(md).toBe('  solo\n\nx')
+    expect(md).toBe(`  solo\n\n${EDITOR_SECTION_BOUNDARY}\n\nx`)
+  })
+
+  it('does not insert a boundary before the first untitled section', () => {
+    const md = sectionsToMarkdown([{ id: '1', heading: '', markdown: 'only' }])
+    expect(md).toBe('only')
+  })
+
+  it('separates a titled section from a following untitled one', () => {
+    const md = sectionsToMarkdown([
+      { id: '1', heading: 'Intro', markdown: 'Hello' },
+      { id: '2', heading: '', markdown: 'More body' },
+    ])
+    expect(md).toBe(`## Intro\n\nHello\n\n${EDITOR_SECTION_BOUNDARY}\n\nMore body`)
+  })
+
+  it('skips fully empty sections', () => {
+    const md = sectionsToMarkdown([
+      { id: '1', heading: '', markdown: '' },
+      { id: '2', heading: 'Keep', markdown: 'yes' },
+    ])
+    expect(md).toBe('## Keep\n\nyes')
   })
 })
 
@@ -42,5 +68,48 @@ describe('markdownToSectionsForEditor', () => {
     const sections = markdownToSectionsForEditor('Plain intro line', () => 'id1')
     expect(sections).toHaveLength(1)
     expect(sections[0]).toEqual({ id: 'id1', heading: '', markdown: 'Plain intro line' })
+  })
+
+  it('splits on editor section boundaries for untitled sections', () => {
+    const ids = ['a', 'b']
+    let i = 0
+    const sections = markdownToSectionsForEditor(
+      `first body\n\n${EDITOR_SECTION_BOUNDARY}\n\nsecond body`,
+      () => ids[i++]!,
+    )
+    expect(sections).toHaveLength(2)
+    expect(sections[0]).toMatchObject({ heading: '', markdown: 'first body' })
+    expect(sections[1]).toMatchObject({ heading: '', markdown: 'second body' })
+  })
+
+  it('round-trips multiple untitled sections', () => {
+    const original = [
+      { id: '1', heading: '', markdown: 'Alpha' },
+      { id: '2', heading: '', markdown: 'Beta' },
+      { id: '3', heading: 'Titled', markdown: 'Gamma' },
+      { id: '4', heading: '', markdown: 'Delta' },
+    ]
+    const md = sectionsToMarkdown(original)
+    const ids = ['w', 'x', 'y', 'z']
+    let i = 0
+    const back = markdownToSectionsForEditor(md, () => ids[i++]!)
+    expect(back).toHaveLength(4)
+    expect(back.map((s) => ({ heading: s.heading, markdown: s.markdown }))).toEqual([
+      { heading: '', markdown: 'Alpha' },
+      { heading: '', markdown: 'Beta' },
+      { heading: 'Titled', markdown: 'Gamma' },
+      { heading: '', markdown: 'Delta' },
+    ])
+  })
+})
+
+describe('stripEditorSectionBoundaries', () => {
+  it('removes boundary markers for reader display', () => {
+    const md = `Alpha\n\n${EDITOR_SECTION_BOUNDARY}\n\nBeta`
+    expect(stripEditorSectionBoundaries(md)).toBe('Alpha\n\nBeta')
+  })
+
+  it('leaves normal content unchanged', () => {
+    expect(stripEditorSectionBoundaries('## Intro\n\nHello')).toBe('## Intro\n\nHello')
   })
 })

--- a/clients/web/src/components/syllabus/syllabus-block-editor.tsx
+++ b/clients/web/src/components/syllabus/syllabus-block-editor.tsx
@@ -145,8 +145,9 @@ type SyllabusBlockEditorProps = {
   /** Sidebar copy: syllabus vs module page / assignment body. */
   documentVariant?: 'syllabus' | 'page'
   /**
-   * With `documentVariant="page"`, replaces the default “Page” sidebar tab (stats + copy actions)
-   * and renames that tab to “Settings”.
+   * With `documentVariant="page"`, replaces the default “Page” sidebar stats/description
+   * and renames that tab to “Settings”. Clipboard Actions (copy markdown/HTML, paste)
+   * are still appended below this panel so quizzes and assignments match content pages.
    */
   pageDocumentPanel?: ReactNode
   /** Syllabus only: require first-visit acceptance from students. */
@@ -161,23 +162,17 @@ type SyllabusBlockEditorProps = {
 
 type ActiveField = { blockId: string; field: 'heading' | 'markdown' }
 
-function SyllabusDocumentPanel({
+/** Copy / paste document body actions shared by content pages, quizzes, and assignments. */
+function DocumentClipboardActions({
   sections,
   onChange,
-  documentVariant,
-  requireSyllabusAcceptance,
-  onRequireSyllabusAcceptanceChange,
+  className = 'border-t border-slate-100 pt-3 dark:border-neutral-700',
 }: {
   sections: SyllabusSection[]
   onChange: (next: SyllabusSection[]) => void
-  documentVariant: 'syllabus' | 'page'
-  requireSyllabusAcceptance?: boolean
-  onRequireSyllabusAcceptanceChange?: (next: boolean) => void
+  className?: string
 }) {
   const { disabled } = useBlockEditor()
-  const blocks = sections.length
-  const chars = sections.reduce((n, s) => n + s.markdown.length + s.heading.length, 0)
-
   const [markdownCopiedFlash, setMarkdownCopiedFlash] = useState(0)
   const [htmlCopiedFlash, setHtmlCopiedFlash] = useState(0)
   const [pastedFlash, setPastedFlash] = useState(0)
@@ -190,7 +185,7 @@ function SyllabusDocumentPanel({
     } catch {
       /* ignore */
     }
-  }, [sections, setMarkdownCopiedFlash])
+  }, [sections])
 
   const copyHtml = useCallback(async () => {
     const md = sectionsToMarkdown(sections)
@@ -201,7 +196,7 @@ function SyllabusDocumentPanel({
     } catch {
       /* ignore */
     }
-  }, [sections, setHtmlCopiedFlash])
+  }, [sections])
 
   const pasteFromClipboard = useCallback(async () => {
     try {
@@ -246,7 +241,96 @@ function SyllabusDocumentPanel({
         /* ignore */
       }
     }
-  }, [onChange, setPastedFlash])
+  }, [onChange])
+
+  return (
+    <div className={className}>
+      <h3 className="text-[13px] font-bold text-slate-900 dark:text-neutral-100">Actions</h3>
+      <div className="mt-2 flex flex-col gap-1" aria-live="polite">
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => void copyMarkdown()}
+            className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
+          >
+            Copy as Markdown
+          </button>
+          <span className="pointer-events-none flex h-5 min-w-[3.25rem] shrink-0 items-center justify-end text-[13px]">
+            {markdownCopiedFlash > 0 ? (
+              <span
+                key={markdownCopiedFlash}
+                className="copy-action-copied-fade font-medium text-emerald-600 dark:text-emerald-400"
+                onAnimationEnd={() => setMarkdownCopiedFlash(0)}
+              >
+                Copied
+              </span>
+            ) : null}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => void copyHtml()}
+            className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
+          >
+            Copy as HTML
+          </button>
+          <span className="pointer-events-none flex h-5 min-w-[3.25rem] shrink-0 items-center justify-end text-[13px]">
+            {htmlCopiedFlash > 0 ? (
+              <span
+                key={htmlCopiedFlash}
+                className="copy-action-copied-fade font-medium text-emerald-600 dark:text-emerald-400"
+                onAnimationEnd={() => setHtmlCopiedFlash(0)}
+              >
+                Copied
+              </span>
+            ) : null}
+          </span>
+        </div>
+        <div className="mt-1 border-t border-slate-100 pt-1 dark:border-neutral-700/50">
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={() => void pasteFromClipboard()}
+              disabled={disabled}
+              className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline disabled:no-underline disabled:opacity-40 dark:text-neutral-300 dark:hover:text-indigo-400"
+            >
+              Paste from Clipboard
+            </button>
+            <span className="pointer-events-none flex h-5 min-w-[3.25rem] shrink-0 items-center justify-end text-[13px]">
+              {pastedFlash > 0 ? (
+                <span
+                  key={pastedFlash}
+                  className="copy-action-copied-fade font-medium text-emerald-600 dark:text-emerald-400"
+                  onAnimationEnd={() => setPastedFlash(0)}
+                >
+                  Pasted
+                </span>
+              ) : null}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SyllabusDocumentPanel({
+  sections,
+  onChange,
+  documentVariant,
+  requireSyllabusAcceptance,
+  onRequireSyllabusAcceptanceChange,
+}: {
+  sections: SyllabusSection[]
+  onChange: (next: SyllabusSection[]) => void
+  documentVariant: 'syllabus' | 'page'
+  requireSyllabusAcceptance?: boolean
+  onRequireSyllabusAcceptanceChange?: (next: boolean) => void
+}) {
+  const { disabled } = useBlockEditor()
+  const blocks = sections.length
+  const chars = sections.reduce((n, s) => n + s.markdown.length + s.heading.length, 0)
 
   return (
     <div data-focus-anchor="syllabus.section" className="space-y-4">
@@ -281,74 +365,7 @@ function SyllabusDocumentPanel({
           <dd className="font-medium text-slate-900 dark:text-neutral-100">{formatNumber(chars)}</dd>
         </div>
       </dl>
-      <div className="border-t border-slate-100 pt-3 dark:border-neutral-700">
-        <h3 className="text-[13px] font-bold text-slate-900 dark:text-neutral-100">Actions</h3>
-        <div className="mt-2 flex flex-col gap-1" aria-live="polite">
-          <div className="flex items-center justify-between gap-3">
-            <button
-              type="button"
-              onClick={copyMarkdown}
-              className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
-            >
-              Copy as Markdown
-            </button>
-            <span className="pointer-events-none flex h-5 min-w-[3.25rem] shrink-0 items-center justify-end text-[13px]">
-              {markdownCopiedFlash > 0 ? (
-                <span
-                  key={markdownCopiedFlash}
-                  className="copy-action-copied-fade font-medium text-emerald-600 dark:text-emerald-400"
-                  onAnimationEnd={() => setMarkdownCopiedFlash(0)}
-                >
-                  Copied
-                </span>
-              ) : null}
-            </span>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <button
-              type="button"
-              onClick={copyHtml}
-              className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
-            >
-              Copy as HTML
-            </button>
-            <span className="pointer-events-none flex h-5 min-w-[3.25rem] shrink-0 items-center justify-end text-[13px]">
-              {htmlCopiedFlash > 0 ? (
-                <span
-                  key={htmlCopiedFlash}
-                  className="copy-action-copied-fade font-medium text-emerald-600 dark:text-emerald-400"
-                  onAnimationEnd={() => setHtmlCopiedFlash(0)}
-                >
-                  Copied
-                </span>
-              ) : null}
-            </span>
-          </div>
-          <div className="mt-1 border-t border-slate-100 pt-1 dark:border-neutral-700/50">
-            <div className="flex items-center justify-between gap-3">
-              <button
-                type="button"
-                onClick={pasteFromClipboard}
-                disabled={disabled}
-                className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline disabled:no-underline disabled:opacity-40 dark:text-neutral-300 dark:hover:text-indigo-400"
-              >
-                Paste from Clipboard
-              </button>
-              <span className="pointer-events-none flex h-5 min-w-[3.25rem] shrink-0 items-center justify-end text-[13px]">
-                {pastedFlash > 0 ? (
-                  <span
-                    key={pastedFlash}
-                    className="copy-action-copied-fade font-medium text-emerald-600 dark:text-emerald-400"
-                    onAnimationEnd={() => setPastedFlash(0)}
-                  >
-                    Pasted
-                  </span>
-                ) : null}
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <DocumentClipboardActions sections={sections} onChange={onChange} />
     </div>
   )
 }
@@ -461,7 +478,14 @@ function SyllabusSidebar({
       blockLabel="Section"
       documentPanel={
         usePageSettings ? (
-          pageDocumentPanel
+          <div className="space-y-4">
+            {pageDocumentPanel}
+            <DocumentClipboardActions
+              sections={sections}
+              onChange={onChange}
+              className="border-t border-slate-100 pt-4 dark:border-neutral-700"
+            />
+          </div>
         ) : (
           <SyllabusDocumentPanel
             sections={sections}

--- a/clients/web/src/components/syllabus/syllabus-markdown-view.tsx
+++ b/clients/web/src/components/syllabus/syllabus-markdown-view.tsx
@@ -16,7 +16,7 @@ import type { ResolvedMarkdownTheme } from '../../lib/markdown-theme'
 import { resolveMarkdownTheme } from '../../lib/markdown-theme'
 import { useReducedData } from '../../context/reduced-data-context'
 import { isMathRenderingEnabled } from '../../lib/math'
-import { sectionsToMarkdown } from './syllabus-section-markdown'
+import { sectionsToMarkdown, stripEditorSectionBoundaries } from './syllabus-section-markdown'
 import { authorizedFetch } from '../../lib/api'
 import { createThemedMarkdownComponents } from '../markdown/markdown-themed-components'
 import type { PluggableList } from 'unified'
@@ -224,7 +224,7 @@ export const MarkdownArticleView = forwardRef<HTMLDivElement, MarkdownArticleVie
     ref,
   ) {
     const reducedData = useReducedData()
-    const src = markdown.trim()
+    const src = stripEditorSectionBoundaries(markdown).trim()
     const hasMath = useMemo(() => markdownLooksLikeMath(src), [src])
     const [userForcedMath, setUserForcedMath] = useState(false)
     const deferMath = reducedData && hasMath && !userForcedMath
@@ -238,7 +238,10 @@ export const MarkdownArticleView = forwardRef<HTMLDivElement, MarkdownArticleVie
       () => createMarkdownComponents(theme, { useCourseFileImages, contentToolsEnabled }),
       [theme, useCourseFileImages, contentToolsEnabled],
     )
-    const normalized = useMemo(() => normalizeMarkdownLists(markdown), [markdown])
+    const normalized = useMemo(
+      () => normalizeMarkdownLists(stripEditorSectionBoundaries(markdown)),
+      [markdown],
+    )
 
     if (!src) {
       return (
@@ -291,7 +294,7 @@ export const MarkdownArticleView = forwardRef<HTMLDivElement, MarkdownArticleVie
 )
 
 export function SyllabusMarkdownView({ sections, theme = defaultResolved, courseCode }: SyllabusMarkdownViewProps) {
-  const src = sectionsToMarkdown(sections)
+  const src = stripEditorSectionBoundaries(sectionsToMarkdown(sections))
   const reducedData = useReducedData()
   const hasMath = useMemo(() => markdownLooksLikeMath(src), [src])
   const [userForcedMath, setUserForcedMath] = useState(false)

--- a/clients/web/src/components/syllabus/syllabus-section-markdown.ts
+++ b/clients/web/src/components/syllabus/syllabus-section-markdown.ts
@@ -1,16 +1,51 @@
 import type { SyllabusSection } from '../../lib/courses-api'
 
+/**
+ * Invisible boundary between untitled sections so save → re-edit keeps them separate.
+ * Only `##` headings otherwise define section breaks; untitled bodies would merge.
+ * Stripped for student/reader display via {@link stripEditorSectionBoundaries}.
+ */
+export const EDITOR_SECTION_BOUNDARY = '<!-- lextures:section -->'
+
+const BOUNDARY_LINE_RE = /^[ \t]*<!--\s*lextures:section\s*-->[ \t]*$/
+/** Split before a section heading or an editor boundary marker. */
+const SECTION_SPLIT_RE = /\n+(?=## |<!--\s*lextures:section\s*-->)/g
+const BOUNDARY_PREFIX_RE = /^<!--\s*lextures:section\s*-->\s*/
+
+/** Remove editor-only section markers before rendering Markdown to students. */
+export function stripEditorSectionBoundaries(markdown: string): string {
+  if (!markdown.includes('lextures:section')) return markdown
+  return markdown
+    .split('\n')
+    .filter((line) => !BOUNDARY_LINE_RE.test(line))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+}
+
 /** Joins syllabus-style sections into one Markdown document (same shape the syllabus viewer uses). */
 export function sectionsToMarkdown(sections: SyllabusSection[]): string {
-  return sections
-    .map((s) => {
-      const h = s.heading.trim()
-      const body = s.markdown.replace(/\s+$/u, '')
-      if (h) return `## ${h}\n\n${body}`
-      return body
-    })
-    .filter((chunk) => chunk.trim().length > 0)
-    .join('\n\n')
+  const parts: string[] = []
+
+  for (const s of sections) {
+    const h = s.heading.trim()
+    const body = s.markdown.replace(/\s+$/u, '')
+    if (!h && !body.trim()) continue
+
+    if (h) {
+      parts.push(`## ${h}\n\n${body}`)
+      continue
+    }
+
+    // Untitled: first block is plain body (back-compat). Later untitled blocks need a
+    // marker so re-edit does not merge them into the previous section.
+    if (parts.length === 0) {
+      parts.push(body)
+    } else {
+      parts.push(`${EDITOR_SECTION_BOUNDARY}\n\n${body}`)
+    }
+  }
+
+  return parts.join('\n\n')
 }
 
 /**
@@ -21,22 +56,27 @@ export function markdownToSectionsForEditor(markdown: string, newId: () => strin
   const trimmed = markdown.trim()
   if (!trimmed) return [{ id: newId(), heading: '', markdown: '' }]
 
-  // Split by "## " at the start of a line, or double newline followed by "## "
-  // We want to be inclusive of how users might paste content.
-  // The split pattern looks for headers that would define a new section.
-  const parts = trimmed.split(/\n+(?=## )/g)
-  
+  const parts = trimmed.split(SECTION_SPLIT_RE)
   const sections: SyllabusSection[] = []
 
   for (const part of parts) {
-    const chunk = part.trim()
+    let chunk = part.trim()
     if (!chunk) continue
 
+    if (BOUNDARY_PREFIX_RE.test(chunk)) {
+      chunk = chunk.replace(BOUNDARY_PREFIX_RE, '').trim()
+      // Boundary with no body still represents a distinct empty untitled section.
+      sections.push({
+        id: newId(),
+        heading: '',
+        markdown: chunk,
+      })
+      continue
+    }
+
     if (chunk.startsWith('## ')) {
-      // Find the end of the heading line
       const firstNewline = chunk.indexOf('\n')
       if (firstNewline === -1) {
-        // Only a heading, no body
         sections.push({
           id: newId(),
           heading: chunk.slice(3).trim(),
@@ -50,7 +90,6 @@ export function markdownToSectionsForEditor(markdown: string, newId: () => strin
         })
       }
     } else {
-      // Body content without a leading heading
       sections.push({
         id: newId(),
         heading: '',

--- a/clients/web/src/components/ui/fullscreen-modal-shell.tsx
+++ b/clients/web/src/components/ui/fullscreen-modal-shell.tsx
@@ -50,9 +50,11 @@ export function FullScreenModalShell({
     '--lx-overlay-duration': `${classes.durationMs}ms`,
   } as CSSProperties
 
+  const exiting = presence.phase === 'closing'
+
   const shell = (
     <div
-      className="fixed inset-0 z-[500] flex items-center justify-center p-3 sm:p-6"
+      className={`fixed inset-0 z-[500] flex items-center justify-center p-3 sm:p-6 ${exiting ? 'pointer-events-none' : ''}`}
       role="presentation"
       style={durationStyle}
       data-overlay-phase={presence.phase}
@@ -61,8 +63,11 @@ export function FullScreenModalShell({
         <button
           type="button"
           aria-label={backdropLabel}
+          disabled={exiting}
           className={`absolute inset-0 cursor-default border-0 bg-slate-950/55 p-0 backdrop-blur-[2px] dark:bg-black/80 ${classes.scrim}`}
-          onClick={onClose}
+          onClick={() => {
+            if (!exiting) onClose()
+          }}
           tabIndex={-1}
         />
       ) : (

--- a/clients/web/src/components/ui/overlay-surface.tsx
+++ b/clients/web/src/components/ui/overlay-surface.tsx
@@ -87,9 +87,12 @@ export function OverlaySurface({
     '--lx-overlay-duration': `${durationMs}ms`,
   } as CSSProperties
 
+  // Keep exit paint for motion, but never leave an invisible full-screen hit target.
+  const exiting = presence.phase === 'closing'
+
   const shell = (
     <div
-      className={`fixed inset-0 ${zClassName} flex items-center justify-center p-4 ${className}`.trim()}
+      className={`fixed inset-0 ${zClassName} flex items-center justify-center p-4 ${exiting ? 'pointer-events-none' : ''} ${className}`.trim()}
       role="presentation"
       style={durationStyle}
       data-overlay-phase={presence.phase}
@@ -99,8 +102,11 @@ export function OverlaySurface({
         <button
           type="button"
           aria-label={backdropLabel}
+          disabled={exiting}
           className={`lex-btn-static absolute inset-0 cursor-default border-0 bg-slate-950/55 p-0 backdrop-blur-[2px] dark:bg-black/80 ${scrim} ${scrimClassName}`.trim()}
-          onClick={onClose}
+          onClick={() => {
+            if (!exiting) onClose()
+          }}
           tabIndex={-1}
         />
       ) : (

--- a/clients/web/src/lib/use-overlay-presence.ts
+++ b/clients/web/src/lib/use-overlay-presence.ts
@@ -104,13 +104,15 @@ export function useOverlayPresence({
         enabled,
         reduceMotion: reducedMotion,
       })
-      if (ms <= 0) {
+      // Failsafe: never leave phase stuck on `closing` (invisible full-screen layer).
+      const exitMs = Number.isFinite(ms) && ms >= 0 ? ms : 0
+      if (exitMs <= 0) {
         setPhase((p) => transitionOverlay(p, 'exitComplete'))
       } else {
         timerRef.current = window.setTimeout(() => {
           timerRef.current = null
           setPhase((p) => transitionOverlay(p, 'exitComplete'))
-        }, ms)
+        }, exitMs)
       }
     }
     return clearTimer

--- a/clients/web/src/pages/lms/__tests__/course-modules-reorder.test.ts
+++ b/clients/web/src/pages/lms/__tests__/course-modules-reorder.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from 'vitest'
-import { structureReorderDropAction } from '../course-modules-reorder'
+import type { CourseStructureItem } from '../../../lib/courses-api'
+import {
+  buildReorderPayloadFromItems,
+  moveChildInStructure,
+  reorderChildrenInStructure,
+  reorderModulesInStructure,
+  structureReorderDropAction,
+} from '../course-modules-reorder'
+
+function item(
+  partial: Pick<CourseStructureItem, 'id' | 'kind' | 'title' | 'parentId' | 'sortOrder'> &
+    Partial<CourseStructureItem>,
+): CourseStructureItem {
+  return {
+    published: true,
+    visibleFrom: null,
+    dueAt: null,
+    assignmentGroupId: null,
+    createdAt: '2020-01-01T00:00:00Z',
+    updatedAt: '2020-01-01T00:00:00Z',
+    ...partial,
+  }
+}
+
+function sampleStructure(): CourseStructureItem[] {
+  return [
+    item({ id: 'm1', kind: 'module', title: 'Module 1', parentId: null, sortOrder: 0 }),
+    item({ id: 'a1', kind: 'assignment', title: 'A1', parentId: 'm1', sortOrder: 1 }),
+    item({ id: 'a2', kind: 'assignment', title: 'A2', parentId: 'm1', sortOrder: 2 }),
+    item({ id: 'm2', kind: 'module', title: 'Module 2', parentId: null, sortOrder: 3 }),
+    item({ id: 'b1', kind: 'content_page', title: 'B1', parentId: 'm2', sortOrder: 4 }),
+    item({ id: 'm3', kind: 'module', title: 'Module 3 empty', parentId: null, sortOrder: 5 }),
+  ]
+}
 
 describe('structureReorderDropAction', () => {
   it('noops without a course code', () => {
@@ -55,5 +88,74 @@ describe('structureReorderDropAction', () => {
         committedDuringDrag: false,
       }),
     ).toBe('apply-over')
+  })
+})
+
+describe('reorderModulesInStructure', () => {
+  it('reorders top-level modules and keeps children nested', () => {
+    const next = reorderModulesInStructure(sampleStructure(), 'm1', 'm2')
+    expect(next).not.toBeNull()
+    const modules = next!.filter((i) => i.kind === 'module').map((m) => m.id)
+    expect(modules).toEqual(['m2', 'm1', 'm3'])
+    expect(next!.find((i) => i.id === 'a1')?.parentId).toBe('m1')
+  })
+})
+
+describe('reorderChildrenInStructure', () => {
+  it('reorders siblings within a module', () => {
+    const next = reorderChildrenInStructure(sampleStructure(), 'm1', 'a1', 'a2')
+    expect(next).not.toBeNull()
+    const m1Kids = next!.filter((i) => i.parentId === 'm1').map((c) => c.id)
+    expect(m1Kids).toEqual(['a2', 'a1'])
+  })
+})
+
+describe('moveChildInStructure', () => {
+  it('moves a child into another module before the over child', () => {
+    const next = moveChildInStructure(sampleStructure(), 'a1', 'b1', 'child')
+    expect(next).not.toBeNull()
+    expect(next!.find((i) => i.id === 'a1')?.parentId).toBe('m2')
+    const m1Kids = next!.filter((i) => i.parentId === 'm1').map((c) => c.id)
+    const m2Kids = next!.filter((i) => i.parentId === 'm2').map((c) => c.id)
+    expect(m1Kids).toEqual(['a2'])
+    expect(m2Kids).toEqual(['a1', 'b1'])
+  })
+
+  it('appends a child when dropped on a module card', () => {
+    const next = moveChildInStructure(sampleStructure(), 'a1', 'm2', 'module')
+    expect(next).not.toBeNull()
+    expect(next!.find((i) => i.id === 'a1')?.parentId).toBe('m2')
+    const m2Kids = next!.filter((i) => i.parentId === 'm2').map((c) => c.id)
+    expect(m2Kids).toEqual(['b1', 'a1'])
+  })
+
+  it('moves a child into an empty module', () => {
+    const next = moveChildInStructure(sampleStructure(), 'a2', 'm3', 'module')
+    expect(next).not.toBeNull()
+    expect(next!.find((i) => i.id === 'a2')?.parentId).toBe('m3')
+    expect(next!.filter((i) => i.parentId === 'm3').map((c) => c.id)).toEqual(['a2'])
+    expect(next!.filter((i) => i.parentId === 'm1').map((c) => c.id)).toEqual(['a1'])
+  })
+
+  it('no-ops when dropping a child onto its own module card', () => {
+    expect(moveChildInStructure(sampleStructure(), 'a1', 'm1', 'module')).toBeNull()
+  })
+
+  it('reorders within the same module via child over', () => {
+    const next = moveChildInStructure(sampleStructure(), 'a1', 'a2', 'child')
+    expect(next).not.toBeNull()
+    expect(next!.filter((i) => i.parentId === 'm1').map((c) => c.id)).toEqual(['a2', 'a1'])
+  })
+
+  it('builds a reorder payload that reflects the cross-module move', () => {
+    const next = moveChildInStructure(sampleStructure(), 'a1', 'm3', 'module')
+    expect(next).not.toBeNull()
+    const payload = buildReorderPayloadFromItems(next!)
+    expect(payload.moduleOrder).toEqual(['m1', 'm2', 'm3'])
+    expect(payload.childOrderByModule).toEqual({
+      m1: ['a2'],
+      m2: ['b1'],
+      m3: ['a1'],
+    })
   })
 })

--- a/clients/web/src/pages/lms/course-module-content-page.tsx
+++ b/clients/web/src/pages/lms/course-module-content-page.tsx
@@ -353,6 +353,7 @@ export default function CourseModuleContentPage() {
   function cancelEdit() {
     setSaveError(null)
     setBuildAiOpen(false)
+    simplifyDlg.setOpen(false)
     setEditing(false)
     setDraft([])
   }
@@ -450,6 +451,8 @@ export default function CourseModuleContentPage() {
           .catch(() => setReadingLevel(null))
       }
       setLastLocalAuthoringSave(new Date().toISOString())
+      setBuildAiOpen(false)
+      simplifyDlg.setOpen(false)
       setEditing(false)
       setDraft([])
       void loadMarkups()

--- a/clients/web/src/pages/lms/course-modules-reorder.ts
+++ b/clients/web/src/pages/lms/course-modules-reorder.ts
@@ -1,9 +1,12 @@
 /**
- * Decide what to do when a modules-page drag ends.
+ * Pure helpers for modules-page structure drag-and-drop.
  *
  * Live `onDragOver` reordering often leaves `activeId === overId` on a successful
  * drop; that must still persist, or a refresh snaps the outline back.
  */
+import { arrayMove } from '@dnd-kit/sortable'
+import type { CourseStructureItem } from '../../lib/courses-api'
+
 export type StructureReorderDropAction =
   | 'noop'
   | 'persist-current'
@@ -22,4 +25,186 @@ export function structureReorderDropAction(args: {
     return args.committedDuringDrag ? 'persist-current' : 'noop'
   }
   return 'apply-over'
+}
+
+export const STRUCTURE_CHILD_KINDS = new Set<CourseStructureItem['kind']>([
+  'heading',
+  'content_page',
+  'assignment',
+  'quiz',
+  'external_link',
+  'survey',
+  'lti_link',
+  'h5p',
+  'scorm',
+  'vibe_activity',
+  'library_resource',
+  'textbook_resource',
+])
+
+export function buildModuleChildrenMap(
+  items: CourseStructureItem[],
+): Map<string, CourseStructureItem[]> {
+  const m = new Map<string, CourseStructureItem[]>()
+  for (const i of items) {
+    if (STRUCTURE_CHILD_KINDS.has(i.kind) && i.parentId) {
+      const list = m.get(i.parentId) ?? []
+      list.push(i)
+      m.set(i.parentId, list)
+    }
+  }
+  for (const [, list] of m) {
+    list.sort((a, b) => a.sortOrder - b.sortOrder)
+  }
+  return m
+}
+
+export function findModuleIdForChildItem(
+  childId: string,
+  moduleChildrenById: Map<string, CourseStructureItem[]>,
+): string | undefined {
+  for (const [mid, list] of moduleChildrenById) {
+    if (list.some((c) => c.id === childId)) return mid
+  }
+  return undefined
+}
+
+export function flattenOrderedStructure(
+  topLevelOrdered: CourseStructureItem[],
+  childrenByModule: Map<string, CourseStructureItem[]>,
+): CourseStructureItem[] {
+  let sortOrder = 0
+  const out: CourseStructureItem[] = []
+  for (const top of topLevelOrdered) {
+    out.push({ ...top, sortOrder: sortOrder++ })
+    if (top.kind === 'module') {
+      for (const child of childrenByModule.get(top.id) ?? []) {
+        out.push({ ...child, sortOrder: sortOrder++ })
+      }
+    }
+  }
+  return out
+}
+
+export function reorderModulesInStructure(
+  items: CourseStructureItem[],
+  activeModuleId: string,
+  overModuleId: string,
+): CourseStructureItem[] | null {
+  const childrenByModule = buildModuleChildrenMap(items)
+  const topLevel = items
+    .filter((i) => !i.parentId)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+  const modules = topLevel.filter((i) => i.kind === 'module')
+  const oldIndex = modules.findIndex((m) => m.id === activeModuleId)
+  const newIndex = modules.findIndex((m) => m.id === overModuleId)
+  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return null
+
+  const nonModules = topLevel.filter((i) => i.kind !== 'module')
+  const nextModules = arrayMove(modules, oldIndex, newIndex)
+  return flattenOrderedStructure([...nonModules, ...nextModules], childrenByModule)
+}
+
+export function reorderChildrenInStructure(
+  items: CourseStructureItem[],
+  moduleId: string,
+  activeChildId: string,
+  overChildId: string,
+): CourseStructureItem[] | null {
+  const childrenByModule = buildModuleChildrenMap(items)
+  const children = [...(childrenByModule.get(moduleId) ?? [])]
+  const oldIndex = children.findIndex((c) => c.id === activeChildId)
+  const newIndex = children.findIndex((c) => c.id === overChildId)
+  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return null
+
+  childrenByModule.set(moduleId, arrayMove(children, oldIndex, newIndex))
+  const topLevel = items
+    .filter((i) => !i.parentId)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+  return flattenOrderedStructure(topLevel, childrenByModule)
+}
+
+/**
+ * Move a child item within its module or into another module.
+ * - `overType === 'module'`: append to the end of that module (or no-op if already last there).
+ * - `overType === 'child'` (or unknown but resolvable as a child): insert at that child's index.
+ */
+export function moveChildInStructure(
+  items: CourseStructureItem[],
+  activeChildId: string,
+  overId: string,
+  overType: 'child' | 'module' | undefined,
+): CourseStructureItem[] | null {
+  if (activeChildId === overId) return null
+
+  const childrenByModule = buildModuleChildrenMap(items)
+  const sourceModuleId = findModuleIdForChildItem(activeChildId, childrenByModule)
+  if (!sourceModuleId) return null
+
+  let targetModuleId: string | undefined
+  let overChildId: string | null = null
+
+  if (overType === 'module') {
+    targetModuleId = overId
+  } else if (overType === 'child') {
+    targetModuleId = findModuleIdForChildItem(overId, childrenByModule)
+    overChildId = overId
+  } else {
+    // Resolve from structure when type data is missing (keyboard / edge cases).
+    targetModuleId = findModuleIdForChildItem(overId, childrenByModule)
+    if (targetModuleId) {
+      overChildId = overId
+    } else if (items.some((i) => i.id === overId && i.kind === 'module' && !i.parentId)) {
+      targetModuleId = overId
+    }
+  }
+
+  if (!targetModuleId) return null
+
+  // Same module: reorder among siblings (or no-op when dropping on own module card).
+  if (sourceModuleId === targetModuleId) {
+    if (!overChildId) return null
+    return reorderChildrenInStructure(items, sourceModuleId, activeChildId, overChildId)
+  }
+
+  const sourceChildren = [...(childrenByModule.get(sourceModuleId) ?? [])]
+  const targetChildren = [...(childrenByModule.get(targetModuleId) ?? [])]
+  const fromIndex = sourceChildren.findIndex((c) => c.id === activeChildId)
+  if (fromIndex < 0) return null
+
+  const [moved] = sourceChildren.splice(fromIndex, 1)
+  const movedWithParent: CourseStructureItem = { ...moved, parentId: targetModuleId }
+
+  let toIndex = targetChildren.length
+  if (overChildId) {
+    const idx = targetChildren.findIndex((c) => c.id === overChildId)
+    if (idx >= 0) toIndex = idx
+  }
+  targetChildren.splice(toIndex, 0, movedWithParent)
+
+  childrenByModule.set(sourceModuleId, sourceChildren)
+  childrenByModule.set(targetModuleId, targetChildren)
+
+  const topLevel = items
+    .filter((i) => !i.parentId)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+  return flattenOrderedStructure(topLevel, childrenByModule)
+}
+
+export function buildReorderPayloadFromItems(items: CourseStructureItem[]): {
+  moduleOrder: string[]
+  childOrderByModule: Record<string, string[]>
+} {
+  const modules = items
+    .filter((i) => i.kind === 'module' && !i.parentId)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+  const moduleOrder = modules.map((m) => m.id)
+  const childOrderByModule: Record<string, string[]> = {}
+  for (const m of modules) {
+    childOrderByModule[m.id] = items
+      .filter((i) => i.parentId === m.id && STRUCTURE_CHILD_KINDS.has(i.kind))
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((c) => c.id)
+  }
+  return { moduleOrder, childOrderByModule }
 }

--- a/clients/web/src/pages/lms/course-modules.tsx
+++ b/clients/web/src/pages/lms/course-modules.tsx
@@ -22,13 +22,18 @@ import {
 } from '@dnd-kit/core'
 import {
   SortableContext,
-  arrayMove,
   useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { KeyboardSensor, defaultKeyboardSensorOptions } from '../../lib/dnd/keyboardSensorConfig'
 import { CSS, type Transform } from '@dnd-kit/utilities'
-import { structureReorderDropAction } from './course-modules-reorder'
+import {
+  buildModuleChildrenMap,
+  buildReorderPayloadFromItems,
+  moveChildInStructure,
+  reorderModulesInStructure,
+  structureReorderDropAction,
+} from './course-modules-reorder'
 import {
   AlertCircle,
   BookMarked,
@@ -140,119 +145,6 @@ const iconGhostPublished =
   'rounded-md p-2.5 text-indigo-600 transition-[background-color,color,border-color] hover:bg-indigo-50/90 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-indigo-400 dark:hover:bg-indigo-950/45 dark:hover:text-indigo-300'
 const iconGhostDraft =
   'rounded-md p-2.5 text-slate-400 transition-[background-color,color,border-color] hover:bg-slate-200/45 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-neutral-500 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-300'
-
-function findModuleIdForChildItem(
-  childId: string,
-  moduleChildrenById: Map<string, CourseStructureItem[]>,
-): string | undefined {
-  for (const [mid, list] of moduleChildrenById) {
-    if (list.some((c) => c.id === childId)) return mid
-  }
-  return undefined
-}
-
-const STRUCTURE_CHILD_KINDS = new Set<CourseStructureItem['kind']>([
-  'heading',
-  'content_page',
-  'assignment',
-  'quiz',
-  'external_link',
-  'survey',
-  'lti_link',
-  'h5p',
-  'scorm',
-  'vibe_activity',
-  'library_resource',
-  'textbook_resource',
-])
-
-function buildModuleChildrenMap(items: CourseStructureItem[]): Map<string, CourseStructureItem[]> {
-  const m = new Map<string, CourseStructureItem[]>()
-  for (const i of items) {
-    if (STRUCTURE_CHILD_KINDS.has(i.kind) && i.parentId) {
-      const list = m.get(i.parentId) ?? []
-      list.push(i)
-      m.set(i.parentId, list)
-    }
-  }
-  for (const [, list] of m) {
-    list.sort((a, b) => a.sortOrder - b.sortOrder)
-  }
-  return m
-}
-
-function flattenOrderedStructure(
-  topLevelOrdered: CourseStructureItem[],
-  childrenByModule: Map<string, CourseStructureItem[]>,
-): CourseStructureItem[] {
-  let sortOrder = 0
-  const out: CourseStructureItem[] = []
-  for (const top of topLevelOrdered) {
-    out.push({ ...top, sortOrder: sortOrder++ })
-    if (top.kind === 'module') {
-      for (const child of childrenByModule.get(top.id) ?? []) {
-        out.push({ ...child, sortOrder: sortOrder++ })
-      }
-    }
-  }
-  return out
-}
-
-function reorderModulesInStructure(
-  items: CourseStructureItem[],
-  activeModuleId: string,
-  overModuleId: string,
-): CourseStructureItem[] | null {
-  const childrenByModule = buildModuleChildrenMap(items)
-  const topLevel = items
-    .filter((i) => !i.parentId)
-    .sort((a, b) => a.sortOrder - b.sortOrder)
-  const modules = topLevel.filter((i) => i.kind === 'module')
-  const oldIndex = modules.findIndex((m) => m.id === activeModuleId)
-  const newIndex = modules.findIndex((m) => m.id === overModuleId)
-  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return null
-
-  const nonModules = topLevel.filter((i) => i.kind !== 'module')
-  const nextModules = arrayMove(modules, oldIndex, newIndex)
-  return flattenOrderedStructure([...nonModules, ...nextModules], childrenByModule)
-}
-
-function reorderChildrenInStructure(
-  items: CourseStructureItem[],
-  moduleId: string,
-  activeChildId: string,
-  overChildId: string,
-): CourseStructureItem[] | null {
-  const childrenByModule = buildModuleChildrenMap(items)
-  const children = [...(childrenByModule.get(moduleId) ?? [])]
-  const oldIndex = children.findIndex((c) => c.id === activeChildId)
-  const newIndex = children.findIndex((c) => c.id === overChildId)
-  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return null
-
-  childrenByModule.set(moduleId, arrayMove(children, oldIndex, newIndex))
-  const topLevel = items
-    .filter((i) => !i.parentId)
-    .sort((a, b) => a.sortOrder - b.sortOrder)
-  return flattenOrderedStructure(topLevel, childrenByModule)
-}
-
-function buildReorderPayloadFromItems(items: CourseStructureItem[]): {
-  moduleOrder: string[]
-  childOrderByModule: Record<string, string[]>
-} {
-  const modules = items
-    .filter((i) => i.kind === 'module' && !i.parentId)
-    .sort((a, b) => a.sortOrder - b.sortOrder)
-  const moduleOrder = modules.map((m) => m.id)
-  const childOrderByModule: Record<string, string[]> = {}
-  for (const m of modules) {
-    childOrderByModule[m.id] = items
-      .filter((i) => i.parentId === m.id && STRUCTURE_CHILD_KINDS.has(i.kind))
-      .sort((a, b) => a.sortOrder - b.sortOrder)
-      .map((c) => c.id)
-  }
-  return { moduleOrder, childOrderByModule }
-}
 
 function sortableDragStyle(
   transform: Transform | null,
@@ -1021,7 +913,7 @@ function SortableChildRow({
                   ? 'opacity-100'
                   : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
               }`}
-              aria-label="Drag to reorder item"
+              aria-label="Drag to reorder or move item to another module"
               {...listeners}
               {...attributes}
             >
@@ -1490,7 +1382,7 @@ function SortableModuleCard({
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.id,
     disabled: !canEditModules,
-    data: { type: 'module' as const },
+    data: { type: 'module' as const, moduleId: item.id },
   })
   const style = sortableDragStyle(transform, transition, isDragging)
 
@@ -1499,8 +1391,10 @@ function SortableModuleCard({
   /** Keep grips visible while a modal/overlay has focus (hover/focus-within on rows no longer applies). */
   const gripsPinned = dragHandlesVisible || anyModalBusy
 
+  // Always render a children SortableContext when expanded so items can be
+  // dropped into empty modules (not only onto the module card itself).
   const childrenList =
-    !minified && !collapsed && children.length > 0 ? (
+    !minified && !collapsed ? (
       <SortableContext
         id={`module-children-${item.id}`}
         items={childIds}
@@ -1508,7 +1402,14 @@ function SortableModuleCard({
       >
         <ul
           id={`module-items-${item.id}`}
-          className="mt-4 divide-y divide-slate-200/55 border-t border-slate-200/55 pt-4 dark:divide-neutral-700/80 dark:border-neutral-700/80"
+          className={`mt-4 border-t border-slate-200/55 pt-4 dark:border-neutral-700/80 ${
+            children.length > 0
+              ? 'divide-y divide-slate-200/55 dark:divide-neutral-700/80'
+              : 'min-h-10'
+          }`}
+          aria-label={
+            children.length === 0 ? `Drop items into ${item.title || 'module'}` : undefined
+          }
         >
           {children.map((child) => (
             <SortableChildRow
@@ -2445,32 +2346,7 @@ export default function CourseModules() {
     })
   }, [moduleIds])
 
-  const moduleChildrenById = useMemo(() => {
-    const m = new Map<string, CourseStructureItem[]>()
-    for (const i of items) {
-      if (
-        (i.kind === 'heading' ||
-          i.kind === 'content_page' ||
-          i.kind === 'assignment' ||
-          i.kind === 'quiz' ||
-          i.kind === 'external_link' ||
-          i.kind === 'survey' ||
-          i.kind === 'lti_link' ||
-          i.kind === 'h5p' ||
-          i.kind === 'scorm' ||
-          i.kind === 'vibe_activity') &&
-        i.parentId
-      ) {
-        const list = m.get(i.parentId) ?? []
-        list.push(i)
-        m.set(i.parentId, list)
-      }
-    }
-    for (const [, list] of m) {
-      list.sort((a, b) => a.sortOrder - b.sortOrder)
-    }
-    return m
-  }, [items])
+  const moduleChildrenById = useMemo(() => buildModuleChildrenMap(items), [items])
 
   const setModulePublishedState = useCallback(
     async (item: CourseStructureItem, published: boolean, includeChildren: boolean) => {
@@ -2556,8 +2432,10 @@ export default function CourseModules() {
     if (!over || active.id === over.id) return
 
     const activeType = active.data.current?.type as string | undefined
+    const overType = over.data.current?.type as 'module' | 'child' | undefined
+
     if (activeType === 'module') {
-      if (over.data.current?.type !== 'module') return
+      if (overType !== 'module') return
       setItems((prev) => {
         const next = reorderModulesInStructure(prev, String(active.id), String(over.id))
         if (!next) return prev
@@ -2568,14 +2446,30 @@ export default function CourseModules() {
     }
 
     if (activeType === 'child') {
-      const moduleId = active.data.current?.moduleId as string | undefined
-      if (!moduleId) return
+      const overModuleId =
+        (over.data.current?.moduleId as string | undefined) ??
+        (overType === 'module' ? String(over.id) : undefined)
+
+      // Expand a collapsed target module so the item can land in a visible list.
+      if (overModuleId) {
+        setCollapsedModuleIds((prev) => {
+          if (!prev.has(overModuleId)) return prev
+          const next = new Set(prev)
+          next.delete(overModuleId)
+          return next
+        })
+      }
+
+      const overIdForMove =
+        overType === 'module' ? (overModuleId ?? String(over.id)) : String(over.id)
+
       setItems((prev) => {
-        const overModuleId =
-          (over.data.current?.moduleId as string | undefined) ??
-          findModuleIdForChildItem(String(over.id), buildModuleChildrenMap(prev))
-        if (!overModuleId || moduleId !== overModuleId) return prev
-        const next = reorderChildrenInStructure(prev, moduleId, String(active.id), String(over.id))
+        const next = moveChildInStructure(
+          prev,
+          String(active.id),
+          overIdForMove,
+          overType === 'module' || overType === 'child' ? overType : undefined,
+        )
         if (!next) return prev
         dragReorderCommittedRef.current = true
         return next
@@ -2615,8 +2509,7 @@ export default function CourseModules() {
       // dropAction === 'apply-over' (over is defined)
       if (!over) return
       const overId = String(over.id)
-      const overType = over.data.current?.type as string | undefined
-      const overModuleIdFromData = over.data.current?.moduleId as string | undefined
+      const overType = over.data.current?.type as 'module' | 'child' | undefined
       const activeType = active.data.current?.type as string | undefined
       setItems((prev) => {
         let next = prev
@@ -2630,23 +2523,25 @@ export default function CourseModules() {
           const reordered = reorderModulesInStructure(prev, String(active.id), overId)
           if (reordered) next = reordered
         } else if (activeType === 'child') {
-          const moduleId = active.data.current?.moduleId as string | undefined
-          if (!moduleId) {
-            if (committedDuringDrag) {
-              void persistReorder(buildReorderPayloadFromItems(prev))
-            }
-            return prev
-          }
           const overModuleId =
-            overModuleIdFromData ?? findModuleIdForChildItem(overId, buildModuleChildrenMap(prev))
-          if (!overModuleId || moduleId !== overModuleId) {
-            if (committedDuringDrag) {
-              void persistReorder(buildReorderPayloadFromItems(prev))
-            }
+            (over.data.current?.moduleId as string | undefined) ??
+            (overType === 'module' ? overId : undefined)
+          const overIdForMove =
+            overType === 'module' ? (overModuleId ?? overId) : overId
+          const moved = moveChildInStructure(
+            prev,
+            String(active.id),
+            overIdForMove,
+            overType === 'module' || overType === 'child' ? overType : undefined,
+          )
+          if (moved) {
+            next = moved
+          } else if (committedDuringDrag) {
+            void persistReorder(buildReorderPayloadFromItems(prev))
+            return prev
+          } else {
             return prev
           }
-          const reordered = reorderChildrenInStructure(prev, moduleId, String(active.id), overId)
-          if (reordered) next = reordered
         } else {
           return prev
         }

--- a/e2e/tests/keyboard-navigation.spec.ts
+++ b/e2e/tests/keyboard-navigation.spec.ts
@@ -52,8 +52,8 @@ test.describe('CourseModules — keyboard navigation', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/modules`)
     await expect(page.getByText(seededCourse.moduleTitle)).toBeVisible({ timeout: 10000 })
 
-    // Child drag handles carry "Drag to reorder item" labels.
-    const handles = page.getByRole('button', { name: /drag to reorder item/i })
+    // Child drag handles carry "Drag to reorder … item" labels (may include move-to-module wording).
+    const handles = page.getByRole('button', { name: /drag to reorder(?: or move)? item/i })
     // There may be zero child items in the seeded course — just assert the locator pattern is valid.
     const count = await handles.count()
     if (count > 0) {

--- a/server/internal/repos/coursestructure/reorder.go
+++ b/server/internal/repos/coursestructure/reorder.go
@@ -15,10 +15,11 @@ const reorderOffset = 10_000_000
 var ErrInvalidReorder = errors.New("coursestructure: invalid reorder")
 
 // ApplyModuleAndChildOrder reassigns sort_order for top-level modules and each module's children.
-// moduleIDsInOrder must list every non-archived top-level module id. For each such module,
-// childrenByModule must list every non-archived child id in the desired order; modules with no
-// children use an empty slice (or may be omitted from the map). Archived modules and children
-// are unchanged.
+// It also reparents children when the same child id appears under a different module than before
+// (move item between modules). moduleIDsInOrder must list every non-archived top-level module id.
+// The union of childrenByModule must equal every non-archived child id in the course (each child
+// appears under exactly one module). Modules with no children use an empty slice (or may be
+// omitted from the map). Archived modules and children are unchanged.
 func ApplyModuleAndChildOrder(
 	ctx context.Context,
 	pool *pgxpool.Pool,
@@ -84,6 +85,8 @@ func ApplyModuleAndChildOrder(
 		}
 	}
 
+	// Current non-archived children: childID → parent moduleID.
+	currentChildParent := make(map[uuid.UUID]uuid.UUID)
 	for _, mid := range visibleModules {
 		childRows, err := tx.Query(ctx, `
 			SELECT id, archived
@@ -94,7 +97,6 @@ func ApplyModuleAndChildOrder(
 		if err != nil {
 			return err
 		}
-		var visibleChildIDs []uuid.UUID
 		for childRows.Next() {
 			var id uuid.UUID
 			var archived bool
@@ -103,33 +105,36 @@ func ApplyModuleAndChildOrder(
 				return err
 			}
 			if !archived {
-				visibleChildIDs = append(visibleChildIDs, id)
+				currentChildParent[id] = mid
 			}
 		}
 		childRows.Close()
 		if err := childRows.Err(); err != nil {
 			return err
 		}
+	}
 
-		visibleChildSet := make(map[uuid.UUID]struct{}, len(visibleChildIDs))
-		for _, id := range visibleChildIDs {
-			visibleChildSet[id] = struct{}{}
-		}
-		specified := childrenByModule[mid]
-		if specified == nil {
-			specified = []uuid.UUID{}
-		}
-		specSet := make(map[uuid.UUID]struct{}, len(specified))
-		for _, id := range specified {
-			specSet[id] = struct{}{}
-		}
-		if len(visibleChildSet) != len(specSet) {
+	// Requested placement: childID → new parent moduleID. Each child may appear once.
+	requestedChildParent := make(map[uuid.UUID]uuid.UUID)
+	for mid, kids := range childrenByModule {
+		if _, ok := visibleModSet[mid]; !ok {
 			return ErrInvalidReorder
 		}
-		for id := range visibleChildSet {
-			if _, ok := specSet[id]; !ok {
+		for _, cid := range kids {
+			if _, dup := requestedChildParent[cid]; dup {
 				return ErrInvalidReorder
 			}
+			requestedChildParent[cid] = mid
+		}
+	}
+	// Modules omitted from the map are treated as empty (no children requested).
+
+	if len(requestedChildParent) != len(currentChildParent) {
+		return ErrInvalidReorder
+	}
+	for cid := range currentChildParent {
+		if _, ok := requestedChildParent[cid]; !ok {
+			return ErrInvalidReorder
 		}
 	}
 
@@ -151,30 +156,32 @@ func ApplyModuleAndChildOrder(
 		}
 	}
 
+	// Bump every child (including archived) so reparent + low sort_order values cannot
+	// collide with the unique (parent_id, sort_order) index mid-update.
+	if _, err := tx.Exec(ctx, `
+		UPDATE course.course_structure_items
+		SET sort_order = sort_order + $2
+		WHERE course_id = $1 AND parent_id IS NOT NULL
+	`, courseID, reorderOffset); err != nil {
+		return err
+	}
+
 	for _, mid := range visibleModules {
 		childIDs := childrenByModule[mid]
 		if childIDs == nil {
 			childIDs = []uuid.UUID{}
 		}
-		if len(childIDs) == 0 {
-			continue
-		}
-
-		if _, err := tx.Exec(ctx, `
-			UPDATE course.course_structure_items
-			SET sort_order = sort_order + $2
-			WHERE parent_id = $1
-		`, mid, reorderOffset); err != nil {
-			return err
-		}
-
 		for ord, cid := range childIDs {
-			if _, err := tx.Exec(ctx, `
+			tag, err := tx.Exec(ctx, `
 				UPDATE course.course_structure_items
-				SET sort_order = $3
-				WHERE id = $1 AND parent_id = $2
-			`, cid, mid, ord); err != nil {
+				SET parent_id = $2, sort_order = $3
+				WHERE id = $1 AND course_id = $4 AND parent_id IS NOT NULL AND NOT archived
+			`, cid, mid, ord, courseID)
+			if err != nil {
 				return err
+			}
+			if tag.RowsAffected() != 1 {
+				return ErrInvalidReorder
 			}
 		}
 	}

--- a/server/internal/repos/coursestructure/reorder_db_test.go
+++ b/server/internal/repos/coursestructure/reorder_db_test.go
@@ -1,0 +1,147 @@
+package coursestructure
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+// TestApplyModuleAndChildOrder_MoveBetweenModules_Pg verifies children can change parent modules.
+func TestApplyModuleAndChildOrder_MoveBetweenModules_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	em := "cstruct-reorder-" + time.Now().Format("20060102150405") + "@e.com"
+	ph, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	row, err := user.InsertUser(ctx, pool, em, ph, nil)
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	uid, _ := uuid.Parse(row.ID)
+	var courseID uuid.UUID
+	cc := fmt.Sprintf("C-R%05d", time.Now().UnixNano()%100000)
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.courses (course_code, title, created_by_user_id) VALUES ($1, 'Reorder', $2) RETURNING id
+`, cc, uid).Scan(&courseID); err != nil {
+		t.Fatalf("course: %v", err)
+	}
+
+	var m1, m2, a1, a2, b1 uuid.UUID
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 0, 'module', 'M1', NULL, true, false) RETURNING id
+`, courseID).Scan(&m1); err != nil {
+		t.Fatalf("m1: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 1, 'module', 'M2', NULL, true, false) RETURNING id
+`, courseID).Scan(&m2); err != nil {
+		t.Fatalf("m2: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 0, 'assignment', 'A1', $2, true, false) RETURNING id
+`, courseID, m1).Scan(&a1); err != nil {
+		t.Fatalf("a1: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 1, 'assignment', 'A2', $2, true, false) RETURNING id
+`, courseID, m1).Scan(&a2); err != nil {
+		t.Fatalf("a2: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 0, 'content_page', 'B1', $2, true, false) RETURNING id
+`, courseID, m2).Scan(&b1); err != nil {
+		t.Fatalf("b1: %v", err)
+	}
+
+	// Move A1 from M1 to M2 (before B1).
+	err = ApplyModuleAndChildOrder(ctx, pool, courseID, []uuid.UUID{m1, m2}, map[uuid.UUID][]uuid.UUID{
+		m1: {a2},
+		m2: {a1, b1},
+	})
+	if err != nil {
+		t.Fatalf("reorder move: %v", err)
+	}
+
+	var parent uuid.UUID
+	var sortOrder int
+	if err := pool.QueryRow(ctx, `
+SELECT parent_id, sort_order FROM course.course_structure_items WHERE id = $1
+`, a1).Scan(&parent, &sortOrder); err != nil {
+		t.Fatalf("select a1: %v", err)
+	}
+	if parent != m2 {
+		t.Fatalf("a1 parent: got %s want %s", parent, m2)
+	}
+	if sortOrder != 0 {
+		t.Fatalf("a1 sort_order: got %d want 0", sortOrder)
+	}
+
+	if err := pool.QueryRow(ctx, `
+SELECT parent_id, sort_order FROM course.course_structure_items WHERE id = $1
+`, b1).Scan(&parent, &sortOrder); err != nil {
+		t.Fatalf("select b1: %v", err)
+	}
+	if parent != m2 || sortOrder != 1 {
+		t.Fatalf("b1 parent/order: %s/%d want m2/1", parent, sortOrder)
+	}
+
+	if err := pool.QueryRow(ctx, `
+SELECT parent_id, sort_order FROM course.course_structure_items WHERE id = $1
+`, a2).Scan(&parent, &sortOrder); err != nil {
+		t.Fatalf("select a2: %v", err)
+	}
+	if parent != m1 || sortOrder != 0 {
+		t.Fatalf("a2 parent/order: %s/%d want m1/0", parent, sortOrder)
+	}
+
+	// Same-module reorder still works.
+	err = ApplyModuleAndChildOrder(ctx, pool, courseID, []uuid.UUID{m1, m2}, map[uuid.UUID][]uuid.UUID{
+		m1: {a2},
+		m2: {b1, a1},
+	})
+	if err != nil {
+		t.Fatalf("same-module reorder: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+SELECT sort_order FROM course.course_structure_items WHERE id = $1
+`, a1).Scan(&sortOrder); err != nil {
+		t.Fatalf("select a1 after reorder: %v", err)
+	}
+	if sortOrder != 1 {
+		t.Fatalf("a1 sort after same-module reorder: got %d want 1", sortOrder)
+	}
+}


### PR DESCRIPTION
## Summary
- **Overlay exit hit-testing**: while dialogs/drawers/command palette close, apply `pointer-events-none` and clear `aria-modal` so an opacity-0 scrim cannot swallow shell nav / Link clicks; harden overlay presence exit timeout failsafe.
- **Cross-module structure moves**: allow dragging module children into other modules (client `moveChildInStructure` + server `ApplyModuleAndChildOrder` reparent), with unit/DB tests and e2e drag-handle label update.
- **Editor & syllabus cleanup**: clear floating editor UI and image-resize listeners on disable/unmount; close build/simplify dialogs on content save/cancel; syllabus section markdown parsing/view/editor improvements.

## Test plan
- [ ] Open/close Confirm, Input, OverlaySurface, FullScreen modal, command palette, and notifications drawer — confirm links/buttons under the exit animation remain clickable
- [ ] On Course Modules: drag a child within a module (reorder) and onto another module (reparent); refresh and verify order persists
- [ ] Collapse target module, drop a child onto it — module expands and item lands
- [ ] Content page: open Build with AI / simplify, then save or cancel — overlays close cleanly; resize a course image then save mid-drag without console errors
- [ ] Syllabus block editor: edit section markdown, switch views, confirm content round-trips
- [ ] `cd clients/web && npm run test` (confirm-dialog, modules reorder, syllabus section markdown)
- [ ] `cd server && go test ./internal/repos/coursestructure/ -count=1` (reorder + DB test when `DATABASE_URL` set)