### PR TITLE
fix(deps): bump amqp091-go to v1.14.0 for CVE-2026-79921

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
-	github.com/rabbitmq/amqp091-go v1.11.0
+	github.com/rabbitmq/amqp091-go v1.14.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/reearth/ygo v1.31.6
 	github.com/russellhaering/goxmldsig v1.6.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -278,8 +278,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/rabbitmq/amqp091-go v1.11.0 h1:HxIctVm9Gid/Vtn706necmZ7Wj6pgGI2eqplRbEY8O8=
-github.com/rabbitmq/amqp091-go v1.11.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/rabbitmq/amqp091-go v1.14.0 h1:RSaT7aOKt/OrkVUyswPDW29lnRz9psuGmfZFBmLqLek=
+github.com/rabbitmq/amqp091-go v1.14.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/reearth/ygo v1.31.6 h1:Z2Z+M08DCFJ4P6bh2oswmsuZAAppuXNtRWWddGh+/Js=


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#245](https://github.com/StudyDrift/lextures/security/dependabot/245):

- **server**: bump `github.com/rabbitmq/amqp091-go` `v1.11.0` → `v1.14.0` ([GHSA-6c5v-hqjr-5xxp](https://github.com/advisories/GHSA-6c5v-hqjr-5xxp) / [CVE-2026-79921](https://nvd.nist.gov/vuln/detail/CVE-2026-79921) — broker-controlled oversized AMQP payload can exhaust client memory)

Patched in 1.13.0 (reject frames exceeding negotiated `frame_max` before allocation). 1.14.0 is the latest and also includes additional pre-negotiation frame-size enforcement.

`go build ./cmd/server` succeeds. No application code changes; our RabbitMQ usage (`Dial`, `QueueDeclare`, `PublishWithContext`, `Consume`) is unchanged.

## Checklist

- [x] Tests added/updated as appropriate
- [x] Blog/help articles were authored in the Marketing Content workspace; this PR does not add file-based articles under `www/src`
- [x] Structure: new/changed code follows [ARCHITECTURE_CONVENTIONS.md](docs/ARCHITECTURE_CONVENTIONS.md) (`make lint-structure`)
- [ ] If moving a plan into `docs/completed/`, added a disposition in `e2e/coverage/completed-feature-manifest.json` and ran `npm run e2e:coverage:check` (E2E.4)
- [ ] Flagged features link settings-toggle / disabled / enabled / authz / dependency / rollback coverage (or an E2E.1–E2E.3 family)

## Marketing SEO (`www/` changes)

- [ ] Route is in `route-manifest.tsx` with unique title/description, canonical, parent/cluster, and internal links
- [ ] OG raster image and appropriate JSON-LD schema are present
- [ ] Content has an owner/author and `reviewDue`
- [ ] Crawler-policy, redirect, or `noindex` changes include their rationale here

N/A — Go module bump only; no marketing routes or content.

## Test plan

- [x] `cd server && go build ./cmd/server`
- [ ] Dependabot alert 245 goes inactive after merge