### PR TITLE
fix(web): restore marketplace destination after login and signup

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -6,6 +6,7 @@ import { AppShell } from './components/layout/app-shell'
 import { RouteFallback } from './components/route-fallback'
 import * as Pages from './lazy-pages'
 import { OnboardingRedirect } from './components/onboarding/onboarding-redirect'
+import { authHandoffHref } from './lib/post-auth-redirect'
 import { applyDocumentScrollMode, isStandalonePublicRoute } from './lib/standalone-public-routes'
 
 export default function App() {
@@ -22,7 +23,7 @@ export default function App() {
       if (isStandalonePublicRoute(location.pathname)) {
         return
       }
-      navigate('/login', { replace: true, state: { from } })
+      navigate(authHandoffHref('/login', from), { replace: true, state: { from } })
     }
     window.addEventListener('studydrift-auth-required', onAuthRequired)
     return () => {

--- a/clients/web/src/auth/__tests__/require-auth.test.tsx
+++ b/clients/web/src/auth/__tests__/require-auth.test.tsx
@@ -69,4 +69,25 @@ describe('RequireAuth', () => {
     expect(screen.getByText('Login page')).toBeInTheDocument()
     expect(loginState?.from).toBe('/marketplace/demo?coupon=LAUNCH25&ref=www')
   })
+
+  it('puts the return path on the login URL so a refresh still has it', () => {
+    vi.mocked(getBearerToken).mockReturnValue(null)
+    let loginPath = ''
+    function LoginProbe() {
+      const loc = useLocation()
+      loginPath = `${loc.pathname}${loc.search}`
+      return <div>Login page</div>
+    }
+    render(
+      <MemoryRouter initialEntries={['/marketplace/ai-essentials-c-hupcnf']}>
+        <Routes>
+          <Route element={<RequireAuth />}>
+            <Route path="/marketplace/:slug" element={<div>Detail</div>} />
+          </Route>
+          <Route path="/login" element={<LoginProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    expect(loginPath).toBe('/login?next=%2Fmarketplace%2Fai-essentials-c-hupcnf')
+  })
 })

--- a/clients/web/src/auth/require-auth.tsx
+++ b/clients/web/src/auth/require-auth.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { getBearerToken } from '../lib/auth'
+import { authHandoffHref } from '../lib/post-auth-redirect'
 
 /** Full return path including query (e.g. ?coupon=) so share links survive sign-in (MKTC.5 FR-11). */
 function returnPathFromLocation(location: {
@@ -13,9 +14,8 @@ function returnPathFromLocation(location: {
 export function RequireAuth() {
   const location = useLocation()
   if (!getBearerToken()) {
-    return (
-      <Navigate to="/login" replace state={{ from: returnPathFromLocation(location) }} />
-    )
+    const from = returnPathFromLocation(location)
+    return <Navigate to={authHandoffHref('/login', from)} replace state={{ from }} />
   }
   return <Outlet />
 }

--- a/clients/web/src/components/onboarding/onboarding-redirect.tsx
+++ b/clients/web/src/components/onboarding/onboarding-redirect.tsx
@@ -1,10 +1,15 @@
 import type { ReactNode } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
+import { authHandoffHref } from '../../lib/post-auth-redirect'
 import { useOnboardingRedirect } from './use-onboarding-redirect'
 
 export function OnboardingRedirect({ children }: { children: ReactNode }) {
   const { checking, shouldRedirect } = useOnboardingRedirect()
+  const location = useLocation()
   if (checking) return null
-  if (shouldRedirect) return <Navigate to="/onboarding" replace />
+  if (shouldRedirect) {
+    const from = `${location.pathname}${location.search}${location.hash}`
+    return <Navigate to={authHandoffHref('/onboarding', from)} replace state={{ from }} />
+  }
   return <>{children}</>
 }

--- a/clients/web/src/lib/__tests__/post-auth-redirect.test.ts
+++ b/clients/web/src/lib/__tests__/post-auth-redirect.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setCachedAccountTypeFromUser } from '../auth'
+import {
+  authHandoffHref,
+  pickPostAuthPath,
+  returnPathFromAuthLocation,
+  sanitizeReturnPath,
+} from '../post-auth-redirect'
+
+function memoryStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    key: (i: number) => [...store.keys()][i] ?? null,
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v))
+    },
+  } as Storage
+}
+
+describe('post-auth-redirect', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', memoryStorage())
+  })
+
+  afterEach(() => {
+    setCachedAccountTypeFromUser(undefined)
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps in-app paths including query strings', () => {
+    expect(sanitizeReturnPath('/marketplace/ai-essentials-c-hupcnf')).toBe(
+      '/marketplace/ai-essentials-c-hupcnf',
+    )
+    expect(sanitizeReturnPath('/marketplace/demo?coupon=LAUNCH25&ref=www')).toBe(
+      '/marketplace/demo?coupon=LAUNCH25&ref=www',
+    )
+  })
+
+  it('rejects open redirects and auth-loop paths', () => {
+    expect(sanitizeReturnPath('https://evil.example')).toBe('/')
+    expect(sanitizeReturnPath('//evil.example')).toBe('/')
+    expect(sanitizeReturnPath('/\\evil.example')).toBe('/')
+    expect(sanitizeReturnPath('/login')).toBe('/')
+    expect(sanitizeReturnPath('/signup?next=/marketplace/x')).toBe('/')
+    expect(sanitizeReturnPath('/onboarding')).toBe('/')
+  })
+
+  it('prefers location state over next query', () => {
+    expect(
+      returnPathFromAuthLocation({
+        search: '?next=%2Fcourses',
+        state: { from: '/marketplace/ai-essentials-c-hupcnf' },
+      }),
+    ).toBe('/marketplace/ai-essentials-c-hupcnf')
+    expect(returnPathFromAuthLocation({ search: '?next=%2Fmarketplace%2Fdemo', state: null })).toBe(
+      '/marketplace/demo',
+    )
+  })
+
+  it('builds a login handoff that survives refresh', () => {
+    expect(authHandoffHref('/login', '/marketplace/demo?coupon=X')).toBe(
+      '/login?next=%2Fmarketplace%2Fdemo%3Fcoupon%3DX',
+    )
+    expect(authHandoffHref('/login', '/login')).toBe('/login')
+  })
+
+  it('sends parent accounts to /parent unless the destination is already a parent path', () => {
+    setCachedAccountTypeFromUser({ accountType: 'parent' })
+    expect(pickPostAuthPath('/marketplace/demo')).toBe('/parent')
+    expect(pickPostAuthPath('/parent/conferences')).toBe('/parent/conferences')
+  })
+})

--- a/clients/web/src/lib/post-auth-redirect.ts
+++ b/clients/web/src/lib/post-auth-redirect.ts
@@ -1,12 +1,67 @@
 import { getAccountType } from './auth'
 
+const AUTH_LOOP_PREFIXES = [
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/reset-password',
+  '/activate-parent',
+  '/saml-callback',
+  '/sso-error',
+  '/onboarding',
+] as const
+
+function pathnameOf(raw: string): string {
+  return raw.split(/[?#]/, 1)[0] ?? raw
+}
+
+function isAuthLoopPath(pathname: string): boolean {
+  return AUTH_LOOP_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`))
+}
+
+/**
+ * Same-origin in-app path only. Rejects protocol-relative URLs, auth pages, and junk.
+ */
+export function sanitizeReturnPath(preferred: string | null | undefined): string {
+  if (preferred == null) return '/'
+  const raw = preferred.trim()
+  if (raw === '') return '/'
+  if (!raw.startsWith('/') || raw.startsWith('//') || raw.includes('\\') || raw.includes('@')) {
+    return '/'
+  }
+  const pathname = pathnameOf(raw)
+  if (pathname.includes('://') || isAuthLoopPath(pathname)) {
+    return '/'
+  }
+  return raw
+}
+
+/** Builds `/login?next=…` (or `/signup`, `/onboarding`) so a refresh still has the destination. */
+export function authHandoffHref(page: string, returnPath: string): string {
+  const dest = sanitizeReturnPath(returnPath)
+  if (dest === '/') return page
+  const join = page.includes('?') ? '&' : '?'
+  return `${page}${join}next=${encodeURIComponent(dest)}`
+}
+
+export function returnPathFromAuthLocation(location: { search: string; state: unknown }): string {
+  const stateFrom =
+    location.state && typeof location.state === 'object' && 'from' in location.state
+      ? (location.state as { from?: unknown }).from
+      : undefined
+  const next = new URLSearchParams(location.search).get('next')
+  const fromState = typeof stateFrom === 'string' ? stateFrom : undefined
+  return sanitizeReturnPath(fromState || next)
+}
+
 /** After login or signup, parent accounts land on the parent dashboard unless they already asked for a `/parent` path. */
 export function pickPostAuthPath(preferred: string): string {
+  const dest = sanitizeReturnPath(preferred)
   if (getAccountType() === 'parent') {
-    if (preferred.startsWith('/parent')) {
-      return preferred
+    if (dest.startsWith('/parent')) {
+      return dest
     }
     return '/parent'
   }
-  return preferred
+  return dest
 }

--- a/clients/web/src/pages/__tests__/login.test.tsx
+++ b/clients/web/src/pages/__tests__/login.test.tsx
@@ -1,13 +1,33 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import App from '../../app'
 import { PermissionsProvider } from '../../context/permissions-provider'
 import { server } from '../../test/mocks/server'
 import { renderWithRouter } from '../../test/render'
 import Login from '../login'
+
+function PathProbe() {
+  const loc = useLocation()
+  return <div data-testid="path">{`${loc.pathname}${loc.search}`}</div>
+}
+
+function renderWithAuthPages(entry: { pathname: string; search?: string; state?: { from: string } }) {
+  const user = userEvent.setup()
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<div>Signup page</div>} />
+        <Route path="/marketplace/:slug" element={<PathProbe />} />
+        <Route path="/" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+  return { user }
+}
 
 describe('Login', () => {
   it('renders sign in heading and Lextures branding', () => {
@@ -161,6 +181,33 @@ describe('Login', () => {
         org_slug: 'chase',
       })
     })
+  })
+
+  it('returns to the original marketplace path after sign-in', async () => {
+    const dest = '/marketplace/ai-essentials-c-hupcnf'
+    const { user } = renderWithAuthPages({
+      pathname: '/login',
+      search: `?next=${encodeURIComponent(dest)}`,
+      state: { from: dest },
+    })
+
+    await user.type(screen.getByLabelText(/^email$/i), 'learner@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'hunter2correct')
+    await user.click(screen.getByRole('button', { name: /^sign in$/i }))
+
+    expect(await screen.findByTestId('path')).toHaveTextContent(dest)
+  })
+
+  it('passes the return path to create-account', async () => {
+    renderWithAuthPages({
+      pathname: '/login',
+      state: { from: '/marketplace/ai-essentials-c-hupcnf' },
+    })
+    const link = screen.getByRole('link', { name: /create an account|create account/i })
+    expect(link).toHaveAttribute(
+      'href',
+      '/signup?next=%2Fmarketplace%2Fai-essentials-c-hupcnf',
+    )
   })
 
   it('shows a friendly error when the request fails at the network layer', async () => {

--- a/clients/web/src/pages/__tests__/signup.test.tsx
+++ b/clients/web/src/pages/__tests__/signup.test.tsx
@@ -1,13 +1,18 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import App from '../../app'
 import { PermissionsProvider } from '../../context/permissions-provider'
 import { server } from '../../test/mocks/server'
 import { renderWithRouter } from '../../test/render'
 import Signup from '../signup'
+
+function PathProbe() {
+  const loc = useLocation()
+  return <div data-testid="path">{`${loc.pathname}${loc.search}`}</div>
+}
 
 describe('Signup', () => {
   it('renders create account heading', () => {
@@ -56,6 +61,28 @@ describe('Signup', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /^dashboard$/i })).toBeInTheDocument()
     })
+  })
+
+  it('returns to the original marketplace path after creating an account', async () => {
+    const dest = '/marketplace/ai-essentials-c-hupcnf'
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter
+        initialEntries={[{ pathname: '/signup', search: `?next=${encodeURIComponent(dest)}`, state: { from: dest } }]}
+      >
+        <Routes>
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/marketplace/:slug" element={<PathProbe />} />
+          <Route path="/" element={<PathProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText(/^email$/i), 'new@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password12')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    expect(await screen.findByTestId('path')).toHaveTextContent(dest)
   })
 
   it('shows a friendly error when signup fails at the network layer', async () => {

--- a/clients/web/src/pages/forgot-password.tsx
+++ b/clients/web/src/pages/forgot-password.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useState } from 'react'
-import { Link, Navigate } from 'react-router-dom'
+import { Link, Navigate, useLocation } from 'react-router-dom'
 import {
   authCardClass,
   authFieldClass,
@@ -9,16 +9,19 @@ import {
 import { PublicAuthShell } from '../components/auth/public-auth-shell'
 import { BrandLogo } from '../components/brand-logo'
 import { getAccessToken } from '../lib/auth'
+import { authHandoffHref, pickPostAuthPath, returnPathFromAuthLocation } from '../lib/post-auth-redirect'
 import { apiUrl } from '../lib/api'
 import { readApiErrorMessage } from '../lib/errors'
 
 export default function ForgotPassword() {
+  const location = useLocation()
+  const from = returnPathFromAuthLocation(location)
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState<'idle' | 'loading' | 'error' | 'sent'>('idle')
   const [message, setMessage] = useState<string | null>(null)
 
   if (getAccessToken()) {
-    return <Navigate to="/" replace />
+    return <Navigate to={pickPostAuthPath(from)} replace />
   }
 
   async function onSubmit(e: FormEvent) {
@@ -71,7 +74,11 @@ export default function ForgotPassword() {
             <p className="text-sm text-stone-700 dark:text-fg-muted" role="status">
               {message}
             </p>
-            <Link to="/login" className={`inline-block text-sm ${authMutedLinkClass}`}>
+            <Link
+              to={authHandoffHref('/login', from)}
+              state={{ from }}
+              className={`inline-block text-sm ${authMutedLinkClass}`}
+            >
               Back to sign in
             </Link>
           </div>
@@ -108,7 +115,7 @@ export default function ForgotPassword() {
 
         {status !== 'sent' && (
           <p className="mt-6 text-center text-sm text-stone-600 dark:text-fg-muted">
-            <Link to="/login" className={authMutedLinkClass}>
+            <Link to={authHandoffHref('/login', from)} state={{ from }} className={authMutedLinkClass}>
               Back to sign in
             </Link>
           </p>

--- a/clients/web/src/pages/login.tsx
+++ b/clients/web/src/pages/login.tsx
@@ -5,7 +5,7 @@ import { BrandLogo } from '../components/brand-logo'
 import { OidcSignInButtons } from '../components/oidc-sign-in-buttons'
 import { getAccessToken } from '../lib/auth'
 import { applyAuthTokenResponse } from '../lib/session-tokens'
-import { pickPostAuthPath } from '../lib/post-auth-redirect'
+import { authHandoffHref, pickPostAuthPath, returnPathFromAuthLocation } from '../lib/post-auth-redirect'
 import { apiUrl } from '../lib/api'
 import { readApiErrorMessage } from '../lib/errors'
 import { applyUiTheme, parseUiTheme } from '../lib/ui-theme'
@@ -31,18 +31,7 @@ export default function Login() {
   const location = useLocation()
   const params = useParams()
   const state = location.state as LocationState | undefined
-  let from = state?.from ?? '/'
-  if (
-    from === '/login' ||
-    from === '/signup' ||
-    from === '/forgot-password' ||
-    from === '/reset-password' ||
-    from === '/activate-parent' ||
-    from.startsWith('/login/mfa') ||
-    from.startsWith('/login/magic-link')
-  ) {
-    from = '/'
-  }
+  const from = returnPathFromAuthLocation(location)
 
   const orgSlug = normalizeOrgSlug(params.orgSlug ?? state?.orgSlug ?? '')
   const [orgName, setOrgName] = useState<string | null>(null)
@@ -129,7 +118,7 @@ export default function Login() {
   }, [retryAfter])
 
   if (getAccessToken()) {
-    return <Navigate to="/" replace />
+    return <Navigate to={pickPostAuthPath(from)} replace />
   }
 
   async function onSubmit(e: FormEvent) {
@@ -179,12 +168,12 @@ export default function Login() {
       const mfaState: LocationState = { from, orgSlug: orgSlug || undefined }
       if (data.requires_mfa && data.mfa_pending_token) {
         setMfaFlow({ token: data.mfa_pending_token, mode: 'challenge' })
-        navigate('/login/mfa', { replace: true, state: mfaState })
+        navigate(authHandoffHref('/login/mfa', from), { replace: true, state: mfaState })
         return
       }
       if (data.mfa_setup_required && data.mfa_pending_token) {
         setMfaFlow({ token: data.mfa_pending_token, mode: 'setup' })
-        navigate('/login/mfa', { replace: true, state: mfaState })
+        navigate(authHandoffHref('/login/mfa', from), { replace: true, state: mfaState })
         return
       }
       if (!data.access_token) {
@@ -289,7 +278,11 @@ export default function Login() {
                     placeholder="••••••••"
                   />
                   <div className="mt-2 text-end">
-                    <Link to="/forgot-password" className={`text-sm ${authMutedLinkClass}`}>
+                    <Link
+                      to={authHandoffHref('/forgot-password', from)}
+                      state={{ from }}
+                      className={`text-sm ${authMutedLinkClass}`}
+                    >
                       {t('auth.login.forgotPassword')}
                     </Link>
                   </div>
@@ -320,7 +313,7 @@ export default function Login() {
             {!saml?.idp?.forceSaml && (
               <p className="mt-6 text-center text-sm text-stone-600 dark:text-fg-muted">
                 {t('auth.login.newHere')}{' '}
-                <Link to="/signup" className={authMutedLinkClass}>
+                <Link to={authHandoffHref('/signup', from)} state={{ from }} className={authMutedLinkClass}>
                   {t('auth.login.createAccount')}
                 </Link>
               </p>

--- a/clients/web/src/pages/magic-link.tsx
+++ b/clients/web/src/pages/magic-link.tsx
@@ -3,7 +3,7 @@ import { Navigate, useNavigate, useSearchParams } from 'react-router-dom'
 import { BrandLogo } from '../components/brand-logo'
 import { getAccessToken } from '../lib/auth'
 import { applyAuthTokenResponse } from '../lib/session-tokens'
-import { pickPostAuthPath } from '../lib/post-auth-redirect'
+import { pickPostAuthPath, sanitizeReturnPath } from '../lib/post-auth-redirect'
 import { apiUrl } from '../lib/api'
 import { readApiErrorMessage } from '../lib/errors'
 import { applyUiTheme, parseUiTheme } from '../lib/ui-theme'
@@ -61,12 +61,18 @@ export default function MagicLinkPage() {
         }
         if (data.requires_mfa && data.mfa_pending_token) {
           setMfaFlow({ token: data.mfa_pending_token, mode: 'challenge' })
-          navigate('/login/mfa', { replace: true, state: { from: redirectTo || '/' } })
+          navigate('/login/mfa', {
+            replace: true,
+            state: { from: sanitizeReturnPath(redirectTo) },
+          })
           return
         }
         if (data.mfa_setup_required && data.mfa_pending_token) {
           setMfaFlow({ token: data.mfa_pending_token, mode: 'setup' })
-          navigate('/login/mfa', { replace: true, state: { from: redirectTo || '/' } })
+          navigate('/login/mfa', {
+            replace: true,
+            state: { from: sanitizeReturnPath(redirectTo) },
+          })
           return
         }
         if (!data.access_token) {
@@ -77,9 +83,7 @@ export default function MagicLinkPage() {
         applyAuthTokenResponse(data)
         applyUiTheme(parseUiTheme(data.user?.uiTheme))
         markPostLoginShortcutTip()
-        const rawDest =
-          redirectTo && redirectTo.startsWith('/') && !redirectTo.startsWith('//') ? redirectTo : '/'
-        navigate(pickPostAuthPath(rawDest), { replace: true })
+        navigate(pickPostAuthPath(sanitizeReturnPath(redirectTo)), { replace: true })
       } catch {
         if (!cancelled) {
           setStatus('error')
@@ -93,7 +97,7 @@ export default function MagicLinkPage() {
   }, [navigate, redirectTo, token])
 
   if (getAccessToken()) {
-    return <Navigate to="/" replace />
+    return <Navigate to={pickPostAuthPath(sanitizeReturnPath(redirectTo))} replace />
   }
 
   return (

--- a/clients/web/src/pages/mfa-login.tsx
+++ b/clients/web/src/pages/mfa-login.tsx
@@ -3,31 +3,17 @@ import { type FormEvent, useState } from 'react'
 import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { BrandLogo } from '../components/brand-logo'
 import { applyAuthTokenResponse } from '../lib/session-tokens'
-import { pickPostAuthPath } from '../lib/post-auth-redirect'
+import { pickPostAuthPath, returnPathFromAuthLocation } from '../lib/post-auth-redirect'
 import { apiUrl } from '../lib/api'
 import { readApiErrorMessage } from '../lib/errors'
 import { applyUiTheme, parseUiTheme } from '../lib/ui-theme'
 import { markPostLoginShortcutTip } from '../lib/post-login-shortcut-tip'
 import { clearMfaFlow, getMfaFlow, type MfaFlowMode } from '../lib/mfa-flow-storage'
 
-type LocationState = { from?: string }
-
 export default function MfaLogin() {
   const navigate = useNavigate()
   const location = useLocation()
-  const state = location.state as LocationState | undefined
-  let from = state?.from ?? '/'
-  if (
-    from === '/login' ||
-    from === '/signup' ||
-    from === '/forgot-password' ||
-    from === '/reset-password' ||
-    from === '/activate-parent' ||
-    from.startsWith('/login/mfa') ||
-    from.startsWith('/login/magic-link')
-  ) {
-    from = '/'
-  }
+  const from = returnPathFromAuthLocation(location)
 
   const [flow] = useState<{ token: string; mode: MfaFlowMode } | null>(() => getMfaFlow())
   const [totpCredId, setTotpCredId] = useState<string | null>(null)

--- a/clients/web/src/pages/onboarding/onboarding-page.tsx
+++ b/clients/web/src/pages/onboarding/onboarding-page.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { ArrowRight, Sparkles } from 'lucide-react'
 import { getAccountType } from '../../lib/auth'
@@ -15,6 +15,7 @@ import {
   type LearnerGoals,
   type PriorKnowledgeLevel,
 } from '../../lib/onboarding-api'
+import { pickPostAuthPath, returnPathFromAuthLocation } from '../../lib/post-auth-redirect'
 import { OnboardingShell } from './onboarding-shell'
 
 type WizardStep = 0 | 1 | 2 | 3 | 4 | 5 | 6
@@ -24,6 +25,8 @@ const EXPERIENCE_LEVELS = ['beginner', 'intermediate', 'advanced'] as const sati
 export default function OnboardingPage() {
   const { t } = useTranslation('onboarding')
   const navigate = useNavigate()
+  const location = useLocation()
+  const afterOnboarding = pickPostAuthPath(returnPathFromAuthLocation(location))
   const { ffOnboardingFlow, gdprModuleEnabled, loading: featuresLoading } = usePlatformFeatures()
   const [step, setStep] = useState<WizardStep>(0)
   const [loading, setLoading] = useState(true)
@@ -50,7 +53,7 @@ export default function OnboardingPage() {
     try {
       const status = await fetchOnboardingStatus()
       if (status?.completed) {
-        navigate('/', { replace: true })
+        navigate(afterOnboarding, { replace: true })
         return
       }
       if (status && status.step > 0) {
@@ -61,7 +64,7 @@ export default function OnboardingPage() {
     } finally {
       setLoading(false)
     }
-  }, [navigate])
+  }, [afterOnboarding, navigate])
 
   useEffect(() => {
     if (featuresLoading) return
@@ -96,7 +99,7 @@ export default function OnboardingPage() {
   }
 
   if (!featuresLoading && !ffOnboardingFlow) {
-    return <Navigate to="/" replace />
+    return <Navigate to={afterOnboarding} replace />
   }
 
   if (loading || featuresLoading) {
@@ -151,7 +154,7 @@ export default function OnboardingPage() {
     setError(null)
     try {
       await postOnboarding({ skipAll: true })
-      navigate('/', { replace: true })
+      navigate(afterOnboarding, { replace: true })
     } catch (err) {
       setError(err instanceof Error ? err.message : t('onboarding.errors.skip'))
     } finally {
@@ -497,7 +500,7 @@ export default function OnboardingPage() {
         <p className="mt-4 text-sm text-fg-muted">{t('onboarding.done.browseCatalog')}</p>
       )}
       <Link
-        to="/"
+        to={afterOnboarding}
         className="mt-6 inline-flex items-center gap-2 rounded-xl bg-accent-solid px-4 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500"
       >
         {t('onboarding.done.goToDashboard')}

--- a/clients/web/src/pages/signup.tsx
+++ b/clients/web/src/pages/signup.tsx
@@ -1,11 +1,11 @@
 import { type FormEvent, useEffect, useState } from 'react'
-import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { BrandLogo } from '../components/brand-logo'
 import { OidcSignInButtons } from '../components/oidc-sign-in-buttons'
 import { getAccessToken } from '../lib/auth'
 import { applyAuthTokenResponse } from '../lib/session-tokens'
-import { pickPostAuthPath } from '../lib/post-auth-redirect'
+import { authHandoffHref, pickPostAuthPath, returnPathFromAuthLocation } from '../lib/post-auth-redirect'
 import { apiUrl } from '../lib/api'
 import { readApiErrorMessage } from '../lib/errors'
 import { passwordStrengthEnglish, passwordStrengthKey, type PasswordStrengthKey } from '../lib/password-strength'
@@ -25,6 +25,8 @@ import { detectBrowserTimezone } from '../lib/format'
 export default function Signup() {
   const { t } = useTranslation('auth')
   const navigate = useNavigate()
+  const location = useLocation()
+  const from = returnPathFromAuthLocation(location)
   const [displayName, setDisplayName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -78,7 +80,7 @@ export default function Signup() {
   const strengthLabel = passwordStrengthEnglish(strengthKey)
 
   if (getAccessToken()) {
-    return <Navigate to="/" replace />
+    return <Navigate to={pickPostAuthPath(from)} replace />
   }
 
   async function onSubmit(e: FormEvent) {
@@ -116,7 +118,7 @@ export default function Signup() {
       applyUiTheme(parseUiTheme(data.user?.uiTheme))
       await syncUserLocale(data.user?.locale)
       markPostLoginShortcutTip()
-      navigate(pickPostAuthPath('/'), { replace: true })
+      navigate(pickPostAuthPath(from), { replace: true })
     } catch {
       setStatus('error')
       setMessage(t('auth.login.serverUnreachable'))
@@ -138,7 +140,7 @@ export default function Signup() {
       </header>
 
       <div className={authCardClass}>
-        <OidcSignInButtons nextPath="/" />
+        <OidcSignInButtons nextPath={from} />
         <form className="mt-4 space-y-5" onSubmit={onSubmit}>
             <div>
               <label
@@ -258,7 +260,7 @@ export default function Signup() {
 
           <p className="mt-6 text-center text-sm text-stone-600 dark:text-fg-muted">
             {t('auth.signup.alreadyHave')}{' '}
-            <Link to="/login" className={authMutedLinkClass}>
+            <Link to={authHandoffHref('/login', from)} state={{ from }} className={authMutedLinkClass}>
               {t('auth.signup.signIn')}
             </Link>
           </p>

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -5,7 +5,7 @@
  *   [x] Sign up with email and password → redirected to dashboard
  *   [x] Log in with valid credentials → redirected to dashboard
  *   [x] Log in with wrong password → error message shown
- *   [x] Redirect to /login when visiting protected route unauthenticated
+ *   [x] Redirect to /login?next=… when visiting protected route unauthenticated
  *   [x] Log out → session cleared, redirected to /login
  */
 import { test, expect, type Page } from '@playwright/test'
@@ -74,7 +74,7 @@ test.describe('Unauthenticated access', () => {
   test('redirects to /login for protected routes', async ({ page }) => {
     // Visit a protected route with no token in storage.
     await page.goto('/courses')
-    await expect(page).toHaveURL('/login')
+    await expect(page).toHaveURL('/login?next=%2Fcourses')
   })
 })
 


### PR DESCRIPTION
## Summary

Unauthenticated marketplace links (for example `/marketplace/ai-essentials-c-hupcnf`) sent people to login, but after they signed in or created an account they landed on the dashboard instead of the course they opened.

- Persist the original in-app path as `?next=` (and location state) on login, signup, MFA, and forgot-password
- After login/signup, navigate back to that path instead of `/`
- Carry the destination through onboarding when that flow is enabled
- Reject open-redirect values so only same-origin app paths are restored

## Checklist

- [x] Tests added/updated as appropriate
- [x] Blog/help articles were authored in the Marketing Content workspace; this PR does not add file-based articles under `www/src`
- [x] Structure: new/changed code follows [ARCHITECTURE_CONVENTIONS.md](docs/ARCHITECTURE_CONVENTIONS.md) (`make lint-structure`)
- [ ] If moving a plan into `docs/completed/`, added a disposition in `e2e/coverage/completed-feature-manifest.json` and ran `npm run e2e:coverage:check` (E2E.4)
- [ ] Flagged features link settings-toggle / disabled / enabled / authz / dependency / rollback coverage (or an E2E.1–E2E.3 family)

## Marketing SEO (`www/` changes)

- [ ] Route is in `route-manifest.tsx` with unique title/description, canonical, parent/cluster, and internal links
- [ ] OG raster image and appropriate JSON-LD schema are present
- [ ] Content has an owner/author and `reviewDue`
- [ ] Crawler-policy, redirect, or `noindex` changes include their rationale here