### PR TITLE
feat(www): install official GA4 gtag snippet

### DIFF
--- a/www/docs/performance-budget.md
+++ b/www/docs/performance-budget.md
@@ -55,7 +55,7 @@ If a legitimate feature needs more budget:
 ## Fonts & third parties
 
 - All fonts are self-hosted under `public/fonts/` (Lextures, Spectral, IBM Plex Mono). **No** `fonts.googleapis.com` / `fonts.gstatic.com`.
-- GA4 loads via `requestIdleCallback` (`src/lib/analytics.ts`); never on the critical path.
+- GA4 is the official async `gtag.js` snippet in `index.html` (`G-JX182Q6KKX`); `src/lib/analytics.ts` is a fallback injector only.
 - Images: run `npm run optimize-images` (part of build) to emit AVIF/WebP next to PNG sources.
 
 ## Related docs

--- a/www/index.html
+++ b/www/index.html
@@ -9,7 +9,15 @@
     <!-- SEO.4 FR-8…FR-10: self-hosted fonts only; preload above-the-fold weights. -->
     <link rel="preload" href="/fonts/lextures-400.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/spectral-600.woff2" as="font" type="font/woff2" crossorigin />
-    <!-- GA4 is loaded deferred via requestIdleCallback (SEO.4 FR-7); not on critical path. -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JX182Q6KKX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-JX182Q6KKX');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/www/scripts/generate-site.test.mjs
+++ b/www/scripts/generate-site.test.mjs
@@ -256,6 +256,44 @@ describe('injectDocument', () => {
     assert.doesNotMatch(out, /fonts\.googleapis/)
   })
 
+  it('preserves the GA4 gtag snippet from the Vite shell', () => {
+    const shell = `<!doctype html><html><head>
+    <title>Old Title</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JX182Q6KKX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JX182Q6KKX');
+    </script>
+  </head><body><div id="root"></div>
+  <script type="module" src="/assets/main-abc.js"></script>
+  </body></html>`
+    const tags = buildHeadTags({
+      title: 'Home — Lextures',
+      description: 'Marketing home.',
+      canonical: 'https://lextures.com/',
+    })
+    const interactive = injectDocument(shell, {
+      headTags: tags,
+      bodyHtml: '<h1>Home</h1>',
+      ssrData: { path: '/' },
+      interactive: true,
+    })
+    const staticPage = injectDocument(shell, {
+      headTags: tags,
+      bodyHtml: '<h1>Privacy</h1>',
+      ssrData: { path: '/privacy' },
+      interactive: false,
+      staticIslandSrc: '/assets/static-island-xyz.js',
+    })
+    for (const out of [interactive, staticPage]) {
+      assert.match(out, /googletagmanager\.com\/gtag\/js\?id=G-JX182Q6KKX/)
+      assert.match(out, /gtag\('config', 'G-JX182Q6KKX'\)/)
+    }
+  })
+
   it('inserts meta name=description when the shell has none', () => {
     const shell = `<!doctype html><html><head>
     <title>Old Title</title>

--- a/www/src/lib/analytics.ts
+++ b/www/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 /**
- * Deferred analytics loader (SEO.4 FR-7, FR-16).
- * GA4 is never on the critical path; loads via requestIdleCallback.
+ * GA4 helpers. The official gtag snippet lives in `index.html` (async, not
+ * parser-blocking). This module captures first-touch attribution and is a
+ * fallback injector when the HTML snippet is missing (SEO.4 FR-7, FR-16).
  */
 
 const GA_ID = 'G-JX182Q6KKX'
@@ -68,13 +69,26 @@ export function trackEvent(name: string, parameters: Record<string, string | num
   window.gtag?.('event', name, parameters)
 }
 
+function hasInstalledTag(): boolean {
+  if (typeof window.gtag === 'function') return true
+  return Boolean(document.querySelector('script[src*="googletagmanager.com/gtag/js"]'))
+}
+
 export function loadAnalytics(): void {
   if (typeof window === 'undefined' || loaded) return
   captureFirstTouch()
   if (document.documentElement.dataset.analytics === 'off') return
+  // Official snippet is already in the document head — do not config twice.
+  if (hasInstalledTag()) {
+    loaded = true
+    return
+  }
 
   const boot = () => {
-    if (loaded) return
+    if (loaded || hasInstalledTag()) {
+      loaded = true
+      return
+    }
     loaded = true
 
     window.dataLayer = window.dataLayer || []

--- a/www/src/main.tsx
+++ b/www/src/main.tsx
@@ -19,7 +19,7 @@ const path =
     ? window.location.pathname.replace(/\/+$/, '') || '/'
     : '/'
 
-// SEO.4 FR-7 / FR-16 / FR-17 — analytics + vitals after idle, never on critical path.
+// First-touch cookie + fallback gtag inject if the HTML snippet is absent.
 loadAnalytics()
 initWebVitals()
 

--- a/www/src/static-island.ts
+++ b/www/src/static-island.ts
@@ -1,6 +1,6 @@
 /**
  * Minimal client entry for interactive:false routes (SEO.4 FR-4).
- * No React — only nav progressive enhancement, deferred analytics, and web-vitals.
+ * No React — only nav progressive enhancement, analytics helpers, and web-vitals.
  */
 import { initNavEnhancements } from './lib/nav-enhancements'
 import { initBlogIndexFilters } from './lib/blog-index-filters'


### PR DESCRIPTION
## Summary

Install the official Google tag (`G-JX182Q6KKX`) in the marketing site HTML so GA4 and Tag Assistant can see it in page source.

The tag was previously injected after idle via JS, which delayed collection and often failed Google's install check. The async `gtag.js` snippet now lives in `www/index.html` and is copied onto every generated page. `loadAnalytics()` still captures first-touch attribution, but skips a second `config` call when the snippet is already present.

## Checklist

- [x] Tests added/updated as appropriate
- [x] Blog/help articles were authored in the Marketing Content workspace; this PR does not add file-based articles under `www/src`
- [x] Structure: new/changed code follows [ARCHITECTURE_CONVENTIONS.md](docs/ARCHITECTURE_CONVENTIONS.md) (`make lint-structure`)
- [ ] If moving a plan into `docs/completed/`, added a disposition in `e2e/coverage/completed-feature-manifest.json` and ran `npm run e2e:coverage:check` (E2E.4)
- [ ] Flagged features link settings-toggle / disabled / enabled / authz / dependency / rollback coverage (or an E2E.1–E2E.3 family)

## Marketing SEO (`www/` changes)

- [ ] Route is in `route-manifest.tsx` with unique title/description, canonical, parent/cluster, and internal links
- [ ] OG raster image and appropriate JSON-LD schema are present
- [ ] Content has an owner/author and `reviewDue`
- [ ] Crawler-policy, redirect, or `noindex` changes include their rationale here