### PR TITLE
Launch any course from Settings → Courses

### DIFF
--- a/clients/web/package-lock.json
+++ b/clients/web/package-lock.json
@@ -5688,9 +5688,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
-      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5724,9 +5724,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -5744,10 +5744,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -5840,9 +5840,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001786",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
-      "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -6591,9 +6591,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -10622,11 +10622,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -99,6 +99,7 @@
   },
   "overrides": {
     "@babel/core": "^7.29.6",
+    "browserslist": "4.28.7",
     "brace-expansion": "5.0.9",
     "fast-uri": "3.1.5",
     "js-yaml": "4.3.1",

--- a/clients/web/src/components/settings/__tests__/courses-panel.test.tsx
+++ b/clients/web/src/components/settings/__tests__/courses-panel.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const {
+  fetchCoursesStats,
+  searchPlatformCourses,
+  ensurePlatformCourseAdminAccess,
+  fetchPlatformCourseReport,
+} = vi.hoisted(() => ({
+  fetchCoursesStats: vi.fn(),
+  searchPlatformCourses: vi.fn(),
+  ensurePlatformCourseAdminAccess: vi.fn(),
+  fetchPlatformCourseReport: vi.fn(),
+}))
+
+vi.mock('../../../lib/platform-courses-api', () => ({
+  fetchCoursesStats,
+  searchPlatformCourses,
+  ensurePlatformCourseAdminAccess,
+  fetchPlatformCourseReport,
+}))
+
+import { CoursesPanel } from '../courses-panel'
+
+const course = {
+  id: '11111111-1111-4111-8111-111111111111',
+  courseCode: 'C-NEW001',
+  title: 'Intro to Algebra',
+  status: 'active' as const,
+  orgId: '22222222-2222-4222-8222-222222222222',
+  orgName: 'Default Org',
+  instructorName: 'Ada Lovelace',
+  termId: null,
+  termName: null,
+  enrollmentCount: 12,
+  createdAt: '2026-09-01T12:00:00.000Z',
+  updatedAt: '2026-09-01T12:00:00.000Z',
+}
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="location">{loc.pathname}</div>
+}
+
+function renderPanel() {
+  return render(
+    <MemoryRouter initialEntries={['/settings/courses']}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/settings/courses" element={<CoursesPanel />} />
+        <Route path="/courses/:courseCode" element={<div>Launched course</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('CoursesPanel', () => {
+  beforeEach(() => {
+    fetchCoursesStats.mockReset()
+    searchPlatformCourses.mockReset()
+    ensurePlatformCourseAdminAccess.mockReset()
+    fetchPlatformCourseReport.mockReset()
+    fetchCoursesStats.mockResolvedValue({
+      createdLast7Days: 1,
+      activeCourses: 4,
+      draftCourses: 2,
+      totalCourses: 7,
+      archivedCourses: 1,
+    })
+    searchPlatformCourses.mockResolvedValue({
+      items: [course],
+      total: 1,
+      page: 1,
+      perPage: 25,
+      totalPages: 1,
+    })
+    ensurePlatformCourseAdminAccess.mockResolvedValue({
+      ...course,
+      description: null,
+      published: true,
+      archived: false,
+    })
+  })
+
+  it('launches a new course from title and course code after granting admin access', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Show New courses/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /Show New courses/i }))
+
+    const titleLink = await screen.findByRole('link', { name: 'Intro to Algebra' })
+    const codeLink = screen.getByRole('link', { name: 'C-NEW001' })
+    expect(titleLink).toHaveAttribute('href', '/courses/C-NEW001')
+    expect(codeLink).toHaveAttribute('href', '/courses/C-NEW001')
+
+    await user.click(titleLink)
+
+    await waitFor(() => {
+      expect(ensurePlatformCourseAdminAccess).toHaveBeenCalledWith(course.id)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/courses/C-NEW001')
+    })
+  })
+
+  it('launches from the course code link', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(await screen.findByRole('button', { name: /Show New courses/i }))
+    await user.click(await screen.findByRole('link', { name: 'C-NEW001' }))
+
+    await waitFor(() => {
+      expect(ensurePlatformCourseAdminAccess).toHaveBeenCalledWith(course.id)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/courses/C-NEW001')
+    })
+  })
+})

--- a/clients/web/src/components/settings/courses-panel.tsx
+++ b/clients/web/src/components/settings/courses-panel.tsx
@@ -1,5 +1,5 @@
-import { type FormEvent, useCallback, useEffect, useId, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { type FormEvent, type ReactNode, useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   Archive,
   ArrowLeft,
@@ -283,6 +283,38 @@ function CoursesDashboardCards({
   )
 }
 
+function courseLaunchPath(courseCode: string): string {
+  return `/courses/${encodeURIComponent(courseCode)}`
+}
+
+function CourseLaunchLink({
+  course,
+  launching,
+  onLaunch,
+  className,
+  children,
+}: {
+  course: PlatformCourseRow
+  launching: boolean
+  onLaunch: (course: PlatformCourseRow) => void
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <Link
+      to={courseLaunchPath(course.courseCode)}
+      className={`inline-flex min-h-6 min-w-6 items-center ${className ?? ''}`}
+      aria-busy={launching || undefined}
+      onClick={(e) => {
+        e.preventDefault()
+        onLaunch(course)
+      }}
+    >
+      {children}
+    </Link>
+  )
+}
+
 function statusLabel(status: string): string {
   switch (status) {
     case 'active':
@@ -446,14 +478,16 @@ function CoursesResultsTable({
   emptyTitle,
   emptyHint,
   loadingLabel,
-  onOpen,
+  launchingId,
+  onLaunch,
 }: {
   data: PaginatedPlatformCourses | null
   loading: boolean
   emptyTitle: string
   emptyHint: string
   loadingLabel: string
-  onOpen: (courseId: string) => void
+  launchingId: string | null
+  onLaunch: (course: PlatformCourseRow) => void
 }) {
   return (
     <div className="overflow-x-auto">
@@ -508,16 +542,24 @@ function CoursesResultsTable({
                 className="transition-colors hover:bg-slate-50/80 dark:hover:bg-neutral-800/40"
               >
                 <td className="px-5 py-3">
-                  <button
-                    type="button"
-                    onClick={() => onOpen(course.id)}
-                    className="font-medium text-fg-default hover:text-accent-fg dark:text-fg-default dark:hover:text-indigo-400"
+                  <CourseLaunchLink
+                    course={course}
+                    launching={launchingId === course.id}
+                    onLaunch={onLaunch}
+                    className="font-medium text-accent-fg hover:underline"
                   >
                     {course.title}
-                  </button>
+                  </CourseLaunchLink>
                 </td>
-                <td className="px-5 py-3 font-mono text-xs text-fg-muted">
-                  {course.courseCode}
+                <td className="px-5 py-3 font-mono text-xs">
+                  <CourseLaunchLink
+                    course={course}
+                    launching={launchingId === course.id}
+                    onLaunch={onLaunch}
+                    className="text-accent-fg hover:underline"
+                  >
+                    {course.courseCode}
+                  </CourseLaunchLink>
                 </td>
                 <td className="px-5 py-3 text-fg-muted">{course.orgName}</td>
                 <td className="px-5 py-3 text-fg-muted">
@@ -595,6 +637,8 @@ export function CoursesPanel() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [accessBusy, setAccessBusy] = useState(false)
+  const [launchingId, setLaunchingId] = useState<string | null>(null)
+  const launchingRef = useRef(false)
 
   const [selectedFilter, setSelectedFilter] = useState<CoursesListFilter | null>(null)
   const [filterPage, setFilterPage] = useState(1)
@@ -717,16 +761,24 @@ export function CoursesPanel() {
     setFilterPage(1)
   }
 
-  function openCourse(courseId: string) {
-    const next = new URLSearchParams(searchParams)
-    next.set('courseId', courseId)
-    setSearchParams(next, { replace: false })
-  }
-
   function closeCourse() {
     const next = new URLSearchParams(searchParams)
     next.delete('courseId')
     setSearchParams(next, { replace: false })
+  }
+
+  async function launchCourse(course: PlatformCourseRow) {
+    if (launchingRef.current) return
+    launchingRef.current = true
+    setLaunchingId(course.id)
+    try {
+      await ensurePlatformCourseAdminAccess(course.id)
+      navigate(courseLaunchPath(course.courseCode))
+    } catch (e) {
+      toastMutationError(e instanceof Error ? e.message : 'Could not grant course access.')
+      launchingRef.current = false
+      setLaunchingId(null)
+    }
   }
 
   async function openWithAccess(path: string) {
@@ -839,7 +891,8 @@ export function CoursesPanel() {
             emptyTitle="No courses in this segment"
             emptyHint="Try another metric or search by code or title."
             loadingLabel="Loading courses…"
-            onOpen={openCourse}
+            launchingId={launchingId}
+            onLaunch={(course) => void launchCourse(course)}
           />
 
           {filterData ? (
@@ -992,7 +1045,8 @@ export function CoursesPanel() {
               emptyTitle="No courses matched your search"
               emptyHint="Try a different code, title, or status filter."
               loadingLabel="Searching…"
-              onOpen={openCourse}
+              launchingId={launchingId}
+              onLaunch={(course) => void launchCourse(course)}
             />
           </div>
         )}

--- a/server/internal/httpserver/platform_courses_db_test.go
+++ b/server/internal/httpserver/platform_courses_db_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lextures/lextures/server/internal/auth"
 	"github.com/lextures/lextures/server/internal/db"
 	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/course"
 	platformcourses "github.com/lextures/lextures/server/internal/repos/platformcourses"
 	"github.com/lextures/lextures/server/internal/repos/rbac"
 	"github.com/lextures/lextures/server/internal/repos/user"
@@ -75,5 +76,111 @@ func TestAdminCoursesStats_OK_Pg(t *testing.T) {
 	}
 	if out != expected {
 		t.Fatalf("API stats %+v != repo stats %+v", out, expected)
+	}
+}
+
+func TestAdminCoursesAccess_CrossOrgGlobalAdminCanGetCourse_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	var otherOrg uuid.UUID
+	if err := pool.QueryRow(ctx, `
+INSERT INTO tenant.organizations (slug, name, status)
+VALUES ($1, $2, 'active') RETURNING id
+`, "ga-launch-"+time.Now().Format("150405.000"), "Global Admin Launch Org").Scan(&otherOrg); err != nil {
+		t.Fatalf("org: %v", err)
+	}
+
+	em := "ga-launch-" + time.Now().Format("20060102150405.000") + "@e.com"
+	ph, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	row, err := user.InsertUser(ctx, pool, em, ph, nil)
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	uid := uuid.MustParse(row.ID)
+	if err := rbac.AssignUserRoleByName(ctx, pool, uid, "Global Admin"); err != nil {
+		t.Fatalf("ga: %v", err)
+	}
+
+	courseCode, err := course.RandomCourseCode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var courseID uuid.UUID
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.courses (course_code, title, created_by_user_id, org_id, published)
+VALUES ($1, 'Launch me', $2, $3, true) RETURNING id
+`, courseCode, uid, otherOrg).Scan(&courseID); err != nil {
+		t.Fatalf("course: %v", err)
+	}
+
+	signer := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
+	tok, err := signer.Sign(ctx, row.ID, em, "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	h := NewHandler(Deps{Pool: pool, JWTSigner: signer})
+
+	getCourse := func() *httptest.ResponseRecorder {
+		rr := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/courses/"+courseCode, nil)
+		r = r.WithContext(ctx)
+		r.Header.Set("Authorization", "Bearer "+tok)
+		h.ServeHTTP(rr, r)
+		return rr
+	}
+
+	before := getCourse()
+	if before.Code != http.StatusNotFound {
+		t.Fatalf("GET course before access status = %d, want 404: %s", before.Code, before.Body.String())
+	}
+
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/courses/"+courseID.String()+"/access", nil)
+	r = r.WithContext(ctx)
+	r.Header.Set("Authorization", "Bearer "+tok)
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST access status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	after := getCourse()
+	if after.Code != http.StatusOK {
+		t.Fatalf("GET course after access status = %d, want 200: %s", after.Code, after.Body.String())
+	}
+	var payload struct {
+		CourseCode            string   `json:"courseCode"`
+		ViewerEnrollmentRoles []string `json:"viewerEnrollmentRoles"`
+	}
+	if err := json.NewDecoder(after.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.CourseCode != courseCode {
+		t.Fatalf("courseCode = %q, want %q", payload.CourseCode, courseCode)
+	}
+	foundTeacher := false
+	for _, role := range payload.ViewerEnrollmentRoles {
+		if role == "teacher" {
+			foundTeacher = true
+			break
+		}
+	}
+	if !foundTeacher {
+		t.Fatalf("expected teacher in viewerEnrollmentRoles, got %v", payload.ViewerEnrollmentRoles)
 	}
 }

--- a/server/internal/repos/enrollment/consortium_access.go
+++ b/server/internal/repos/enrollment/consortium_access.go
@@ -16,4 +16,18 @@ OR (
 )
 `
 
-const userCourseOrgMatch = `(c.org_id = u.org_id` + consortiumGuestAccessOr + `)`
+// globalAdminAccessOr lets Global Admins (global:app:rbac:manage) use an enrollment
+// even when the course lives in another organization. Regular users stay org-scoped
+// (see TestEnrollment_OrgIsolation_Pg).
+const globalAdminAccessOr = `
+OR EXISTS (
+  SELECT 1
+  FROM "user".user_app_roles uar
+  INNER JOIN "user".rbac_role_permissions rp ON rp.role_id = uar.role_id
+  INNER JOIN "user".permissions p ON p.id = rp.permission_id
+  WHERE uar.user_id = u.id
+    AND p.permission_string = 'global:app:rbac:manage'
+)
+`
+
+const userCourseOrgMatch = `(c.org_id = u.org_id` + consortiumGuestAccessOr + globalAdminAccessOr + `)`

--- a/server/internal/repos/enrollment/enrollment.go
+++ b/server/internal/repos/enrollment/enrollment.go
@@ -214,7 +214,7 @@ FROM course.course_enrollments ce
 INNER JOIN course.courses c ON c.id = ce.course_id
 INNER JOIN "user".users u ON u.id = ce.user_id
 INNER JOIN course.enrollment_roles er ON er.role_key = ce.role AND er.is_staff = true
-WHERE ce.user_id = $1 AND ce.active AND c.org_id = u.org_id
+WHERE ce.user_id = $1 AND ce.active AND (c.org_id = u.org_id`+globalAdminAccessOr+`)
 ORDER BY c.course_code ASC
 `, userID)
 	if err != nil {

--- a/server/internal/repos/platformcourses/access_db_test.go
+++ b/server/internal/repos/platformcourses/access_db_test.go
@@ -1,0 +1,104 @@
+package platformcourses
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	"github.com/lextures/lextures/server/internal/repos/enrollment"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+func TestEnsureAdminAccess_GlobalAdminCrossOrg_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	var otherOrg uuid.UUID
+	if err := pool.QueryRow(ctx, `
+INSERT INTO tenant.organizations (slug, name, status)
+VALUES ($1, $2, 'active') RETURNING id
+`, "ga-access-"+time.Now().Format("150405.000"), "Global Admin Access Org").Scan(&otherOrg); err != nil {
+		t.Fatalf("org: %v", err)
+	}
+
+	em := "ga-access-" + time.Now().Format("20060102150405.000") + "@e.com"
+	ph, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	row, err := user.InsertUser(ctx, pool, em, ph, nil)
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	uid := uuid.MustParse(row.ID)
+	if err := rbac.AssignUserRoleByName(ctx, pool, uid, "Global Admin"); err != nil {
+		t.Fatalf("ga: %v", err)
+	}
+
+	courseCode, err := course.RandomCourseCode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var courseID uuid.UUID
+	if err := pool.QueryRow(ctx, `
+INSERT INTO course.courses (course_code, title, created_by_user_id, org_id, published)
+VALUES ($1, 'Other org course', $2, $3, true) RETURNING id
+`, courseCode, uid, otherOrg).Scan(&courseID); err != nil {
+		t.Fatalf("course: %v", err)
+	}
+
+	ok, err := enrollment.UserHasAccess(ctx, pool, courseCode, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("expected no access before admin enrollment")
+	}
+
+	if err := EnsureAdminAccess(ctx, pool, courseID, uid); err != nil {
+		t.Fatalf("EnsureAdminAccess: %v", err)
+	}
+
+	ok, err = enrollment.UserHasAccess(ctx, pool, courseCode, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected Global Admin to access a course in another org after access grant")
+	}
+
+	roles, err := enrollment.UserRolesInCourse(ctx, pool, courseCode, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundTeacher := false
+	for _, r := range roles {
+		if r == "teacher" {
+			foundTeacher = true
+			break
+		}
+	}
+	if !foundTeacher {
+		t.Fatalf("expected teacher role after access grant, got %v", roles)
+	}
+}


### PR DESCRIPTION
## Summary

On Settings → Courses, title and course code in the platform courses list (including New courses) are now links that grant the administrator instructor access and open the course.

Global Admins can launch courses in any organization. Enrollment access previously required the course to live in the admin’s org, so the grant succeeded but the course still 404’d.

## Checklist

- [x] Tests added/updated as appropriate
- [x] Blog/help articles were authored in the Marketing Content workspace; this PR does not add file-based articles under `www/src`
- [x] Structure: new/changed code follows [ARCHITECTURE_CONVENTIONS.md](docs/ARCHITECTURE_CONVENTIONS.md) (`make lint-structure`)
- [ ] If moving a plan into `docs/completed/`, added a disposition in `e2e/coverage/completed-feature-manifest.json` and ran `npm run e2e:coverage:check` (E2E.4)
- [ ] Flagged features link settings-toggle / disabled / enabled / authz / dependency / rollback coverage (or an E2E.1–E2E.3 family)

## Marketing SEO (`www/` changes)

- [ ] Route is in `route-manifest.tsx` with unique title/description, canonical, parent/cluster, and internal links
- [ ] OG raster image and appropriate JSON-LD schema are present
- [ ] Content has an owner/author and `reviewDue`
- [ ] Crawler-policy, redirect, or `noindex` changes include their rationale here