### PR TITLE
fix(billing): use Managed Payments–eligible Stripe tax code

### DIFF
--- a/server/internal/repos/billing/tax.go
+++ b/server/internal/repos/billing/tax.go
@@ -12,53 +12,53 @@ import (
 )
 
 const (
-	TaxTypeNone      = "none"
-	TaxTypeVAT       = "vat"
-	TaxTypeGST       = "gst"
-	TaxTypeSalesTax  = "sales_tax"
-	PriceDisplayInc  = "inclusive"
-	PriceDisplayExc  = "exclusive"
+	TaxTypeNone     = "none"
+	TaxTypeVAT      = "vat"
+	TaxTypeGST      = "gst"
+	TaxTypeSalesTax = "sales_tax"
+	PriceDisplayInc = "inclusive"
+	PriceDisplayExc = "exclusive"
 )
 
 // OrgTaxSettings is per-org tax configuration (plan 15.13).
 type OrgTaxSettings struct {
-	OrgID                     uuid.UUID
-	Enabled                   bool
-	RegisteredJurisdictions   []string
-	DefaultTaxCategory        string
-	PriceDisplay              string
-	FilingMode                string
-	RecordRetentionYears      int
-	SellerName                string
-	SellerAddress             string
-	SellerTaxID               string
-	UpdatedAt                 time.Time
+	OrgID                   uuid.UUID
+	Enabled                 bool
+	RegisteredJurisdictions []string
+	DefaultTaxCategory      string
+	PriceDisplay            string
+	FilingMode              string
+	RecordRetentionYears    int
+	SellerName              string
+	SellerAddress           string
+	SellerTaxID             string
+	UpdatedAt               time.Time
 }
 
 // TaxFields captures tax metadata stored on an entitlement.
 type TaxFields struct {
-	SubtotalCents            int
-	TaxAmountCents           int
-	TaxRate                  *float64
-	TaxJurisdiction          string
-	TaxType                  string
-	TaxInclusive             bool
-	CustomerCountry          string
-	CustomerRegion           string
-	CustomerTaxIDEnc         string
-	ReverseCharge            bool
-	StripeTaxCalculationID   string
-	InvoiceID                *uuid.UUID
+	SubtotalCents          int
+	TaxAmountCents         int
+	TaxRate                *float64
+	TaxJurisdiction        string
+	TaxType                string
+	TaxInclusive           bool
+	CustomerCountry        string
+	CustomerRegion         string
+	CustomerTaxIDEnc       string
+	ReverseCharge          bool
+	StripeTaxCalculationID string
+	InvoiceID              *uuid.UUID
 }
 
 // TaxInvoice is a tax-compliant invoice record.
 type TaxInvoice struct {
-	ID             uuid.UUID
-	EntitlementID  uuid.UUID
-	InvoiceNumber  string
-	PDFStorageKey  string
-	IssuedAt       time.Time
-	CreditedBy     *uuid.UUID
+	ID            uuid.UUID
+	EntitlementID uuid.UUID
+	InvoiceNumber string
+	PDFStorageKey string
+	IssuedAt      time.Time
+	CreditedBy    *uuid.UUID
 }
 
 // TaxReportRow aggregates tax collected for a jurisdiction and period.
@@ -89,7 +89,7 @@ WHERE org_id = $1
 	if errors.Is(err, pgx.ErrNoRows) {
 		return &OrgTaxSettings{
 			OrgID:                orgID,
-			DefaultTaxCategory:   "txcd_99999999",
+			DefaultTaxCategory:   "txcd_10103000",
 			PriceDisplay:         PriceDisplayExc,
 			FilingMode:           "manual",
 			RecordRetentionYears: 7,
@@ -110,8 +110,8 @@ func UpsertOrgTaxSettings(ctx context.Context, pool *pgxpool.Pool, s OrgTaxSetti
 	if err != nil {
 		return err
 	}
-	if s.DefaultTaxCategory == "" {
-		s.DefaultTaxCategory = "txcd_99999999"
+	if s.DefaultTaxCategory == "" || s.DefaultTaxCategory == "txcd_99999999" {
+		s.DefaultTaxCategory = "txcd_10103000"
 	}
 	if s.PriceDisplay == "" {
 		s.PriceDisplay = PriceDisplayExc

--- a/server/internal/service/billing/stripe.go
+++ b/server/internal/service/billing/stripe.go
@@ -28,30 +28,30 @@ import (
 
 // CheckoutRequest is the learner checkout payload.
 type CheckoutRequest struct {
-	UserID              uuid.UUID
-	Email               string
-	CourseID            *uuid.UUID
-	Plan                string // monthly | annual
-	PromoCode           string
-	AffiliateCode       string
-	SuccessURL          string
-	CancelURL           string
-	PlatformTaxEnabled  bool
+	UserID             uuid.UUID
+	Email              string
+	CourseID           *uuid.UUID
+	Plan               string // monthly | annual
+	PromoCode          string
+	AffiliateCode      string
+	SuccessURL         string
+	CancelURL          string
+	PlatformTaxEnabled bool
 }
 
 // CheckoutResult is a Stripe Checkout redirect.
 type CheckoutResult struct {
-	SessionID  string
+	SessionID   string
 	CheckoutURL string
 }
 
 // Config bundles Stripe credentials and price ids.
 type StripeConfig struct {
-	SecretKey         string
-	WebhookSecret     string
-	MonthlyPriceID    string
-	AnnualPriceID     string
-	PublicWebOrigin   string
+	SecretKey       string
+	WebhookSecret   string
+	MonthlyPriceID  string
+	AnnualPriceID   string
+	PublicWebOrigin string
 }
 
 // ConfigFrom merges process config for Stripe calls.
@@ -74,7 +74,7 @@ func CreateCheckoutSession(ctx context.Context, pool *pgxpool.Pool, cfg StripeCo
 	if !cfg.IsConfigured() {
 		return nil, errors.New("stripe not configured")
 	}
-	taxCode := "txcd_99999999"
+	taxCode := paymentprovider.DefaultDigitalTaxCode
 	if req.CourseID != nil {
 		price, err := repoBilling.CoursePriceByID(ctx, pool, *req.CourseID)
 		if err != nil {
@@ -82,7 +82,7 @@ func CreateCheckoutSession(ctx context.Context, pool *pgxpool.Pool, cfg StripeCo
 		}
 		if price != nil {
 			if taxEnabled, settings, _ := TaxEnabledForOrg(ctx, pool, price.OrgID, req.PlatformTaxEnabled); taxEnabled && settings != nil {
-				taxCode = settings.DefaultTaxCategory
+				taxCode = paymentprovider.NormalizeTaxCode(settings.DefaultTaxCategory)
 			}
 		}
 	}
@@ -139,7 +139,7 @@ type WebhookResult struct {
 
 // WebhookOptions configures optional post-payment side effects.
 type WebhookOptions struct {
-	RevenueShareEnabled bool
+	RevenueShareEnabled  bool
 	TaxCollectionEnabled bool
 }
 

--- a/server/internal/service/billing/transcript_checkout.go
+++ b/server/internal/service/billing/transcript_checkout.go
@@ -89,11 +89,11 @@ func StartTranscriptCheckout(
 		orgID = *o.OrgID
 	}
 	meta := map[string]string{
-		"checkout_key":         checkoutKey,
-		"entitlement_type":     EntitlementTranscriptOrder,
-		"transcript_order_id":  o.ID.String(),
-		"stripe_customer_id":   customerID,
-		"user_id":              req.UserID.String(),
+		"checkout_key":        checkoutKey,
+		"entitlement_type":    EntitlementTranscriptOrder,
+		"transcript_order_id": o.ID.String(),
+		"stripe_customer_id":  customerID,
+		"user_id":             req.UserID.String(),
 	}
 	if orgID != uuid.Nil {
 		meta["org_id"] = orgID.String()
@@ -116,7 +116,7 @@ func StartTranscriptCheckout(
 		OrgID:       orgID,
 		SuccessURL:  success,
 		CancelURL:   cancel,
-		TaxCode:     "txcd_99999999",
+		TaxCode:     paymentprovider.DefaultDigitalTaxCode,
 		Metadata:    meta,
 	})
 	if err != nil {

--- a/server/internal/service/paymentprovider/checkout.go
+++ b/server/internal/service/paymentprovider/checkout.go
@@ -63,10 +63,7 @@ func StartCheckout(ctx context.Context, pool *pgxpool.Pool, cfg Config, req Star
 		if code := strings.TrimSpace(req.AffiliateCode); code != "" {
 			meta["affiliate_code"] = code
 		}
-		taxCode := req.TaxCode
-		if taxCode == "" {
-			taxCode = "txcd_99999999"
-		}
+		taxCode := NormalizeTaxCode(req.TaxCode)
 		if providerName == ProviderStripe {
 			customerID, err := ensureStripeCustomer(ctx, pool, cfg, req.UserID, req.Email)
 			if err != nil {

--- a/server/internal/service/paymentprovider/stripe.go
+++ b/server/internal/service/paymentprovider/stripe.go
@@ -56,10 +56,7 @@ func (p *StripeProvider) CreateCheckoutSession(ctx context.Context, req Checkout
 	if currency == "" {
 		currency = "usd"
 	}
-	taxCode := req.TaxCode
-	if taxCode == "" {
-		taxCode = "txcd_99999999"
-	}
+	taxCode := NormalizeTaxCode(req.TaxCode)
 	params.PaymentIntentData = &stripe.CheckoutSessionPaymentIntentDataParams{
 		Metadata: params.Metadata,
 	}

--- a/server/internal/service/paymentprovider/types.go
+++ b/server/internal/service/paymentprovider/types.go
@@ -6,6 +6,18 @@ import (
 	"github.com/google/uuid"
 )
 
+// DefaultDigitalTaxCode is Stripe's "Software as a service (SaaS) - personal use".
+// Eligible for Managed Payments; replaces the legacy catch-all txcd_99999999.
+const DefaultDigitalTaxCode = "txcd_10103000"
+
+// NormalizeTaxCode returns a Managed Payments–eligible product tax code.
+func NormalizeTaxCode(code string) string {
+	if code == "" || code == "txcd_99999999" {
+		return DefaultDigitalTaxCode
+	}
+	return code
+}
+
 // CheckoutRequest starts a hosted checkout flow.
 type CheckoutRequest struct {
 	UserID             uuid.UUID
@@ -22,8 +34,11 @@ type CheckoutRequest struct {
 	CancelURL          string
 	Country            string
 	PlatformTaxEnabled bool
-	TaxCode            string
-	Metadata           map[string]string
+	// TaxCode is a Stripe product tax code (e.g. txcd_10103000 for SaaS personal).
+	// Empty or the legacy catch-all txcd_99999999 is replaced with DefaultDigitalTaxCode
+	// so Checkout works with Managed Payments accounts.
+	TaxCode  string
+	Metadata map[string]string
 }
 
 // SubscriptionRequest starts a recurring checkout.

--- a/server/migrations/467_stripe_managed_payments_tax_code.down.sql
+++ b/server/migrations/467_stripe_managed_payments_tax_code.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE billing.org_tax_settings
+    ALTER COLUMN default_tax_category SET DEFAULT 'txcd_99999999';
+
+-- Do not rewrite rows back to the ineligible code; leave corrected values in place.

--- a/server/migrations/467_stripe_managed_payments_tax_code.sql
+++ b/server/migrations/467_stripe_managed_payments_tax_code.sql
@@ -1,0 +1,11 @@
+-- Managed Payments rejects the legacy catch-all tax code txcd_99999999.
+-- Default digital LMS sales to SaaS personal (txcd_10103000), which is eligible.
+
+ALTER TABLE billing.org_tax_settings
+    ALTER COLUMN default_tax_category SET DEFAULT 'txcd_10103000';
+
+UPDATE billing.org_tax_settings
+SET default_tax_category = 'txcd_10103000'
+WHERE default_tax_category IS NULL
+   OR btrim(default_tax_category) = ''
+   OR default_tax_category = 'txcd_99999999';


### PR DESCRIPTION
## Summary
- Replace the legacy catch-all product tax code `txcd_99999999` with Stripe’s SaaS personal code `txcd_10103000`, which is eligible for Managed Payments.
- Centralize default/normalization in `paymentprovider` (`DefaultDigitalTaxCode`, `NormalizeTaxCode`) and use it for course checkout, transcript checkout, and empty/legacy tax codes.
- Migration 467 updates `billing.org_tax_settings` default and rewrites empty/legacy rows so existing orgs don’t keep an ineligible code.

## Test plan
- [ ] Apply migration 467 and confirm `default_tax_category` default is `txcd_10103000` and legacy rows are updated
- [ ] Start a course checkout with Stripe Managed Payments enabled and confirm session creates without tax-code rejection
- [ ] Start a transcript checkout and confirm the same tax code path
- [ ] Org tax settings with empty or `txcd_99999999` normalize to `txcd_10103000` on upsert/read defaults
- [ ] Custom non-legacy tax codes are left unchanged by `NormalizeTaxCode`