### PR TITLE
feat(iac): wire Stripe and Apple IAP secrets into self-aws ECS

### DIFF
--- a/iac/self-aws/README.md
+++ b/iac/self-aws/README.md
@@ -177,6 +177,26 @@ Secrets Manager secret `${project}-${environment}/app` is a JSON object. ECS inj
 | `SQS_*_URL` | Per-queue SQS URLs |
 | `STORAGE_BACKEND` | `s3` |
 | `STORAGE_BUCKET` / `STORAGE_REGION` | Course files |
+| `STRIPE_SECRET_KEY` | Stripe secret key (`stripe_secret_key` TFC var) — required for “Stripe is configured” |
+| `STRIPE_WEBHOOK_SECRET` | Webhook signing secret (`stripe_webhook_secret`) |
+| `STRIPE_MONTHLY_PRICE_ID` / `STRIPE_ANNUAL_PRICE_ID` | Stripe Price ids |
+| `APPLE_IAP_*` | StoreKit product mapping (`apple_iap_*` TFC vars) |
+
+### Stripe / Apple IAP (HCP Terraform Cloud)
+
+Workspace **Terraform variables** (not only shell `export`, and not unused env vars on the runner):
+
+| Terraform variable | Container env | Sensitive |
+|--------------------|---------------|-----------|
+| `stripe_secret_key` | `STRIPE_SECRET_KEY` | Yes |
+| `stripe_webhook_secret` | `STRIPE_WEBHOOK_SECRET` | Yes |
+| `stripe_monthly_price_id` | `STRIPE_MONTHLY_PRICE_ID` | No |
+| `stripe_annual_price_id` | `STRIPE_ANNUAL_PRICE_ID` | No |
+| `apple_iap_bundle_id` | `APPLE_IAP_BUNDLE_ID` | No |
+| `apple_iap_monthly_product_id` | `APPLE_IAP_MONTHLY_PRODUCT_ID` | No |
+| `apple_iap_annual_product_id` | `APPLE_IAP_ANNUAL_PRODUCT_ID` | No |
+
+After apply, ECS must roll a **new task definition** (this stack updates the secret + task). Confirm the API task has `STRIPE_SECRET_KEY` set. Also enable **Stripe billing** under Settings → Global platform (`ffStripeBilling`).
 
 `PLATFORM_SECRETS_KEY` is auto-generated (`random_id`, 32 bytes → base64) unless you set Terraform variable `platform_secrets_key` (e.g. `openssl rand -base64 32`). Keep it stable: rotating the key makes previously encrypted DB secrets undecryptable until they are re-entered.
 

--- a/iac/self-aws/ecs.tf
+++ b/iac/self-aws/ecs.tf
@@ -36,6 +36,7 @@ locals {
   )
 
   # Secret keys injected from the JSON blob in Secrets Manager.
+  # Must match keys written in secrets.tf (including empty billing/IAP placeholders).
   app_secret_keys = [
     "DATABASE_URL",
     "REDIS_URL",
@@ -50,6 +51,13 @@ locals {
     "STORAGE_BUCKET",
     "STORAGE_REGION",
     "AWS_REGION",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "STRIPE_MONTHLY_PRICE_ID",
+    "STRIPE_ANNUAL_PRICE_ID",
+    "APPLE_IAP_BUNDLE_ID",
+    "APPLE_IAP_MONTHLY_PRODUCT_ID",
+    "APPLE_IAP_ANNUAL_PRODUCT_ID",
   ]
 
   # Optional private-registry pull credentials (GHCR, etc.).

--- a/iac/self-aws/secrets.tf
+++ b/iac/self-aws/secrets.tf
@@ -58,6 +58,14 @@ resource "aws_secretsmanager_secret_version" "app" {
     STORAGE_BUCKET                 = aws_s3_bucket.course_files.id
     STORAGE_REGION                 = data.aws_region.current.name
     AWS_REGION                     = data.aws_region.current.name
+    # Billing / IAP — empty strings leave those features unconfigured until set in TFC.
+    STRIPE_SECRET_KEY              = var.stripe_secret_key
+    STRIPE_WEBHOOK_SECRET          = var.stripe_webhook_secret
+    STRIPE_MONTHLY_PRICE_ID        = var.stripe_monthly_price_id
+    STRIPE_ANNUAL_PRICE_ID         = var.stripe_annual_price_id
+    APPLE_IAP_BUNDLE_ID            = var.apple_iap_bundle_id
+    APPLE_IAP_MONTHLY_PRODUCT_ID   = var.apple_iap_monthly_product_id
+    APPLE_IAP_ANNUAL_PRODUCT_ID    = var.apple_iap_annual_product_id
   })
 }
 

--- a/iac/self-aws/terraform.tfvars.example
+++ b/iac/self-aws/terraform.tfvars.example
@@ -37,6 +37,18 @@ aws_region   = "us-east-1"
 # First password signup with this email gets Global Admin (only when no human users yet):
 # bootstrap_admin_email = "you@example.com"
 
+# Stripe (web checkout). Prefer HCP/TFC workspace variables (sensitive for keys).
+# Names must match these Terraform variable names — not the container env names alone.
+# stripe_secret_key       = "sk_live_..."   # sensitive
+# stripe_webhook_secret   = "whsec_..."     # sensitive
+# stripe_monthly_price_id = "price_..."
+# stripe_annual_price_id  = "price_..."
+
+# Apple IAP product mapping (iOS StoreKit). Non-sensitive product ids.
+# apple_iap_bundle_id          = "com.lextures.ios"
+# apple_iap_monthly_product_id = "com.lextures.ios.sub.monthly"
+# apple_iap_annual_product_id  = "com.lextures.ios.sub.annual"
+
 # Amazon SES (transactional email). Resources are created when ses_domain is set.
 # enable_ses   = true
 # ses_domain   = "example.com"

--- a/iac/self-aws/variables.tf
+++ b/iac/self-aws/variables.tf
@@ -129,6 +129,50 @@ variable "course_files_cors_allowed_origins" {
   default     = []
 }
 
+variable "stripe_secret_key" {
+  description = "Stripe API secret key (sk_live_… or sk_test_…). Injected as STRIPE_SECRET_KEY on the API task. Empty leaves Stripe checkout unconfigured."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "stripe_webhook_secret" {
+  description = "Stripe webhook signing secret (whsec_…). Injected as STRIPE_WEBHOOK_SECRET. Required for reliable entitlement grants after checkout."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "stripe_monthly_price_id" {
+  description = "Stripe Price id for monthly platform subscription (price_…). Injected as STRIPE_MONTHLY_PRICE_ID."
+  type        = string
+  default     = ""
+}
+
+variable "stripe_annual_price_id" {
+  description = "Stripe Price id for annual platform subscription (price_…). Injected as STRIPE_ANNUAL_PRICE_ID."
+  type        = string
+  default     = ""
+}
+
+variable "apple_iap_bundle_id" {
+  description = "iOS app bundle id for StoreKit verification (e.g. com.lextures.ios). Injected as APPLE_IAP_BUNDLE_ID."
+  type        = string
+  default     = ""
+}
+
+variable "apple_iap_monthly_product_id" {
+  description = "App Store product id for monthly access (e.g. com.lextures.ios.sub.monthly). Injected as APPLE_IAP_MONTHLY_PRODUCT_ID."
+  type        = string
+  default     = ""
+}
+
+variable "apple_iap_annual_product_id" {
+  description = "App Store product id for annual access (e.g. com.lextures.ios.sub.annual). Injected as APPLE_IAP_ANNUAL_PRODUCT_ID."
+  type        = string
+  default     = ""
+}
+
 variable "bootstrap_admin_email" {
   description = "If set, the first password signup whose email matches (case-insensitive) receives Global Admin when no human users exist yet. Empty disables bootstrap-on-signup (use server/cmd/bootstrap-admin instead)."
   type        = string


### PR DESCRIPTION
## Summary
- Add Terraform variables for Stripe (`stripe_secret_key`, webhook secret, price IDs) and Apple IAP (bundle + product IDs), with sensitive flags where appropriate.
- Write those values into the app Secrets Manager JSON and inject them as ECS task secret env vars (`STRIPE_*`, `APPLE_IAP_*`).
- Document TFC workspace variable mapping and example `tfvars` so production can enable billing without ad-hoc shell exports.

## Test plan
- [ ] `terraform validate` (or TFC plan) in `iac/self-aws` with empty defaults — apply should leave billing unconfigured.
- [ ] Set Stripe/IAP vars in TFC, apply, confirm new task definition includes `STRIPE_SECRET_KEY` and related secrets.
- [ ] After roll, API reports Stripe configured; enable `ffStripeBilling` under Global platform and smoke checkout / webhook if keys are live/test.