### PR TITLE
feat(marketing): repair all article findings in one AI pass

### DIFF
--- a/clients/web/src/components/marketing-content/editor/__tests__/article-finding-nav.test.ts
+++ b/clients/web/src/components/marketing-content/editor/__tests__/article-finding-nav.test.ts
@@ -5,6 +5,7 @@ import {
   findingLocationLabel,
   markdownLineRange,
   mergeRepairDraft,
+  solveAllFindings,
   solveFindingsSequentially,
   visibleLineSnippet,
 } from '../article-finding-nav'
@@ -70,6 +71,39 @@ describe('article finding navigation', () => {
       pillar: 'Old pillar',
       keywords: ['attention', 'classroom'],
     })
+  })
+
+  it('repairs every finding in a single pass', async () => {
+    const result = await solveAllFindings({
+      article: {
+        kind: 'blog',
+        title: 'Old title',
+        slug: 'old-title',
+        description: 'Old description',
+        bodyMd: 'Old body',
+        primaryQuestion: '',
+        cluster: '',
+        pillar: '',
+        keywords: [],
+      },
+      findings: [
+        { rule: 'passage.length', severity: 'warning', message: 'Direct answer is 69 words; target is 40-60.', line: 10 },
+        { rule: 'extractability.score', severity: 'warning', message: 'Extractability score 3.5 is below 8.0.', line: 1 },
+      ],
+      repair: async (article, findings) => ({
+        title: article.title,
+        slug: article.slug,
+        description: article.description,
+        bodyMd: `fixed:${findings.map((finding) => finding.rule).join(',')}`,
+        primaryQuestion: article.primaryQuestion,
+        cluster: article.cluster,
+        pillar: article.pillar,
+        keywords: article.keywords,
+      }),
+    })
+    expect(result.applied).toBe(2)
+    expect(result.error).toBeUndefined()
+    expect(result.article.bodyMd).toBe('fixed:passage.length,extractability.score')
   })
 
   it('walks every finding, including warnings, and applies each repair', async () => {

--- a/clients/web/src/components/marketing-content/editor/__tests__/article-findings-bar.test.tsx
+++ b/clients/web/src/components/marketing-content/editor/__tests__/article-findings-bar.test.tsx
@@ -35,7 +35,7 @@ describe('ArticleFindingsBar', () => {
     expect(screen.getByText('FAQ must contain 3–6 questions; found 0.')).toBeInTheDocument()
     expect(screen.queryByText('5 blocking')).not.toBeInTheDocument()
     expect(screen.getByText('1 blocking')).toBeInTheDocument()
-    expect(screen.getByText('1 warning')).toBeInTheDocument()
+    expect(screen.getByText('1 suggestion')).toBeInTheDocument()
     expect(screen.getByText('/ 8.0 floor')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /Required metadata field is missing/i }))

--- a/clients/web/src/components/marketing-content/editor/article-finding-nav.ts
+++ b/clients/web/src/components/marketing-content/editor/article-finding-nav.ts
@@ -113,6 +113,28 @@ function draftLooksEmpty(draft: MarketingArticleAIDraft): boolean {
   return !draft.bodyMd.trim() && !draft.title.trim() && !draft.description.trim() && !draft.cluster.trim() && !draft.primaryQuestion.trim()
 }
 
+/** Send every finding in one repair request so a single model pass can fix them together. */
+export async function solveAllFindings(input: {
+  article: RepairableArticle
+  findings: MarketingFinding[]
+  repair: (article: RepairableArticle, findings: MarketingFinding[]) => Promise<MarketingArticleAIDraft>
+  onProgress?: (total: number) => void
+}): Promise<{ article: RepairableArticle; applied: number; error?: string }> {
+  if (!input.findings.length) return { article: input.article, applied: 0 }
+  input.onProgress?.(input.findings.length)
+  let draft: MarketingArticleAIDraft
+  try {
+    draft = await input.repair(input.article, input.findings)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Could not solve findings with AI.'
+    return { article: input.article, applied: 0, error: detail }
+  }
+  if (draftLooksEmpty(draft)) {
+    return { article: input.article, applied: 0, error: 'AI did not return a usable revision.' }
+  }
+  return { article: { ...input.article, ...mergeRepairDraft(input.article, draft) }, applied: input.findings.length }
+}
+
 /** Walk each finding in order, apply the returned draft, and continue with the updated article. */
 export async function solveFindingsSequentially(input: {
   article: RepairableArticle

--- a/clients/web/src/components/marketing-content/editor/article-findings-bar.tsx
+++ b/clients/web/src/components/marketing-content/editor/article-findings-bar.tsx
@@ -57,7 +57,7 @@ export function ArticleFindingsBar({
           <span className="hidden text-xs text-fg-muted sm:inline">/ 8.0 floor</span>
           <span className="ms-auto flex items-center gap-2">
             {blocking.length ? <Badge tone="danger">{blocking.length} blocking</Badge> : null}
-            {warnings.length ? <Badge tone="warning">{warnings.length} warning{warnings.length === 1 ? '' : 's'}</Badge> : null}
+            {warnings.length ? <Badge tone="warning">{warnings.length} suggestion{warnings.length === 1 ? '' : 's'}</Badge> : null}
             {!findings.length ? <span className="text-xs text-fg-muted">{score == null ? 'Not checked yet' : 'No findings'}</span> : null}
             <ChevronDown aria-hidden className={`h-4 w-4 text-fg-muted motion-safe:transition-transform ${open ? '' : 'rotate-180'}`} />
           </span>
@@ -72,7 +72,7 @@ export function ArticleFindingsBar({
       {open ? (
         <div className="max-h-64 overflow-y-auto border-t border-border-subtle px-4 py-3 sm:px-6">
           {solveError ? <InlineAlert tone="danger" className="mb-3">{solveError}</InlineAlert> : null}
-          {solving ? <p role="status" className="mb-2 text-xs text-fg-muted">{solveProgress || `Solving ${findings.length} finding${findings.length === 1 ? '' : 's'} with AI, including warnings…`}</p> : null}
+          {solving ? <p role="status" className="mb-2 text-xs text-fg-muted">{solveProgress || `Solving ${findings.length} finding${findings.length === 1 ? '' : 's'} with AI…`}</p> : null}
           {findings.length ? (
             <ul className="space-y-1.5">
               {findings.map((finding, index) => {
@@ -80,7 +80,7 @@ export function ArticleFindingsBar({
                 const location = findingLocationLabel(finding)
                 const template = directiveTemplateForFinding(finding.rule)
                 const canInsert = Boolean(template && !bodyHasDirective(bodyMd, finding.rule))
-                const label = [isBlockingFinding(finding.severity) ? 'Error' : 'Warning', finding.message, location].filter(Boolean).join('. ')
+                const label = [isBlockingFinding(finding.severity) ? 'Error' : 'Suggestion', finding.message, location].filter(Boolean).join('. ')
                 const active = solving && solvingFindingKey === key
                 return (
                   <li key={key} className={`flex flex-wrap items-start gap-2 ${active ? 'rounded-lg bg-accent-surface' : ''}`}>
@@ -91,7 +91,7 @@ export function ArticleFindingsBar({
                       onClick={() => onSelectFinding(finding)}
                       aria-label={`${label}. Jump to this finding.`}
                     >
-                      <Badge tone={isBlockingFinding(finding.severity) ? 'danger' : 'warning'}>{isBlockingFinding(finding.severity) ? 'Error' : 'Warning'}</Badge>
+                      <Badge tone={isBlockingFinding(finding.severity) ? 'danger' : 'warning'}>{isBlockingFinding(finding.severity) ? 'Error' : 'Suggestion'}</Badge>
                       <span className="min-w-0 flex-1">
                         <span className="block text-sm text-fg-default">{finding.message || finding.rule}</span>
                         <span className="mt-0.5 block font-mono text-xs text-fg-muted">

--- a/clients/web/src/lib/__tests__/marketing-content-ai-api.test.ts
+++ b/clients/web/src/lib/__tests__/marketing-content-ai-api.test.ts
@@ -62,4 +62,36 @@ describe('repairMarketingArticle', () => {
       }),
     )
   })
+
+  it('retries a transient 503 once for repair', async () => {
+    authorizedFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          title: 'Fixed',
+          slug: 'fixed',
+          description: 'Desc',
+          bodyMd: ':::answer\nYes.\n:::',
+          primaryQuestion: 'Q?',
+          cluster: 'C',
+          pillar: 'P',
+          keywords: ['k'],
+        }),
+      })
+
+    const draft = await repairMarketingArticle({
+      kind: 'blog',
+      existingTitle: 'Old',
+      existingBodyMd: 'Body',
+      findings: [{ rule: 'extractability.score', severity: 'warning', message: 'low' }],
+    })
+
+    expect(draft.title).toBe('Fixed')
+    expect(authorizedFetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/clients/web/src/lib/marketing-content-ai-api.ts
+++ b/clients/web/src/lib/marketing-content-ai-api.ts
@@ -13,6 +13,27 @@ export type MarketingArticleAIDraft = {
   keywords: string[]
 }
 
+function draftFromBody(body: Partial<MarketingArticleAIDraft>): MarketingArticleAIDraft {
+  return {
+    title: body.title ?? '',
+    slug: body.slug ?? '',
+    description: body.description ?? '',
+    bodyMd: body.bodyMd ?? '',
+    primaryQuestion: body.primaryQuestion ?? '',
+    cluster: body.cluster ?? '',
+    pillar: body.pillar ?? '',
+    keywords: Array.isArray(body.keywords) ? body.keywords.filter(Boolean) : [],
+  }
+}
+
+function generateErrorMessage(status: number, body: unknown): string {
+  const message = readApiErrorMessage(body)
+  if (message !== 'Request failed') return message
+  if (status === 503 || status === 502) return 'AI is temporarily unavailable. Try Solve with AI again.'
+  if (status === 429) return 'Too many AI requests. Wait a moment and try again.'
+  return `Request failed (${status}). Try Solve with AI again.`
+}
+
 /** POST `/api/v1/admin/marketing/articles/generate` — draft fields only (not persisted). */
 export async function generateMarketingArticle(input: {
   prompt?: string
@@ -28,24 +49,20 @@ export async function generateMarketingArticle(input: {
   knownPaths?: string[]
   findings?: Array<Pick<MarketingFinding, 'rule' | 'severity' | 'message' | 'line' | 'path'>>
 }): Promise<MarketingArticleAIDraft> {
-  const res = await authorizedFetch('/api/v1/admin/marketing/articles/generate', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
-  })
-  const body = await res.json().catch(() => ({}))
-  if (!res.ok) throw new Error(readApiErrorMessage(body))
-  const value = body as Partial<MarketingArticleAIDraft>
-  return {
-    title: value.title ?? '',
-    slug: value.slug ?? '',
-    description: value.description ?? '',
-    bodyMd: value.bodyMd ?? '',
-    primaryQuestion: value.primaryQuestion ?? '',
-    cluster: value.cluster ?? '',
-    pillar: value.pillar ?? '',
-    keywords: Array.isArray(value.keywords) ? value.keywords.filter(Boolean) : [],
+  const attempts = input.mode === 'repair' ? 2 : 1
+  let lastError: Error | null = null
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const res = await authorizedFetch('/api/v1/admin/marketing/articles/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    const body = await res.json().catch(() => ({}))
+    if (res.ok) return draftFromBody(body as Partial<MarketingArticleAIDraft>)
+    lastError = new Error(generateErrorMessage(res.status, body))
+    if (res.status !== 502 && res.status !== 503) break
   }
+  throw lastError ?? new Error('Request failed')
 }
 
 /** Fill slug, description, and search metadata from the current title/body. */

--- a/clients/web/src/pages/admin/marketing-content/article-editor-page.tsx
+++ b/clients/web/src/pages/admin/marketing-content/article-editor-page.tsx
@@ -7,7 +7,7 @@ import { ArticlePreview } from '../../../components/marketing-content/editor/art
 import { EditorPane } from '../../../components/marketing-content/editor/article-editor-pane'
 import { TranslationSourcePane } from '../../../components/marketing-content/editor/translation-source-pane'
 import { directives, isBlockingFinding, lintMetadata, slugify, writePayload } from '../../../components/marketing-content/editor/article-editor-utils'
-import { METADATA_FINDING_PATHS, findingKey, jumpEditorToMarkdownLine, selectTextareaLine, solveFindingsSequentially } from '../../../components/marketing-content/editor/article-finding-nav'
+import { METADATA_FINDING_PATHS, findingKey, jumpEditorToMarkdownLine, selectTextareaLine, solveAllFindings } from '../../../components/marketing-content/editor/article-finding-nav'
 import { ArticleFindingsBar } from '../../../components/marketing-content/editor/article-findings-bar'
 import { BuildArticleWithAiModal } from '../../../components/marketing-content/editor/build-article-with-ai-modal'
 import { RevisionDrawer } from '../../../components/marketing-content/editor/revision-drawer'
@@ -232,14 +232,14 @@ export default function ArticleEditorPage() {
     setSolveProgress('')
     setFindingsOpen(true)
     try {
-      const result = await solveFindingsSequentially({
+      const result = await solveAllFindings({
         article: articleRef.current,
         findings: snapshot,
-        onProgress: (index, total, finding) => {
-          setSolvingFindingKey(findingKey(finding, index))
-          setSolveProgress(`Solving ${index + 1} of ${total}: ${finding.message || finding.rule}`)
+        onProgress: (total) => {
+          setSolvingFindingKey(findingKey(snapshot[0], 0))
+          setSolveProgress(`Solving ${total} finding${total === 1 ? '' : 's'} with AI…`)
         },
-        repair: (current, finding) => repairMarketingArticle({
+        repair: (current, findings) => repairMarketingArticle({
           kind: current.kind,
           existingTitle: current.title,
           existingBodyMd: current.bodyMd,
@@ -249,13 +249,13 @@ export default function ArticleEditorPage() {
           pillar: current.pillar,
           keywords: current.keywords,
           knownPaths,
-          findings: [{
+          findings: findings.map((finding) => ({
             rule: finding.rule,
             severity: finding.severity,
             message: finding.message,
             line: finding.line,
             path: finding.path,
-          }],
+          })),
         }),
       })
       articleRef.current = { ...articleRef.current, ...result.article }
@@ -469,9 +469,9 @@ export default function ArticleEditorPage() {
       onClose={() => setTransition(null)}
       title={`${transition?.replaceAll('_', ' ') ?? ''} article`}
       description={blocking.length && (transition === 'publish' || transition === 'schedule')
-        ? `${blocking.length} blocking finding(s) must be resolved before publishing.`
+        ? `${blocking.length} finding(s) would normally block publishing. Override to continue, or resolve them in Quality.`
         : 'This action is recorded in the article history.'}
-      footer={<><Button variant="secondary" onClick={() => setTransition(null)}>Cancel</Button><Button disabled={Boolean((transition === 'schedule' && !scheduledFor) || (blocking.length && (transition === 'publish' || transition === 'schedule') && (!lintOverride || actionNote.trim().length < 20)))} onClick={() => void doTransition()}>Confirm</Button></>}
+      footer={<><Button variant="secondary" onClick={() => setTransition(null)}>Cancel</Button><Button disabled={Boolean((transition === 'schedule' && !scheduledFor) || (blocking.length && (transition === 'publish' || transition === 'schedule') && !lintOverride))} onClick={() => void doTransition()}>Confirm</Button></>}
     >
       <div className="space-y-3">
         {blocking.length && (transition === 'publish' || transition === 'schedule') ? (
@@ -487,7 +487,7 @@ export default function ArticleEditorPage() {
         ) : null}
         {transition === 'schedule' ? <label className="block text-sm font-medium">Publish date and time<Input className="mt-1" type="datetime-local" value={scheduledFor} onChange={(e) => setScheduledFor(e.target.value)} /></label> : null}
         <label className="block text-sm font-medium">Change note<Textarea className="mt-1" value={actionNote} onChange={(e) => setActionNote(e.target.value)} /></label>
-        {blocking.length && (transition === 'publish' || transition === 'schedule') && canPublish ? <Checkbox checked={lintOverride} onChange={(e) => setLintOverride(e.target.checked)} label="Override validation" description="Requires a justification of at least 20 characters in the change note." /> : null}
+        {blocking.length && (transition === 'publish' || transition === 'schedule') && canPublish ? <Checkbox checked={lintOverride} onChange={(e) => setLintOverride(e.target.checked)} label="Override validation" description="Publish despite remaining validation findings. A change note is optional." /> : null}
       </div>
     </Dialog>
   </main>

--- a/server/internal/httpserver/marketing_content_errors.go
+++ b/server/internal/httpserver/marketing_content_errors.go
@@ -18,7 +18,7 @@ func writeMarketingError(w http.ResponseWriter, r *http.Request, err error) {
 		apierr.WriteJSON(w, 404, apierr.CodeNotFound, "Marketing content resource not found.")
 	case errors.Is(err, mcrepo.ErrDuplicateSlug):
 		apierr.WriteJSON(w, 409, "duplicate_slug", "An article or redirect already uses that path.")
-	case errors.Is(err, mcservice.ErrInvalidTransition), errors.Is(err, mcservice.ErrScheduledInPast), errors.Is(err, mcservice.ErrReviewNoteTooShort), errors.Is(err, mcservice.ErrReviewerRequired), errors.Is(err, mcservice.ErrOverrideJustification):
+	case errors.Is(err, mcservice.ErrInvalidTransition), errors.Is(err, mcservice.ErrScheduledInPast), errors.Is(err, mcservice.ErrReviewNoteTooShort), errors.Is(err, mcservice.ErrReviewerRequired):
 		apierr.WriteJSON(w, 422, apierr.CodeUnprocessableEntity, err.Error())
 	case errors.Is(err, mcservice.ErrLintBlocked):
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/server/internal/service/marketingarticleai/repair.go
+++ b/server/internal/service/marketingarticleai/repair.go
@@ -137,19 +137,31 @@ func RepairFromFindings(
 		fmt.Fprintf(&user, "\nCurrent draft:\n%s", in.BodyMD)
 	}
 
-	res, meta, err := client.Complete(ctx, model, []aiprovider.Message{
+	messages := []aiprovider.Message{
 		{Role: "system", Content: RepairSystemPrompt},
 		{Role: "user", Content: user.String()},
-	}, aiprovider.ChatOptions{JSONMode: true, MaxTokens: 8_000})
+	}
+	opts := aiprovider.ChatOptions{JSONMode: true, MaxTokens: repairMaxTokens}
+	res, meta, err := client.Complete(ctx, model, messages, opts)
 	if err != nil {
 		return Draft{}, meta, err
 	}
 	draft, err := ParseDraftJSON(res.Text)
 	if err != nil {
-		return Draft{}, meta, err
+		// One retry: models intermittently return truncated or non-JSON text.
+		res, meta, err = client.Complete(ctx, model, messages, opts)
+		if err != nil {
+			return Draft{}, meta, err
+		}
+		draft, err = ParseDraftJSON(res.Text)
+		if err != nil {
+			return Draft{}, meta, err
+		}
 	}
 	return draft, meta, nil
 }
+
+const repairMaxTokens = 12_000
 
 const maxRepairKnownPaths = 80
 

--- a/server/internal/service/marketingarticleai/service_test.go
+++ b/server/internal/service/marketingarticleai/service_test.go
@@ -164,7 +164,7 @@ func TestRepairFromFindings(t *testing.T) {
 		if !strings.Contains(user, "/blog") || !strings.Contains(user, "always resolve") {
 			t.Fatalf("expected hub paths to be treated as valid: %q", user)
 		}
-		if len(opts) == 0 || !opts[0].JSONMode || opts[0].MaxTokens != 8_000 {
+		if len(opts) == 0 || !opts[0].JSONMode || opts[0].MaxTokens != 12_000 {
 			t.Fatalf("opts=%#v", opts)
 		}
 		return aiprovider.ChatResult{Text: `{"title":"Fixed","description":"D","primaryQuestion":"Q?","cluster":"C","pillar":"P","keywords":["k"],"bodyMd":":::answer\nYes.\n:::"}`}, aiprovider.CallMeta{ModelID: model}, nil
@@ -184,6 +184,28 @@ func TestRepairFromFindings(t *testing.T) {
 	}
 	if got.Title != "Fixed" || got.BodyMD == "" || meta.ModelID != "test-model" {
 		t.Fatalf("got %#v meta=%#v", got, meta)
+	}
+}
+
+func TestRepairFromFindings_RetriesInvalidJSON(t *testing.T) {
+	calls := 0
+	ai := mockCompleter{fn: func(ctx context.Context, model string, messages []aiprovider.Message, opts ...aiprovider.ChatOptions) (aiprovider.ChatResult, aiprovider.CallMeta, error) {
+		calls++
+		if calls == 1 {
+			return aiprovider.ChatResult{Text: "not json"}, aiprovider.CallMeta{ModelID: model}, nil
+		}
+		return aiprovider.ChatResult{Text: `{"title":"Fixed","description":"D","primaryQuestion":"Q?","cluster":"C","pillar":"P","keywords":["k"],"bodyMd":":::answer\nYes.\n:::"}`}, aiprovider.CallMeta{ModelID: model}, nil
+	}}
+	got, _, err := RepairFromFindings(context.Background(), ai, "test-model", RepairInput{
+		Title:    "Old",
+		BodyMD:   ":::answer\nToo long.\n:::",
+		Findings: []Finding{{Rule: "passage.length", Message: "too long"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || got.Title != "Fixed" {
+		t.Fatalf("calls=%d got=%#v", calls, got)
 	}
 }
 

--- a/server/internal/service/marketingcontent/service.go
+++ b/server/internal/service/marketingcontent/service.go
@@ -38,7 +38,6 @@ type TransitionInput struct {
 var ErrLintBlocked = errors.New("marketingcontent: publish blocked by content validation")
 var ErrReviewNoteTooShort = errors.New("marketingcontent: request-changes note must be at least 10 characters")
 var ErrReviewerRequired = errors.New("marketingcontent: reviewer assignment is required")
-var ErrOverrideJustification = errors.New("marketingcontent: publish override justification must be at least 10 characters")
 
 // LintBlockedError carries the quality report that blocked publish/schedule.
 type LintBlockedError struct {
@@ -196,9 +195,6 @@ func (s *Service) Transition(ctx context.Context, id, actor uuid.UUID, in Transi
 		blocked := (in.Action == ActionPublish || in.Action == ActionSchedule) && blocksPublish(report)
 		if blocked && !in.LintOverride {
 			return &LintBlockedError{Report: report}
-		}
-		if blocked && in.LintOverride && len(strings.TrimSpace(in.Note)) < 10 {
-			return ErrOverrideJustification
 		}
 		if in.Action == ActionRequestChanges && len(strings.TrimSpace(in.Note)) < 10 {
 			return ErrReviewNoteTooShort

--- a/server/internal/service/marketingcontent/validate/validate.go
+++ b/server/internal/service/marketingcontent/validate/validate.go
@@ -88,12 +88,9 @@ func Article(in Input) (out Report) {
 	for _, r := range rules {
 		out.Findings = append(out.Findings, r.check(in, a)...)
 	}
-	sev := "warn"
-	if out.Score < 6 {
-		sev = "error"
-	}
+	// Extractability is advisory and never blocks publish.
 	if out.Score < 8 {
-		out.Findings = append(out.Findings, Finding{Rule: "extractability.score", Severity: sev, Message: fmt.Sprintf("Extractability score %.1f is below 8.0.", out.Score), Line: 1, Column: 1})
+		out.Findings = append(out.Findings, Finding{Rule: "extractability.score", Severity: "warn", Message: fmt.Sprintf("Extractability score %.1f is below 8.0.", out.Score), Line: 1, Column: 1})
 	}
 	return
 }

--- a/server/internal/service/marketingcontent/validate/validate_test.go
+++ b/server/internal/service/marketingcontent/validate/validate_test.go
@@ -95,6 +95,19 @@ func TestFindingJSONUsesCamelCase(t *testing.T) {
 	}
 }
 
+func TestExtractabilityScoreIsAdvisory(t *testing.T) {
+	report := Article(Input{Kind: "blog", BodyMD: "short draft", Metadata: validMetadata()})
+	if report.Score >= 8 {
+		t.Fatalf("expected a score below the floor, got %.1f", report.Score)
+	}
+	if !has(report, "extractability.score", "warn") {
+		t.Fatalf("expected extractability to be a suggestion, got %+v", report.Findings)
+	}
+	if has(report, "extractability.score", "error") {
+		t.Fatalf("extractability must not block publish: %+v", report.Findings)
+	}
+}
+
 func TestScoreMatchesPublishedFormula(t *testing.T) {
 	answer := strings.Repeat("complete answer words ", 15)
 	passage := strings.Repeat("clear passage words ", 45)


### PR DESCRIPTION
## Summary
- Send every marketing-article lint finding in a single AI repair request instead of walking them one by one.
- Retry transient 502/503 client failures and invalid JSON from the repair model, and raise the repair token budget.
- Treat extractability score as advisory so it no longer blocks publish; relabel warnings as suggestions.
- Allow publish/schedule overrides without a 10-character justification note.

## Test plan
- [x] Unit tests for `solveAllFindings`, repair 503 retry, extractability advisory severity, and invalid-JSON retry
- [ ] In the article editor, run Quality check, then Solve with AI and confirm all findings are sent together
- [ ] Confirm a low extractability score shows as a suggestion and does not block publish
- [ ] Confirm Override validation no longer requires a change-note justification
- [ ] Confirm a 503 from generate/repair retries once and surfaces a clearer error if it still fails