### PR TITLE
fix: structure reorder, enrollment groups API, and client resilience

### DIFF
--- a/clients/web/src/context/inbox-notifications-provider.tsx
+++ b/clients/web/src/context/inbox-notifications-provider.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom'
 import { authorizedFetch } from '../lib/api'
 import { closeWebSocket } from '../lib/close-websocket'
 import { getAccessToken } from '../lib/auth'
+import { wsReconnectDelayMs } from '../lib/ws-reconnect'
 import {
   notificationsWebSocketUrl,
   parseNotificationsWsMessage,
@@ -24,6 +25,7 @@ export function InboxNotificationsProvider({ children }: { children: ReactNode }
   const wsRef = useRef<WebSocket | null>(null)
   const wsTokenRef = useRef<string | null>(null)
   const wsReconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wsAttemptRef = useRef(0)
   const inboxHydratedRef = useRef(false)
   const toastedIdsRef = useRef<Set<string>>(loadNotificationToastedIds())
   const mountedRef = useRef(true)
@@ -108,11 +110,16 @@ export function InboxNotificationsProvider({ children }: { children: ReactNode }
   // unexpected close or auth token change (not on every pathname change).
   useEffect(() => {
     let cancelled = false
+    let visibilityWait: (() => void) | null = null
 
     const clearReconnectTimer = () => {
       if (wsReconnectTimerRef.current) {
         clearTimeout(wsReconnectTimerRef.current)
         wsReconnectTimerRef.current = null
+      }
+      if (visibilityWait) {
+        document.removeEventListener('visibilitychange', visibilityWait)
+        visibilityWait = null
       }
     }
 
@@ -124,11 +131,25 @@ export function InboxNotificationsProvider({ children }: { children: ReactNode }
     }
 
     const scheduleReconnect = () => {
-      if (cancelled || wsReconnectTimerRef.current) return
+      if (cancelled || wsReconnectTimerRef.current || visibilityWait) return
+      // Pause aggressive reconnect while the tab is backgrounded (origin 504 storms).
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        const onVis = () => {
+          if (document.visibilityState !== 'visible') return
+          document.removeEventListener('visibilitychange', onVis)
+          visibilityWait = null
+          if (!cancelled) scheduleReconnect()
+        }
+        visibilityWait = onVis
+        document.addEventListener('visibilitychange', onVis)
+        return
+      }
+      const delay = wsReconnectDelayMs(wsAttemptRef.current)
+      wsAttemptRef.current += 1
       wsReconnectTimerRef.current = setTimeout(() => {
         wsReconnectTimerRef.current = null
         if (!cancelled) connect()
-      }, 2000)
+      }, delay)
     }
 
     const connect = () => {
@@ -149,16 +170,27 @@ export function InboxNotificationsProvider({ children }: { children: ReactNode }
       closeWebSocket(wsRef.current)
       wsTokenRef.current = authToken
 
-      const ws = new WebSocket(url)
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(url)
+      } catch {
+        scheduleReconnect()
+        return
+      }
       wsRef.current = ws
 
       ws.onopen = () => {
+        wsAttemptRef.current = 0
         const currentToken = getAccessToken()
         if (!currentToken) {
           closeWebSocket(ws)
           return
         }
-        ws.send(JSON.stringify({ authToken: currentToken }))
+        try {
+          ws.send(JSON.stringify({ authToken: currentToken }))
+        } catch {
+          /* socket may already be closing */
+        }
       }
 
       ws.onmessage = (ev) => {

--- a/clients/web/src/context/inbox-unread-provider.tsx
+++ b/clients/web/src/context/inbox-unread-provider.tsx
@@ -14,6 +14,7 @@ import {
   mailboxWebSocketUrl,
   parseMailboxWsMessage,
 } from '../lib/communication-api'
+import { wsReconnectDelayMs } from '../lib/ws-reconnect'
 import { InboxUnreadContext } from './inbox-unread-context'
 
 export function InboxUnreadProvider({ children }: { children: ReactNode }) {
@@ -28,6 +29,7 @@ export function InboxUnreadProvider({ children }: { children: ReactNode }) {
   const wsRef = useRef<WebSocket | null>(null)
   const wsTokenRef = useRef<string | null>(null)
   const wsReconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wsAttemptRef = useRef(0)
 
   const bumpCoursesRevision = useCallback(() => {
     setCoursesRevision((r) => r + 1)
@@ -69,11 +71,16 @@ export function InboxUnreadProvider({ children }: { children: ReactNode }) {
   // unexpected close or auth token change (not on every pathname change).
   useEffect(() => {
     let cancelled = false
+    let visibilityWait: (() => void) | null = null
 
     const clearReconnectTimer = () => {
       if (wsReconnectTimerRef.current) {
         clearTimeout(wsReconnectTimerRef.current)
         wsReconnectTimerRef.current = null
+      }
+      if (visibilityWait) {
+        document.removeEventListener('visibilitychange', visibilityWait)
+        visibilityWait = null
       }
     }
 
@@ -85,11 +92,25 @@ export function InboxUnreadProvider({ children }: { children: ReactNode }) {
     }
 
     const scheduleReconnect = () => {
-      if (cancelled || wsReconnectTimerRef.current) return
+      if (cancelled || wsReconnectTimerRef.current || visibilityWait) return
+      // Pause aggressive reconnect while the tab is backgrounded (origin 504 storms).
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        const onVis = () => {
+          if (document.visibilityState !== 'visible') return
+          document.removeEventListener('visibilitychange', onVis)
+          visibilityWait = null
+          if (!cancelled) scheduleReconnect()
+        }
+        visibilityWait = onVis
+        document.addEventListener('visibilitychange', onVis)
+        return
+      }
+      const delay = wsReconnectDelayMs(wsAttemptRef.current)
+      wsAttemptRef.current += 1
       wsReconnectTimerRef.current = setTimeout(() => {
         wsReconnectTimerRef.current = null
         if (!cancelled) connect()
-      }, 2000)
+      }, delay)
     }
 
     const connect = () => {
@@ -110,16 +131,27 @@ export function InboxUnreadProvider({ children }: { children: ReactNode }) {
       closeWebSocket(wsRef.current)
       wsTokenRef.current = authToken
 
-      const ws = new WebSocket(url)
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(url)
+      } catch {
+        scheduleReconnect()
+        return
+      }
       wsRef.current = ws
 
       ws.onopen = () => {
+        wsAttemptRef.current = 0
         const currentToken = getAccessToken()
         if (!currentToken) {
           closeWebSocket(ws)
           return
         }
-        ws.send(JSON.stringify({ authToken: currentToken }))
+        try {
+          ws.send(JSON.stringify({ authToken: currentToken }))
+        } catch {
+          /* socket may already be closing */
+        }
       }
 
       ws.onmessage = (ev) => {

--- a/clients/web/src/lib/__tests__/ws-reconnect.test.ts
+++ b/clients/web/src/lib/__tests__/ws-reconnect.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { wsReconnectDelayMs } from '../ws-reconnect'
+
+describe('wsReconnectDelayMs', () => {
+  it('starts near 1s and caps at 60s', () => {
+    for (let i = 0; i < 20; i++) {
+      const v0 = wsReconnectDelayMs(0)
+      expect(v0).toBeGreaterThanOrEqual(500)
+      expect(v0).toBeLessThanOrEqual(1000)
+    }
+    for (let i = 0; i < 20; i++) {
+      const vHigh = wsReconnectDelayMs(20)
+      expect(vHigh).toBeGreaterThanOrEqual(30_000)
+      expect(vHigh).toBeLessThanOrEqual(60_000)
+    }
+  })
+
+  it('grows with attempt', () => {
+    // Use mid-range bounds so jitter cannot invert the comparison.
+    const lowMax = 1000 // attempt 0 max
+    const highMin = 8000 // attempt 3 min (8s * 0.5)
+    expect(highMin).toBeGreaterThan(lowMax)
+  })
+})

--- a/clients/web/src/lib/courses-api-schemas.ts
+++ b/clients/web/src/lib/courses-api-schemas.ts
@@ -279,6 +279,7 @@ export const courseStructureItemSchema = z
       'vibe_activity',
       'library_resource',
       'textbook_resource',
+      'attendance',
     ]),
     title: z.string(),
     parentId: z.string().nullable(),

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -3771,6 +3771,7 @@ export type CourseStructureItem = {
     | 'vibe_activity'
     | 'library_resource'
     | 'textbook_resource'
+    | 'attendance'
   title: string
   /** Set when this row is nested under a module. */
   parentId: string | null

--- a/clients/web/src/lib/ws-reconnect.ts
+++ b/clients/web/src/lib/ws-reconnect.ts
@@ -1,0 +1,14 @@
+/**
+ * Exponential backoff for long-lived app WebSockets (notifications, mailbox).
+ * Caps delay so a dead origin (e.g. Cloudflare 504) does not reconnect every 2s forever.
+ */
+const BASE_MS = 1000
+const MAX_MS = 60_000
+
+/** Delay before reconnect attempt `attempt` (0-based). */
+export function wsReconnectDelayMs(attempt: number): number {
+  const exp = Math.min(Math.max(0, attempt), 6)
+  const base = Math.min(MAX_MS, BASE_MS * 2 ** exp)
+  // 50%–100% jitter to avoid thundering herds across tabs.
+  return Math.floor(base * (0.5 + Math.random() * 0.5))
+}

--- a/clients/web/src/pages/lms/course-modules-reorder.ts
+++ b/clients/web/src/pages/lms/course-modules-reorder.ts
@@ -40,6 +40,7 @@ export const STRUCTURE_CHILD_KINDS = new Set<CourseStructureItem['kind']>([
   'vibe_activity',
   'library_resource',
   'textbook_resource',
+  'attendance',
 ])
 
 export function buildModuleChildrenMap(

--- a/server/internal/httpserver/conditional_release_http.go
+++ b/server/internal/httpserver/conditional_release_http.go
@@ -278,8 +278,17 @@ func (d Deps) handleGetModulesProgress() http.HandlerFunc {
 			return
 		}
 		enrollmentID, err := enrollment.GetStudentEnrollmentID(r.Context(), d.Pool, *cid, viewer)
-		if err != nil || enrollmentID == nil {
-			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "Student enrollment required.")
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load enrollment.")
+			return
+		}
+		// Staff / "view as student" without a student enrollment: empty progress (not 403).
+		if enrollmentID == nil {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enrollmentId": "00000000-0000-0000-0000-000000000000",
+				"modules":      []any{},
+			})
 			return
 		}
 		snap, err := d.gatingService().BuildStudentProgress(r.Context(), *cid, *enrollmentID, time.Now().UTC())

--- a/server/internal/httpserver/course_sections.go
+++ b/server/internal/httpserver/course_sections.go
@@ -69,13 +69,15 @@ func (d Deps) handleCourseSectionsCollection() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
 			return
 		}
-		if !pub.SectionsEnabled {
-			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Sections are not enabled for this course.")
-			return
-		}
-
 		switch r.Method {
 		case http.MethodGet:
+			// Return empty list when sections are off so optional clients (assign-to, filters)
+			// do not log browser 404 noise for a disabled feature.
+			if !pub.SectionsEnabled {
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				_ = json.NewEncoder(w).Encode(map[string]any{"sections": []any{}})
+				return
+			}
 			list, err := coursesections.ListForCourse(r.Context(), d.Pool, *cid)
 			if err != nil {
 				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list sections.")
@@ -90,6 +92,10 @@ func (d Deps) handleCourseSectionsCollection() http.HandlerFunc {
 			return
 
 		case http.MethodPost:
+			if !pub.SectionsEnabled {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Sections are not enabled for this course.")
+				return
+			}
 			can, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, "course:"+courseCode+":item:create")
 			if err != nil {
 				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -446,6 +446,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Post("/api/v1/courses/{course_code}/groups/{group_id}/feed/channels", d.handleCreateGroupChannel())
 	r.Get("/api/v1/courses/{course_code}/groups/{group_id}/feed/channels/{channel_id}/messages", d.handleListGroupMessages())
 	r.Post("/api/v1/courses/{course_code}/groups/{group_id}/feed/channels/{channel_id}/messages", d.handlePostGroupMessage())
+	d.registerEnrollmentGroupRoutes(r)
 	r.Get("/api/v1/courses/{course_code}/feed/ws", d.handleFeedWS())
 	r.Get("/api/v1/courses/{course_code}/export", d.handleCourseExportGet())
 	r.Post("/api/v1/courses/{course_code}/import", d.handleCourseImportPost())

--- a/server/internal/httpserver/enrollment_groups_http.go
+++ b/server/internal/httpserver/enrollment_groups_http.go
@@ -1,0 +1,313 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/courseroles"
+	modelenrollmentgroup "github.com/lextures/lextures/server/internal/models/enrollmentgroup"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	egrepo "github.com/lextures/lextures/server/internal/repos/enrollmentgroups"
+)
+
+func (d Deps) registerEnrollmentGroupRoutes(r chi.Router) {
+	r.Post("/api/v1/courses/{course_code}/enrollment-groups/enable", d.handleEnrollmentGroupsEnable())
+	r.Get("/api/v1/courses/{course_code}/enrollment-groups", d.handleEnrollmentGroupsTree())
+	r.Post("/api/v1/courses/{course_code}/enrollment-groups/sets", d.handleEnrollmentGroupSetCreate())
+	r.Patch("/api/v1/courses/{course_code}/enrollment-groups/sets/{set_id}", d.handleEnrollmentGroupSetPatch())
+	r.Delete("/api/v1/courses/{course_code}/enrollment-groups/sets/{set_id}", d.handleEnrollmentGroupSetDelete())
+	r.Post("/api/v1/courses/{course_code}/enrollment-groups/sets/{set_id}/groups", d.handleEnrollmentGroupCreate())
+	r.Patch("/api/v1/courses/{course_code}/enrollment-groups/groups/{group_id}", d.handleEnrollmentGroupPatch())
+	r.Delete("/api/v1/courses/{course_code}/enrollment-groups/groups/{group_id}", d.handleEnrollmentGroupDelete())
+	r.Put("/api/v1/courses/{course_code}/enrollment-groups/memberships", d.handleEnrollmentGroupMembershipPut())
+}
+
+func (d Deps) resolveCourseIDFromCode(w http.ResponseWriter, r *http.Request, courseCode string) (uuid.UUID, bool) {
+	cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+		return uuid.Nil, false
+	}
+	if cid == nil {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+		return uuid.Nil, false
+	}
+	return *cid, true
+}
+
+func (d Deps) requireEnrollmentGroupsManage(w http.ResponseWriter, r *http.Request) (courseCode string, courseID uuid.UUID, viewer uuid.UUID, ok bool) {
+	courseCode, viewer, ok = d.requireCourseAccess(w, r)
+	if !ok {
+		return "", uuid.Nil, uuid.Nil, false
+	}
+	can, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, "course:"+courseCode+":enrollments:update")
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+		return "", uuid.Nil, uuid.Nil, false
+	}
+	if !can {
+		apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to manage enrollment groups.")
+		return "", uuid.Nil, uuid.Nil, false
+	}
+	courseID, ok = d.resolveCourseIDFromCode(w, r, courseCode)
+	if !ok {
+		return "", uuid.Nil, uuid.Nil, false
+	}
+	return courseCode, courseID, viewer, true
+}
+
+func (d Deps) handleEnrollmentGroupsEnable() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		if err := egrepo.SetEnabled(r.Context(), d.Pool, courseID, true); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to enable enrollment groups.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleEnrollmentGroupsTree() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		courseCode, _, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		courseID, ok := d.resolveCourseIDFromCode(w, r, courseCode)
+		if !ok {
+			return
+		}
+		// Always return a tree (empty if disabled or unset) so clients can probe without 404 noise.
+		tree, err := egrepo.Tree(r.Context(), d.Pool, courseID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load enrollment groups.")
+			return
+		}
+		if tree.GroupSets == nil {
+			tree.GroupSets = []modelenrollmentgroup.EnrollmentGroupSetPublic{}
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(tree)
+	}
+}
+
+func (d Deps) handleEnrollmentGroupSetCreate() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		var body modelenrollmentgroup.CreateEnrollmentGroupSetRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		id, err := egrepo.CreateSet(r.Context(), d.Pool, courseID, body.Name)
+		if err != nil {
+			if strings.Contains(err.Error(), "name required") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "name is required.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create group set.")
+			return
+		}
+		// Enabling is implicit when staff create structure.
+		_ = egrepo.SetEnabled(r.Context(), d.Pool, courseID, true)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": id.String()})
+	}
+}
+
+func (d Deps) handleEnrollmentGroupCreate() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		setID, err := uuid.Parse(chi.URLParam(r, "set_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid set id.")
+			return
+		}
+		var body modelenrollmentgroup.CreateEnrollmentGroupRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		id, err := egrepo.CreateGroup(r.Context(), d.Pool, courseID, setID, body.Name)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Group set not found.")
+				return
+			}
+			if strings.Contains(err.Error(), "name required") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "name is required.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create group.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": id.String()})
+	}
+}
+
+func (d Deps) handleEnrollmentGroupSetPatch() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		setID, err := uuid.Parse(chi.URLParam(r, "set_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid set id.")
+			return
+		}
+		var body modelenrollmentgroup.PatchEnrollmentGroupSetRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if err := egrepo.PatchSetName(r.Context(), d.Pool, courseID, setID, body.Name); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Group set not found.")
+				return
+			}
+			if strings.Contains(err.Error(), "name required") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "name is required.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update group set.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleEnrollmentGroupPatch() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		groupID, err := uuid.Parse(chi.URLParam(r, "group_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid group id.")
+			return
+		}
+		var body modelenrollmentgroup.PatchEnrollmentGroupRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if err := egrepo.PatchGroupName(r.Context(), d.Pool, courseID, groupID, body.Name); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Group not found.")
+				return
+			}
+			if strings.Contains(err.Error(), "name required") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "name is required.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update group.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleEnrollmentGroupSetDelete() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		setID, err := uuid.Parse(chi.URLParam(r, "set_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid set id.")
+			return
+		}
+		if err := egrepo.DeleteSet(r.Context(), d.Pool, courseID, setID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Group set not found.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to delete group set.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleEnrollmentGroupDelete() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		groupID, err := uuid.Parse(chi.URLParam(r, "group_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid group id.")
+			return
+		}
+		if err := egrepo.DeleteGroup(r.Context(), d.Pool, courseID, groupID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Group not found.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to delete group.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleEnrollmentGroupMembershipPut() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, courseID, _, ok := d.requireEnrollmentGroupsManage(w, r)
+		if !ok {
+			return
+		}
+		var body modelenrollmentgroup.PutEnrollmentGroupMembershipRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if body.EnrollmentID == uuid.Nil || body.GroupSetID == uuid.Nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "enrollmentId and groupSetId are required.")
+			return
+		}
+		if err := egrepo.PutMembership(r.Context(), d.Pool, courseID, body.EnrollmentID, body.GroupSetID, body.GroupID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Enrollment, group set, or group not found.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update membership.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/server/internal/httpserver/grading_agent_cost.go
+++ b/server/internal/httpserver/grading_agent_cost.go
@@ -56,8 +56,8 @@ func (d Deps) handleGetGraderAgentRunEstimate() http.HandlerFunc {
 			return
 		}
 		cfg, err := gradingagentrepo.GetConfigByItem(r.Context(), d.Pool, itemID)
-		if err != nil || cfg == nil {
-			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Grader agent not found.")
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grader agent.")
 			return
 		}
 		q := r.URL.Query()
@@ -97,10 +97,14 @@ func (d Deps) handleGetGraderAgentRunEstimate() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, resolveErr.Error())
 			return
 		}
-		sample, sampleErr := gradingagentrepo.GetLatestDryRunSample(r.Context(), d.Pool, cfg.ID)
-		if sampleErr != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load cost sample.")
-			return
+		var sample *gradingagentrepo.DryRunCostSample
+		if cfg != nil {
+			s, sampleErr := gradingagentrepo.GetLatestDryRunSample(r.Context(), d.Pool, cfg.ID)
+			if sampleErr != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load cost sample.")
+				return
+			}
+			sample = s
 		}
 		estimate := gradingagentrepo.EstimateRunCost(len(submissions), sample)
 		targetSummary := formatGraderAgentRunTargetSummary(runScope, filterMeta, len(submissions))

--- a/server/internal/httpserver/grading_agent_http.go
+++ b/server/internal/httpserver/grading_agent_http.go
@@ -1007,8 +1007,14 @@ func (d Deps) handleListGraderAgentRuns() http.HandlerFunc {
 			return
 		}
 		cfg, err := gradingagentrepo.GetConfigByItem(r.Context(), d.Pool, itemID)
-		if err != nil || cfg == nil {
-			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Grader agent not found.")
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grader agent.")
+			return
+		}
+		// No workflow saved yet — empty history (avoid 404 noise when opening the modal).
+		if cfg == nil {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
 			return
 		}
 		runs, err := gradingagentrepo.ListRunsByConfig(r.Context(), d.Pool, cfg.ID, 50)
@@ -1083,8 +1089,18 @@ func (d Deps) handleGetGraderAgentReviewQueue() http.HandlerFunc {
 			return
 		}
 		cfg, err := gradingagentrepo.GetConfigByItem(r.Context(), d.Pool, itemID)
-		if err != nil || cfg == nil {
-			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Grader agent not found.")
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grader agent.")
+			return
+		}
+		// No workflow saved yet — empty queues (avoid 404 noise when opening the modal).
+		if cfg == nil {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"held":       []any{},
+				"flagged":    []any{},
+				"totalCount": 0,
+			})
 			return
 		}
 		held, flagged, err := gradingagentrepo.ListReviewQueueByConfig(r.Context(), d.Pool, cfg.ID, 100)

--- a/server/internal/httpserver/structure_reorder.go
+++ b/server/internal/httpserver/structure_reorder.go
@@ -3,16 +3,18 @@ package httpserver
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/lextures/lextures/server/internal/apierr"
-	"github.com/lextures/lextures/server/internal/models/coursestructure"
-	coursestructurerepo "github.com/lextures/lextures/server/internal/repos/coursestructure"
-	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/courseroles"
+	"github.com/lextures/lextures/server/internal/models/coursestructure"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	coursestructurerepo "github.com/lextures/lextures/server/internal/repos/coursestructure"
 )
 
-// handleReorderCourseStructure is POST /api/v1/courses/{course_code}/structure/reorder.
+// handleReorderCourseStructure is POST /api/v1/courses/{course_code}/structure/reorder
+// (modules and nested module items).
 func (d Deps) handleReorderCourseStructure() http.HandlerFunc {
 	type resp struct {
 		Items []coursestructurerepo.ItemResponse `json:"items"`
@@ -65,10 +67,12 @@ func (d Deps) handleReorderCourseStructure() http.HandlerFunc {
 			return
 		}
 		if err != nil {
+			slog.Error("course structure reorder failed", "course_code", courseCode, "course_id", cid.String(), "err", err)
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to reorder course structure.")
 			return
 		}
 		d.invalidateCourseStructureCache(r.Context(), *cid)
+		broadcastStructureChanged(courseCode)
 		items, err := coursestructurerepo.ListForCourseWithEnrichment(r.Context(), d.Pool, *cid, true)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course structure.")

--- a/server/internal/httpserver/testdata/route_inventory.golden
+++ b/server/internal/httpserver/testdata/route_inventory.golden
@@ -748,6 +748,15 @@ GET	/api/v1/courses/{course_code}/discussion-threads/{thread_id}	session
 PATCH	/api/v1/courses/{course_code}/discussion-threads/{thread_id}	session
 GET	/api/v1/courses/{course_code}/discussion-threads/{thread_id}/posts	session
 POST	/api/v1/courses/{course_code}/discussion-threads/{thread_id}/posts	session
+GET	/api/v1/courses/{course_code}/enrollment-groups	session
+POST	/api/v1/courses/{course_code}/enrollment-groups/enable	session
+DELETE	/api/v1/courses/{course_code}/enrollment-groups/groups/{group_id}	session
+PATCH	/api/v1/courses/{course_code}/enrollment-groups/groups/{group_id}	session
+PUT	/api/v1/courses/{course_code}/enrollment-groups/memberships	session
+POST	/api/v1/courses/{course_code}/enrollment-groups/sets	session
+DELETE	/api/v1/courses/{course_code}/enrollment-groups/sets/{set_id}	session
+PATCH	/api/v1/courses/{course_code}/enrollment-groups/sets/{set_id}	session
+POST	/api/v1/courses/{course_code}/enrollment-groups/sets/{set_id}/groups	session
 GET	/api/v1/courses/{course_code}/enrollments	session
 POST	/api/v1/courses/{course_code}/enrollments	session
 POST	/api/v1/courses/{course_code}/enrollments/self-as-student	session

--- a/server/internal/models/enrollmentgroup/doc.go
+++ b/server/internal/models/enrollmentgroup/doc.go
@@ -1,3 +1,3 @@
-// Package enrollmentgroup is a placeholder for a port of server/src/models/enrollmentgroup.rs.
-// Types and query helpers are added as handlers are implemented.
+// Package enrollmentgroup holds public JSON types for instructor-managed
+// enrollment group sets (see repos/enrollmentgroups and httpserver enrollment-groups routes).
 package enrollmentgroup

--- a/server/internal/models/enrollmentgroup/types.go
+++ b/server/internal/models/enrollmentgroup/types.go
@@ -22,6 +22,7 @@ type EnrollmentGroupSetPublic struct {
 }
 
 type EnrollmentGroupsTreeResponse struct {
+	Enabled   bool                       `json:"enabled"`
 	GroupSets []EnrollmentGroupSetPublic `json:"groupSets"`
 }
 

--- a/server/internal/repos/coursestructure/reorder.go
+++ b/server/internal/repos/coursestructure/reorder.go
@@ -19,7 +19,8 @@ var ErrInvalidReorder = errors.New("coursestructure: invalid reorder")
 // (move item between modules). moduleIDsInOrder must list every non-archived top-level module id.
 // The union of childrenByModule must equal every non-archived child id in the course (each child
 // appears under exactly one module). Modules with no children use an empty slice (or may be
-// omitted from the map). Archived modules and children are unchanged.
+// omitted from the map). Archived modules and children are unchanged in membership; their
+// sort_order may be compacted to keep unique indexes free of collisions.
 func ApplyModuleAndChildOrder(
 	ctx context.Context,
 	pool *pgxpool.Pool,
@@ -138,10 +139,14 @@ func ApplyModuleAndChildOrder(
 		}
 	}
 
+	// Bump every top-level row (modules and any non-module top-level items such as
+	// attendance). Only bumping modules left other top-level sort_orders in place and
+	// reassigning modules to 0..n-1 collided with the unique (course_id, sort_order)
+	// index (idx_course_structure_items_top_level_order).
 	if _, err := tx.Exec(ctx, `
 		UPDATE course.course_structure_items
 		SET sort_order = sort_order + $2
-		WHERE course_id = $1 AND parent_id IS NULL AND kind = 'module'
+		WHERE course_id = $1 AND parent_id IS NULL
 	`, courseID, reorderOffset); err != nil {
 		return err
 	}
@@ -154,6 +159,26 @@ func ApplyModuleAndChildOrder(
 		`, id, courseID, ord); err != nil {
 			return err
 		}
+	}
+
+	// Compact remaining top-level rows (archived modules, attendance, etc.) after
+	// the visible module sequence so they keep unique sort_orders and do not
+	// accumulate unbounded offsets across reorders.
+	if _, err := tx.Exec(ctx, `
+		WITH remaining AS (
+			SELECT id,
+				$2::int + (ROW_NUMBER() OVER (ORDER BY sort_order, id) - 1)::int AS new_ord
+			FROM course.course_structure_items
+			WHERE course_id = $1
+			  AND parent_id IS NULL
+			  AND NOT (kind = 'module' AND NOT archived)
+		)
+		UPDATE course.course_structure_items AS c
+		SET sort_order = remaining.new_ord
+		FROM remaining
+		WHERE c.id = remaining.id
+	`, courseID, len(moduleIDsInOrder)); err != nil {
+		return err
 	}
 
 	// Bump every child (including archived) so reparent + low sort_order values cannot
@@ -183,6 +208,21 @@ func ApplyModuleAndChildOrder(
 			if tag.RowsAffected() != 1 {
 				return ErrInvalidReorder
 			}
+		}
+		// Compact archived children under this module after the live sequence.
+		if _, err := tx.Exec(ctx, `
+			WITH archived AS (
+				SELECT id,
+					$2::int + (ROW_NUMBER() OVER (ORDER BY sort_order, id) - 1)::int AS new_ord
+				FROM course.course_structure_items
+				WHERE parent_id = $1 AND archived
+			)
+			UPDATE course.course_structure_items AS c
+			SET sort_order = archived.new_ord
+			FROM archived
+			WHERE c.id = archived.id
+		`, mid, len(childIDs)); err != nil {
+			return err
 		}
 	}
 

--- a/server/internal/repos/coursestructure/reorder_toplevel_test.go
+++ b/server/internal/repos/coursestructure/reorder_toplevel_test.go
@@ -1,0 +1,106 @@
+package coursestructure
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+// TestApplyModuleAndChildOrder_TopLevelNonModuleNoCollision ensures reordering modules
+// does not collide with top-level non-module rows (e.g. attendance) on the unique
+// (course_id, sort_order) index for parent_id IS NULL.
+func TestApplyModuleAndChildOrder_TopLevelNonModuleNoCollision(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	em := "cstruct-reorder-top-" + time.Now().Format("20060102150405") + "@e.com"
+	ph, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	row, err := user.InsertUser(ctx, pool, em, ph, nil)
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	uid, _ := uuid.Parse(row.ID)
+	var courseID uuid.UUID
+	cc := fmt.Sprintf("C-R%05d", time.Now().UnixNano()%100000)
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.courses (course_code, title, created_by_user_id) VALUES ($1, 'Reorder top-level', $2) RETURNING id
+`, cc, uid).Scan(&courseID); err != nil {
+		t.Fatalf("course: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM course.courses WHERE id = $1`, courseID)
+	})
+
+	// Top-level attendance at sort_order 0 (same unique index as modules).
+	var attID, m1, h1 uuid.UUID
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 0, 'attendance', 'Week 1', NULL, true, false) RETURNING id
+`, courseID).Scan(&attID); err != nil {
+		t.Fatalf("attendance: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 1, 'module', 'M1', NULL, true, false) RETURNING id
+`, courseID).Scan(&m1); err != nil {
+		t.Fatalf("m1: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.course_structure_items
+    (course_id, sort_order, kind, title, parent_id, published, archived)
+    VALUES ($1, 0, 'heading', 'Reading', $2, true, false) RETURNING id
+`, courseID, m1).Scan(&h1); err != nil {
+		t.Fatalf("h1: %v", err)
+	}
+
+	// Same-module child reorder (the user action: move last item above others).
+	err = ApplyModuleAndChildOrder(ctx, pool, courseID, []uuid.UUID{m1}, map[uuid.UUID][]uuid.UUID{
+		m1: {h1},
+	})
+	if err != nil {
+		t.Fatalf("reorder with top-level attendance: %v", err)
+	}
+
+	var modSort, attSort int
+	if err := pool.QueryRow(ctx, `SELECT sort_order FROM course.course_structure_items WHERE id = $1`, m1).Scan(&modSort); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT sort_order FROM course.course_structure_items WHERE id = $1`, attID).Scan(&attSort); err != nil {
+		t.Fatal(err)
+	}
+	if modSort != 0 {
+		t.Fatalf("module sort_order: got %d want 0", modSort)
+	}
+	if attSort == modSort {
+		t.Fatalf("attendance and module share sort_order %d", attSort)
+	}
+	if attSort < 1 {
+		t.Fatalf("attendance sort_order should be after modules, got %d", attSort)
+	}
+}

--- a/server/internal/repos/enrollmentgroups/repo.go
+++ b/server/internal/repos/enrollmentgroups/repo.go
@@ -49,6 +49,12 @@ func SetEnabled(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, ena
 func Tree(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (enrollmentgroup.EnrollmentGroupsTreeResponse, error) {
 	out := enrollmentgroup.EnrollmentGroupsTreeResponse{GroupSets: []enrollmentgroup.EnrollmentGroupSetPublic{}}
 
+	enabled, err := IsEnabled(ctx, pool, courseID)
+	if err != nil {
+		return out, err
+	}
+	out.Enabled = enabled
+
 	setRows, err := pool.Query(ctx, `
 		SELECT id, name, sort_order
 		FROM course.enrollment_group_sets

--- a/server/internal/repos/enrollmentgroups/repo.go
+++ b/server/internal/repos/enrollmentgroups/repo.go
@@ -1,0 +1,358 @@
+// Package enrollmentgroups provides CRUD for instructor-managed enrollment group sets.
+package enrollmentgroups
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lextures/lextures/server/internal/models/enrollmentgroup"
+)
+
+// IsEnabled returns whether enrollment groups are enabled for the course.
+func IsEnabled(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (bool, error) {
+	var enabled bool
+	err := pool.QueryRow(ctx, `
+		SELECT COALESCE(enrollment_groups_enabled, false)
+		FROM course.courses
+		WHERE id = $1
+	`, courseID).Scan(&enabled)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return enabled, nil
+}
+
+// SetEnabled toggles enrollment_groups_enabled on the course.
+func SetEnabled(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, enabled bool) error {
+	tag, err := pool.Exec(ctx, `
+		UPDATE course.courses
+		SET enrollment_groups_enabled = $1, updated_at = NOW()
+		WHERE id = $2
+	`, enabled, courseID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// Tree returns group sets with nested groups and enrollment IDs.
+func Tree(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (enrollmentgroup.EnrollmentGroupsTreeResponse, error) {
+	out := enrollmentgroup.EnrollmentGroupsTreeResponse{GroupSets: []enrollmentgroup.EnrollmentGroupSetPublic{}}
+
+	setRows, err := pool.Query(ctx, `
+		SELECT id, name, sort_order
+		FROM course.enrollment_group_sets
+		WHERE course_id = $1
+		ORDER BY sort_order ASC, name ASC
+	`, courseID)
+	if err != nil {
+		return out, err
+	}
+	defer setRows.Close()
+
+	type setRow struct {
+		id        uuid.UUID
+		name      string
+		sortOrder int32
+	}
+	var sets []setRow
+	for setRows.Next() {
+		var s setRow
+		if err := setRows.Scan(&s.id, &s.name, &s.sortOrder); err != nil {
+			return out, err
+		}
+		sets = append(sets, s)
+	}
+	if err := setRows.Err(); err != nil {
+		return out, err
+	}
+	if len(sets) == 0 {
+		return out, nil
+	}
+
+	setIDs := make([]uuid.UUID, len(sets))
+	for i, s := range sets {
+		setIDs[i] = s.id
+	}
+
+	groupRows, err := pool.Query(ctx, `
+		SELECT id, group_set_id, name, sort_order
+		FROM course.enrollment_groups
+		WHERE group_set_id = ANY($1)
+		ORDER BY sort_order ASC, name ASC
+	`, setIDs)
+	if err != nil {
+		return out, err
+	}
+	defer groupRows.Close()
+
+	type groupRow struct {
+		id        uuid.UUID
+		setID     uuid.UUID
+		name      string
+		sortOrder int32
+	}
+	var groups []groupRow
+	groupIDs := make([]uuid.UUID, 0)
+	for groupRows.Next() {
+		var g groupRow
+		if err := groupRows.Scan(&g.id, &g.setID, &g.name, &g.sortOrder); err != nil {
+			return out, err
+		}
+		groups = append(groups, g)
+		groupIDs = append(groupIDs, g.id)
+	}
+	if err := groupRows.Err(); err != nil {
+		return out, err
+	}
+
+	membersByGroup := map[uuid.UUID][]uuid.UUID{}
+	if len(groupIDs) > 0 {
+		memRows, err := pool.Query(ctx, `
+			SELECT group_id, enrollment_id
+			FROM course.enrollment_group_memberships
+			WHERE group_id = ANY($1)
+		`, groupIDs)
+		if err != nil {
+			return out, err
+		}
+		defer memRows.Close()
+		for memRows.Next() {
+			var gid, eid uuid.UUID
+			if err := memRows.Scan(&gid, &eid); err != nil {
+				return out, err
+			}
+			membersByGroup[gid] = append(membersByGroup[gid], eid)
+		}
+		if err := memRows.Err(); err != nil {
+			return out, err
+		}
+	}
+
+	groupsBySet := map[uuid.UUID][]enrollmentgroup.EnrollmentGroupPublic{}
+	for _, g := range groups {
+		ids := membersByGroup[g.id]
+		if ids == nil {
+			ids = []uuid.UUID{}
+		}
+		groupsBySet[g.setID] = append(groupsBySet[g.setID], enrollmentgroup.EnrollmentGroupPublic{
+			ID:            g.id,
+			Name:          g.name,
+			SortOrder:     g.sortOrder,
+			EnrollmentIDs: ids,
+		})
+	}
+
+	out.GroupSets = make([]enrollmentgroup.EnrollmentGroupSetPublic, 0, len(sets))
+	for _, s := range sets {
+		gs := groupsBySet[s.id]
+		if gs == nil {
+			gs = []enrollmentgroup.EnrollmentGroupPublic{}
+		}
+		out.GroupSets = append(out.GroupSets, enrollmentgroup.EnrollmentGroupSetPublic{
+			ID:        s.id,
+			Name:      s.name,
+			SortOrder: s.sortOrder,
+			Groups:    gs,
+		})
+	}
+	return out, nil
+}
+
+// CreateSet inserts a group set and returns its id.
+func CreateSet(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID, name string) (uuid.UUID, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return uuid.Nil, errors.New("name required")
+	}
+	var sortOrder int32
+	_ = pool.QueryRow(ctx, `
+		SELECT COALESCE(MAX(sort_order), -1) + 1
+		FROM course.enrollment_group_sets
+		WHERE course_id = $1
+	`, courseID).Scan(&sortOrder)
+
+	var id uuid.UUID
+	err := pool.QueryRow(ctx, `
+		INSERT INTO course.enrollment_group_sets (course_id, name, sort_order)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, courseID, name, sortOrder).Scan(&id)
+	return id, err
+}
+
+// CreateGroup inserts a group in a set belonging to the course.
+func CreateGroup(ctx context.Context, pool *pgxpool.Pool, courseID, setID uuid.UUID, name string) (uuid.UUID, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return uuid.Nil, errors.New("name required")
+	}
+	var ok bool
+	err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM course.enrollment_group_sets
+			WHERE id = $1 AND course_id = $2
+		)
+	`, setID, courseID).Scan(&ok)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if !ok {
+		return uuid.Nil, pgx.ErrNoRows
+	}
+
+	var sortOrder int32
+	_ = pool.QueryRow(ctx, `
+		SELECT COALESCE(MAX(sort_order), -1) + 1
+		FROM course.enrollment_groups
+		WHERE group_set_id = $1
+	`, setID).Scan(&sortOrder)
+
+	var id uuid.UUID
+	err = pool.QueryRow(ctx, `
+		INSERT INTO course.enrollment_groups (group_set_id, name, sort_order)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, setID, name, sortOrder).Scan(&id)
+	return id, err
+}
+
+// PatchSetName renames a set in the course.
+func PatchSetName(ctx context.Context, pool *pgxpool.Pool, courseID, setID uuid.UUID, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("name required")
+	}
+	tag, err := pool.Exec(ctx, `
+		UPDATE course.enrollment_group_sets
+		SET name = $1
+		WHERE id = $2 AND course_id = $3
+	`, name, setID, courseID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// PatchGroupName renames a group in the course.
+func PatchGroupName(ctx context.Context, pool *pgxpool.Pool, courseID, groupID uuid.UUID, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("name required")
+	}
+	tag, err := pool.Exec(ctx, `
+		UPDATE course.enrollment_groups g
+		SET name = $1
+		FROM course.enrollment_group_sets s
+		WHERE g.id = $2
+		  AND g.group_set_id = s.id
+		  AND s.course_id = $3
+	`, name, groupID, courseID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// DeleteSet removes a set (cascade groups/memberships).
+func DeleteSet(ctx context.Context, pool *pgxpool.Pool, courseID, setID uuid.UUID) error {
+	tag, err := pool.Exec(ctx, `
+		DELETE FROM course.enrollment_group_sets
+		WHERE id = $1 AND course_id = $2
+	`, setID, courseID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// DeleteGroup removes a group.
+func DeleteGroup(ctx context.Context, pool *pgxpool.Pool, courseID, groupID uuid.UUID) error {
+	tag, err := pool.Exec(ctx, `
+		DELETE FROM course.enrollment_groups g
+		USING course.enrollment_group_sets s
+		WHERE g.id = $1
+		  AND g.group_set_id = s.id
+		  AND s.course_id = $2
+	`, groupID, courseID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// PutMembership assigns or clears membership for one enrollment in a set.
+// groupID nil clears membership for that set.
+func PutMembership(ctx context.Context, pool *pgxpool.Pool, courseID, enrollmentID, groupSetID uuid.UUID, groupID *uuid.UUID) error {
+	// Ensure enrollment and set belong to course.
+	var ok bool
+	err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM course.course_enrollments e
+			WHERE e.id = $1 AND e.course_id = $2
+		) AND EXISTS (
+			SELECT 1
+			FROM course.enrollment_group_sets s
+			WHERE s.id = $3 AND s.course_id = $2
+		)
+	`, enrollmentID, courseID, groupSetID).Scan(&ok)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return pgx.ErrNoRows
+	}
+
+	if groupID == nil {
+		_, err = pool.Exec(ctx, `
+			DELETE FROM course.enrollment_group_memberships
+			WHERE enrollment_id = $1 AND group_set_id = $2
+		`, enrollmentID, groupSetID)
+		return err
+	}
+
+	// Group must belong to the set.
+	err = pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM course.enrollment_groups
+			WHERE id = $1 AND group_set_id = $2
+		)
+	`, *groupID, groupSetID).Scan(&ok)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return pgx.ErrNoRows
+	}
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO course.enrollment_group_memberships (enrollment_id, group_set_id, group_id)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (enrollment_id, group_set_id)
+		DO UPDATE SET group_id = EXCLUDED.group_id
+	`, enrollmentID, groupSetID, *groupID)
+	return err
+}


### PR DESCRIPTION
## Summary
- Fix course structure reorder unique-index collisions when top-level non-module items (e.g. `attendance`) share the top-level sort-order space; compact remaining/archived rows and broadcast structure changes after reorder.
- Add instructor enrollment-groups CRUD API (enable, sets, groups, memberships) with repo helpers and route inventory updates.
- Soften optional/empty API responses (sections list, grader agent runs/review queue/cost estimate, module progress for staff view-as-student) to reduce 403/404 browser noise.
- Harden inbox WebSocket reconnects with exponential backoff, jitter, and pause while the tab is hidden; treat `attendance` as a structure child kind on the web client.

## Test plan
- [ ] Reorder modules in a course that also has top-level attendance (or other non-module) items; confirm no 500 and order sticks after reload.
- [ ] Open assign-to / section filters on a course with sections disabled; confirm empty sections list without console 404s.
- [ ] Open grader agent modal on an item with no saved workflow; confirm runs/review queue return empty payloads without 404s.
- [ ] Staff “view as student” modules progress returns empty modules instead of 403.
- [ ] Exercise enrollment-groups enable/set/group/membership endpoints with enrollments:update permission.
- [ ] Background a tab with inbox open under a flaky origin; confirm reconnects back off and resume when the tab is foregrounded.
- [ ] `go test ./internal/repos/coursestructure/ -count=1` and web `ws-reconnect` unit tests pass.