### PR TITLE
Fix marketing editor quality and media behavior

### DIFF
--- a/clients/web/src/components/marketing-content/editor/__tests__/article-editor-utils.test.ts
+++ b/clients/web/src/components/marketing-content/editor/__tests__/article-editor-utils.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import type { MarketingArticle } from '../../../../lib/marketing-content-api'
 import {
   directives,
   formatQualityScore,
+  reconcileConcurrentSave,
   isBlockingFinding,
   lintMetadata,
   scoreMeterPercent,
@@ -51,5 +53,22 @@ describe('article editor helpers', () => {
     expect(formatQualityScore(8.5)).toBe('8.5')
     expect(isBlockingFinding('error')).toBe(true)
     expect(isBlockingFinding('warn')).toBe(false)
+  })
+  it('keeps edits made while an older save was in flight', () => {
+    const current = {
+      id: 'article-1', heroMediaId: 'new-image', path: '/blog/old-path', status: 'draft',
+      revisionNo: 4, updatedAt: '2026-08-17T04:00:00Z',
+    } as MarketingArticle
+    const saved = {
+      ...current, heroMediaId: null, path: '/blog/saved-path', revisionNo: 5,
+      updatedAt: '2026-08-17T04:01:00Z',
+    }
+
+    expect(reconcileConcurrentSave(current, saved)).toMatchObject({
+      heroMediaId: 'new-image',
+      path: '/blog/saved-path',
+      revisionNo: 5,
+      updatedAt: '2026-08-17T04:01:00Z',
+    })
   })
 })

--- a/clients/web/src/components/marketing-content/editor/__tests__/article-findings-bar.test.tsx
+++ b/clients/web/src/components/marketing-content/editor/__tests__/article-findings-bar.test.tsx
@@ -23,8 +23,6 @@ describe('ArticleFindingsBar', () => {
         findings={findings}
         score={1}
         validating={false}
-        open
-        onOpenChange={vi.fn()}
         bodyMd="# Title"
         onSelectFinding={onSelectFinding}
         onInsertTemplate={onInsertTemplate}
@@ -53,8 +51,6 @@ describe('ArticleFindingsBar', () => {
         findings={findings}
         score={1}
         validating={false}
-        open
-        onOpenChange={vi.fn()}
         bodyMd="# Title"
         onSelectFinding={vi.fn()}
         onInsertTemplate={vi.fn()}
@@ -73,8 +69,6 @@ describe('ArticleFindingsBar', () => {
         findings={findings}
         score={1}
         validating={false}
-        open
-        onOpenChange={vi.fn()}
         bodyMd="# Title"
         onSelectFinding={vi.fn()}
         onInsertTemplate={vi.fn()}
@@ -95,8 +89,6 @@ describe('ArticleFindingsBar', () => {
         findings={findings}
         score={1}
         validating={false}
-        open
-        onOpenChange={vi.fn()}
         bodyMd="# Title"
         onSelectFinding={vi.fn()}
         onInsertTemplate={vi.fn()}

--- a/clients/web/src/components/marketing-content/editor/article-editor-menu.tsx
+++ b/clients/web/src/components/marketing-content/editor/article-editor-menu.tsx
@@ -1,0 +1,17 @@
+import { useRef, useState, type ReactNode } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { Button, Menu, type MenuItem } from '../../ui'
+
+type Props = {
+  label: string
+  items: MenuItem[]
+  variant?: 'secondary' | 'ghost'
+  icon?: ReactNode
+  placement?: 'bottom-start' | 'bottom-end'
+}
+
+export function ArticleEditorMenu({ label, items, variant = 'ghost', icon, placement = 'bottom-start' }: Props) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLButtonElement>(null)
+  return <><Button ref={ref} size="sm" variant={variant} className="min-h-6" aria-haspopup="menu" aria-expanded={open} onClick={() => setOpen((value) => !value)}>{icon}{label}<ChevronDown aria-hidden className="h-3.5 w-3.5 opacity-70" /></Button><Menu open={open} onOpenChange={setOpen} anchorRef={ref} items={items} placement={placement} /></>
+}

--- a/clients/web/src/components/marketing-content/editor/article-editor-utils.ts
+++ b/clients/web/src/components/marketing-content/editor/article-editor-utils.ts
@@ -94,6 +94,17 @@ export function writePayload(article: MarketingArticle): MarketingArticleWrite {
   }
 }
 
+export function reconcileConcurrentSave(current: MarketingArticle, saved: MarketingArticle): MarketingArticle {
+  return {
+    ...current,
+    path: saved.path,
+    status: saved.status,
+    liveStatus: saved.liveStatus,
+    revisionNo: saved.revisionNo,
+    updatedAt: saved.updatedAt,
+  }
+}
+
 export function commaList(value: string): string[] {
   return value.split(',').map((item) => item.trim()).filter(Boolean)
 }

--- a/clients/web/src/components/marketing-content/editor/article-findings-bar.tsx
+++ b/clients/web/src/components/marketing-content/editor/article-findings-bar.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Sparkles } from 'lucide-react'
+import { Sparkles } from 'lucide-react'
 import { Badge, Button, InlineAlert } from '../../ui'
 import type { MarketingFinding } from '../../../lib/marketing-content-api'
 import { formatQualityScore, isBlockingFinding, scoreBarClass, scoreMeterPercent, scoreToneClass } from './article-editor-utils'
@@ -8,8 +8,6 @@ type Props = {
   findings: MarketingFinding[]
   score: number | null
   validating: boolean
-  open: boolean
-  onOpenChange: (open: boolean) => void
   bodyMd: string
   onSelectFinding: (finding: MarketingFinding) => void
   onInsertTemplate: (markdown: string) => void
@@ -25,8 +23,6 @@ export function ArticleFindingsBar({
   findings,
   score,
   validating,
-  open,
-  onOpenChange,
   bodyMd,
   onSelectFinding,
   onInsertTemplate,
@@ -46,34 +42,32 @@ export function ArticleFindingsBar({
   const showSolve = Boolean(canSolve && onSolveWithAI && findings.length)
 
   return (
-    <section id="article-findings" aria-live="polite" className="sticky bottom-0 z-20 border-t border-border-default bg-surface-raised/95 backdrop-blur supports-[backdrop-filter]:bg-surface-raised/80">
-      <div className="flex items-center gap-2 px-4 py-2 sm:px-6">
-        <Button type="button" variant="ghost" aria-expanded={open} onClick={() => onOpenChange(!open)} className="h-auto min-h-6 min-w-0 flex-1 items-center justify-start gap-3 rounded-lg px-0 py-0.5 text-start hover:bg-transparent">
+    <section id="article-findings" aria-live="polite" className="space-y-3">
+      <div className="rounded-xl border border-border-default bg-surface-raised p-3">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="text-xs font-medium text-fg-muted">Quality</span>
-          <span aria-hidden className="h-1.5 w-24 overflow-hidden rounded-full bg-surface-sunken sm:w-40">
+          <span aria-hidden className="h-1.5 min-w-16 flex-1 overflow-hidden rounded-full bg-surface-sunken">
             <span className={`block h-full rounded-full motion-safe:transition-[width] ${scoreBar}`} style={{ width: `${scoreWidth}%` }} />
           </span>
           <span className={`text-sm font-semibold tabular-nums ${scoreTone}`}>{validating ? 'checking…' : formatQualityScore(score)}</span>
-          <span className="hidden text-xs text-fg-muted sm:inline">/ 8.0 floor</span>
-          <span className="ms-auto flex items-center gap-2">
-            {blocking.length ? <Badge tone="danger">{blocking.length} blocking</Badge> : null}
-            {warnings.length ? <Badge tone="warning">{warnings.length} suggestion{warnings.length === 1 ? '' : 's'}</Badge> : null}
-            {!findings.length ? <span className="text-xs text-fg-muted">{score == null ? 'Not checked yet' : 'No findings'}</span> : null}
-            <ChevronDown aria-hidden className={`h-4 w-4 text-fg-muted motion-safe:transition-transform ${open ? '' : 'rotate-180'}`} />
-          </span>
-        </Button>
+          <span className="text-xs text-fg-muted">/ 8.0 floor</span>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {blocking.length ? <Badge tone="danger">{blocking.length} blocking</Badge> : null}
+          {warnings.length ? <Badge tone="warning">{warnings.length} suggestion{warnings.length === 1 ? '' : 's'}</Badge> : null}
+          {!findings.length ? <span className="text-xs text-fg-muted">{score == null ? 'Not checked yet' : 'No findings'}</span> : null}
+        </div>
         {showSolve ? (
-          <Button type="button" size="sm" variant="secondary" className="min-h-6 shrink-0" loading={solving} disabled={solving} onClick={() => onSolveWithAI?.()}>
+          <Button type="button" size="sm" variant="secondary" className="mt-3 w-full" loading={solving} disabled={solving} onClick={() => onSolveWithAI?.()}>
             <Sparkles className="h-3.5 w-3.5" aria-hidden />
             Solve with AI
           </Button>
         ) : null}
       </div>
-      {open ? (
-        <div className="max-h-64 overflow-y-auto border-t border-border-subtle px-4 py-3 sm:px-6">
-          {solveError ? <InlineAlert tone="danger" className="mb-3">{solveError}</InlineAlert> : null}
-          {solving ? <p role="status" className="mb-2 text-xs text-fg-muted">{solveProgress || `Solving ${findings.length} finding${findings.length === 1 ? '' : 's'} with AI…`}</p> : null}
-          {findings.length ? (
+      <div>
+        {solveError ? <InlineAlert tone="danger" className="mb-3">{solveError}</InlineAlert> : null}
+        {solving ? <p role="status" className="mb-2 text-xs text-fg-muted">{solveProgress || `Solving ${findings.length} finding${findings.length === 1 ? '' : 's'} with AI…`}</p> : null}
+        {findings.length ? (
             <ul className="space-y-1.5">
               {findings.map((finding, index) => {
                 const key = findingKey(finding, index)
@@ -110,11 +104,10 @@ export function ArticleFindingsBar({
                 )
               })}
             </ul>
-          ) : (
-            <p className="text-sm text-fg-muted">Nothing to fix. Findings appear here as you write.</p>
-          )}
-        </div>
-      ) : null}
+        ) : (
+          <p className="text-sm text-fg-muted">Nothing to fix. Findings appear here as you write.</p>
+        )}
+      </div>
     </section>
   )
 }

--- a/clients/web/src/pages/admin/marketing-content/article-editor-page.tsx
+++ b/clients/web/src/pages/admin/marketing-content/article-editor-page.tsx
@@ -1,17 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Editor } from '@tiptap/core'
-import { ArrowLeft, Braces, ChevronDown, Eye, FileText, History, Keyboard, PanelRight, Save, Sparkles } from 'lucide-react'
+import { ArrowLeft, Braces, Eye, FileText, History, Keyboard, PanelRight, Save, Sparkles } from 'lucide-react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { ArticleMetadataPanel } from '../../../components/marketing-content/editor/article-metadata-panel'
 import { ArticlePreview } from '../../../components/marketing-content/editor/article-preview'
 import { EditorPane } from '../../../components/marketing-content/editor/article-editor-pane'
 import { TranslationSourcePane } from '../../../components/marketing-content/editor/translation-source-pane'
-import { directives, isBlockingFinding, lintMetadata, slugify, writePayload } from '../../../components/marketing-content/editor/article-editor-utils'
+import { directives, isBlockingFinding, lintMetadata, reconcileConcurrentSave, slugify, writePayload } from '../../../components/marketing-content/editor/article-editor-utils'
 import { METADATA_FINDING_PATHS, findingKey, jumpEditorToMarkdownLine, selectTextareaLine, solveAllFindings } from '../../../components/marketing-content/editor/article-finding-nav'
 import { ArticleFindingsBar } from '../../../components/marketing-content/editor/article-findings-bar'
+import { ArticleEditorMenu } from '../../../components/marketing-content/editor/article-editor-menu'
 import { BuildArticleWithAiModal } from '../../../components/marketing-content/editor/build-article-with-ai-modal'
 import { RevisionDrawer } from '../../../components/marketing-content/editor/revision-drawer'
-import { Badge, Button, Checkbox, Dialog, EmptyState, InlineAlert, Input, Menu, SegmentedControl, Skeleton, Textarea, type MenuItem } from '../../../components/ui'
+import { Badge, Button, Checkbox, Dialog, EmptyState, InlineAlert, Input, SegmentedControl, Skeleton, Tab, TabList, TabPanel, Tabs, Textarea, type MenuItem } from '../../../components/ui'
 import { usePermissions } from '../../../context/use-permissions'
 import { generateMarketingArticle, repairMarketingArticle, type MarketingArticleAIDraft } from '../../../lib/marketing-content-ai-api'
 import { createMarketingArticle, createMarketingPreviewToken, getMarketingArticle, lintMarketingArticle, listMarketingAuthors, listMarketingCategories, listMarketingKnownPaths, MarketingConflictError, MarketingValidationError, restoreMarketingRevision, transitionMarketingArticle, updateMarketingArticle, type MarketingArticle, type MarketingFinding } from '../../../lib/marketing-content-api'
@@ -26,12 +27,6 @@ const emptyArticle = (kind: 'blog' | 'doc'): MarketingArticle => ({
 })
 
 type View = 'write' | 'split' | 'preview' | 'details'
-
-function EditorMenu({ label, items, variant = 'ghost', icon, placement = 'bottom-start' }: { label: string; items: MenuItem[]; variant?: 'secondary' | 'ghost'; icon?: React.ReactNode; placement?: 'bottom-start' | 'bottom-end' }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLButtonElement>(null)
-  return <><Button ref={ref} size="sm" variant={variant} className="min-h-6" aria-haspopup="menu" aria-expanded={open} onClick={() => setOpen((value) => !value)}>{icon}{label}<ChevronDown aria-hidden className="h-3.5 w-3.5 opacity-70" /></Button><Menu open={open} onOpenChange={setOpen} anchorRef={ref} items={items} placement={placement} /></>
-}
 
 export default function ArticleEditorPage() {
   const { articleId = '' } = useParams()
@@ -54,7 +49,7 @@ export default function ArticleEditorPage() {
   const [view, setView] = useState<View>('write')
   const [simple, setSimple] = useState(false)
   const [metadataOpen, setMetadataOpen] = useState(true)
-  const [findingsOpen, setFindingsOpen] = useState(false)
+  const [panelTab, setPanelTab] = useState<'details' | 'quality'>('details')
   const [highlightField, setHighlightField] = useState<string | null>(null)
   const [revisionsOpen, setRevisionsOpen] = useState(false)
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
@@ -80,16 +75,18 @@ export default function ArticleEditorPage() {
   const editorRef = useRef<Editor | null>(null)
   const articleRef = useRef(article)
   const dirtyRef = useRef(dirty)
-  const openedFindingsRef = useRef(false)
+  const editVersionRef = useRef(0)
   useEffect(() => { articleRef.current = article }, [article])
   useEffect(() => { dirtyRef.current = dirty }, [dirty])
 
   const patch = useCallback((value: Partial<MarketingArticle>) => {
+    editVersionRef.current += 1
     setArticle((old) => ({ ...old, ...value }))
     setDirty(true)
     setSaveError('')
   }, [])
   const patchMetadata = useCallback((value: Partial<MarketingArticle>) => {
+    editVersionRef.current += 1
     setArticle((old) => {
       const autoSlug = !old.slug || old.slug === slugify(old.title)
       return { ...old, ...value, ...(value.title !== undefined && autoSlug ? { slug: slugify(value.title) } : {}) }
@@ -155,10 +152,6 @@ export default function ArticleEditorPage() {
         const next = report.findings ?? []
         setFindings(next)
         setScore(report.score)
-        if (next.length && !openedFindingsRef.current) {
-          openedFindingsRef.current = true
-          setFindingsOpen(true)
-        }
       }).catch(() => undefined).finally(() => setValidating(false))
     }, dirty ? 800 : 0)
     return () => window.clearTimeout(timer)
@@ -167,13 +160,30 @@ export default function ArticleEditorPage() {
   const saveArticle = useCallback(async () => {
     if (!dirtyRef.current || saving) return articleRef.current
     const current = articleRef.current
+    const savingEditVersion = editVersionRef.current
     if (!current.title.trim() || !current.slug.trim() || !current.authorSlug || (current.kind === 'doc' && !current.categoryId)) { setSaveError('Title, slug, author, and help-article category are required.'); return null }
     setSaving(true); setSaveError('')
     try {
       const saved = isNew ? await createMarketingArticle(writePayload(current)) : await updateMarketingArticle(articleId, current.revisionNo, writePayload(current))
-      setArticle(saved); setDirty(false); setLastSaved(new Date()); sessionStorage.removeItem(`mc:draft:${saved.id}`)
+      const hasConcurrentEdits = editVersionRef.current !== savingEditVersion
+      if (hasConcurrentEdits) {
+        setArticle((latest) => {
+          const reconciled = reconcileConcurrentSave(latest, saved)
+          articleRef.current = reconciled
+          return reconciled
+        })
+        dirtyRef.current = true
+        setDirty(true)
+      } else {
+        articleRef.current = saved
+        dirtyRef.current = false
+        setArticle(saved)
+        setDirty(false)
+        sessionStorage.removeItem(`mc:draft:${saved.id}`)
+      }
+      setLastSaved(new Date())
       if (isNew) navigate(`/admin/marketing-content/${saved.id}`, { replace: true })
-      return saved
+      return hasConcurrentEdits ? null : saved
     } catch (e) {
       if (e instanceof MarketingConflictError) setConflict(e.detail)
       else setSaveError(e instanceof Error ? e.message : 'Save failed.')
@@ -211,7 +221,9 @@ export default function ArticleEditorPage() {
       if (e instanceof MarketingValidationError) {
         setFindings(e.findings)
         if (e.score != null) setScore(e.score)
-        setFindingsOpen(true)
+        setPanelTab('quality')
+        setMetadataOpen(true)
+        setView('details')
         setSaveError(`${e.message} Open Quality below for the blocking findings.`)
       } else {
         setSaveError(e instanceof Error ? e.message : String(e))
@@ -230,7 +242,7 @@ export default function ArticleEditorPage() {
     setSolvingFindings(true)
     setSolveError('')
     setSolveProgress('')
-    setFindingsOpen(true)
+    setPanelTab('quality')
     try {
       const result = await solveAllFindings({
         article: articleRef.current,
@@ -261,6 +273,7 @@ export default function ArticleEditorPage() {
       articleRef.current = { ...articleRef.current, ...result.article }
       setArticle((old) => ({ ...old, ...result.article }))
       if (result.applied) {
+        editVersionRef.current += 1
         setDirty(true)
         setSaveError('')
       }
@@ -272,6 +285,7 @@ export default function ArticleEditorPage() {
     }
   }, [findings, knownPaths, solvingFindings])
   const applyAIDraft = (draft: MarketingArticleAIDraft) => {
+    editVersionRef.current += 1
     setArticle((old) => {
       const autoSlug = !old.slug || old.slug === slugify(old.title)
       return {
@@ -301,6 +315,7 @@ export default function ArticleEditorPage() {
   const revealFinding = (finding: MarketingFinding) => {
     const path = finding.path
     if (path && METADATA_FINDING_PATHS.has(path)) {
+      setPanelTab('details')
       setHighlightField(path)
       window.setTimeout(() => setHighlightField((current) => (current === path ? null : current)), 2500)
       if (path === 'title') {
@@ -360,13 +375,15 @@ export default function ArticleEditorPage() {
   const editorPane = <EditorPane article={article} canAuthor={canAuthor} simple={simple} titleHighlight={highlightField === 'title'} titleError={titleFinding?.severity === 'error' ? titleFinding.message : undefined} onTitleChange={changeTitle} onBodyChange={changeBody} onBlur={() => void saveArticle()} onEditorChange={registerEditor} />
   const previewPane = <div className="min-w-0 overflow-auto rounded-2xl border border-border-default bg-surface-raised shadow-sm"><ArticlePreview title={article.title} body={article.bodyMd} dir={article.locale.startsWith('ar') ? 'rtl' : 'ltr'} /></div>
   const metadataPane = <ArticleMetadataPanel article={article} onChange={patchMetadata} categories={categories} authors={authors} knownPaths={knownPaths} isNew={isNew} findings={findings} highlightField={highlightField} canFillWithAI={canAuthor} />
+  const qualityPane = <ArticleFindingsBar findings={findings} score={score} validating={validating} bodyMd={article.bodyMd} onSelectFinding={revealFinding} onInsertTemplate={insertDirective} canSolve={canAuthor} solving={solvingFindings} solvingFindingKey={solvingFindingKey} solveProgress={solveProgress} solveError={solveError} onSolveWithAI={() => void solveFindingsWithAI()} />
+  const sidePanelPane = <Tabs value={panelTab} onValueChange={(value) => setPanelTab(value as 'details' | 'quality')}><TabList aria-label="Article panel"><Tab value="details">Details</Tab><Tab value="quality">Quality{findings.length ? ` (${findings.length})` : ''}</Tab></TabList><TabPanel value="details">{metadataPane}</TabPanel><TabPanel value="quality">{qualityPane}</TabPanel></Tabs>
   const missingLocales = locales.filter((loc) => loc.enabled && loc.code !== article.locale && !translations.some((row) => row.locale === loc.code))
   const translationItems: MenuItem[] = [
     ...translations.filter((row) => row.id !== article.id).map((row) => ({ id: row.id, label: `${row.locale.toUpperCase()} · ${row.status}${row.stale ? ' · stale' : ''}`, onSelect: () => navigate(`/admin/marketing-content/${row.id}`) })),
     ...(canAuthor && localesEnabled ? missingLocales.map((loc) => ({ id: `add-${loc.code}`, label: `Add ${loc.label} translation`, onSelect: () => void addTranslation(loc.code) })) : []),
   ]
 
-  return <main className="min-w-0 pb-16">
+  return <main className="min-w-0 pb-4">
     <div className="sticky top-0 z-20 border-b border-border-default bg-surface-raised/95 backdrop-blur supports-[backdrop-filter]:bg-surface-raised/80">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2.5 sm:px-6">
         <Link to="/admin/marketing-content" aria-label="Back to Marketing Content" className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-fg-muted hover:bg-surface-sunken hover:text-fg-default"><ArrowLeft className="h-4 w-4" /></Link>
@@ -382,12 +399,12 @@ export default function ArticleEditorPage() {
         <div className="flex items-center gap-2">
           <Button size="sm" variant="secondary" className="min-h-6" onClick={() => void openPreview()}><Eye className="h-4 w-4" /> <span className="hidden sm:inline">Preview</span></Button>
           <Button size="sm" className="min-h-6" loading={saving} disabled={!dirty} onClick={() => void saveArticle()}><Save className="h-4 w-4" /> Save</Button>
-          {!isNew ? <EditorMenu label="Actions" variant="secondary" placement="bottom-end" items={[
+          {!isNew ? <ArticleEditorMenu label="Actions" variant="secondary" placement="bottom-end" items={[
             ...(canAuthor ? [{ id: 'submit', label: 'Submit for review', onSelect: () => setTransition('submit') }] : []),
             ...(canReview ? [{ id: 'approve', label: 'Approve', onSelect: () => setTransition('approve') }, { id: 'request_changes', label: 'Request changes', onSelect: () => setTransition('request_changes') }] : []),
             ...(canPublish ? [{ id: 'publish', label: 'Publish', onSelect: () => setTransition('publish') }, { id: 'schedule', label: 'Schedule', onSelect: () => setTransition('schedule') }, { id: 'unpublish', label: 'Unpublish', onSelect: () => setTransition('unpublish') }, { id: 'archive', label: 'Archive', onSelect: () => setTransition('archive') }] : []),
           ]} /> : null}
-          {!isNew && localesEnabled ? <EditorMenu label="Translations" variant="ghost" placement="bottom-end" items={translationItems.length ? translationItems : [{ id: 'none', label: 'This article is only available in this locale', disabled: true }]} /> : null}
+          {!isNew && localesEnabled ? <ArticleEditorMenu label="Translations" variant="ghost" placement="bottom-end" items={translationItems.length ? translationItems : [{ id: 'none', label: 'This article is only available in this locale', disabled: true }]} /> : null}
         </div>
       </div>
       <div className="flex flex-wrap items-center gap-2 border-t border-border-subtle px-4 py-2 sm:px-6" role="toolbar" aria-label="Article editor tools">
@@ -407,7 +424,7 @@ export default function ArticleEditorPage() {
         />
         <span aria-hidden className="mx-1 hidden h-5 w-px bg-border-default sm:block" />
         {canAuthor ? <Button size="sm" variant="ghost" className="min-h-6" onClick={() => setBuildAiOpen(true)}><Sparkles className="h-4 w-4" /> Build with AI</Button> : null}
-        <EditorMenu label="Insert block" items={directives.map((v) => ({ id: v.id, label: v.label, onSelect: () => insertDirective(v.markdown) }))} />
+        <ArticleEditorMenu label="Insert block" items={directives.map((v) => ({ id: v.id, label: v.label, onSelect: () => insertDirective(v.markdown) }))} />
         <Button size="sm" variant="ghost" className="min-h-6" aria-pressed={simple} onClick={() => setSimple((v) => !v)}><Braces className="h-4 w-4" /> <span className="hidden lg:inline">{simple ? 'Visual editor' : 'Markdown source'}</span></Button>
         <Button size="sm" variant="ghost" className="min-h-6" disabled={isNew} onClick={() => setRevisionsOpen(true)}><History className="h-4 w-4" /> <span className="hidden lg:inline">Revisions</span></Button>
         <Button size="sm" variant="ghost" className="min-h-6" onClick={() => setShortcutsOpen(true)}><Keyboard className="h-4 w-4" /> <span className="hidden lg:inline">Shortcuts</span></Button>
@@ -419,12 +436,12 @@ export default function ArticleEditorPage() {
 
     <div className="px-4 pt-4 sm:px-6">
       {saveError ? <InlineAlert tone="danger" className="mb-3"><span className="flex flex-wrap items-center gap-2"><strong>Action failed.</strong> {saveError}{dirty ? <Button size="sm" variant="secondary" onClick={() => void saveArticle()}>Retry save</Button> : null}</span></InlineAlert> : null}
-      {recovery ? <InlineAlert tone="warning" className="mb-3"><span className="flex flex-wrap items-center gap-2"><strong>Unsaved browser draft found.</strong><Button size="sm" onClick={() => { setArticle(recovery); setRecovery(null); setDirty(true) }}>Recover</Button><Button size="sm" variant="secondary" onClick={() => { sessionStorage.removeItem(`mc:draft:${articleId}`); setRecovery(null) }}>Discard</Button></span></InlineAlert> : null}
+      {recovery ? <InlineAlert tone="warning" className="mb-3"><span className="flex flex-wrap items-center gap-2"><strong>Unsaved browser draft found.</strong><Button size="sm" onClick={() => { editVersionRef.current += 1; setArticle(recovery); setRecovery(null); setDirty(true) }}>Recover</Button><Button size="sm" variant="secondary" onClick={() => { sessionStorage.removeItem(`mc:draft:${articleId}`); setRecovery(null) }}>Discard</Button></span></InlineAlert> : null}
     </div>
 
     {/* Mobile: one pane at a time. */}
     <div className="px-4 pb-4 md:hidden">
-      {view === 'details' ? <div className="rounded-2xl border border-border-default bg-surface-raised p-3">{metadataPane}</div> : view === 'preview' ? previewPane : editorPane}
+      {view === 'details' ? <div className="rounded-2xl border border-border-default bg-surface-raised p-3">{sidePanelPane}</div> : view === 'preview' ? previewPane : editorPane}
     </div>
 
     {/* Desktop: canvas + metadata rail. */}
@@ -434,25 +451,8 @@ export default function ArticleEditorPage() {
         {showDesktopEditor ? editorPane : null}
         {desktopSplit ? previewPane : null}
       </div>
-      {railOpen ? <aside aria-label="Article metadata" className="min-w-0"><div className="sticky top-[7rem] max-h-[calc(100dvh-9.5rem)] overflow-y-auto pb-2">{metadataPane}</div></aside> : null}
+      {railOpen ? <aside aria-label="Article panel" className="min-w-0"><div className="sticky top-[7rem] max-h-[calc(100dvh-9.5rem)] overflow-y-auto pb-2">{sidePanelPane}</div></aside> : null}
     </div>
-
-    <ArticleFindingsBar
-      findings={findings}
-      score={score}
-      validating={validating}
-      open={findingsOpen}
-      onOpenChange={setFindingsOpen}
-      bodyMd={article.bodyMd}
-      onSelectFinding={revealFinding}
-      onInsertTemplate={insertDirective}
-      canSolve={canAuthor}
-      solving={solvingFindings}
-      solvingFindingKey={solvingFindingKey}
-      solveProgress={solveProgress}
-      solveError={solveError}
-      onSolveWithAI={() => void solveFindingsWithAI()}
-    />
 
     <RevisionDrawer open={revisionsOpen} articleId={article.id} currentBody={article.bodyMd} onClose={() => setRevisionsOpen(false)} onRestore={restore} />
     <BuildArticleWithAiModal

--- a/server/internal/httpserver/marketing_media_http.go
+++ b/server/internal/httpserver/marketing_media_http.go
@@ -3,7 +3,6 @@ package httpserver
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -230,10 +229,20 @@ func (d Deps) handlePublicMarketingMedia() http.HandlerFunc {
 			return
 		}
 		defer func() { _ = obj.Close() }()
-		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-		w.Header().Set("Content-Type", rend.MIME)
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("Content-Length", fmt.Sprint(rend.Bytes))
-		_, _ = io.Copy(w, obj)
+		data, e := io.ReadAll(obj)
+		if e != nil {
+			slog.Error("read public marketing media", "media_id", id, "key", rend.Key, "err", e)
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not read media.")
+			return
+		}
+		writePublicMarketingMedia(w, rend.MIME, data)
 	}
+}
+
+func writePublicMarketingMedia(w http.ResponseWriter, mime string, data []byte) {
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	w.Header().Set("Content-Type", mime)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	_, _ = w.Write(data)
 }

--- a/server/internal/httpserver/marketing_media_http_test.go
+++ b/server/internal/httpserver/marketing_media_http_test.go
@@ -1,0 +1,26 @@
+package httpserver
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWritePublicMarketingMediaWritesExactBodyLength(t *testing.T) {
+	t.Parallel()
+	body := []byte("image bytes")
+	response := httptest.NewRecorder()
+
+	writePublicMarketingMedia(response, "image/png", body)
+
+	result := response.Result()
+	defer func() { _ = result.Body.Close() }()
+	if got := response.Body.Bytes(); string(got) != string(body) {
+		t.Fatalf("body = %q, want %q", got, body)
+	}
+	if got := result.Header.Get("Content-Length"); got != "11" {
+		t.Fatalf("Content-Length = %q, want 11", got)
+	}
+	if got := result.Header.Get("Content-Type"); got != "image/png" {
+		t.Fatalf("Content-Type = %q, want image/png", got)
+	}
+}

--- a/www/scripts/generate-site.mjs
+++ b/www/scripts/generate-site.mjs
@@ -1180,7 +1180,7 @@ async function main() {
     if (content?.article?.socialDescription) head.ogDescription = content.article.socialDescription
     const hero = content?.article?.media?.find(media => media.id === content.article.heroMediaId || media.usage === 'hero')
     const heroRendition = pickSocialRendition(hero)
-    const cardOverride = heroRendition ? `${SITE_ORIGIN}${localizedMediaPath(hero, heroRendition)}` : route.descriptor?.ogImage
+    const cardOverride = heroRendition?.localizedPath ? `${SITE_ORIGIN}${heroRendition.localizedPath}` : route.descriptor?.ogImage
     if (cardOverride && !/\.(png|jpe?g)(?:[?#]|$)/i.test(cardOverride)) {
       allErrors.push(`${route.path}: ogImage override must be a raster PNG or JPEG`)
     }
@@ -1756,11 +1756,6 @@ async function localizeContentMedia(articles) {
   })
 }
 
-function localizedMediaPath(media, rendition) {
-  const checksum = String(media.checksum || media.id).replace(/[^a-zA-Z0-9_-]/g, '')
-  return `/assets/content/${checksum}/${rendition.name}.${rendition.ext}`
-}
-
 async function localizeOneMedia(media, checksum) {
   const dir = path.join(DIST, 'assets', 'content', checksum)
   await mkdir(dir, { recursive: true })
@@ -1773,9 +1768,10 @@ async function localizeOneMedia(media, checksum) {
     if (!buffer) continue
     const filename = `${rendition.name}.${rendition.ext}`
     await writeFile(path.join(dir, filename), buffer)
+    rendition.localizedPath = `/assets/content/${checksum}/${filename}`
     if (!sourceBuffer || rendition.name === 'original') sourceBuffer = buffer
-    replacements.push([rendition.url, `/assets/content/${checksum}/${filename}`])
-    replacements.push([remote, `/assets/content/${checksum}/${filename}`])
+    replacements.push([rendition.url, rendition.localizedPath])
+    replacements.push([remote, rendition.localizedPath])
   }
   if (sourceBuffer) {
     const names = new Set((media.renditions || []).map(r => `${r.name}.${r.ext}`))

--- a/www/scripts/generate-site.mjs
+++ b/www/scripts/generate-site.mjs
@@ -1769,8 +1769,8 @@ async function localizeOneMedia(media, checksum) {
   for (const rendition of media.renditions || []) {
     const remote = resolveApiAssetUrl(rendition.url, CONTENT_API_BASE)
     if (!remote) continue
-    const response = await fetchWithRetry(remote, { userAgent: PRERENDER_UA })
-    const buffer = Buffer.from(await response.arrayBuffer())
+    const buffer = await fetchMediaRendition(remote)
+    if (!buffer) continue
     const filename = `${rendition.name}.${rendition.ext}`
     await writeFile(path.join(dir, filename), buffer)
     if (!sourceBuffer || rendition.name === 'original') sourceBuffer = buffer
@@ -1783,6 +1783,16 @@ async function localizeOneMedia(media, checksum) {
     if (![...names].some(name => name.endsWith('.avif'))) await sharp(sourceBuffer).avif().toFile(path.join(dir, 'generated.avif'))
   }
   return replacements
+}
+
+export async function fetchMediaRendition(remote, fetcher = fetchWithRetry, warn = console.warn) {
+  try {
+    const response = await fetcher(remote, { userAgent: PRERENDER_UA })
+    return Buffer.from(await response.arrayBuffer())
+  } catch (error) {
+    warn(`[generate-site] WARN: content media unavailable at ${remote}: ${error.message || error}`)
+    return null
+  }
 }
 
 // Back-compat exports matching prerender-courses.test.mjs names

--- a/www/scripts/generate-site.test.mjs
+++ b/www/scripts/generate-site.test.mjs
@@ -8,6 +8,7 @@ import {
   buildRedirectsFile,
   buildSitemap,
   escapeHtml,
+  fetchMediaRendition,
   injectDocument,
   injectHead,
   parseMarkdownDate,
@@ -26,6 +27,19 @@ import {
   buildLinkGraph,
   validateLinkGraph,
 } from './generate-site.mjs'
+
+describe('fetchMediaRendition', () => {
+  it('leaves unavailable content media remote instead of failing the build', async () => {
+    const warnings = []
+    const result = await fetchMediaRendition(
+      'https://self.lextures.com/missing.png',
+      async () => { throw new Error('404 Media not found') },
+      warning => warnings.push(warning),
+    )
+    assert.equal(result, null)
+    assert.match(warnings[0], /content media unavailable.*404 Media not found/)
+  })
+})
 
 describe('escapeHtml', () => {
   it('escapes script payloads', () => {


### PR DESCRIPTION
## Summary

- move article Quality findings from the sticky footer accordion into a right-panel tab
- keep social-image edits made while a prior save is in flight instead of overwriting them with a stale response
- serve public marketing media from concrete bytes with an exact content length, preventing `ERR_CONTENT_LENGTH_MISMATCH`
- extract the article editor menu wrapper to keep the editor page within its structure budget

## Verification

- `npx vitest run src/components/marketing-content/editor/__tests__/article-findings-bar.test.tsx src/components/marketing-content/editor/__tests__/article-editor-utils.test.ts`
- `npm run typecheck`
- `npx oxlint` on changed frontend files
- `go test ./internal/httpserver -count=1 -short -timeout=1m`
- pre-commit file-size and file-naming structure checks
- `git diff --check`